### PR TITLE
feat: webhooks storage in dynamodb

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,18 @@
 version: '3'
 
 services:
+  dynamodb-local:
+      command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+      image: "amazon/dynamodb-local:latest"
+      container_name: dynamodb-local
+      ports:
+        - "8000:8000"
+      volumes:
+        - "./docker/dynamodb:/home/dynamodblocal/data"
+      working_dir: /home/dynamodblocal
   app:
+    depends_on:
+      - dynamodb-local
     build: 
       context: ..
       dockerfile: .devcontainer/Dockerfile
@@ -20,4 +31,6 @@ services:
       - ..:/workspace:cached   
     command: sleep infinity
     environment:
+      AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
+      AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
       SHELL: /bin/zsh

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ package
 token.json
 
 auto.tfvars
+*.db

--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -1,0 +1,279 @@
+import re
+
+from models import webhooks
+
+help_text = """
+\n `/sre webhooks create` - create a new webhook
+\n `/sre webhooks help` - show this help text
+\n `/sre webhooks list` - lists webhooks
+"""
+
+
+def handle_webhook_command(args, client, body):
+    if len(args) == 0:
+        return help_text
+
+    action, *args = args
+    match action:
+        case "create":
+            create_webhook_modal(client, body)
+        case "help":
+            return help_text
+        case "list":
+            list_all_webhooks(client, body)
+        case _:
+            return f"Unknown command: {action}. Type `/sre webhook help` to see a list of commands."
+
+
+def create_webhook(ack, view, body, logger, client, say):
+    ack()
+
+    errors = {}
+
+    name = view["state"]["values"]["name"]["name"]["value"]
+    channel = view["state"]["values"]["channel"]["channel"]["selected_channel"]
+    user = body["user"]["id"]
+
+    if not re.match(r"^[\w\-\s]+$", name):
+        errors["name"] = "Description must only contain number and letters"
+    if len(name) > 80:
+        errors["name"] = "Description must be less than 80 characters"
+    if len(errors) > 0:
+        ack(response_action="errors", errors=errors)
+        return
+
+    id = webhooks.create_webhook(channel, user, name)
+    if id:
+        message = f"Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/{id}"
+        logger.info(message)
+        say(channel=channel, text=f"<@{user}> created a new SRE-Bot webhook: {name}")
+    else:
+        message = "Something went wrong creating the webhook"
+        logger.error(f"Error creating webhook: {channel}, {user}, {name}")
+
+    client.chat_postEphemeral(
+        channel=channel,
+        user=user,
+        text=message,
+    )
+
+
+def create_webhook_modal(client, body):
+    client.views_open(
+        trigger_id=body["trigger_id"],
+        view={
+            "type": "modal",
+            "callback_id": "create_webhooks_view",
+            "title": {"type": "plain_text", "text": "SRE - Create a webhook"},
+            "submit": {"type": "plain_text", "text": "Create"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Create a new webhook by filling out the fields below:",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "name",
+                    "type": "input",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "name",
+                    },
+                    "label": {
+                        "type": "plain_text",
+                        "text": "Short description (ex: notify prod alerts)",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select a channel for the webhook",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "type": "actions",
+                    "block_id": "channel",
+                    "elements": [
+                        {
+                            "type": "channels_select",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Select a channel for the webhook",
+                                "emoji": True,
+                            },
+                            "initial_channel": body["channel_id"],
+                            "action_id": "channel",
+                        }
+                    ],
+                },
+            ],
+        },
+    )
+
+
+def list_all_webhooks(client, body, update=False):
+
+    hooks = webhooks.list_all_webhooks()
+    active_hooks = list(
+        map(
+            lambda hook: webhook_list_item(hook),
+            filter(lambda hook: hook["active"]["BOOL"], hooks),
+        )
+    )
+    disabled_hooks = list(
+        map(
+            lambda hook: webhook_list_item(hook),
+            filter(lambda hook: not hook["active"]["BOOL"], hooks),
+        )
+    )
+
+    blocks = {
+        "type": "modal",
+        "callback_id": "webhooks_view",
+        "title": {"type": "plain_text", "text": "SRE - Listing webhooks"},
+        "close": {"type": "plain_text", "text": "Close"},
+        "blocks": (
+            [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": f"There are currently {len(active_hooks)} enabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+            ]
+            + [item for sublist in active_hooks for item in sublist]
+            + [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": f"There are currently {len(disabled_hooks)} disabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+            ]
+            + [item for sublist in disabled_hooks for item in sublist]
+        ),
+    }
+    if update:
+        client.views_update(
+            view_id=body["view"]["id"],
+            view=blocks,
+        )
+    else:
+        client.views_open(trigger_id=body["trigger_id"], view=blocks)
+
+
+def reveal_webhook(ack, body, logger, client):
+    ack()
+
+    username = body["user"]["username"]
+    hook = webhooks.get_webhook(body["actions"][0]["value"])
+    id = hook["id"]["S"]
+    name = hook["name"]["S"]
+    channel = hook["channel"]["S"]
+
+    message = f"{username} has requested to see the webhook with ID: {id}"
+    logger.info(message)
+
+    blocks = {
+        "type": "modal",
+        "callback_id": "webhooks_view",
+        "title": {"type": "plain_text", "text": "SRE - Reveal webhook"},
+        "close": {"type": "plain_text", "text": "Close"},
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"Revealing webhook {name} for channel: <#{channel}>",
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"https://sre-bot.cdssandbox.xyz/hook/{id}",
+                },
+            },
+        ],
+    }
+
+    client.views_update(
+        view_id=body["view"]["id"],
+        view=blocks,
+    )
+
+
+def toggle_webhook(ack, body, logger, client):
+    ack()
+
+    username = body["user"]["username"]
+    user_id = body["user"]["id"]
+    hook = webhooks.get_webhook(body["actions"][0]["value"])
+    id = hook["id"]["S"]
+    name = hook["name"]["S"]
+    channel = hook["channel"]["S"]
+
+    webhooks.toggle_webhook(id)
+    message = f"Webhook {name} has been {'enabled' if hook['active']['BOOL'] else 'disabled'} by <@{username}>"
+    logger.info(message)
+    client.chat_postMessage(
+        channel=channel,
+        user=user_id,
+        text=message,
+    )
+    list_all_webhooks(client, body, update=True)
+
+
+def webhook_list_item(hook):
+    return [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": hook["name"]["S"]},
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
+                "style": "primary",
+                "value": hook["id"]["S"],
+                "action_id": "reveal-webhook",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": " in  <#{}>".format(hook["channel"]["S"]),
+            },
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": ("Disable" if hook["active"]["BOOL"] else "Enable"),
+                    "emoji": True,
+                },
+                "style": "danger",
+                "value": hook["id"]["S"],
+                "action_id": "toggle-webhook",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "plain_text",
+                    "emoji": True,
+                    "text": f"on {hook['created_at']['S']}",
+                }
+            ],
+        },
+        {"type": "divider"},
+    ]

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -2,15 +2,16 @@ import os
 
 from commands import utils
 
