### PR TITLE
fix: Trivy action Docker image platform

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -62,11 +62,10 @@ jobs:
           log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
-        env:
-          DOCKER_DEFAULT_PLATFORM: linux/arm64        
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@2ac1ab2344ce61d314f8a4a78b731097ae6c4f6d # v2.1.2    
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "app/Dockerfile"
+          platform: "linux/arm64"
           sbom_name: "sre-bot"
           token: "${{ secrets.GITHUB_TOKEN }}"          

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -1,9 +1,9 @@
 name: Docker vulnerability scan
 
+# Disabling schedule until the Trivy action supports specifying the
+# Docker image architecture.  Currently it defaults to `linux/amd64`
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *"
 
 env:
   REGISTRY: 283582579564.dkr.ecr.ca-central-1.amazonaws.com
@@ -30,8 +30,6 @@ jobs:
 
       - name: Docker vulnerability scan
         uses: cds-snc/security-tools/.github/actions/docker-scan@19c655b47ec24d168ecbc701cee18701ab55f071 # v2.1.1
-        env:
-          DOCKER_DEFAULT_PLATFORM: linux/arm64
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "app/Dockerfile"


### PR DESCRIPTION
# Summary
Update the Docker SBOM action to provide the Docker image architecture.

Disable the scheduled Docker vulnerability scan until the Trivy GitHub action provides support for setting the image architecture.

# Related
- #126 
- #127 
- cds-snc/security-tools#199