### PR TITLE
feat: adds metadata to folder

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -6,7 +6,7 @@ help_text = """
 \n `/sre incident list-folders` - list all folders in the incident drive"""
 
 
-def handle_incident_command(args, client, body, respond):
+def handle_incident_command(args, client, body, respond, ack):
 
     if len(args) == 0:
         respond(help_text)
@@ -20,9 +20,199 @@ def handle_incident_command(args, client, body, respond):
         case "help":
             respond(help_text)
         case "list-folders":
-            names = list(n["name"] for n in google_drive.list_folders())
-            respond(", ".join(names))
+            list_folders(client, body, ack)
         case _:
             respond(
                 f"Unknown command: {action}. Type `/sre incident help` to see a list of commands."
             )
+
+
+def add_folder_metadata(client, body, ack):
+    ack()
+    folder_id = body["actions"][0]["value"]
+    blocks = {
+        "type": "modal",
+        "callback_id": "add_metadata_view",
+        "title": {"type": "plain_text", "text": "SRE - Add metadata"},
+        "submit": {"type": "plain_text", "text": "Save metadata"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "private_metadata": folder_id,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Add metadata*",
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "key",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "key",
+                    "placeholder": {"type": "plain_text", "text": "Key"},
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Key",
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "value",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "value",
+                    "placeholder": {"type": "plain_text", "text": "Value"},
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Value",
+                },
+            },
+        ],
+    }
+    client.views_update(
+        view_id=body["view"]["id"],
+        view=blocks,
+    )
+
+
+def delete_folder_metadata(client, body, ack):
+    ack()
+    folder_id = body["view"]["private_metadata"]
+    key = body["actions"][0]["value"]
+    google_drive.delete_metadata(folder_id, key)
+    body["actions"] = [{"value": folder_id}]
+    view_folder_metadata(client, body, ack)
+
+
+def list_folders(client, body, ack):
+    ack()
+    folders = google_drive.list_folders()
+    folders.sort(key=lambda x: x["name"])
+    blocks = {
+        "type": "modal",
+        "callback_id": "list_folders_view",
+        "title": {"type": "plain_text", "text": "SRE - Listing folders"},
+        "close": {"type": "plain_text", "text": "Close"},
+        "blocks": [
+            item for sublist in list(map(folder_item, folders)) for item in sublist
+        ],
+    }
+    client.views_open(trigger_id=body["trigger_id"], view=blocks)
+
+
+def save_metadata(client, body, ack, view):
+    ack()
+    folder_id = view["private_metadata"]
+    key = view["state"]["values"]["key"]["key"]["value"]
+    value = view["state"]["values"]["value"]["value"]["value"]
+    google_drive.add_metadata(folder_id, key, value)
+    body["actions"] = [{"value": folder_id}]
+    del body["view"]
+    view_folder_metadata(client, body, ack)
+
+
+def view_folder_metadata(client, body, ack):
+    ack()
+    folder_id = body["actions"][0]["value"]
+    folder = google_drive.list_metadata(folder_id)
+    blocks = {
+        "type": "modal",
+        "callback_id": "view_folder_metadata_modal",
+        "title": {"type": "plain_text", "text": "SRE - Showing metadata"},
+        "submit": {"type": "plain_text", "text": "Return to folders"},
+        "private_metadata": folder_id,
+        "blocks": (
+            [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "plain_text",
+                        "text": folder["name"],
+                    },
+                    "accessory": {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Add metadata"},
+                        "value": folder_id,
+                        "action_id": "add_folder_metadata",
+                    },
+                },
+                {"type": "divider"},
+            ]
+            + metadata_items(folder)
+        ),
+    }
+    if "view" in body:
+        client.views_update(
+            view_id=body["view"]["id"],
+            view=blocks,
+        )
+    else:
+        client.views_open(trigger_id=body["trigger_id"], view=blocks)
+
+
+def folder_item(folder):
+    return [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*{folder['name']}*"},
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Manage metadata",
+                    "emoji": True,
+                },
+                "value": f"{folder['id']}",
+                "action_id": "view_folder_metadata",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"<https://drive.google.com/drive/u/0/folders/{folder['id']}|View in Google Drive>",
+                }
+            ],
+        },
+        {"type": "divider"},
+    ]
+
+
+def metadata_items(folder):
+    if "appProperties" not in folder or len(folder["appProperties"]) == 0:
+        return [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*No metadata found. Click the button above to add metadata.*",
+                },
+            },
+        ]
+    else:
+        return [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{key}*\n{value}",
+                },
+                "accessory": {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Delete metadata",
+                        "emoji": True,
+                    },
+                    "value": key,
+                    "style": "danger",
+                    "action_id": "delete_folder_metadata",
+                },
+            }
+            for key, value in folder["appProperties"].items()
+        ]

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -24,7 +24,7 @@ def sre_command(ack, command, logger, respond, client, body):
         case "help":
             respond(help_text)
         case "incident":