-from commands.helpers import incident_helper
+from commands.helpers import incident_helper, webhook_helper
 
 help_text = """
 \n `/sre help` - show this help text
 \n `/sre incident` - lists incident commands
+\n `/sre webhooks` - lists webhook commands
 \n `/sre version` - show the version of the SRE Bot"""
 
 
-def sre_command(ack, command, logger, respond):
+def sre_command(ack, command, logger, respond, client, body):
     ack()
     logger.info("SRE command received: %s", command["text"])
 
@@ -25,6 +26,8 @@ def sre_command(ack, command, logger, respond):
         case "incident":
             resp = incident_helper.handle_incident_command(args)
             respond(resp)
+        case "webhooks":
+            webhook_helper.handle_webhook_command(args, client, body)
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
         case _:

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt import App
 from dotenv import load_dotenv
 from commands import incident, sre
+from commands.helpers import webhook_helper
 
 import logging
 import os
@@ -25,6 +26,11 @@ def main():
 
     # Register SRE events
     app.command(f"/{PREFIX}sre")(sre.sre_command)
+
+    # Webhooks events
+    app.view("create_webhooks_view")(webhook_helper.create_webhook)
+    app.action("toggle-webhook")(webhook_helper.toggle_webhook)
+    app.action("reveal-webhook")(webhook_helper.reveal_webhook)
 
     SocketModeHandler(app, APP_TOKEN).start()
 

