### PR TITLE
chore: bump to latest generate SBOM action

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -62,7 +62,7 @@ jobs:
           log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@2ac1ab2344ce61d314f8a4a78b731097ae6c4f6d # v2.1.2    
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3    
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "app/Dockerfile"


### PR DESCRIPTION
# Summary
Latest release contains the fix for re-tagging a non `linux/amd64` architecture Docker image.

# Related
- cds-snc/security-tools#200