### PR TITLE
Feat/fastapi endpoint for hooks

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       image: "amazon/dynamodb-local:latest"
       container_name: dynamodb-local
       ports:
-        - "8000:8000"
+        - "9000:8000"
       volumes:
         - "./docker/dynamodb:/home/dynamodblocal/data"
       working_dir: /home/dynamodblocal

--- a/app/Makefile
+++ b/app/Makefile
@@ -26,4 +26,4 @@ fmt-ci:
 	black --check . --target-version py310
 
 run:
-	python3 main.py
+	uvicorn main:server_app

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dev fmt install lint test fmt-ci lint-ci install-dev run
 
 dev:
-	PREFIX="dev-" jurigged main.py
+	PREFIX="dev-" uvicorn main:server_app --reload
 
 fmt:
 	black . $(ARGS) --target-version py310

--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -244,7 +244,7 @@ def webhook_list_item(hook):
                 "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
                 "style": "primary",
                 "value": hook["id"]["S"],
-                "action_id": "reveal-webhook",
+                "action_id": "reveal_webhook",
             },
         },
         {
@@ -262,7 +262,7 @@ def webhook_list_item(hook):
                 },
                 "style": "danger",
                 "value": hook["id"]["S"],
-                "action_id": "toggle-webhook",
+                "action_id": "toggle_webhook",
             },
         },
         {

--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -43,6 +43,7 @@ def create_webhook(ack, view, body, logger, client, say):
         return
 
     id = webhooks.create_webhook(channel, user, name)
+    client.conversations_join(channel=channel)
     if id:
         message = f"Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/{id}"
         logger.info(message)

--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -1,3 +1,9 @@
+def log_ops_message(client, message):
+    channel_id = "C0388M21LKZ"
+    client.conversations_join(channel=channel_id)
+    client.chat_postMessage(channel=channel_id, text=message, as_user=True)
+
+
 def parse_command(command):
     """
     Parses a command string into a list of arguments.

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,15 @@
+import os
+import logging
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt import App
 from dotenv import load_dotenv
 from commands import incident, sre
 from commands.helpers import webhook_helper
+from server import bot_middleware, server
 
-import logging
-import os
+server_app = server.handler
 
 logging.basicConfig(level=logging.INFO)
-
 
 load_dotenv()
 
@@ -18,22 +19,27 @@ def main():
     APP_TOKEN = os.environ.get("APP_TOKEN")
 
     PREFIX = os.environ.get("PREFIX", "")
-    app = App(token=SLACK_TOKEN)
+    bot = App(token=SLACK_TOKEN)
+
+    # Add bot to server_app
+    server_app.add_middleware(bot_middleware.BotMiddleware, bot=bot)
 
     # Register incident events
-    app.command(f"/{PREFIX}incident")(incident.open_modal)
-    app.view("incident_view")(incident.submit)
+    bot.command(f"/{PREFIX}incident")(incident.open_modal)
+    bot.view("incident_view")(incident.submit)
+    bot.action("handle_incident_action_buttons")(
+        incident.handle_incident_action_buttons
+    )
 
     # Register SRE events
-    app.command(f"/{PREFIX}sre")(sre.sre_command)
+    bot.command(f"/{PREFIX}sre")(sre.sre_command)
 
     # Webhooks events
-    app.view("create_webhooks_view")(webhook_helper.create_webhook)
-    app.action("toggle-webhook")(webhook_helper.toggle_webhook)
-    app.action("reveal-webhook")(webhook_helper.reveal_webhook)
+    bot.view("create_webhooks_view")(webhook_helper.create_webhook)
+    bot.action("toggle_webhook")(webhook_helper.toggle_webhook)
+    bot.action("reveal_webhook")(webhook_helper.reveal_webhook)
 
-    SocketModeHandler(app, APP_TOKEN).start()
+    SocketModeHandler(bot, APP_TOKEN).connect()
 
 
-if __name__ == "__main__":
-    main()
+server_app.add_event_handler("startup", main)

--- a/app/models/webhooks.py
+++ b/app/models/webhooks.py
@@ -25,6 +25,8 @@ def create_webhook(channel, user_id, name):
             "created_at": {"S": str(datetime.datetime.now())},
             "active": {"BOOL": True},
             "user_id": {"S": user_id},
+            "invocation_count": {"N": "0"},
+            "acknowledged_count": {"N": "0"},
         },
     )
 
@@ -41,7 +43,30 @@ def delete_webhook(id):
 
 def get_webhook(id):
     response = client.get_item(TableName=table, Key={"id": {"S": id}})
-    return response["Item"]
+    if "Item" in response:
+        return response["Item"]
+    else:
+        return None
+
+
+def increment_acknowledged_count(id):
+    response = client.update_item(
+        TableName=table,
+        Key={"id": {"S": id}},
+        UpdateExpression="SET acknowledged_count = acknowledged_count + :inc",
+        ExpressionAttributeValues={":inc": {"N": "1"}},
+    )
+    return response
+
+
+def increment_invocation_count(id):
+    response = client.update_item(
+        TableName=table,
+        Key={"id": {"S": id}},
+        UpdateExpression="SET invocation_count = invocation_count + :inc",
+        ExpressionAttributeValues={":inc": {"N": "1"}},
+    )
+    return response
 
 
 def list_all_webhooks():

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+asyncio_mode = auto
 env =  
     SLACK_TOKEN = "SLACK_TOKEN"
     APP_TOKEN = "APP_TOKEN"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,8 @@
 boto3==1.21.23
+fastapi==0.75.0
 google-api-python-client==2.37.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.6
 python-dotenv==0.19.2
 slack-bolt==1.11.4
+uvicorn==0.17.6

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -1,6 +1,6 @@
 black==22.1.0
 coverage==5.5
 flake8==3.9.2
-jurigged==0.4.1
 pytest==6.2.4
+pytest-asyncio==0.18.2
 pytest-env==0.6.2

--- a/app/server/bot_middleware.py
+++ b/app/server/bot_middleware.py
@@ -1,0 +1,12 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class BotMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, bot):
+        super().__init__(app)
+        self.bot = bot
+
+    async def dispatch(self, request, call_next):
+        request.state.bot = self.bot
+        response = await call_next(request)
+        return response

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -1,0 +1,77 @@
+import json
+import os
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel, Extra
+from models import webhooks
+
+
+class WebhookPayload(BaseModel):
+    channel: str | None = None
+    text: str | None = None
+    as_user: bool | None = None
+    attachments: str | list | None = []
+    blocks: str | list | None = []
+    thread_ts: str | None = None
+    reply_broadcast: bool | None = None
+    unfurl_links: bool | None = None
+    unfurl_media: bool | None = None
+    icon_emoji: str | None = None
+    icon_url: str | None = None
+    mrkdwn: bool | None = None
+    link_names: bool | None = None
+    username: str | None = None
+    parse: str | None = None
+
+    class Config:
+        extra = Extra.forbid
+
+
+handler = FastAPI()
+
+
+@handler.post("/hook/{id}")
+def handle_webhook(id: str, payload: WebhookPayload, request: Request):
+    webhook = webhooks.get_webhook(id)
+    if webhook:
+        webhooks.increment_invocation_count(id)
+        payload.channel = webhook["channel"]["S"]
+        payload = append_incident_buttons(payload, id)
+        request.state.bot.client.api_call(
+            "chat.postMessage", json=json.loads(payload.json(exclude_none=True))
+        )
+        return {"ok": True}
+    else:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+
+@handler.get("/version")
+def get_version():
+    return {"version": os.environ.get("GIT_SHA", "unknown")}
+
+
+def append_incident_buttons(payload, webhook_id):
+    payload.attachments = payload.attachments + [
+        {
+            "fallback": "Incident",
+            "callback_id": "handle_incident_action_buttons",
+            "color": "#3AA3E3",
+            "attachment_type": "default",
+            "actions": [
+                {
+                    "name": "call-incident",
+                    "text": "🎉   Call incident ",
+                    "type": "button",
+                    "value": payload.text,
+                    "style": "primary",
+                },
+                {
+                    "name": "ignore-incident",
+                    "text": "🙈   Acknowledge and ignore",
+                    "type": "button",
+                    "value": webhook_id,
+                    "style": "default",
+                },
+            ],
+        }
+    ]
+    return payload

--- a/app/tests/commands/helpers/test_webhook_helper.py
+++ b/app/tests/commands/helpers/test_webhook_helper.py
@@ -189,7 +189,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
                         "style": "primary",
                         "value": "id1",
-                        "action_id": "reveal-webhook",
+                        "action_id": "reveal_webhook",
                     },
                 },
                 {
@@ -204,7 +204,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         },
                         "style": "danger",
                         "value": "id1",
-                        "action_id": "toggle-webhook",
+                        "action_id": "toggle_webhook",
                     },
                 },
                 {
@@ -226,7 +226,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         "text": {"type": "plain_text", "text": "Reveal", "emoji": True},
                         "style": "primary",
                         "value": "id2",
-                        "action_id": "reveal-webhook",
+                        "action_id": "reveal_webhook",
                     },
                 },
                 {
@@ -241,7 +241,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         },
                         "style": "danger",
                         "value": "id2",
-                        "action_id": "toggle-webhook",
+                        "action_id": "toggle_webhook",
                     },
                 },
                 {
@@ -328,7 +328,7 @@ def test_webhook_list_item():
     assert webhook_helper.webhook_list_item(hook) == [
         {
             "accessory": {
-                "action_id": "reveal-webhook",
+                "action_id": "reveal_webhook",
                 "style": "primary",
                 "text": {"emoji": True, "text": "Reveal", "type": "plain_text"},
                 "type": "button",
@@ -339,7 +339,7 @@ def test_webhook_list_item():
         },
         {
             "accessory": {
-                "action_id": "toggle-webhook",
+                "action_id": "toggle_webhook",
                 "style": "danger",
                 "text": {"emoji": True, "text": "Disable", "type": "plain_text"},
                 "type": "button",

--- a/app/tests/commands/test_utils.py
+++ b/app/tests/commands/test_utils.py
@@ -1,5 +1,16 @@
 from commands import utils
 
+from unittest.mock import MagicMock
+
+
+def test_log_ops_message():
+    client = MagicMock()
+    msg = "foo bar baz"
+    utils.log_ops_message(client, msg)
+    client.chat_postMessage.assert_called_with(
+        channel="C0388M21LKZ", text=msg, as_user=True
+    )
+
 
 def test_parse_command_empty_string():
     assert utils.parse_command("") == []

--- a/app/tests/server/test_bot_middleware.py
+++ b/app/tests/server/test_bot_middleware.py
@@ -1,0 +1,15 @@
+from server.bot_middleware import BotMiddleware
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bot_middleware_dispatch():
+    app = MagicMock()
+    bot = MagicMock()
+    call_next = AsyncMock()
+    middleware = BotMiddleware(app, bot)
+    assert middleware.bot == bot
+    assert await middleware.dispatch(MagicMock(), call_next) == call_next.return_value

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -1,0 +1,89 @@
+from server import server
+
+import os
+from fastapi.testclient import TestClient
+from unittest.mock import call, MagicMock, patch, PropertyMock
+
+
+@patch("server.server.append_incident_buttons")
+@patch("server.server.webhooks.get_webhook")
+@patch("server.server.webhooks.increment_invocation_count")
+def test_handle_webhook_found(
+    increment_invocation_count_mock, get_webhook_mock, append_incident_buttons_mock
+):
+    get_webhook_mock.return_value = {"channel": {"S": "channel"}}
+    payload = {"channel": "channel"}
+    append_incident_buttons_mock.return_value.json.return_value = "[]"
+    client = TestClient(server.handler)
+    response = client.post("/hook/id", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert get_webhook_mock.call_count == 1
+    assert increment_invocation_count_mock.call_count == 1
+    assert append_incident_buttons_mock.call_count == 1
+
+
+@patch("server.server.webhooks.get_webhook")
+def test_handle_webhook_not_found(get_webhook_mock):
+    get_webhook_mock.return_value = None
+    payload = {"channel": "channel"}
+    client = TestClient(server.handler)
+    response = client.post("/hook/id", json=payload)
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Webhook not found"}
+    assert get_webhook_mock.call_count == 1
+
+
+def test_get_version_unkown():
+    client = TestClient(server.handler)
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": "unknown"}
+
+
+@patch.dict(os.environ, {"GIT_SHA": "foo"}, clear=True)
+def test_get_version_known():
+    client = TestClient(server.handler)
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": "foo"}
+
+
+def test_append_incident_buttons():
+    payload = MagicMock()
+    attachments = PropertyMock(return_value=[])
+    type(payload).attachments = attachments
+    type(payload).text = PropertyMock(return_value="text")
+    webhook_id = "bar"
+    resp = server.append_incident_buttons(payload, webhook_id)
+    assert payload == resp
+    assert attachments.call_count == 2
+    assert attachments.call_args_list == [
+        call(),
+        call(
+            [
+                {
+                    "fallback": "Incident",
+                    "callback_id": "handle_incident_action_buttons",
+                    "color": "#3AA3E3",
+                    "attachment_type": "default",
+                    "actions": [
+                        {
+                            "name": "call-incident",
+                            "text": "🎉   Call incident ",
+                            "type": "button",
+                            "value": "text",
+                            "style": "primary",
+                        },
+                        {
+                            "name": "ignore-incident",
+                            "text": "🙈   Acknowledge and ignore",
+                            "type": "button",
+                            "value": "bar",
+                            "style": "default",
+                        },
+                    ],
+                }
+            ]
+        ),
+    ]

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -1,6 +1,7 @@
 from server import server
 
 import os
+import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import call, MagicMock, patch, PropertyMock
 
@@ -21,6 +22,26 @@ def test_handle_webhook_found(
     assert get_webhook_mock.call_count == 1
     assert increment_invocation_count_mock.call_count == 1
     assert append_incident_buttons_mock.call_count == 1
+
+
+@patch("server.server.append_incident_buttons")
+@patch("server.server.webhooks.get_webhook")
+@patch("server.server.webhooks.increment_invocation_count")
+@patch("server.server.log_ops_message")
+def test_handle_webhook_found_but_exception(
+    log_ops_message_mock,
+    increment_invocation_count_mock,
+    get_webhook_mock,
+    append_incident_buttons_mock,
+):
+    get_webhook_mock.return_value = {"channel": {"S": "channel"}}
+    payload = MagicMock()
+    append_incident_buttons_mock.return_value.json.return_value = "[]"
+    request = MagicMock()
+    request.state.bot.client.api_call.side_effect = Exception("error")
+    with pytest.raises(Exception):
+        server.handle_webhook("id", payload, request)
+        assert log_ops_message_mock.call_count == 1
 
 
 @patch("server.server.webhooks.get_webhook")

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -13,7 +13,13 @@ def test_main_invokes_socket_handler(mock_app, mock_socket_mode_handler):
 
     mock_app.return_value.command.assert_any_call("/incident")
     mock_app.return_value.view.assert_any_call("incident_view")
+    mock_app.return_value.action.assert_any_call("handle_incident_action_buttons")
+
     mock_app.return_value.command.assert_any_call("/sre")
+
+    mock_app.return_value.view.assert_any_call("create_webhooks_view")
+    mock_app.return_value.action.assert_any_call("toggle_webhook")
+    mock_app.return_value.action.assert_any_call("reveal_webhook")
 
     mock_socket_mode_handler.assert_called_once_with(
         mock_app(), os.environ.get("APP_TOKEN")

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,37 @@
+resource "aws_acm_certificate" "sre_bot" {
+  domain_name               = "sre-bot.cdssandbox.xyz"
+  subject_alternative_names = ["*.sre-bot.cdssandbox.xyz"]
+  validation_method         = "DNS"
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "sre_bot_certificate_validation" {
+  zone_id = aws_route53_zone.sre_bot.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.sre_bot.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "sre_bot" {
+  certificate_arn         = aws_acm_certificate.sre_bot.arn
+  validation_record_fqdns = [for record in aws_route53_record.sre_bot_certificate_validation : record.fqdn]
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,57 @@
+resource "aws_lb_target_group" "sre_bot" {
+  name                 = "sre-bot"
+  port                 = 8000
+  protocol             = "HTTP"
+  target_type          = "ip"
+  deregistration_delay = 30
+  vpc_id               = module.vpc.id
+
+  health_check {
+    enabled             = true
+    interval            = 10
+    path                = "/version"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+}
+
+resource "aws_lb_listener" "sre_bot_listener" {
+  depends_on = [
+    aws_acm_certificate.sre_bot,
+    aws_route53_record.sre_bot_certificate_validation,
+    aws_acm_certificate_validation.sre_bot,
+  ]
+
+  load_balancer_arn = aws_lb.sre_bot.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  certificate_arn   = aws_acm_certificate.sre_bot.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.sre_bot.arn
+  }
+}
+
+resource "aws_lb" "sre_bot" {
+
+  name               = "sre-bot"
+  internal           = false #tfsec:ignore:AWS005
+  load_balancer_type = "application"
+
+  security_groups = [
+    aws_security_group.sre_bot_load_balancer.id
+  ]
+
+  subnets = module.vpc.public_subnet_ids
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -30,7 +30,7 @@ resource "aws_lb_listener" "sre_bot_listener" {
   load_balancer_arn = aws_lb.sre_bot.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = aws_acm_certificate.sre_bot.arn
 
   default_action {

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "sre_bot" {
   protocol             = "HTTP"
   target_type          = "ip"
   deregistration_delay = 30
-  vpc_id               = module.vpc.id
+  vpc_id               = module.vpc.vpc_id
 
   health_check {
     enabled             = true

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,16 +1,3 @@
-resource "aws_security_group" "ecs_tasks" {
-  name        = "sre-bot-security-group"
-  description = "Only allow outbound traffic"
-  vpc_id      = module.vpc.vpc_id
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
 resource "aws_ecs_cluster" "sre-bot" {
   name = "sre-bot-cluster"
 }
@@ -62,7 +49,16 @@ resource "aws_ecs_service" "main" {
     assign_public_ip = false
   }
 
-  depends_on = [aws_iam_role_policy_attachment.ecs_task_execution]
+  depends_on = [
+    aws_lb_listener.sre_bot_listener,
+    aws_iam_role_policy_attachment.ecs_task_execution
+  ]
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.sre_bot.arn
+    container_name   = "sre-bot"
+    container_port   = 8000
+  }
 
   tags = {
     "CostCentre" = var.billing_code

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,32 @@
+resource "aws_route53_zone" "sre_bot" {
+  name = "sre-bot.cdssandbox.xyz"
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+}
+
+resource "aws_route53_record" "sre_bot" {
+  zone_id = aws_route53_zone.sre_bot.zone_id
+  name    = aws_route53_zone.sre_bot.name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.sre_bot.dns_name
+    zone_id                = aws_lb.sre_bot.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_health_check" "sre_bot_healthcheck" {
+  fqdn              = aws_route53_zone.sre_bot.name
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/version"
+  failure_threshold = "3"
+  request_interval  = "30"
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "sre_bot_load_balancer" {
   name        = "SRE Bot load balancer"
   description = "Ingress - SRE Bot Load Balancer"
-  vpc_id      = module.vpc.id
+  vpc_id      = module.vpc.vpc_id
 
   ingress {
     protocol    = "tcp"

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,0 +1,48 @@
+resource "aws_security_group" "sre_bot_load_balancer" {
+  name        = "SRE Bot load balancer"
+  description = "Ingress - SRE Bot Load Balancer"
+  vpc_id      = module.vpc.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
+  }
+
+  egress {
+    protocol    = "tcp"
+    from_port   = 8000
+    to_port     = 8000
+    cidr_blocks = module.vpc.cidr_block #tfsec:ignore:AWS008
+  }
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name        = "sre-bot-security-group"
+  description = "Allow inbound and outbout traffic for SRE Bot"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 8000
+    to_port     = 8000
+    cidr_blocks = module.vpc.cidr_block
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    "CostCentre" = var.billing_code
+  }
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "sre_bot_load_balancer" {
     protocol    = "tcp"
     from_port   = 8000
     to_port     = 8000
-    cidr_blocks = module.vpc.cidr_block #tfsec:ignore:AWS008
+    cidr_blocks = ["${module.vpc.cidr_block}"] #tfsec:ignore:AWS008
   }
 
   tags = {
@@ -32,7 +32,7 @@ resource "aws_security_group" "ecs_tasks" {
     protocol    = "tcp"
     from_port   = 8000
     to_port     = 8000
-    cidr_blocks = module.vpc.cidr_block
+    cidr_blocks = ["${module.vpc.cidr_block}"]
   }
 
   egress {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -2,6 +2,8 @@ module "vpc" {
   source = "github.com/cds-snc/terraform-modules?ref=v1.0.11//vpc"
   name   = "SREBotVPC"
 
+  allow_https_request_in           = true
+  allow_https_request_in_response  = true
   allow_https_request_out          = true
   allow_https_request_out_response = true
 


### PR DESCRIPTION
Closes #9 and part of #7. 

Adds two url endpoints 

`/hook` and `/version`. `/hook` will proxy a slack webhook and add two buttons to the attachments of the message. Adds the TF to create a domain, ACM, and ingress for the ECS container.