-            incident_helper.handle_incident_command(args, client, body, respond)
+            incident_helper.handle_incident_command(args, client, body, respond, ack)
         case "webhooks":
             webhook_helper.handle_webhook_command(args, client, body, respond)
         case "version":

--- a/app/integrations/google_drive.py
+++ b/app/integrations/google_drive.py
@@ -42,6 +42,21 @@ def get_google_service(service, version):
     return build(service, version, credentials=creds)
 
 
+def add_metadata(file_id, key, value):
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .update(
+            fileId=file_id,
+            body={"appProperties": {key: value}},
+            fields="name, appProperties",
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    return result
+
+
 def create_folder(name):
     service = get_google_service("drive", "v3")
     results = (
@@ -74,6 +89,21 @@ def create_new_incident(name, folder):
     return result["id"]
 
 
+def delete_metadata(file_id, key):
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .update(
+            fileId=file_id,
+            body={"appProperties": {key: None}},
+            fields="name, appProperties",
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    return result
+
+
 def list_folders():
     service = get_google_service("drive", "v3")
     results = (
@@ -92,6 +122,16 @@ def list_folders():
         .execute()
     )
     return results.get("files", [])
+
+
+def list_metadata(file_id):
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .get(supportsAllDrives=True, fileId=file_id, fields="id, name, appProperties")
+        .execute()
+    )
+    return result
 
 
 def merge_data(file_id, name, product, slack_channel):

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt import App
 from dotenv import load_dotenv
 from commands import incident, sre
-from commands.helpers import webhook_helper
+from commands.helpers import incident_helper, webhook_helper
 from server import bot_middleware, server
 
 server_app = server.handler
@@ -30,6 +30,13 @@ def main():
     bot.action("handle_incident_action_buttons")(
         incident.handle_incident_action_buttons
     )
+
+    # Incident events
+    bot.action("add_folder_metadata")(incident_helper.add_folder_metadata)
+    bot.action("view_folder_metadata")(incident_helper.view_folder_metadata)
+    bot.view("view_folder_metadata_modal")(incident_helper.list_folders)
+    bot.view("add_metadata_view")(incident_helper.save_metadata)
+    bot.action("delete_folder_metadata")(incident_helper.delete_folder_metadata)
 
     # Register SRE events
     bot.command(f"/{PREFIX}sre")(sre.sre_command)

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -1,12 +1,13 @@
 from commands.helpers import incident_helper
 
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 
 def test_handle_incident_command_with_empty_args():
     respond = MagicMock()
-    incident_helper.handle_incident_command([], MagicMock(), MagicMock(), respond)
+    ack = MagicMock()
+    incident_helper.handle_incident_command([], MagicMock(), MagicMock(), respond, ack)
     respond.assert_called_once_with(incident_helper.help_text)
 
 
@@ -14,31 +15,213 @@ def test_handle_incident_command_with_empty_args():
 def test_handle_incident_command_with_create_command(create_folder_mock):
     create_folder_mock.return_value = "folder created"
     respond = MagicMock()
+    ack = MagicMock()
     incident_helper.handle_incident_command(
-        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond
+        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond, ack
     )
     respond.assert_called_once_with("folder created")
 
 
 def test_handle_incident_command_with_help():
     respond = MagicMock()
-    incident_helper.handle_incident_command(["help"], MagicMock(), MagicMock(), respond)
+    ack = MagicMock()
+    incident_helper.handle_incident_command(
+        ["help"], MagicMock(), MagicMock(), respond, ack
+    )
     respond.assert_called_once_with(incident_helper.help_text)
 
 
-@patch("commands.helpers.incident_helper.google_drive.list_folders")
+@patch("commands.helpers.incident_helper.list_folders")
 def test_handle_incident_command_with_list_folders(list_folders_mock):
+    client = MagicMock()
+    body = MagicMock()
     respond = MagicMock()
-    list_folders_mock.return_value = [{"name": "foo"}, {"name": "bar"}]
+    ack = MagicMock()
     incident_helper.handle_incident_command(
-        ["list-folders"], MagicMock(), MagicMock(), respond
+        ["list-folders"], client, body, respond, ack
     )
-    respond.assert_called_once_with("foo, bar")
+    list_folders_mock.assert_called_once_with(client, body, ack)
 
 
 def test_handle_incident_command_with_unknown_command():
     respond = MagicMock()
-    incident_helper.handle_incident_command(["foo"], MagicMock(), MagicMock(), respond)
+    ack = MagicMock()
+    incident_helper.handle_incident_command(
+        ["foo"], MagicMock(), MagicMock(), respond, ack
+    )
     respond.assert_called_once_with(
         "Unknown command: foo. Type `/sre incident help` to see a list of commands."
     )
+
+
+def test_add_folder_metadata():
+    client = MagicMock()
+    body = {"actions": [{"value": "foo"}], "view": {"id": "bar"}}
+    ack = MagicMock()
+    incident_helper.add_folder_metadata(client, body, ack)
+    ack.assert_called_once()
+    client.views_update.assert_called_once_with(view_id="bar", view=ANY)
+
+
+@patch("commands.helpers.incident_helper.google_drive.delete_metadata")
+@patch("commands.helpers.incident_helper.view_folder_metadata")
+def test_delete_folder_metadata(view_folder_metadata_mock, delete_metadata_mock):
+    client = MagicMock()
+    body = {"actions": [{"value": "foo"}], "view": {"private_metadata": "bar"}}
+    ack = MagicMock()
+    incident_helper.delete_folder_metadata(client, body, ack)
+    ack.assert_called_once()
+    delete_metadata_mock.assert_called_once_with("bar", "foo")
+    view_folder_metadata_mock.assert_called_once_with(
+        client,
+        {"actions": [{"value": "bar"}], "view": {"private_metadata": "bar"}},
+        ack,
+    )
+
+
+@patch("commands.helpers.incident_helper.google_drive.list_folders")
+@patch("commands.helpers.incident_helper.folder_item")
+def test_list_folders(folder_item_mock, list_folders_mock):
+    client = MagicMock()
+    body = {"trigger_id": "foo"}
+    ack = MagicMock()
+    list_folders_mock.return_value = [{"id": "foo", "name": "bar"}]
+    folder_item_mock.return_value = [["folder item"]]
+    incident_helper.list_folders(client, body, ack)
+    list_folders_mock.assert_called_once()
+    folder_item_mock.assert_called_once_with({"id": "foo", "name": "bar"})
+    ack.assert_called_once()
+    client.views_open.assert_called_once_with(trigger_id="foo", view=ANY)
+
+
+@patch("commands.helpers.incident_helper.google_drive.add_metadata")
+@patch("commands.helpers.incident_helper.view_folder_metadata")
+def test_save_metadata(view_folder_metadata_mock, add_metadata_mock):
+    client = MagicMock()
+    body = {"actions": [{"value": "foo"}], "view": {"private_metadata": "bar"}}
+    view = {
+        "state": {
+            "values": {
+                "key": {"key": {"value": "key"}},
+                "value": {"value": {"value": "value"}},
+            }
+        },
+        "private_metadata": "bar",
+    }
+    ack = MagicMock()
+    incident_helper.save_metadata(client, body, ack, view)
+    ack.assert_called_once()
+    add_metadata_mock.assert_called_once_with("bar", "key", "value")
+    view_folder_metadata_mock.assert_called_once_with(
+        client,
+        {"actions": [{"value": "bar"}]},
+        ack,
+    )
+
+
+@patch("commands.helpers.incident_helper.google_drive.list_metadata")
+@patch("commands.helpers.incident_helper.metadata_items")
+def test_view_folder_metadata_open(metadata_items_mock, list_metadata_mock):
+    client = MagicMock()
+    body = {"actions": [{"value": "foo"}], "trigger_id": "trigger_id"}
+    ack = MagicMock()
+    list_metadata_mock.return_value = {
+        "name": "folder",
+        "appProperties": [{"key": "key", "value": "value"}],
+    }
+
+    metadata_items_mock.return_value = [["metadata item"]]
+    incident_helper.view_folder_metadata(client, body, ack)
+    ack.assert_called_once()
+    list_metadata_mock.assert_called_once_with("foo")
+    metadata_items_mock.assert_called_once_with(
+        {"name": "folder", "appProperties": [{"key": "key", "value": "value"}]}
+    )
+    client.views_open(trigger_id="trigger_id", view=ANY)
+
+
+@patch("commands.helpers.incident_helper.google_drive.list_metadata")
+@patch("commands.helpers.incident_helper.metadata_items")
+def test_view_folder_metadata_update(metadata_items_mock, list_metadata_mock):
+    client = MagicMock()
+    body = {"actions": [{"value": "foo"}], "view": {"id": "view_id"}}
+    ack = MagicMock()
+    list_metadata_mock.return_value = {
+        "name": "folder",
+        "appProperties": [{"key": "key", "value": "value"}],
+    }
+
+    metadata_items_mock.return_value = [["metadata item"]]
+    incident_helper.view_folder_metadata(client, body, ack)
+    ack.assert_called_once()
+    list_metadata_mock.assert_called_once_with("foo")
+    metadata_items_mock.assert_called_once_with(
+        {"name": "folder", "appProperties": [{"key": "key", "value": "value"}]}
+    )
+    client.views_update(view_id="view_id", view=ANY)
+
+
+def test_folder_item():
+    assert incident_helper.folder_item({"id": "foo", "name": "bar"}) == [
+        {
+            "accessory": {
+                "action_id": "view_folder_metadata",
+                "text": {
+                    "emoji": True,
+                    "text": "Manage metadata",
+                    "type": "plain_text",
+                },
+                "type": "button",
+                "value": "foo",
+            },
+            "text": {"text": "*bar*", "type": "mrkdwn"},
+            "type": "section",
+        },
+        {
+            "elements": [
+                {
+                    "text": "<https://drive.google.com/drive/u/0/folders/foo|View in Google Drive>",
+                    "type": "mrkdwn",
+                }
+            ],
+            "type": "context",
+        },
+        {"type": "divider"},
+    ]
+
+
+def test_metadata_items_empty():
+    empty = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*No metadata found. Click the button above to add metadata.*",
+            },
+        },
+    ]
+    assert incident_helper.metadata_items({}) == empty
+    assert incident_helper.metadata_items({"appProperties": []}) == empty
+
+
+def test_metadata_items():
+    assert incident_helper.metadata_items({"appProperties": {"key": "value"}}) == [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*key*\nvalue",
+            },
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Delete metadata",
+                    "emoji": True,
+                },
+                "value": "key",
+                "style": "danger",
+                "action_id": "delete_folder_metadata",
+            },
+        },
+    ]

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -210,7 +210,7 @@ def test_metadata_items():
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*key*\nvalue",
+                "text": "*key*\nvalue",
             },
             "accessory": {
                 "type": "button",

--- a/app/tests/commands/test_sre.py
+++ b/app/tests/commands/test_sre.py
@@ -53,15 +53,16 @@ def test_sre_command_with_incident_argument(command_runner):
     clientMock = MagicMock()
     body = MagicMock()
     respond = MagicMock()
+    ack = MagicMock()
     sre.sre_command(
-        MagicMock(),
+        ack,
         {"text": "incident"},
         MagicMock(),
         respond,
         clientMock,
         body,
     )
-    command_runner.assert_called_once_with([], clientMock, body, respond)
+    command_runner.assert_called_once_with([], clientMock, body, respond, ack)
 
 
 @patch("commands.sre.webhook_helper.handle_webhook_command")

--- a/app/tests/intergrations/test_google_drive.py
+++ b/app/tests/intergrations/test_google_drive.py
@@ -31,6 +31,16 @@ def test_get_google_service_raises_exception_if_pickle_string_is_invalid(pickle_
 
 
 @patch("integrations.google_drive.get_google_service")
+def test_add_metadata_returns_result(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.update.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
+    result = google_drive.add_metadata("file_id", "key", "value")
+    assert result == {"name": "test_folder", "appProperties": {"key": "value"}}
+
+
+@patch("integrations.google_drive.get_google_service")
 def test_create_folder_returns_folder_name(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
         "name": "test_folder"
@@ -50,11 +60,40 @@ def test_create_new_incident(get_google_service_mock):
 
 
 @patch("integrations.google_drive.get_google_service")
+def test_delete_metadata_returns_result(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.update.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {},
+    }
+    result = google_drive.delete_metadata("file_id", "key")
+    get_google_service_mock.return_value.files.return_value.update.assert_called_once_with(
+        fileId="file_id",
+        body={"appProperties": {"key": None}},
+        fields="name, appProperties",
+        supportsAllDrives=True,
+    )
+    assert result == {"name": "test_folder", "appProperties": {}}
+
+
+@patch("integrations.google_drive.get_google_service")
 def test_list_folders_returns_folder_names(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
         "files": [{"name": "test_folder"}]
     }
     assert google_drive.list_folders() == [{"name": "test_folder"}]
+
+
+@patch("integrations.google_drive.get_google_service")
+def test_list_metadata(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.get.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
+
+    assert google_drive.list_metadata("file_id") == {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
 
 
 @patch("integrations.google_drive.get_google_service")


### PR DESCRIPTION
Closes #18. This PR adds a UI to manage metadata for folders in Google Drive. Metadata it app specific so it needs to be either managed through the slack UI or a web UI, but can't be done through the Google Drive UI, where one would think it would be.

Refactored folder list
<img width="532" alt="Screen Shot 2022-04-04 at 3 29 46 PM" src="https://user-images.githubusercontent.com/867334/161618976-72c68c60-5952-48c9-9946-5865019f35d0.png">


Viewing metadata, no items
<img width="525" alt="Screen Shot 2022-04-04 at 3 29 56 PM" src="https://user-images.githubusercontent.com/867334/161619014-a5ba34c7-3579-4529-b297-8d626f4d216e.png">


Adding metadata
<img width="530" alt="Screen Shot 2022-04-04 at 3 31 35 PM" src="https://user-images.githubusercontent.com/867334/161619038-f6c1248a-9955-473c-b0b1-068d489f8af3.png">

Viewing metadata, one item
<img width="529" alt="Screen Shot 2022-04-04 at 3 32 06 PM" src="https://user-images.githubusercontent.com/867334/161619083-452b215a-760b-475c-8783-c8a8aee02dfa.png">

