### PR TITLE
Github action to record workflow failure in PR

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,3 +1,5 @@
+name: Sync repository labels workflow
+
 on: [issues, pull_request, workflow_dispatch]
 jobs:
   sync-labels:

--- a/.github/workflows/log_workflow_error.yml
+++ b/.github/workflows/log_workflow_error.yml
@@ -1,0 +1,24 @@
+name: Log Workflow error in PR
+
+on:
+    workflow_run:
+      workflows:
+        - Source code security scan using Bandit 
+        - Build and Push to Container Registry
+        - Lint, format and test code
+        - Build containers CI
+        - Docker vulnerability scan
+        - GitHub repository metadata exporter
+        -  Sync repository labels workflow
+        - Scorecards supply-chain security
+        - S3 backup
+        - Shellcheck
+        - Terraform Apply
+        - Terraform plan
+      types: [ completed ]
+
+jobs:
+    log-error:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: quipper/comment-failure-action@v0.1.1

--- a/.github/workflows/log_workflow_error.yml
+++ b/.github/workflows/log_workflow_error.yml
@@ -9,7 +9,7 @@ on:
         - Build containers CI
         - Docker vulnerability scan
         - GitHub repository metadata exporter
-        -  Sync repository labels workflow
+        - Sync repository labels workflow
         - Scorecards supply-chain security
         - S3 backup
         - Shellcheck


### PR DESCRIPTION
# Summary | Résumé

Closes [Issue #439](https://github.com/cds-snc/site-reliability-engineering/issues/439) Github action to record that a workflow has failed. I am putting all the workflows so that the PR fails for all the workflows in the repo. The output is supposed to look like the following:
 
<img width="1021" alt="Screenshot 2023-08-21 at 3 08 53 PM" src="https://github.com/cds-snc/sre-bot/assets/85905333/e76c6325-144a-48a3-863c-e942701b7120">

If this works, we can roll it to other repos. 