### PR TITLE
feat: get stale channel list.

### DIFF
--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -1,3 +1,53 @@
+import time
+from datetime import datetime, timedelta
+
+
+def get_incident_channels(client):
+    channels = []
+    response = client.conversations_list(
+        exclude_archived=True, limit=1000, types="public_channel"
+    )
+    if response["ok"]:
+        channels = list(
+            filter(lambda x: x["name"].startswith("incident"), response["channels"])
+        )
+    return channels
+
+
+def get_messages_in_time_period(client, channel_id, time_delta):
+    client.conversations_join(channel=channel_id)
+    messages = client.conversations_history(
+        channel=channel_id,
+        oldest=time.mktime((datetime.now() - time_delta).timetuple()),
+    )
+    if messages["ok"]:
+        return list(
+            filter(lambda x: "team" in x, messages["messages"])
+        )  # Return only messages from users
+    else:
+        return []
+
+
+def get_stale_channels(client):
+    STALE_PERIOD = timedelta(days=14)
+    now = datetime.now()
+    stale_channels = []
+    channels = list(
+        filter(
+            lambda x: x["created"] < time.mktime((now - STALE_PERIOD).timetuple()),
+            get_incident_channels(client),
+        )
+    )
+    stale_channels = list(
+        filter(
+            lambda x: len(get_messages_in_time_period(client, x["id"], STALE_PERIOD))
+            == 0,
+            channels,
+        )
+    )
+    return stale_channels
+
+
 def log_ops_message(client, message):
     channel_id = "C0388M21LKZ"
     client.conversations_join(channel=channel_id)


### PR DESCRIPTION
Part of #21. This PR adds the `/sre incident stale` command which will show incident channels that have not seen any user message activity in 14 days. This look something like this:
<img width="531" alt="Screen Shot 2022-04-06 at 2 51 23 PM" src="https://user-images.githubusercontent.com/867334/162052858-b9232859-fc54-442d-afc1-a033375fcc9f.png">