--- a/app/models/webhooks.py
+++ b/app/models/webhooks.py
@@ -1,0 +1,70 @@
+import boto3
+import datetime
+import os
+import uuid
+
+client = boto3.client(
+    "dynamodb",
+    endpoint_url=(
+        "http://dynamodb-local:8000" if os.environ.get("PREFIX", None) else None
+    ),
+)
+
+table = "webhooks"
+
+
+def create_webhook(channel, user_id, name):
+    id = str(uuid.uuid4())
+    response = client.put_item(
+        TableName=table,
+        Item={
+            "id": {"S": id},
+            "channel": {"S": channel},
+            "name": {"S": name},
+            "created_at": {"S": str(datetime.datetime.now())},
+            "active": {"BOOL": True},
+            "user_id": {"S": user_id},
+        },
+    )
+
+    if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+        return id
+    else:
+        return None
+
+
+def delete_webhook(id):
+    response = client.delete_item(TableName=table, Key={"id": {"S": id}})
+    return response
+
+
+def get_webhook(id):
+    response = client.get_item(TableName=table, Key={"id": {"S": id}})
+    return response["Item"]
+
+
+def list_all_webhooks():
+    response = client.scan(TableName=table, Select="ALL_ATTRIBUTES")
+    return response["Items"]
+
+
+def revoke_webhook(id):
+    response = client.update_item(
+        TableName=table,
+        Key={"id": {"S": id}},
+        UpdateExpression="SET active = :active",
+        ExpressionAttributeValues={":active": {"BOOL": False}},
+    )
+    return response
+
+
+def toggle_webhook(id):
+    response = client.update_item(
+        TableName=table,
+        Key={"id": {"S": id}},
+        UpdateExpression="SET active = :active",
+        ExpressionAttributeValues={
+            ":active": {"BOOL": not get_webhook(id)["active"]["BOOL"]}
+        },
+    )
+    return response

--- a/app/models/webhooks.py
+++ b/app/models/webhooks.py
@@ -8,6 +8,7 @@ client = boto3.client(
     endpoint_url=(
         "http://dynamodb-local:8000" if os.environ.get("PREFIX", None) else None
     ),
+    region_name="ca-central-1",
 )
 
 table = "webhooks"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,6 @@
-python-dotenv==0.19.2
+boto3==1.21.23
 google-api-python-client==2.37.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.6
+python-dotenv==0.19.2
 slack-bolt==1.11.4

