### PR TITLE
feat: Implement OSSF Scorecard

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           publish_results: false
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action@main
+        uses: cds-snc/sentinel-forward-data-action
         with:
           file_name: ossf-results.json
           log_type: GitHubMetadata_OSSF_Scorecard

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,27 @@
+name: Scorecards supply-chain security
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly on Saturdays.
+    - cron: "30 1 * * 6"
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # tag=v1.1.1
+        with:
+          results_file: results.json
+          results_format: json
+
+      - name: "Echo results"
+        run: cat results.json

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,6 +5,9 @@ on:
     # Weekly on Saturdays.
     - cron: "30 1 * * 6"
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions: read-all
 
@@ -27,9 +30,14 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86
         with:
-          results_file: results.json
+          results_file: ossf-results.json
           results_format: json
           publish_results: false
 
-      - name: "Echo results"
-        run: cat results.json
+      - name: "Post results to Sentinel"
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          file_name: ossf-results.json
+          log_type: GitHubMetadata_OSSF_Scorecard
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           publish_results: false
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action@main
+        uses: cds-snc/sentinel-forward-data-action@707222ad5374a3961f849ff2a1c0a2c0634448a0
         with:
           file_name: ossf-results.json
           log_type: GitHubMetadata_OSSF_Scorecard

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           publish_results: false
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action
+        uses: cds-snc/sentinel-forward-data-action@main
         with:
           file_name: ossf-results.json
           log_type: GitHubMetadata_OSSF_Scorecard

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -12,16 +12,24 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      actions: read
+      contents: read
 
     steps:
       - name: "Checkout code"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # tag=v1.1.1
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86
         with:
           results_file: results.json
           results_format: json
+          publish_results: false
 
       - name: "Echo results"
         run: cat results.json

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     # Weekly on Saturdays.
     - cron: "30 1 * * 6"
-  pull_request:
   push:
     branches:
       - main
@@ -35,7 +34,7 @@ jobs:
           publish_results: false
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action@707222ad5374a3961f849ff2a1c0a2c0634448a0
+        uses: cds-snc/sentinel-forward-data-action@main
         with:
           file_name: ossf-results.json
           log_type: GitHubMetadata_OSSF_Scorecard


### PR DESCRIPTION
Closes https://github.com/cds-snc/site-reliability-engineering/issues/742. This PR adds a workflow that will use the OSSF Scorecard action on this repository and upload the result to Sentinel.