### PR TITLE
fix: set the Docker default platform to arm64

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/arm64        
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "app/Dockerfile"

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Docker vulnerability scan
         uses: cds-snc/security-tools/.github/actions/docker-scan@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/arm64
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "app/Dockerfile"


### PR DESCRIPTION
# Summary
Update the Docker scans to look for the `linux/arm64` platform version of the Docker image.  This fixes the `image does not exist` error.