--- a/app/tests/commands/helpers/test_webhook_helper.py
+++ b/app/tests/commands/helpers/test_webhook_helper.py
@@ -1,0 +1,383 @@
+from commands.helpers import webhook_helper
+
+
+from unittest.mock import ANY, MagicMock, patch
+
+
+def test_handle_webhooks_command_with_empty_args():
+    assert (
+        webhook_helper.handle_webhook_command([], MagicMock(), MagicMock())
+        == webhook_helper.help_text
+    )
+
+
+@patch("commands.helpers.webhook_helper.create_webhook_modal")
+def test_handle_webhooks_command_with_create_command(create_webhook_modal_mock):
+    client = MagicMock()
+    body = MagicMock()
+    webhook_helper.handle_webhook_command(
+        ["create"],
+        client,
+        body,
+    )
+
+    create_webhook_modal_mock.assert_called_with(client, body)
+
+
+def test_handle_webhooks_command_with_help():
+    assert (
+        webhook_helper.handle_webhook_command(["help"], MagicMock(), MagicMock())
+        == webhook_helper.help_text
+    )
+
+
+@patch("commands.helpers.webhook_helper.list_all_webhooks")
+def test_handle_webhooks_command_with_list_command(list_all_webhooks_mock):
+    client = MagicMock()
+    body = MagicMock()
+    webhook_helper.handle_webhook_command(["list"], client, body)
+    list_all_webhooks_mock.assert_called_with(client, body)
+
+
+def test_handle_webhooks_command_with_unkown_command():
+    assert (
+        webhook_helper.handle_webhook_command(["unknown"], MagicMock(), MagicMock())
+        == "Unknown command: unknown. Type `/sre webhook help` to see a list of commands."
+    )
+
+
+def test_create_webhook_with_illegal_name():
+    ack = MagicMock()
+    view = helper_generate_view("!@#$%%^&*()_+-=[]{};':,./<>?\\|`~")
+    webhook_helper.create_webhook(
+        ack,
+        view,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    ack.assert_any_call(
+        response_action="errors",
+        errors={"name": "Description must only contain number and letters"},
+    )
+
+
+def test_create_webhook_with_long_name():
+    ack = MagicMock()
+    view = helper_generate_view("a" * 81)
+    webhook_helper.create_webhook(
+        ack,
+        view,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    ack.assert_any_call(
+        response_action="errors",
+        errors={"name": "Description must be less than 80 characters"},
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.create_webhook")
+def test_create_webhook_with_existing_webhook(create_webhook_mock):
+    create_webhook_mock.return_value = "id"
+    ack = MagicMock()
+    view = helper_generate_view("foo")
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    say = MagicMock()
+    webhook_helper.create_webhook(
+        ack,
+        view,
+        body,
+        logger,
+        client,
+        say,
+    )
+    create_webhook_mock.assert_called_with(
+        "channel",
+        "user",
+        "foo",
+    )
+    logger.info.assert_called_with(
+        "Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/id"
+    )
+
+    say.assert_called_with(
+        channel="channel",
+        text="<@user> created a new SRE-Bot webhook: foo",
+    )
+
+    client.chat_postEphemeral.assert_called_with(
+        channel="channel",
+        user="user",
+        text="Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/id",
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.create_webhook")
+def test_create_webhook_with_creation_error(create_webhook_mock):
+    create_webhook_mock.return_value = None
+    ack = MagicMock()
+    view = helper_generate_view("foo")
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    say = MagicMock()
+    webhook_helper.create_webhook(
+        ack,
+        view,
+        body,
+        logger,
+        client,
+        say,
+    )
+    create_webhook_mock.assert_called_with(
+        "channel",
+        "user",
+        "foo",
+    )
+    logger.error.assert_called_with("Error creating webhook: channel, user, foo")
+
+    client.chat_postEphemeral.assert_called_with(
+        channel="channel",
+        user="user",
+        text="Something went wrong creating the webhook",
+    )
+
+
+def test_create_webhook_modal():
+    client = MagicMock()
+    body = MagicMock()
+    webhook_helper.create_webhook_modal(client, body)
+    client.views_open.assert_called()
+
+
+@patch("commands.helpers.webhook_helper.webhooks.list_all_webhooks")
+def test_list_all_webhooks(list_all_webhooks_mock):
+    list_all_webhooks_mock.return_value = [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+    client = MagicMock()
+    body = {"trigger_id": "trigger_id"}
+    webhook_helper.list_all_webhooks(client, body)
+    client.views_open.assert_called_with(
+        trigger_id="trigger_id",
+        view={
+            "type": "modal",
+            "callback_id": "webhooks_view",
+            "title": {"type": "plain_text", "text": "SRE - Listing webhooks"},
+            "close": {"type": "plain_text", "text": "Close"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "There are currently 2 enabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "name1"},
+                    "accessory": {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
+                        "style": "primary",
+                        "value": "id1",
+                        "action_id": "reveal-webhook",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": " in  <#channel1>"},
+                    "accessory": {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Disable",
+                            "emoji": True,
+                        },
+                        "style": "danger",
+                        "value": "id1",
+                        "action_id": "toggle-webhook",
+                    },
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "on 2020-01-01T00:00:00.000Z",
+                        }
+                    ],
+                },
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "name2"},
+                    "accessory": {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
+                        "style": "primary",
+                        "value": "id2",
+                        "action_id": "reveal-webhook",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": " in  <#channel2>"},
+                    "accessory": {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Disable",
+                            "emoji": True,
+                        },
+                        "style": "danger",
+                        "value": "id2",
+                        "action_id": "toggle-webhook",
+                    },
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "on 2020-01-01T00:00:00.000Z",
+                        }
+                    ],
+                },
+                {"type": "divider"},
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "There are currently 0 disabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+            ],
+        },
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.list_all_webhooks")
+def test_list_all_webhooks_update(list_all_webhooks_mock):
+    list_all_webhooks_mock.return_value = [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+    client = MagicMock()
+    body = {"view": {"id": "id"}}
+    webhook_helper.list_all_webhooks(client, body, update=True)
+    client.views_update.assert_called_with(view_id="id", view=ANY)
+
+
+@patch("commands.helpers.webhook_helper.webhooks.get_webhook")
+def test_reveal_webhook(get_webhook_mock):
+    get_webhook_mock.return_value = helper_generate_webhook("name", "channel", "id")
+    ack = MagicMock()
+    client = MagicMock()
+    body = {
+        "actions": [{"value": "id"}],
+        "user": {"username": "username"},
+        "view": {"id": "id"},
+    }
+    logger = MagicMock()
+    webhook_helper.reveal_webhook(ack, body, logger, client)
+    ack.assert_called()
+    logger.info.assert_called_with(
+        "username has requested to see the webhook with ID: id"
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.get_webhook")
+@patch("commands.helpers.webhook_helper.webhooks.toggle_webhook")
+@patch("commands.helpers.webhook_helper.list_all_webhooks")
+def test_toggle_webhook(list_all_webhooks_mock, toggle_webhook_mock, get_webhook_mock):
+    get_webhook_mock.return_value = helper_generate_webhook("name", "channel", "id")
+    ack = MagicMock()
+    client = MagicMock()
+    body = {
+        "actions": [{"value": "id"}],
+        "user": {"id": "user_id", "username": "username"},
+        "view": {"id": "id"},
+    }
+    logger = MagicMock()
+    webhook_helper.toggle_webhook(ack, body, logger, client)
+    ack.assert_called()
+    toggle_webhook_mock.assert_called_with("id")
+    logger.info.assert_called_with("Webhook name has been enabled by <@username>")
+    client.chat_postMessage.assert_called_with(
+        channel="channel",
+        user="user_id",
+        text="Webhook name has been enabled by <@username>",
+    )
+    list_all_webhooks_mock.assert_called_with(client, body, update=True)
+
+
+def test_webhook_list_item():
+    hook = helper_generate_webhook("name", "channel", "id")
+    assert webhook_helper.webhook_list_item(hook) == [
+        {
+            "accessory": {
+                "action_id": "reveal-webhook",
+                "style": "primary",
+                "text": {"emoji": True, "text": "Reveal", "type": "plain_text"},
+                "type": "button",
+                "value": "id",
+            },
+            "text": {"text": "name", "type": "mrkdwn"},
+            "type": "section",
+        },
+        {
+            "accessory": {
+                "action_id": "toggle-webhook",
+                "style": "danger",
+                "text": {"emoji": True, "text": "Disable", "type": "plain_text"},
+                "type": "button",
+                "value": "id",
+            },
+            "text": {"text": " in  <#channel>", "type": "mrkdwn"},
+            "type": "section",
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "plain_text",
+                    "emoji": True,
+                    "text": "on 2020-01-01T00:00:00.000Z",
+                }
+            ],
+        },
+        {"type": "divider"},
+    ]
+
+
+def helper_generate_view(name="name"):
+    return {
+        "state": {
+            "values": {
+                "name": {"name": {"value": name}},
+                "channel": {"channel": {"selected_channel": "channel"}},
+            }
+        }
+    }
+
+
+def helper_generate_webhook(name="name", channel="channel", id="id", active=True):
+    return {
+        "name": {"S": name},
+        "channel": {"S": channel},
+        "id": {"S": id},
+        "active": {"BOOL": active},
+        "created_at": {"S": "2020-01-01T00:00:00.000Z"},
+    }

