### PR TITLE
feat: more logging to debug failed acknowledgement

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -12,7 +12,7 @@ load_dotenv()
 INCIDENT_CHANNEL = os.environ.get("INCIDENT_CHANNEL")
 
 
-def handle_incident_action_buttons(client, ack, body):
+def handle_incident_action_buttons(client, ack, body, logger):
     name = body["actions"][0]["name"]
     value = body["actions"][0]["value"]
     user = body["user"]["id"]
@@ -30,6 +30,8 @@ def handle_incident_action_buttons(client, ack, body):
         }
         body["original_message"]["attachments"] = attachments
         body["original_message"]["channel"] = body["channel"]["id"]
+
+        logger.info(f"Updating chat: {body['original_message']}")
         client.api_call("chat.update", json=body["original_message"])
 
 

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -11,6 +11,7 @@ DATE = datetime.datetime.now().strftime("%Y-%m-%d")
 def test_handle_incident_action_buttons_call_incident(open_modal_mock):
     client = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
     body = {
         "actions": [
             {
@@ -21,7 +22,7 @@ def test_handle_incident_action_buttons_call_incident(open_modal_mock):
         ],
         "user": {"id": "user_id"},
     }
-    incident.handle_incident_action_buttons(client, ack, body)
+    incident.handle_incident_action_buttons(client, ack, body, logger)
     open_modal_mock.assert_called_with(client, ack, {"text": "incident_id"}, body)
 
 
@@ -29,6 +30,7 @@ def test_handle_incident_action_buttons_call_incident(open_modal_mock):
 def test_handle_incident_action_buttons_ignore(increment_acknowledged_count_mock):
     client = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
     body = {
         "actions": [
             {
@@ -49,7 +51,7 @@ def test_handle_incident_action_buttons_ignore(increment_acknowledged_count_mock
             ],
         },
     }
-    incident.handle_incident_action_buttons(client, ack, body)
+    incident.handle_incident_action_buttons(client, ack, body, logger)
     increment_acknowledged_count_mock.assert_called_with("incident_id")
     client.api_call.assert_called_with(
         "chat.update",


### PR DESCRIPTION
Currently can't acknowledge the slack message in the billing ops channel. Adding additional logging to get more details on why the slack api call is failing.

```
ERROR:slack_bolt.App:Failed to run listener function (error: The request to the Slack API failed. (url: https://www.slack.com/api/chat.update)

The server responded with: {'ok': False, 'error': 'invalid_blocks'})
```