### PR TITLE
Fixing bug where block sizes of more than 100 items can't be displayed

### DIFF
--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -14,9 +14,9 @@ help_text = """
 \n      - lister les webhooks
 """
 
-# see 3 webhooks at a time. This is done to avoid hitting the 100 block size limit and for the view to be more managable to see.
+# see 4 webhooks at a time. This is done to avoid hitting the 100 block size limit and for the view to be more managable to see.
 # has to be divisible by 4 since each webhook is 4 blocks
-MAX_BLOCK_SIZE = 12
+MAX_BLOCK_SIZE = 16
 
 
 def handle_webhook_command(args, client, body, respond):
@@ -133,8 +133,10 @@ def create_webhook_modal(client, body):
     )
 
 
+# return the list of webhooks based on the type (active or disabled)
 def get_webhooks(type):
     all_hooks = webhooks.list_all_webhooks()
+    # based on type, return the list of webhooks
     if type == "active":
         hooks = list(
             map(
@@ -142,22 +144,28 @@ def get_webhooks(type):
                 filter(lambda hook: hook["active"]["BOOL"], all_hooks),
             )
         )
-    else:
+    elif type == "disabled":
         hooks = list(
             map(
                 lambda hook: webhook_list_item(hook),
                 filter(lambda hook: not hook["active"]["BOOL"], all_hooks),
             )
         )
+    else:
+        # unrecongized type, return empty list
+        hooks = []
     return hooks
 
 
+# function to flatten the webhooks and return them in a flattened list
 def get_webhooks_list(hooks):
     return [item for sublist in hooks for item in sublist]
 
 
+# generate the button for the webhook. If there are more than 4 webhooks (MAX_BLOCK_SIZE/the number of elements in a block list),
+# show the next page button. Otherwise, show nothing
 def get_webhooks_button_block(type, hooks_list, end):
-    if len(hooks_list) > 1:
+    if len(hooks_list) > (MAX_BLOCK_SIZE / 4):
         button_block = [
             {
                 "type": "actions",
@@ -167,9 +175,7 @@ def get_webhooks_button_block(type, hooks_list, end):
                         "text": {
                             "type": "plain_text",
                             "text": (
-                                "Next page"
-                                if end < len(hooks_list)
-                                else "End of results"
+                                "Next page" if end < len(hooks_list) else "First page"
                             ),
                             "emoji": True,
                         },
@@ -184,16 +190,22 @@ def get_webhooks_button_block(type, hooks_list, end):
     return button_block
 
 
+# Get and return all webhooks. Start is the index of the first webhook to show, end is the index of the last webhook to show.
+# Type is the type of webhooks to show (active, disabled, or all)
 def list_all_webhooks(client, body, start, end, type, update=False):
+    # get the active webhooks and button block
     active_hooks = get_webhooks("active")
     active_hooks_list = get_webhooks_list(active_hooks)
     active_button_block = get_webhooks_button_block("active", active_hooks_list, end)
+
+    # get the disabled webhooks and button block
     disabled_hooks = get_webhooks("disabled")
     disabled_hooks_list = get_webhooks_list(disabled_hooks)
     disabled_button_block = get_webhooks_button_block(
         "disabled", disabled_hooks_list, end
     )
 
+    # display the webhooks in the modal
     blocks = {
         "type": "modal",
         "callback_id": "webhooks_view",
@@ -210,11 +222,14 @@ def list_all_webhooks(client, body, start, end, type, update=False):
                 },
                 {"type": "divider"},
             ]
+            # this is used to traverse the list of webhooks for the pagination. Show the webhooks slice of array based on
+            # start and end index
             + (
                 active_hooks_list[start:end]
                 if type == "active" or type == "all"
                 else active_hooks_list[0:MAX_BLOCK_SIZE]
             )
+            # display the button block
             + active_button_block
             + [
                 {
@@ -351,10 +366,14 @@ def webhook_list_item(hook):
     ]
 
 
-def next_page(ack, body, logger, client):
+# Function to handle pagination and displaying next pages
+def next_page(ack, body, client):
     ack()
     end_index, type = body["actions"][0]["value"].split(",")
     end_index = int(end_index)
+
+    # if we go to the next page, then pudate the start and end index to be the next 4 elements. Else, display the results
+    # from the beginning
     if body["actions"][0]["text"]["text"] == "Next page":
         list_all_webhooks(
             client, body, end_index, (end_index + MAX_BLOCK_SIZE), type, update=True

--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -158,21 +158,27 @@ def get_webhooks_list(hooks):
 
 def get_webhooks_button_block(type, hooks_list, end):
     if len(hooks_list) > 1:
-        button_block = [{
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": ("Next page" if end < len(hooks_list) else "End of results"),
-                        "emoji": True
-                    },
-                    "value": f"{end},{type}",
-                    "action_id": "next_page"
-                }
-            ]
-        }]
+        button_block = [
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": (
+                                "Next page"
+                                if end < len(hooks_list)
+                                else "End of results"
+                            ),
+                            "emoji": True,
+                        },
+                        "value": f"{end},{type}",
+                        "action_id": "next_page",
+                    }
+                ],
+            }
+        ]
     else:
         button_block = []
     return button_block