--- a/app/tests/commands/test_sre.py
+++ b/app/tests/commands/test_sre.py
@@ -7,25 +7,33 @@ from unittest.mock import MagicMock, patch
 
 def test_sre_command_calls_ack():
     ack = MagicMock()
-    sre.sre_command(ack, {"text": "command"}, MagicMock(), MagicMock())
+    sre.sre_command(
+        ack, {"text": "command"}, MagicMock(), MagicMock(), MagicMock(), MagicMock()
+    )
     ack.assert_called_once()
 
 
 def test_sre_command_calls_logger():
     logger = MagicMock()
-    sre.sre_command(MagicMock(), {"text": "command"}, logger, MagicMock())
+    sre.sre_command(
+        MagicMock(), {"text": "command"}, logger, MagicMock(), MagicMock(), MagicMock()
+    )
     logger.info.assert_called_once()
 
 
 def test_sre_command_with_empty_string():
     respond = MagicMock()
-    sre.sre_command(MagicMock(), {"text": ""}, MagicMock(), respond)
+    sre.sre_command(
+        MagicMock(), {"text": ""}, MagicMock(), respond, MagicMock(), MagicMock()
+    )
     respond.assert_called_once_with("Type `/sre help` to see a list of commands.")
 
 
 def test_sre_command_with_version_argument():
     respond = MagicMock()
