### PR TITLE
feat: load env from paramstore on startup

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -24,4 +24,6 @@ RUN cp /app/geodb/GeoLite2-City_*/GeoLite2-City.mmdb /app/geodb/GeoLite2-City.mm
 RUN rm -rf /app/geodb/GeoLite2-City_*
 RUN rm /app/geodb/GeoLite2-City.tar.gz
 
-CMD [ "uvicorn", "main:server_app", "--host=0.0.0.0" ]
+COPY bin/entry.sh /app
+
+ENTRYPOINT [ "/entry.sh" ]

--- a/app/bin/entry.sh
+++ b/app/bin/entry.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "Retrieving environment parameters"
+aws ssm get-parameters --region ca-central-1 --with-decryption --names sre-bot-config --query 'Parameters[*].Value' --output text > ".env"
+
+echo "Starting server ..."
+exec uvicorn main:server_app --host=0.0.0.0

--- a/app/tests/jobs/test_notify_stale_incident_channels.py
+++ b/app/tests/jobs/test_notify_stale_incident_channels.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 @patch("commands.utils.get_stale_channels")
 def test_notify_stale_incident_channels(get_stale_channels_mock):
-    get_stale_channels_mock.return_value = ["channel_id"]
+    get_stale_channels_mock.return_value = [{"id": "channel_id"}]
     client = MagicMock()
     notify_stale_incident_channels.notify_stale_incident_channels(client)
     client.chat_postMessage.assert_called_once_with(

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -27,6 +27,16 @@ data "aws_iam_policy_document" "sre-bot_secrets_manager" {
 
   statement {
     effect = "Allow"
+    actions = [
+      "ssm:GetParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/sre-bot-config"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
 
     actions = [
       "dynamodb:Query",

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 data "aws_iam_policy_document" "sre-bot" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "sre-bot" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -31,7 +33,7 @@ data "aws_iam_policy_document" "sre-bot_secrets_manager" {
       "ssm:GetParameters",
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/sre-bot-config"
+      "arn:aws:ssm:ca-central-1:${data.aws_caller_identity.current.account_id}:parameter/sre-bot-config"
     ]
   }
 

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -44,24 +44,6 @@
         "containerPort": 8000
       }
     ],
-    "secrets": [
-      {
-        "name": "SLACK_TOKEN",
-        "valueFrom": "${slack_token}"
-      },
-      {
-        "name": "APP_TOKEN",
-        "valueFrom": "${app_token}"
-      },
-      {
-        "name": "OPSGENIE_KEY",
-        "valueFrom": "${opsgenie_key}"
-      },
-      {
-        "name": "PICKLE_STRING",
-        "valueFrom": "${pickle_string}"
-      }
-    ],
     "ulimits": [
       {
         "hardLimit": 1000000,


### PR DESCRIPTION
This PR loads the ENV variables from the param store instead of the secret store.