@@ -184,7 +190,9 @@ def list_all_webhooks(client, body, start, end, type, update=False):
     active_button_block = get_webhooks_button_block("active", active_hooks_list, end)
     disabled_hooks = get_webhooks("disabled")
     disabled_hooks_list = get_webhooks_list(disabled_hooks)
-    disabled_button_block = get_webhooks_button_block("disabled", disabled_hooks_list, end)
+    disabled_button_block = get_webhooks_button_block(
+        "disabled", disabled_hooks_list, end
+    )
 
     blocks = {
         "type": "modal",
@@ -202,7 +210,11 @@ def list_all_webhooks(client, body, start, end, type, update=False):
                 },
                 {"type": "divider"},
             ]
-            + (active_hooks_list[start:end] if type == "active" or type == "all" else active_hooks_list[0:MAX_BLOCK_SIZE])
+            + (
+                active_hooks_list[start:end]
+                if type == "active" or type == "all"
+                else active_hooks_list[0:MAX_BLOCK_SIZE]
+            )
             + active_button_block
             + [
                 {
@@ -214,7 +226,11 @@ def list_all_webhooks(client, body, start, end, type, update=False):
                 },
                 {"type": "divider"},
             ]
-            + (disabled_hooks_list[start:end] if type == "disabled" or type == "all" else disabled_hooks_list[0:MAX_BLOCK_SIZE])
+            + (
+                disabled_hooks_list[start:end]
+                if type == "disabled" or type == "all"
+                else disabled_hooks_list[0:MAX_BLOCK_SIZE]
+            )
             + disabled_button_block
         ),
     }
@@ -340,6 +356,8 @@ def next_page(ack, body, logger, client):
     end_index, type = body["actions"][0]["value"].split(",")
     end_index = int(end_index)
     if body["actions"][0]["text"]["text"] == "Next page":
-        list_all_webhooks(client, body, end_index, (end_index + MAX_BLOCK_SIZE), type, update=True)
+        list_all_webhooks(
+            client, body, end_index, (end_index + MAX_BLOCK_SIZE), type, update=True
+        )
     else:
         list_all_webhooks(client, body, 0, MAX_BLOCK_SIZE, type, update=True)

--- a/app/commands/helpers/webhook_helper.py
+++ b/app/commands/helpers/webhook_helper.py
@@ -282,11 +282,11 @@ def toggle_webhook(ack, body, logger, client):
     webhooks.toggle_webhook(id)
     message = f"Webhook {name} has been {'enabled' if hook['active']['BOOL'] else 'disabled'} by <@{username}>"
     logger.info(message)
