### PR TITLE
feat: handle abuse notifications

### DIFF
--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -13,6 +13,8 @@ def parse(payload, client):
         blocks = format_cloudwatch_alarm(msg)
     elif isinstance(msg, str) and "AWS Budget Notification" in msg:
         blocks = format_budget_notification(payload)
+    elif isinstance(msg, dict) and nested_get(msg, ["detail", "service"]) == "ABUSE":
+        blocks = format_abuse_notification(payload, msg)
     else:
         blocks = []
         log_ops_message(
@@ -21,6 +23,45 @@ def parse(payload, client):
         )
 
     return blocks
+
+
+def nested_get(dictionary, keys):
+    for key in keys:
+        try:
+            dictionary = dictionary[key]
+        except KeyError:
+            return None
+    return dictionary
+
+
+def format_abuse_notification(payload, msg):
+    regex = r"arn:aws:sns:\w.*:(\d.*):\w.*"
+    account = re.search(regex, payload.TopicArn).groups()[0]
+
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": " "}},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*<https://health.aws.amazon.com/health/home#/account/dashboard/open-issues| 🚨 Abuse Alert | {account}>*",
+            },
+        },
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{msg['detail']['eventTypeCode'].replace('_', ' ')}",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"{msg['detail']['eventDescription'][0]['latestDescription']}",
+            },
+        },
+    ]
 
 
 def format_budget_notification(payload):

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -37,6 +37,25 @@ def test_parse_returns_blocks_if_budget_notification_in_msg(
     format_budget_notification_mock.assert_called_once_with(payload)
 
 
+@patch("server.event_handlers.aws.format_abuse_notification")
+def test_parse_returns_blocks_if_service_is_ABUSE(format_abuse_notification_mock):
+    client = MagicMock()
+    format_abuse_notification_mock.return_value = ["foo", "bar"]
+    payload = mock_abuse_alert()
+    response = aws.parse(payload, client)
+    assert response == ["foo", "bar"]
+    format_abuse_notification_mock.assert_called_once_with(
+        payload, json.loads(payload.Message)
+    )
+
+
+def test_format_abuse_notification_extracts_the_account_id_and_inserts_it_into_blocks():
+    payload = mock_abuse_alert()
+    msg = json.loads(payload.Message)
+    response = aws.format_abuse_notification(payload, msg)
+    assert "017790921725" in response[1]["text"]["text"]
+
+
 def test_format_budget_notification_extracts_the_account_id_and_inserts_it_into_blocks():
     payload = mock_budget_alert()
     response = aws.format_budget_notification(payload)
@@ -86,6 +105,21 @@ def test_format_cloudwatch_alarm_replaces_empty_AlarmDescription_with_blank():
     msg["AlarmDescription"] = None
     response = aws.format_cloudwatch_alarm(msg)
     assert response[3]["text"]["text"] == " "
+
+
+def mock_abuse_alert():
+    return MagicMock(
+        Type="Notification",
+        MessageId="0da238f6-da6c-5214-96e1-635d27a9b79b",
+        TopicArn="arn:aws:sns:ca-central-1:017790921725:test-sre-bot",
+        Subject="",
+        Message='{"version":"0","id":"7bf73129-1428-4cd3-a780-95db273d1602","detail-type":"AWS Health Abuse Event","source":"aws.health","account":"123456789012","time":"2018-08-01T06:27:57Z","region":"global","resources":["arn:aws:ec2:us-east-1:123456789012:instance/i-abcd1111","arn:aws:ec2:us-east-1:123456789012:instance/i-abcd2222"],"detail":{"eventArn":"arn:aws:health:global::event/AWS_ABUSE_DOS_REPORT_92387492375_4498_2018_08_01_02_33_00","service":"ABUSE","eventTypeCode":"AWS_ABUSE_DOS_REPORT","eventTypeCategory":"issue","startTime":"Wed, 01 Aug 2018 06:27:57 GMT","eventDescription":[{"language":"en_US","latestDescription":"A description of the event will be provided here"}],"affectedEntities":[{"entityValue":"arn:aws:ec2:us-east-1:123456789012:instance/i-abcd1111"},{"entityValue":"arn:aws:ec2:us-east-1:123456789012:instance/i-abcd2222"}]}}',
+        Timestamp="2022-09-26T19:20:37.147Z",
+        SignatureVersion="1",
+        Signature="HLsCTKHEC2FXGe6LFkV/JGD7k/apzJZD42R8ph4AzcD9NcrxZyjINTyPFe1zMtg3kcGSge2J3MqFcTTyQJtkRrKZZftIVZRflwWKu4OLHt1atHSOavI8n7Qh3bRtwR5C3mezhtu6oWbfEdTXAuyz4AWcZ0L9dxE4B3bOMS302ViQA3hIfjSlGLRr+j/Ra7+IbzY35QUJLxtVcmcAAw/ByuyXeDRy+6qhJtKndOTeMBLTKAQlIOPubyJP1Q2BWo0spREmIESnPtB14c5k+6LWxa/srPjfOWu66ICUNnydKnvf5EuIlpooycLldttvDtwmD2NZt6kQr2FJhkqARyr/Ng==",
+        SigningCertURL="https://sns.ca-central-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem",
+        UnsubscribeURL="https://sns.ca-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ca-central-1:017790921725:test-sre-bot:4636a013-5224-4207-91b2-d6d7c7ab7ea7",
+    )
 
 
 def mock_budget_alert():


### PR DESCRIPTION
This PR adds a feature that handles Abuse notifications from our internal sre notification end points. Abuse notifications are filtered in event bridge, sent to the Internal SRE event topic, sent to the SRE Bot and the put into the channel.