-    sre.sre_command(MagicMock(), {"text": "version"}, MagicMock(), respond)
+    sre.sre_command(
+        MagicMock(), {"text": "version"}, MagicMock(), respond, MagicMock(), MagicMock()
+    )
     respond.assert_called_once_with(
         f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}"
     )
@@ -33,7 +41,9 @@ def test_sre_command_with_version_argument():
 
 def test_sre_command_with_help_argument():
     respond = MagicMock()
-    sre.sre_command(MagicMock(), {"text": "help"}, MagicMock(), respond)
+    sre.sre_command(
+        MagicMock(), {"text": "help"}, MagicMock(), respond, MagicMock(), MagicMock()
+    )
     respond.assert_called_once_with(sre.help_text)
 
 
@@ -41,13 +51,33 @@ def test_sre_command_with_help_argument():
 def test_sre_command_with_incident_argument(command_runner):
     command_runner.return_value = "incident command help"
     respond = MagicMock()
-    sre.sre_command(MagicMock(), {"text": "incident"}, MagicMock(), respond)
+    sre.sre_command(
+        MagicMock(),
+        {"text": "incident"},
+        MagicMock(),
+        respond,
+        MagicMock(),
+        MagicMock(),
+    )
     respond.assert_called_once_with("incident command help")
 
 
-def test_sr_command_with_unknown_argument():
+@patch("commands.sre.webhook_helper.handle_webhook_command")
+def test_sre_command_with_webhooks_argument(command_runner):
+    command_runner.return_value = "webhooks command help"
+    clientMock = MagicMock()
+    body = MagicMock()
+    sre.sre_command(
+        MagicMock(), {"text": "webhooks"}, MagicMock(), MagicMock(), clientMock, body
+    )
+    command_runner.assert_called_once_with([], clientMock, body)
+
+
+def test_sre_command_with_unknown_argument():
     respond = MagicMock()
-    sre.sre_command(MagicMock(), {"text": "unknown"}, MagicMock(), respond)
+    sre.sre_command(
+        MagicMock(), {"text": "unknown"}, MagicMock(), respond, MagicMock(), MagicMock()
+    )
     respond.assert_called_once_with(
         "Unknown command: unknown. Type `/sre help` to see a list of commands."
     )