-    # client.chat_postMessage(
-    #    channel=channel,
-    #    user=user_id,
-    #    text=message,
-    # )
+    client.chat_postMessage(
+        channel=channel,
+        user=user_id,
+        text=message,
+    )
     list_all_webhooks(client, body, 0, MAX_BLOCK_SIZE, "all", update=True)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -67,6 +67,7 @@ def main(bot):
     bot.view("create_webhooks_view")(webhook_helper.create_webhook)
     bot.action("toggle_webhook")(webhook_helper.toggle_webhook)
     bot.action("reveal_webhook")(webhook_helper.reveal_webhook)
+    bot.action("next_page")(webhook_helper.next_page)
 
     SocketModeHandler(bot, APP_TOKEN).connect()
 

--- a/app/tests/commands/helpers/test_webhook_helper.py
+++ b/app/tests/commands/helpers/test_webhook_helper.py
@@ -35,7 +35,139 @@ def test_handle_webhooks_command_with_list_command(list_all_webhooks_mock):
     client = MagicMock()
     body = MagicMock()
     webhook_helper.handle_webhook_command(["list"], client, body, MagicMock())
-    list_all_webhooks_mock.assert_called_with(client, body)
+    list_all_webhooks_mock.assert_called_with(
+        client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all"
+    )
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks")
+def test_get_webhooks_active(get_webhooks_mock):
+    get_webhooks_mock.return_value = [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+
+    assert webhook_helper.get_webhooks("active") == [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks")
+def test_get_webhooks_disabled(get_webhooks_mock):
+    get_webhooks_mock.return_value = [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+
+    assert webhook_helper.get_webhooks("disabled") == [
+        helper_generate_webhook("name1", "channel1", "id1"),
+        helper_generate_webhook("name2", "channel2", "id2"),
+    ]
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks")
+def test_get_webhooks_not_recognized_value(get_webhooks_mock):
+    get_webhooks_mock.return_value = []
+    assert webhook_helper.get_webhooks("test") == []
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks_list")
+def test_get_webhooks_list_all(get_webhooks_list_mock):
+    webhooks_list = helper_generate_webhook("name1", "channel1", "id1")
+    get_webhooks_list_mock.return_value = [webhooks_list]
+    assert (
+        webhook_helper.get_webhooks_list([webhooks_list])
+        == get_webhooks_list_mock.return_value
+    )
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks_button_block")
+def test_get_button_block_active(get_webhooks_button_block_mock):
+    webhooks_list = helper_generate_webhook("name1", "channel1", "id1")
+    get_webhooks_button_block_mock.return_value = [
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ("Next page"),
+                        "emoji": True,
+                    },
+                    "value": "0,active",
+                    "action_id": "next_page",
+                }
+            ],
+        }
+    ]
+    assert (
+        webhook_helper.get_webhooks_button_block("active", [webhooks_list], 0)
+        == get_webhooks_button_block_mock.return_value
+    )
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks_button_block")
+def test_get_button_block_disabled(get_webhooks_button_block_mock):
+    webhooks_list = helper_generate_webhook("name1", "channel1", "id1")
+    get_webhooks_button_block_mock.return_value = [
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ("Next page"),
+                        "emoji": True,
+                    },
+                    "value": "0,active",
+                    "action_id": "next_page",
+                }
+            ],
+        }
+    ]
+    assert (
+        webhook_helper.get_webhooks_button_block("disabled", [webhooks_list], 0)
+        == get_webhooks_button_block_mock.return_value
+    )
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks_button_block")
+def test_get_button_block_active_last_page(get_webhooks_button_block_mock):
+    webhooks_list = helper_generate_webhook("name1", "channel1", "id1")
+    get_webhooks_button_block_mock.return_value = [
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ("First page"),
+                        "emoji": True,
+                    },
+                    "value": "4,active",
+                    "action_id": "next_page",
+                }
+            ],
+        }
+    ]
+    assert (
+        webhook_helper.get_webhooks_button_block("active", [webhooks_list], 4)
+        == get_webhooks_button_block_mock.return_value
+    )
+
+
+@patch("commands.helpers.webhook_helper.get_webhooks_button_block")
+def test_get_button_block_empty(get_webhooks_button_block_mock):
+    get_webhooks_button_block_mock.return_value = []
+    webhooks_list = []
+    assert (
+        webhook_helper.get_webhooks_button_block("active", [webhooks_list], 0)
+        == get_webhooks_button_block_mock.return_value
+    )
 
 
 def test_handle_webhooks_command_with_unkown_command():
