### PR TITLE
refactor: Adds a loading screen for stale incidents

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -122,7 +122,29 @@ def save_metadata(client, body, ack, view):
 
 def stale_incidents(client, body, ack):
     ack()
+
+    placeholder = {
+        "type": "modal",
+        "callback_id": "stale_incidents_view",
+        "title": {"type": "plain_text", "text": "SRE - Stale incidents"},
+        "close": {"type": "plain_text", "text": "Close"},
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Loading stale incident list ...",
+                },
+            }
+        ],
+    }
+
+    placeholder_modal = client.views_open(
+        trigger_id=body["trigger_id"], view=placeholder
+    )
+
     stale_channels = get_stale_channels(client)
+
     blocks = {
         "type": "modal",
         "callback_id": "stale_incidents_view",
@@ -134,7 +156,8 @@ def stale_incidents(client, body, ack):
             for item in sublist
         ],
     }
-    client.views_open(trigger_id=body["trigger_id"], view=blocks)
+
+    client.views_update(view_id=placeholder_modal["view"]["id"], view=blocks)
 
 
 def view_folder_metadata(client, body, ack):

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -137,9 +137,11 @@ def test_stale_incidents(get_stale_channels_mock):
     get_stale_channels_mock.return_value = [
         {"id": "id", "topic": {"value": "topic_value"}}
     ]
+    client.views_open.return_value = {"view": {"id": "view_id"}}
     incident_helper.stale_incidents(client, body, ack)
     ack.assert_called_once()
     client.views_open.assert_called_once_with(trigger_id="foo", view=ANY)
+    client.views_update.assert_called_once_with(view_id="view_id", view=ANY)
 
 
 @patch("commands.helpers.incident_helper.google_drive.list_metadata")


### PR DESCRIPTION
Refactors the modal code slightly to show a loading dialog before updating the modal. The reason is that the initial modal needs to respond within three seconds and sorting through all the stale incidents can last longer :(. You can see this behaviour in slack if you load their channel lists, although they have a much nicer loading animation.