### PR TITLE
Fix a bug where empty messages are being posted to Slack

### DIFF
--- a/app/integrations/sentinel.py
+++ b/app/integrations/sentinel.py
@@ -77,7 +77,7 @@ def post_data(customer_id, shared_key, body, log_type):
         "x-ms-date": rfc1123date,
     }
 
-    response = requests.post(uri, data=body, headers=headers)
+    response = requests.post(uri, data=body, headers=headers, timeout=60)
     if response.status_code >= 200 and response.status_code <= 299:
         logging.info(f"Response code: {response.status_code}, log type: {log_type}")
         return True

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -112,7 +112,7 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
                 blocks = aws.parse(payload, request.state.bot.client)
                 # if we have an empty message, log that we have an empty
                 # message and return without posting to slack
-                if blocks is None or len(blocks) == 0:
+                if not blocks:
                     logging.info("No blocks to post, returning")
                     return
                 payload = WebhookPayload(blocks=blocks)

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -93,7 +93,7 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
                     status_code=500, detail=f"Failed to parse AWS event message: {e}"
                 )
             if payload.Type == "SubscriptionConfirmation":
-                requests.get(payload.SubscribeURL)
+                requests.get(payload.SubscribeURL, timeout=60)
                 logging.info(f"Subscribed webhook {id} to topic {payload.TopicArn}")
                 log_ops_message(
                     request.state.bot.client,

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -110,6 +110,11 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
 
             if payload.Type == "Notification":
                 blocks = aws.parse(payload, request.state.bot.client)
+                # if we have an empty message, log that we have an empty
+                # message and return without posting to slack
+                if blocks is None or len(blocks) == 0:
+                    logging.info("No blocks to post, returning")
+                    return
                 payload = WebhookPayload(blocks=blocks)
 
         payload.channel = webhook["channel"]["S"]


### PR DESCRIPTION
# Summary | Résumé

Closes #178. Currently if there is an unrecognized AWS event, the content is posted as empty and we get an empty notification with the Acknowledge and Ignore buttons. What the fix does is if the message is empty, it should not post the message in Slack.

I also added timeouts (although quite large mostly to satisfy bandit) to the requests methods in order to satisfy bandit security scan. 