### PR TITLE
feat: SRE command

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        VARIANT: "3.9"
+        VARIANT: "3.10"
         INSTALL_NODE: "true"
         NODE_VERSION: "lts/*"
         SHELLCHECK_VERSION: "0.7.2"

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.0-slim
+FROM python:3.10.0-slim
 
 WORKDIR /app
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,7 +1,10 @@
-.PHONY: fmt install lint test fmt-ci lint-ci install-dev run
+.PHONY: dev fmt install lint test fmt-ci lint-ci install-dev run
+
+dev:
+	jurigged main.py
 
 fmt:
-	black . $(ARGS)
+	black . $(ARGS) --target-version py310
 
 install:
 	pip3 install --user -r requirements.txt

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -1,0 +1,26 @@
+import os
+
+from commands import utils
+
+
+def sre_command(ack, command, logger, respond):
+    ack()
+    logger.info("SRE command received: %s", command["text"])
+
+    if command["text"] == "":
+        respond("Type `/sre help` to see a list of commands.")
+        return
+
+    action, *args = utils.parse_command(command["text"])
+    match action:
+        case "version":
+            respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
+        case "help":
+            help_text = """
+\n `/sre help` - show this help text
+\n `/sre version` - show the version of the SRE Bot"""
+            respond(help_text)
+        case _:
+            respond(
+                f"Unknown command: {action}. Type `/sre help` to see a list of commands."
+            )

--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -1,0 +1,23 @@
+def parse_command(command):
+    """
+    Parses a command string into a list of arguments.
+    """
+    args = []
+    arg = ""
+    in_quote = False
+    for char in command:
+        if char == '"':
+            if in_quote:
+                args.append(arg)
+                arg = ""
+                in_quote = False
+            else:
+                in_quote = True
+        elif char == " " and not in_quote:
+            args.append(arg)
+            arg = ""
+        else:
+            arg += char
+    if arg:
+        args.append(arg)
+    return args

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,13 @@
-from commands import incident
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_bolt import App
+from dotenv import load_dotenv
+from commands import incident, sre
+
+import logging
 import os
 
-from dotenv import load_dotenv
+logging.basicConfig(level=logging.INFO)
 
-from slack_bolt import App
-from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 load_dotenv()
 
@@ -18,6 +21,9 @@ def main():
     # Register incident events
     app.command("/incident")(incident.open_modal)
     app.view("incident_view")(incident.submit)
+
+    # Register SRE events
+    app.command("/sre")(sre.sre_command)
 
     SocketModeHandler(app, APP_TOKEN).start()
 

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -1,5 +1,6 @@
 black==21.7b0
 coverage==5.5
 flake8==3.9.2
+jurigged==0.4.1
 pytest==6.2.4
 pytest-env==0.6.2

--- a/app/tests/commands/test_sre.py
+++ b/app/tests/commands/test_sre.py
@@ -1,0 +1,49 @@
+import os
+
+from commands import sre
+
+from unittest.mock import MagicMock
+
+
+def test_sre_command_calls_ack():
+    ack = MagicMock()
+    sre.sre_command(ack, {"text": "command"}, MagicMock(), MagicMock())
+    ack.assert_called_once()
+
+
+def test_sre_command_calls_logger():
+    logger = MagicMock()
+    sre.sre_command(MagicMock(), {"text": "command"}, logger, MagicMock())
+    logger.info.assert_called_once()
+
+
+def test_sre_command_with_empty_string():
+    respond = MagicMock()
+    sre.sre_command(MagicMock(), {"text": ""}, MagicMock(), respond)
+    respond.assert_called_once_with("Type `/sre help` to see a list of commands.")
+
+
+def test_sre_command_with_version_argument():
+    respond = MagicMock()
+    sre.sre_command(MagicMock(), {"text": "version"}, MagicMock(), respond)
+    respond.assert_called_once_with(
+        f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}"
+    )
+
+
+def test_sre_command_with_help_argument():
+    respond = MagicMock()
+    sre.sre_command(MagicMock(), {"text": "help"}, MagicMock(), respond)
+    respond.assert_called_once_with(
+        """
+\n `/sre help` - show this help text
+\n `/sre version` - show the version of the SRE Bot"""
+    )
+
+
+def test_sr_command_with_unknown_argument():
+    respond = MagicMock()
+    sre.sre_command(MagicMock(), {"text": "unknown"}, MagicMock(), respond)
+    respond.assert_called_once_with(
+        f"Unknown command: unknown. Type `/sre help` to see a list of commands."
+    )

--- a/app/tests/commands/test_utils.py
+++ b/app/tests/commands/test_utils.py
@@ -1,0 +1,21 @@
+from commands import utils
+
+
+def test_parse_command_empty_string():
+    assert utils.parse_command("") == []
+
+
+def test_parse_command_no_args():
+    assert utils.parse_command("sre") == ["sre"]
+
+
+def test_parse_command_one_arg():
+    assert utils.parse_command("sre foo") == ["sre", "foo"]
+
+
+def test_parse_command_two_args():
+    assert utils.parse_command("sre foo bar") == ["sre", "foo", "bar"]
+
+
+def test_parse_command_with_quotes():
+    assert utils.parse_command('sre "foo bar baz"') == ["sre", "foo bar baz"]

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -11,8 +11,9 @@ def test_main_invokes_socket_handler(mock_app, mock_socket_mode_handler):
 
     mock_app.assert_called_once_with(token=os.environ.get("SLACK_TOKEN"))
 
-    mock_app.return_value.command.assert_called_once_with("/incident")
-    mock_app.return_value.view.assert_called_once_with("incident_view")
+    mock_app.return_value.command.assert_any_call("/incident")
+    mock_app.return_value.view.assert_any_call("incident_view")
+    mock_app.return_value.command.assert_any_call("/sre")
 
     mock_socket_mode_handler.assert_called_once_with(
         mock_app(), os.environ.get("APP_TOKEN")


### PR DESCRIPTION
This PR adds the `/sre` command to the bot. Currently only the `help` and `version` commands are supported.