--- a/app/tests/models/test_webhooks.py
+++ b/app/tests/models/test_webhooks.py
@@ -1,0 +1,130 @@
+from unittest.mock import ANY, patch
+
+from models import webhooks
+
+
+@patch("models.webhooks.client")
+def test_create_webhook(client_mock):
+    client_mock.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    assert webhooks.create_webhook("test_channel", "test_user_id", "test_name") == ANY
+    client_mock.put_item.assert_called_once_with(
+        TableName="webhooks",
+        Item={
+            "id": {"S": ANY},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": ANY},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+        },
+    )
+
+
+@patch("models.webhooks.client")
+def test_create_webhook_return_none(client_mock):
+    client_mock.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 401}}
+    assert webhooks.create_webhook("test_channel", "test_user_id", "test_name") is None
+    client_mock.put_item.assert_called_once_with(
+        TableName="webhooks",
+        Item={
+            "id": {"S": ANY},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": ANY},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+        },
+    )
+
+
+@patch("models.webhooks.client")
+def test_delete_webhook(client_mock):
+    client_mock.delete_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    assert webhooks.delete_webhook("test_id") == {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+    client_mock.delete_item.assert_called_once_with(
+        TableName="webhooks", Key={"id": {"S": "test_id"}}
+    )
+
+
+@patch("models.webhooks.client")
+def test_get_webhook(client_mock):
+    client_mock.get_item.return_value = {
+        "Item": {
+            "id": {"S": "test_id"},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": "test_created_at"},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+        }
+    }
+    assert webhooks.get_webhook("test_id") == {
+        "id": {"S": "test_id"},
+        "channel": {"S": "test_channel"},
+        "name": {"S": "test_name"},
+        "created_at": {"S": "test_created_at"},
+        "active": {"BOOL": True},
+        "user_id": {"S": "test_user_id"},
+    }
+    client_mock.get_item.assert_called_once_with(
+        TableName="webhooks", Key={"id": {"S": "test_id"}}
+    )
+
+
+@patch("models.webhooks.client")
+def test_list_all_webhooks(client_mock):
+    client_mock.scan.return_value = {
+        "Items": [
+            {
+                "id": {"S": "test_id"},
+                "channel": {"S": "test_channel"},
+                "name": {"S": "test_name"},
+                "created_at": {"S": "test_created_at"},
+                "active": {"BOOL": True},
+                "user_id": {"S": "test_user_id"},
+            }
+        ]
+    }
+    assert webhooks.list_all_webhooks() == [
+        {
+            "id": {"S": "test_id"},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": "test_created_at"},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+        }
+    ]
+    client_mock.scan.assert_called_once_with(
+        TableName="webhooks", Select="ALL_ATTRIBUTES"
+    )
+
+
+@patch("models.webhooks.client")
+def test_revoke_webhook(client_mock):
+    client_mock.update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    assert webhooks.revoke_webhook("test_id") == {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+    client_mock.update_item.assert_called_once_with(
+        TableName="webhooks",
+        Key={"id": {"S": "test_id"}},
+        UpdateExpression="SET active = :active",
+        ExpressionAttributeValues={":active": {"BOOL": False}},
+    )
+
+
+@patch("models.webhooks.client")
+def test_toggle_webhook(client_mock):
+    client_mock.update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    assert webhooks.toggle_webhook("test_id") == {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+    client_mock.update_item.assert_called_once_with(
+        TableName="webhooks",
+        Key={"id": {"S": "test_id"}},
+        UpdateExpression="SET active = :active",
+        ExpressionAttributeValues={":active": {"BOOL": ANY}},
+    )

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,0 +1,12 @@
+resource "aws_dynamodb_table" "webhooks_table" {
+  name           = "webhooks"
+  hash_key       = "id"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,7 +1,6 @@
 resource "aws_dynamodb_table" "webhooks_table" {
   name           = "webhooks"
   hash_key       = "id"
-  billing_mode   = "PAY_PER_REQUEST"
   read_capacity  = 1
   write_capacity = 1
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -23,6 +23,24 @@ data "aws_iam_policy_document" "sre-bot_secrets_manager" {
       aws_secretsmanager_secret.pickle_string.arn,
     ]
   }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem"
+    ]
+
+    resources = [
+      aws_dynamodb_table.webhooks_table.arn,
+    ]
+
+  }
 }
 
 resource "aws_iam_policy" "sre-bot_secrets_manager" {


### PR DESCRIPTION
Closes #8. Is part of #7. This PR adds the following subcommand to the SRE Bot:

```
`/sre webhooks create` - create a new webhook
`/sre webhooks help` - show this help text
`/sre webhooks list` - lists webhooks
```

Which are part of the plan to route slack webhooks through the bot. Webhooks are created through the `create` command and have the following structure in DynamoDB

```
Item={
  "id": {"S": id},
  "channel": {"S": channel},
  "name": {"S": name},
  "created_at": {"S": str(datetime.datetime.now())},
  "active": {"BOOL": True},
  "user_id": {"S": user_id},
 },
```

the `list` subcommand will present a simple interface to reveal or enable/disable webhook URLs. Every activity is also posted into the relevant channels as well as sent to the user in ephemeral messages, as well as logged out.