### PR TITLE
feat: set roles in incident channel

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -207,3 +207,6 @@ def submit(ack, view, say, body, client, logger):
     # Invite oncall to channel
     for user in oncall:
         client.conversations_invite(channel=channel_id, users=user["id"])
+
+    text = "Run `/sre incident roles` to assign roles to the incident"
+    say(text=text, channel=channel_id)

--- a/app/integrations/google_drive.py
+++ b/app/integrations/google_drive.py
@@ -104,6 +104,24 @@ def delete_metadata(file_id, key):
     return result
 
 
+def get_document_by_channel_name(channel_name):
+    service = get_google_service("drive", "v3")
+    results = (
+        service.files()
+        .list(
+            pageSize=1,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            corpora="drive",
+            q="trashed=false and name='{}'".format(channel_name),
+            driveId=SRE_DRIVE_ID,
+            fields="files(appProperties, id, name)",
+        )
+        .execute()
+    )
+    return results.get("files", [])
+
+
 def list_folders():
     service = get_google_service("drive", "v3")
     results = (

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ def main():
     bot.view("add_metadata_view")(incident_helper.save_metadata)
     bot.action("delete_folder_metadata")(incident_helper.delete_folder_metadata)
     bot.action("archive_channel")(incident_helper.archive_channel_action)
+    bot.view("view_save_incident_roles")(incident_helper.save_incident_roles)
 
     # Register SRE events
     bot.command(f"/{PREFIX}sre")(sre.sre_command)

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -182,7 +182,7 @@ def test_manage_roles_with_no_result(get_document_by_channel_name_mock):
     incident_helper.manage_roles(client, body, ack, respond)
     ack.assert_called_once()
     respond.assert_called_once_with(
-        f"No incident document found for `channel_name`. Please make sure the channel matches the document name."
+        "No incident document found for `channel_name`. Please make sure the channel matches the document name."
     )
 
 

--- a/app/tests/intergrations/test_google_drive.py
+++ b/app/tests/intergrations/test_google_drive.py
@@ -76,6 +76,22 @@ def test_delete_metadata_returns_result(get_google_service_mock):
 
 
 @patch("integrations.google_drive.get_google_service")
+def test_get_document_by_channel_name(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {
+                "name": "test_document",
+                "id": "test_document_id",
+                "appProperties": {},
+            }
+        ]
+    }
+    assert google_drive.get_document_by_channel_name("test_channel_name") == [
+        {"name": "test_document", "id": "test_document_id", "appProperties": {}}
+    ]
+
+
+@patch("integrations.google_drive.get_google_service")
 def test_list_folders_returns_folder_names(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
         "files": [{"name": "test_folder"}]

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -19,6 +19,14 @@ def test_main_invokes_socket_handler(
     mock_app.return_value.view.assert_any_call("incident_view")
     mock_app.return_value.action.assert_any_call("handle_incident_action_buttons")
 
+    mock_app.return_value.action.assert_any_call("add_folder_metadata")
+    mock_app.return_value.action.assert_any_call("view_folder_metadata")
+    mock_app.return_value.view.assert_any_call("view_folder_metadata_modal")
+    mock_app.return_value.view.assert_any_call("add_metadata_view")
+    mock_app.return_value.action.assert_any_call("delete_folder_metadata")
+    mock_app.return_value.action.assert_any_call("archive_channel")
+    mock_app.return_value.view.assert_any_call("view_save_incident_roles")
+
     mock_app.return_value.command.assert_any_call("/sre")
 
     mock_app.return_value.view.assert_any_call("create_webhooks_view")


### PR DESCRIPTION
Part of #16. The PR introduce the `/sre incident roles` which provides a UI to manage incident roles inside an incident channel. If you are not in an incident channel, the bot will inform you:

<img width="847" alt="Screen Shot 2022-04-12 at 4 29 40 PM" src="https://user-images.githubusercontent.com/867334/163048811-6251cbbe-aac3-4878-b940-fce116e59961.png">

If you are in an incident channel you will see the following:

<img width="533" alt="Screen Shot 2022-04-12 at 4 30 46 PM" src="https://user-images.githubusercontent.com/867334/163048907-25e11152-0fa3-4732-b2e6-77f0438c5bb7.png">

Once you have chosen an OL and IC it will notify the channel:

<img width="586" alt="Screen Shot 2022-04-12 at 4 30 07 PM" src="https://user-images.githubusercontent.com/867334/163049193-ded2de7f-22f0-45d8-ada0-b0bbad7f48da.png">

and sets the topic:

<img width="493" alt="Screen Shot 2022-04-12 at 4 30 17 PM" src="https://user-images.githubusercontent.com/867334/163049354-915c2d93-0eff-4d57-8e3d-e1e2abdd2028.png">


