### PR TITLE
feat: add account health check endpoint

### DIFF
--- a/app/integrations/aws_account_health.py
+++ b/app/integrations/aws_account_health.py
@@ -1,0 +1,99 @@
+import arrow
+import boto3
+import datetime
+import os
+
+ROLE_ARN = os.environ.get("AWS_ORG_ACCOUNT_ROLE_ARN")
+
+
+def assume_role_client(client_type):
+    client = boto3.client("sts")
+
+    response = client.assume_role(
+        RoleArn=ROLE_ARN, RoleSessionName="SREBot_Org_Account_Role"
+    )
+
+    session = boto3.Session(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"],
+    )
+
+    return session.client(client_type)
+
+
+def get_accounts():
+    client = assume_role_client("organizations")
+    response = client.list_accounts()
+    accounts = {}
+    # Loop response for NextToken
+    while True:
+        for account in response["Accounts"]:
+            accounts[account["Id"]] = account["Name"]
+        if "NextToken" in response:
+            response = client.list_accounts(NextToken=response["NextToken"])
+        else:
+            break
+    return dict(sorted(accounts.items(), key=lambda item: item[1]))
+
+
+def get_account_health(account_id):
+    last_day_of_current_month = arrow.utcnow().span("month")[1].format("YYYY-MM-DD")
+    first_day_of_current_month = arrow.utcnow().span("month")[0].format("YYYY-MM-DD")
+    last_day_of_last_month = (
+        arrow.utcnow().shift(months=-1).span("month")[1].format("YYYY-MM-DD")
+    )
+    first_day_of_last_month = (
+        arrow.utcnow().shift(months=-1).span("month")[0].format("YYYY-MM-DD")
+    )
+
+    data = {
+        "account_id": account_id,
+        "cost": {
+            "last_month": {
+                "start_date": first_day_of_last_month,
+                "end_date": last_day_of_last_month,
+                "amount": get_account_spend(
+                    account_id, first_day_of_last_month, last_day_of_last_month
+                ),
+            },
+            "current_month": {
+                "start_date": first_day_of_current_month,
+                "end_date": last_day_of_current_month,
+                "amount": get_account_spend(
+                    account_id, first_day_of_current_month, last_day_of_current_month
+                ),
+            },
+        },
+        "security": {
+            "config": 0,
+            "guardduty": 0,
+            "securityhub": 0,
+            "trusted_advisor": 0,
+        },
+    }
+
+    return data
+
+
+def get_account_spend(account_id, start_date, end_date):
+    client = assume_role_client("ce")
+    response = client.get_cost_and_usage(
+        TimePeriod={"Start": start_date, "End": end_date},
+        Granularity="MONTHLY",
+        Metrics=["UnblendedCost"],
+        GroupBy=[
+            {"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"},
+        ],
+        Filter={"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": [account_id]}},
+    )
+    if "Groups" in response["ResultsByTime"][0]:
+        return "{:0,.2f}".format(
+            float(
+                response["ResultsByTime"][0]["Groups"][0]["Metrics"]["UnblendedCost"][
+                    "Amount"
+                ]
+            )
+        )
+    else:
+        return "0.00"

--- a/app/integrations/aws_account_health.py
+++ b/app/integrations/aws_account_health.py
@@ -1,6 +1,5 @@
 import arrow
 import boto3
-import datetime
 import os
 
 ROLE_ARN = os.environ.get("AWS_ORG_ACCOUNT_ROLE_ARN")

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ def main():
     # Register AWS commands
     bot.command(f"/{PREFIX}aws")(aws.aws_command)
     bot.view("aws_access_view")(aws.access_view_handler)
+    bot.view("aws_health_view")(aws.health_view_handler)
 
     # Register incident events
     bot.command(f"/{PREFIX}incident")(incident.open_modal)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
+arrow==1.2.3
 awscli==1.23.4
 aws-sns-message-validator==0.0.5
 boto3==1.22.4

--- a/app/tests/intergrations/test_aws_account_health.py
+++ b/app/tests/intergrations/test_aws_account_health.py
@@ -106,12 +106,11 @@ def test_get_account_spend_with_data(assume_role_client_mock):
         Filter={"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": ["test_account_id"]}},
     )
 
+
 @patch("integrations.aws_account_health.assume_role_client")
 def test_get_account_spend_with_no_data(assume_role_client_mock):
     client = MagicMock()