@@ -166,7 +298,9 @@ def test_list_all_webhooks(list_all_webhooks_mock):
     ]
     client = MagicMock()
     body = {"trigger_id": "trigger_id"}
-    webhook_helper.list_all_webhooks(client, body)
+    webhook_helper.list_all_webhooks(
+        client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all"
+    )
     client.views_open.assert_called_with(
         trigger_id="trigger_id",
         view={
@@ -258,6 +392,59 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                 },
                 {"type": "divider"},
                 {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "First page",
+                                "emoji": True,
+                            },
+                            "value": "16,active",
+                            "action_id": "next_page",
+                        }
+                    ],
+                },
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "There are currently 0 disabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+            ],
+        },
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.list_all_webhooks")
+def test_list_all_webhooks_empty(list_all_webhooks_mock):
+    list_all_webhooks_mock.return_value = []
+
+    client = MagicMock()
+    body = {"trigger_id": "trigger_id"}
+    webhook_helper.list_all_webhooks(
+        client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all"
+    )
+    client.views_open.assert_called_with(
+        trigger_id="trigger_id",
+        view={
+            "type": "modal",
+            "callback_id": "webhooks_view",
+            "title": {"type": "plain_text", "text": "SRE - Listing webhooks"},
+            "close": {"type": "plain_text", "text": "Close"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "There are currently 0 enabled webhooks",
+                    },
+                },
+                {"type": "divider"},
+                {
                     "type": "header",
                     "text": {
                         "type": "plain_text",
@@ -278,7 +465,9 @@ def test_list_all_webhooks_update(list_all_webhooks_mock):
     ]
     client = MagicMock()
     body = {"view": {"id": "id"}}
-    webhook_helper.list_all_webhooks(client, body, update=True)
+    webhook_helper.list_all_webhooks(
+        client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all", update=True
+    )
     client.views_update.assert_called_with(view_id="id", view=ANY)
 
 
@@ -322,7 +511,33 @@ def test_toggle_webhook(list_all_webhooks_mock, toggle_webhook_mock, get_webhook
         user="user_id",
         text="Webhook name has been enabled by <@username>",
     )
-    list_all_webhooks_mock.assert_called_with(client, body, update=True)
+    list_all_webhooks_mock.assert_called_with(
+        client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all", update=True
+    )
+
+
+@patch("commands.helpers.webhook_helper.webhooks.list_all_webhooks")
+def test_button_next_page(list_all_webhooks_mock):
+    client = MagicMock()
+    ack = MagicMock()
+    body = {"actions": [{"value": "5,active"}, {"text": {"text": "Next page"}}]}
+    body = {
+        "actions": [
+            {
+                "action_id": "next_page",
+                "block_id": "zBh",
+                "text": {"type": "plain_text", "text": "Next page", "emoji": True},
+                "value": "5,active",
+                "type": "button",
+                "action_ts": "1687986765.093236",
+            }
+        ],
+        "user": {"id": "user_id", "username": "username"},
+        "view": {"id": "id"},
+    }
+    webhook_helper.next_page(ack, body, client)
+    ack.assert_called()
+    list_all_webhooks_mock.assert_called()
 
 
 def test_webhook_list_item():


### PR DESCRIPTION
# Summary | Résumé

Closes #197 

There is a bug in the SRE bot due to a limitation in Slacks API, where you can't display more than 100 blocks in a modal (https://api.slack.com/reference/block-kit/blocks). This was not an issue before but as we create more webhooks, we are currently hitting the 100 block limit and will continue to do so. This PR contains a fix where we are displaying 3 webhooks at a time for usability reasons and are implementing a Next page that we can scroll to. 

![Screenshot 2023-06-27 at 5 09 10 PM](https://github.com/cds-snc/sre-bot/assets/85905333/550c0a0b-f9c8-490e-8492-67fabb47b2a4)