### PR TITLE
feat: stale reminder

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -84,6 +84,20 @@ def add_folder_metadata(client, body, ack):
     )
 
 
+def archive_channel_action(client, body, ack):
+    ack()
+    channel_id = body["channel"]["id"]
+    action = body["actions"][0]["value"]
+    user = body["user"]["id"]
+    if action == "ignore":
+        msg = f"<@{user}> has delayed archiving this channel for 14 days."
+        client.chat_update(
+            channel=channel_id, text=msg, ts=body["message_ts"], attachments=[]
+        )
+    elif action == "archive":
+        client.conversations_archive(channel=channel_id)
+
+
 def delete_folder_metadata(client, body, ack):
     ack()
     folder_id = body["view"]["private_metadata"]

--- a/app/jobs/notify_stale_incident_channels.py
+++ b/app/jobs/notify_stale_incident_channels.py
@@ -1,0 +1,32 @@
+from commands import utils
+
+
+def notify_stale_incident_channels(client):
+    channels = utils.get_stale_channels(client)
+    text = "👋  Hi! There have been no updates in this incident channel for 14 days! Consider archiving it."
+    attachments = [
+        {
+            "text": "Would you like to archive the channel now?",
+            "fallback": "You are unable to archive the channel",
+            "callback_id": "archive_channel",
+            "color": "#3AA3E3",
+            "attachment_type": "default",
+            "actions": [
+                {
+                    "name": "archive",
+                    "text": "Yes",
+                    "type": "button",
+                    "value": "archive",
+                    "style": "danger",
+                },
+                {
+                    "name": "ignore",
+                    "text": "No",
+                    "type": "button",
+                    "value": "ignore",
+                },
+            ],
+        }
+    ]
+    for channel in channels:
+        client.chat_postMessage(channel=channel, text=text, attachments=attachments)

--- a/app/jobs/scheduled_tasks.py
+++ b/app/jobs/scheduled_tasks.py
@@ -1,0 +1,37 @@
+import threading
+import time
+import schedule
+
+from jobs.notify_stale_incident_channels import notify_stale_incident_channels
+
+
+def init(bot):
+    schedule.every().day.at("16:00").do(
+        notify_stale_incident_channels, client=bot.client
+    )
+    return
+
+
+def run_continuously(interval=1):
+    """Continuously run, while executing pending jobs at each
+    elapsed time interval.
+    @return cease_continuous_run: threading. Event which can
+    be set to cease continuous run. Please note that it is
+    *intended behavior that run_continuously() does not run
+    missed jobs*. For example, if you've registered a job that
+    should run every minute and you set a continuous run
+    interval of one hour then your job won't be run 60 times
+    at each interval but only once.
+    """
+    cease_continuous_run = threading.Event()
+
+    class ScheduleThread(threading.Thread):
+        @classmethod
+        def run(cls):
+            while not cease_continuous_run.is_set():
+                schedule.run_pending()
+                time.sleep(interval)
+
+    continuous_thread = ScheduleThread()
+    continuous_thread.start()
+    return cease_continuous_run

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,5 +4,6 @@ google-api-python-client==2.37.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.6
 python-dotenv==0.19.2
+schedule==1.1.0
 slack-bolt==1.11.4
 uvicorn==0.17.6

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -73,6 +73,39 @@ def test_add_folder_metadata():
     client.views_update.assert_called_once_with(view_id="bar", view=ANY)
 
 
+def test_archive_channel_action_ignore():
+    client = MagicMock()
+    body = {
+        "actions": [{"value": "ignore"}],
+        "channel": {"id": "channel_id"},
+        "message_ts": "message_ts",
+        "user": {"id": "user_id"},
+    }
+    ack = MagicMock()
+    incident_helper.archive_channel_action(client, body, ack)
+    ack.assert_called_once()
+    client.chat_update(
+        channel="channel_id",
+        text="<@user_id> has delayed archiving this channel for 14 days.",
+        ts="message_ts",
+        attachments=[],
+    )
+
+
+def test_archive_channel_action_archive():
+    client = MagicMock()
+    body = {
+        "actions": [{"value": "archive"}],
+        "channel": {"id": "channel_id"},
+        "message_ts": "message_ts",
+        "user": {"id": "user_id"},
+    }
+    ack = MagicMock()
+    incident_helper.archive_channel_action(client, body, ack)
+    ack.assert_called_once()
+    client.conversations_archive(channel="channel_id")
+
+
 @patch("commands.helpers.incident_helper.google_drive.delete_metadata")
 @patch("commands.helpers.incident_helper.view_folder_metadata")
 def test_delete_folder_metadata(view_folder_metadata_mock, delete_metadata_mock):

