### PR TITLE
feat: opsgenie integration

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_sre_incident_template: ${{ secrets.INCIDENT_TEMPLATE }}
   TF_VAR_sre_incident_list: ${{ secrets.INCIDENT_LIST }}
   TF_VAR_slack_incident_channel: ${{ secrets.INCIDENT_CHANNEL }}
+  TF_VAR_opsgenie_key: ${{ secrets.OPSGENIE_KEY }}
   TF_VAR_pickle_string: ${{ secrets.PICKLE_STRING }}
 
 permissions:

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_sre_incident_template: ${{ secrets.INCIDENT_TEMPLATE }}
   TF_VAR_sre_incident_list: ${{ secrets.INCIDENT_LIST }}
   TF_VAR_slack_incident_channel: ${{ secrets.INCIDENT_CHANNEL }}
+  TF_VAR_opsgenie_key: ${{ secrets.OPSGENIE_KEY }}
   TF_VAR_pickle_string: ${{ secrets.PICKLE_STRING }}
 
 permissions:

--- a/app/integrations/google_drive.py
+++ b/app/integrations/google_drive.py
@@ -134,7 +134,7 @@ def list_metadata(file_id):
     return result
 
 
-def merge_data(file_id, name, product, slack_channel):
+def merge_data(file_id, name, product, slack_channel, on_call_names):
     changes = {
         "requests": [
             {
@@ -147,6 +147,12 @@ def merge_data(file_id, name, product, slack_channel):
                 "replaceAllText": {
                     "containsText": {"text": "{{name}}", "matchCase": "true"},
                     "replaceText": str(name),
+                }
+            },
+            {
+                "replaceAllText": {
+                    "containsText": {"text": "{{on-call-names}}", "matchCase": "true"},
+                    "replaceText": str(on_call_names),
                 }
             },
             {

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -20,5 +20,5 @@ def get_on_call_users(schedule):
 def api_get_request(url, auth):
     req = Request(url)
     req.add_header("Authorization", f"{auth['name']} {auth['token']}")
-    conn = urlopen(req)
+    conn = urlopen(req)  # nosec - Scheme is hardcoded to https
     return conn.read().decode("utf-8")

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -1,0 +1,24 @@
+import json
+import os
+from urllib.request import Request, urlopen
+
+OPSGENIE_KEY = os.getenv("OPSGENIE_KEY", None)
+
+
+def get_on_call_users(schedule):
+    content = api_get_request(
+        f"https://api.opsgenie.com/v2/schedules/{schedule}/on-calls",
+        {"name": "GenieKey", "token": OPSGENIE_KEY},
+    )
+    try:
+        data = json.loads(content)
+        return list(map(lambda x: x["name"], data["data"]["onCallParticipants"]))
+    except Exception:
+        return []
+
+
+def api_get_request(url, auth):
+    req = Request(url)
+    req.add_header("Authorization", f"{auth['name']} {auth['token']}")
+    conn = urlopen(req)
+    return conn.read().decode("utf-8")

--- a/app/tests/intergrations/test_google_drive.py
+++ b/app/tests/intergrations/test_google_drive.py
@@ -102,7 +102,8 @@ def test_merge_data(get_google_service_mock):
         True
     )
     assert (
-        google_drive.merge_data("file_id", "name", "product", "slack_channel") is True
+        google_drive.merge_data("file_id", "name", "product", "slack_channel", "")
+        is True
     )
 
 

--- a/app/tests/intergrations/test_opsgenie.py
+++ b/app/tests/intergrations/test_opsgenie.py
@@ -1,0 +1,42 @@
+from integrations import opsgenie
+
+from unittest.mock import patch
+
+
+@patch("integrations.opsgenie.api_get_request")
+@patch("integrations.opsgenie.OPSGENIE_KEY", "OPSGENIE_KEY")
+def test_get_on_call_users(api_get_request_mock):
+    api_get_request_mock.return_value = (
+        '{"data": {"onCallParticipants": [{"name": "test_user"}]}}'
+    )
+    assert opsgenie.get_on_call_users("test_schedule") == ["test_user"]
+    api_get_request_mock.assert_called_once_with(
+        "https://api.opsgenie.com/v2/schedules/test_schedule/on-calls",
+        {"name": "GenieKey", "token": "OPSGENIE_KEY"},
+    )
+
+
+@patch("integrations.opsgenie.api_get_request")
+def test_get_on_call_users_with_exception(api_get_request_mock):
+    api_get_request_mock.return_value = "{]"
+    assert opsgenie.get_on_call_users("test_schedule") == []
+
+
+@patch("integrations.opsgenie.Request")
+@patch("integrations.opsgenie.urlopen")
+def test_api_get_request(urlopen_mock, request_mock):
+    urlopen_mock.return_value.read.return_value.decode.return_value = (
+        '{"data": {"onCallParticipants": [{"name": "test_user"}]}}'
+    )
+    assert (
+        opsgenie.api_get_request(
+            "test_url", {"name": "GenieKey", "token": "OPSGENIE_KEY"}
+        )
+        == '{"data": {"onCallParticipants": [{"name": "test_user"}]}}'
+    )
+
+    request_mock.assert_called_once_with("test_url")
+    request_mock.return_value.add_header.assert_called_once_with(
+        "Authorization", "GenieKey OPSGENIE_KEY"
+    )
+    urlopen_mock.assert_called_once_with(request_mock.return_value)

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -15,6 +15,7 @@ data "template_file" "sre-bot" {
     aws_region            = "ca-central-1"
     slack_token           = aws_secretsmanager_secret_version.slack_token.arn
     app_token             = aws_secretsmanager_secret_version.app_token.arn
+    opsgenie_key          = aws_secretsmanager_secret_version.opsgenie_key.arn
     pickle_string         = aws_secretsmanager_secret_version.pickle_string.arn
     sre_drive_id          = var.sre_drive_id
     sre_incident_folder   = var.sre_incident_folder

--- a/terraform/secretsmanager.tf
+++ b/terraform/secretsmanager.tf
@@ -30,3 +30,12 @@ resource "aws_secretsmanager_secret_version" "pickle_string" {
   secret_id     = aws_secretsmanager_secret.pickle_string.id
   secret_string = var.pickle_string
 }
+
+resource "aws_secretsmanager_secret" "opsgenie_key" {
+  name = "opsgenie-key-${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "opsgenie_key" {
+  secret_id     = aws_secretsmanager_secret.opsgenie_key.id
+  secret_string = var.opsgenie_key
+}

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -54,6 +54,10 @@
         "valueFrom": "${app_token}"
       },
       {
+        "name": "OPSGENIE_KEY",
+        "valueFrom": "${opsgenie_key}"
+      }
+      {
         "name": "PICKLE_STRING",
         "valueFrom": "${pickle_string}"
       }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,12 @@ variable "app_token" {
 
 # Container secrets for Google Drive
 
+variable "opsgenie_key" {
+  description = "The API key for OpsGenie"
+  type        = string
+  sensitive   = true
+}
+
 variable "pickle_string" {
   description = "The pickle string used to access Google Drive"
   type        = string


### PR DESCRIPTION
Closes #12. This PR adds code that will check for a `genie_schedule` on the folder metadata, pull out the emails of the people on-call for that schedule, look them up in slack, and add them to the incident channel. It also includes the names of the people on-call at the time in the incident document.