-    client.get_cost_and_usage.return_value = {
-        "ResultsByTime": [{}]
-    }
+    client.get_cost_and_usage.return_value = {"ResultsByTime": [{}]}
     assume_role_client_mock.return_value = client
     assert (
         aws_account_health.get_account_spend(

--- a/app/tests/intergrations/test_aws_account_health.py
+++ b/app/tests/intergrations/test_aws_account_health.py
@@ -1,0 +1,128 @@
+import arrow
+
+from integrations import aws_account_health
+
+from unittest.mock import call, MagicMock, patch
+
+
+@patch("integrations.aws_account_health.boto3")
+def test_assume_role_client_returns_session(boto3_mock):
+    client = MagicMock()
+    client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "test_access_key_id",
+            "SecretAccessKey": "test_secret_access_key",
+            "SessionToken": "test_session_token",
+        }
+    }
+    session = MagicMock()
+    session.client.return_value = "session-client"
+    boto3_mock.client.return_value = client
+    boto3_mock.Session.return_value = session
+    assert aws_account_health.assume_role_client("identitystore") == "session-client"
+    assert boto3_mock.client.call_count == 1
+    assert boto3_mock.Session.call_count == 1
+    assert boto3_mock.Session.call_args == call(
+        aws_access_key_id="test_access_key_id",
+        aws_secret_access_key="test_secret_access_key",
+        aws_session_token="test_session_token",
+    )
+
+
+@patch("integrations.aws_account_health.assume_role_client")
+def test_get_accounts(assume_role_client_mock):
+    client = MagicMock()
+    client.list_accounts.side_effect = [
+        {
+            "Accounts": [
+                {
+                    "Id": "test_account_id",
+                    "Name": "test_account_name",
+                }
+            ],
+            "NextToken": "test_next_token",
+        },
+        {
+            "Accounts": [
+                {
+                    "Id": "test_account_id_2",
+                    "Name": "test_account_name_2",
+                }
+            ],
+        },
+    ]
+    assume_role_client_mock.return_value = client
+    assert aws_account_health.get_accounts() == {
+        "test_account_id": "test_account_name",
+        "test_account_id_2": "test_account_name_2",
+    }
+
+
+@patch("integrations.aws_account_health.get_account_spend")
+def test_get_account_health(get_account_spend_mock):
+    last_day_of_current_month = arrow.utcnow().span("month")[1].format("YYYY-MM-DD")
+    first_day_of_current_month = arrow.utcnow().span("month")[0].format("YYYY-MM-DD")
+    last_day_of_last_month = (
+        arrow.utcnow().shift(months=-1).span("month")[1].format("YYYY-MM-DD")
+    )
+    first_day_of_last_month = (
+        arrow.utcnow().shift(months=-1).span("month")[0].format("YYYY-MM-DD")
+    )
+
+    result = aws_account_health.get_account_health("test_account_id")
+
+    assert get_account_spend_mock.called_with(
+        "test_account_id", first_day_of_current_month, last_day_of_current_month
+    )
+    assert get_account_spend_mock.called_with(
+        "test_account_id", first_day_of_last_month, last_day_of_last_month
+    )
+
+    assert result.get("account_id") == "test_account_id"
+    assert "cost" in result
+    assert "security" in result
+
+
+@patch("integrations.aws_account_health.assume_role_client")
+def test_get_account_spend_with_data(assume_role_client_mock):
+    client = MagicMock()
+    client.get_cost_and_usage.return_value = {
+        "ResultsByTime": [
+            {"Groups": [{"Metrics": {"UnblendedCost": {"Amount": "100.123456789"}}}]}
+        ]
+    }
+    assume_role_client_mock.return_value = client
+    assert (
+        aws_account_health.get_account_spend(
+            "test_account_id", "2020-01-01", "2020-01-31"
+        )
+        == "100.12"
+    )
+    assert client.get_cost_and_usage.called_with(
+        TimePeriod={"Start": "2020-01-01", "End": "2020-01-31"},
+        Granularity="MONTHLY",
+        Metrics=["UnblendedCost"],
+        GroupBy=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
+        Filter={"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": ["test_account_id"]}},
+    )
+
+@patch("integrations.aws_account_health.assume_role_client")
+def test_get_account_spend_with_no_data(assume_role_client_mock):
+    client = MagicMock()
+    client.get_cost_and_usage.return_value = {
+        "ResultsByTime": [{}]
+    }
+    assume_role_client_mock.return_value = client
+    assert (
+        aws_account_health.get_account_spend(
+            "test_account_id", "2020-01-01", "2020-01-31"
+        )
+        == "0.00"
+    )
+    assert client.get_cost_and_usage.called_with(
+        TimePeriod={"Start": "2020-01-01", "End": "2020-01-31"},
+        Granularity="MONTHLY",
+        Metrics=["UnblendedCost"],
+        GroupBy=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
+        Filter={"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": ["test_account_id"]}},
+    )


### PR DESCRIPTION
This PR adds the `/aws health` command that should show you health data for specific account in AWS. You start by selecting an account from a drop down:

<img width="552" alt="Screen Shot 2022-10-20 at 1 22 04 PM" src="https://user-images.githubusercontent.com/867334/197016629-b61e7baa-54e9-4035-895c-6e1fa5f237af.png">

and then shows some health data on the account. Currently only the cost section is hooked up to show data from the last two months:

<img width="540" alt="Screen Shot 2022-10-20 at 1 22 10 PM" src="https://user-images.githubusercontent.com/867334/197016758-5b55d93a-4fc4-48a1-a135-392e9f9ed8d3.png">

The security section is a placeholder and will be hooked up shortly.