--- a/app/tests/jobs/test_notify_stale_incident_channels.py
+++ b/app/tests/jobs/test_notify_stale_incident_channels.py
@@ -1,0 +1,38 @@
+from jobs import notify_stale_incident_channels
+
+from unittest.mock import MagicMock, patch
+
+
+@patch("commands.utils.get_stale_channels")
+def test_notify_stale_incident_channels(get_stale_channels_mock):
+    get_stale_channels_mock.return_value = ["channel_id"]
+    client = MagicMock()
+    notify_stale_incident_channels.notify_stale_incident_channels(client)
+    client.chat_postMessage.assert_called_once_with(
+        channel="channel_id",
+        text="👋  Hi! There have been no updates in this incident channel for 14 days! Consider archiving it.",
+        attachments=[
+            {
+                "text": "Would you like to archive the channel now?",
+                "fallback": "You are unable to archive the channel",
+                "callback_id": "archive_channel",
+                "color": "#3AA3E3",
+                "attachment_type": "default",
+                "actions": [
+                    {
+                        "name": "archive",
+                        "text": "Yes",
+                        "type": "button",
+                        "value": "archive",
+                        "style": "danger",
+                    },
+                    {
+                        "name": "ignore",
+                        "text": "No",
+                        "type": "button",
+                        "value": "ignore",
+                    },
+                ],
+            }
+        ],
+    )

--- a/app/tests/jobs/test_scheduled_tasks.py
+++ b/app/tests/jobs/test_scheduled_tasks.py
@@ -1,0 +1,24 @@
+from jobs import scheduled_tasks
+
+from unittest.mock import MagicMock, patch
+
+
+@patch("jobs.scheduled_tasks.schedule")
+def test_init(schedule_mock):
+    bot = MagicMock()
+    scheduled_tasks.init(bot)
+    schedule_mock.every().day.at.assert_called_once_with("16:00")
+    schedule_mock.every().day.at.return_value.do.assert_called_once_with(
+        scheduled_tasks.notify_stale_incident_channels, client=bot.client
+    )
+
+
+@patch("jobs.scheduled_tasks.schedule")
+@patch("jobs.scheduled_tasks.threading")
+@patch("jobs.scheduled_tasks.time")
+def test_run_continuously(time_mock, threading_mock, schedule_mock):
+    cease_continuous_run = MagicMock()
+    cease_continuous_run.is_set.return_value = True
+    threading_mock.Event.return_value = cease_continuous_run
+    result = scheduled_tasks.run_continuously(interval=1)
+    assert result == cease_continuous_run

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 
 @patch("main.SocketModeHandler")
 @patch("main.App")
-def test_main_invokes_socket_handler(mock_app, mock_socket_mode_handler):
+@patch("main.scheduled_tasks")
+def test_main_invokes_socket_handler(
+    mock_scheduled_tasks, mock_app, mock_socket_mode_handler
+):
     main.main()
 
     mock_app.assert_called_once_with(token=os.environ.get("SLACK_TOKEN"))
@@ -24,3 +27,6 @@ def test_main_invokes_socket_handler(mock_app, mock_socket_mode_handler):
     mock_socket_mode_handler.assert_called_once_with(
         mock_app(), os.environ.get("APP_TOKEN")
     )
+
+    mock_scheduled_tasks.init.assert_called_once_with(mock_app.return_value)
+    mock_scheduled_tasks.run_continuously.assert_called_once_with()


### PR DESCRIPTION
Close #21. This PR adds a scheduler that will run a job every day at 17:00 GMT to see if any incident channels have been stale for more that 14 days. If it does it will send the following message:
<img width="695" alt="Screen Shot 2022-04-07 at 6 44 47 PM" src="https://user-images.githubusercontent.com/867334/162759604-7a275adf-6906-4dc5-a1ca-faa745257766.png">
