### PR TITLE
fix: atip command with argument

### DIFF
--- a/app/commands/atip.py
+++ b/app/commands/atip.py
@@ -30,10 +30,10 @@ def atip_command(ack, command, logger, respond, client, body):
             respond(i18n.t("atip.help_text", command=command["command"]))
         case "start":
             i18n.set("locale", "en-US")
-            request_start_modal(client, body, locale="en-US", *args)
+            request_start_modal(client, body, "en-US", *args)
         case "lancer":
             i18n.set("locale", "fr-FR")
-            request_start_modal(client, body, locale="fr-FR", *args)
+            request_start_modal(client, body, "fr-FR", *args)
         case _:
             respond(
                 i18n.t(

--- a/app/tests/commands/test_atip.py
+++ b/app/tests/commands/test_atip.py
@@ -144,7 +144,7 @@ def test_atip_command_handles_access_EN_command(request_start_modal):
 
     atip.atip_command(ack, {"text": "start"}, MagicMock(), respond, client, body)
     ack.assert_called
-    request_start_modal.assert_called_with(client, body, locale="en-US")
+    request_start_modal.assert_called_with(client, body, "en-US")
 
 
 @patch("commands.atip.request_start_modal")
@@ -157,7 +157,7 @@ def test_atip_command_handles_access_FR_command(request_start_modal):
 
     atip.atip_command(ack, {"text": "lancer"}, MagicMock(), respond, client, body)
     ack.assert_called
-    request_start_modal.assert_called_with(client, body, locale="fr-FR")
+    request_start_modal.assert_called_with(client, body, "fr-FR")
 
 
 @patch("commands.atip.atip_modal_view")


### PR DESCRIPTION
# Summary | Résumé

Fixes an additional issue when starting the ATIP command with an argument such as
`atip start 1234`