### PR TITLE
Fixing logging in production (frontend)

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -130,9 +130,12 @@ async def logout(request: Request):
 # Login route. You will be redirected to the google login page
 @handler.get("/login")
 async def login(request: Request):
+    # this is the route that will be called after the user logs in
     redirect_uri = request.url_for(
-        "auth"
-    )  # this is the route that will be called after the user logs in
+        "auth",
+    )
+    if (request.url.__str__()).startswith("https"):
+        redirect_uri = redirect_uri.__str__().replace("http", "https")
     return await oauth.google.authorize_redirect(request, redirect_uri)
 
 


### PR DESCRIPTION
# Summary | Résumé

In production, logging via google was not working since it was redirecting the url to http instead of https. Http requests were being blocked by the load balancer. I have now fixed the redirect url to have https instead of http only for production.  
