### PR TITLE
Update requirements.txt

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,10 +1,10 @@
 arrow==1.2.3
-awscli==1.27.165
+awscli==1.29.2
 aws-sns-message-validator==0.0.5
-boto3==1.26.165
-fastapi==0.99.1
+boto3==1.28.2
+fastapi==0.100.0
 geoip2==4.7.0
-google-api-python-client==2.91.0
+google-api-python-client==2.93.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.8.0
 python-dotenv==0.21.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,6 +7,7 @@ geoip2==4.7.0
 google-api-python-client==2.93.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.8.0
+PyYaml==5.3.1 # need to pin down the PyYaml version since the newest version is currently broken - https://github.com/yaml/pyyaml/issues/724
 python-dotenv==0.21.1
 python-i18n==0.3.9
 requests==2.31.0

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "github.com/cds-snc/terraform-modules?ref=v1.0.15//vpc"
+  source = "github.com/cds-snc/terraform-modules//vpc?ref=v6.1.1"
   name   = "SREBotVPC"
 
   allow_https_request_in           = true


### PR DESCRIPTION
# Summary | Résumé

We need to pin down the PyYaml version to 5.3.1 in order to install the dependencies due to an error in the new PyYaml version. This was due to the fact that CPython 3.0 released recently which appears to have https://github.com/yaml/pyyaml/issues/601#issuecomment-1011355313 that leads to https://github.com/yaml/pyyaml/issues/724 (and likely other packages). This PR downgrades PyYaml until the issue is resolved. 