### PR TITLE
fix: drop rich_text blocks since its not supported by API

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -36,7 +36,7 @@ def handle_incident_action_buttons(client, ack, body, logger):
         # https://github.com/slackapi/bolt-js/issues/1324
         if "blocks" in body["original_message"]:
             for block in body["original_message"]["blocks"]:
-                if block["type"] == "rich_text":
+                if "type" in block and block["type"] == "rich_text":
                     delete_block = True
 
         if delete_block:

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -125,6 +125,74 @@ def test_handle_incident_action_buttons_ignore_drop_richtext_block(
     )
 
 
+@patch("commands.incident.webhooks.increment_acknowledged_count")
+def test_handle_incident_action_buttons_ignore_drop_richtext_block_no_type(
+    increment_acknowledged_count_mock,
+):
+    client = MagicMock()
+    ack = MagicMock()
+    logger = MagicMock()
+    body = {
+        "actions": [
+            {
+                "name": "ignore-incident",
+                "value": "incident_id",
+                "type": "button",
+            }
+        ],
+        "channel": {"id": "channel_id"},
+        "user": {"id": "user_id"},
+        "original_message": {
+            "attachments": [
+                {
+                    "color": "3AA3E3",
+                    "fallback": "foo",
+                    "text": "bar",
+                }
+            ],
+            "blocks": [
+                {
+                    "foo": "rich_text",
+                    "block_id": "6Qv",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [{"type": "text", "text": "AWS notification"}],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    incident.handle_incident_action_buttons(client, ack, body, logger)
+    increment_acknowledged_count_mock.assert_called_with("incident_id")
+    client.api_call.assert_called_with(
+        "chat.update",
+        json={
+            "channel": "channel_id",
+            "attachments": [
+                {
+                    "color": "3AA3E3",
+                    "fallback": "🙈  <@user_id> has acknowledged and ignored the incident.",
+                    "text": "🙈  <@user_id> has acknowledged and ignored the incident.",
+                }
+            ],
+            "blocks": [
+                {
+                    "foo": "rich_text",
+                    "block_id": "6Qv",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [{"type": "text", "text": "AWS notification"}],
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+
 @patch("commands.incident.google_drive.list_folders")
 def test_incident_open_modal_calls_ack(mock_list_folders):
     mock_list_folders.return_value = [{"id": "id", "name": "name"}]


### PR DESCRIPTION
If the webhook being wrapped contains `rich_text` the call to slack will fail since rich_text blocks are only available for 1st party Slack clients (meaning Desktop, iOS, Android Slack apps)

`The server responded with: {'ok': False, 'error': 'invalid_blocks'})`

According to https://github.com/slackapi/bolt-js/issues/1324 we can drop the blocks element as long as the text parameter is valid. Tested via Postman and it's working as we expect with the AWS SNS topics.