### PR TITLE
Adding logic for production google login 

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,3 +27,4 @@ services:
       AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
       AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
       SHELL: /bin/zsh
+      ENVIRONMENT: 'dev'

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -130,12 +130,16 @@ async def logout(request: Request):
 # Login route. You will be redirected to the google login page
 @handler.get("/login")
 async def login(request: Request):
+    # get the current environment (ie dev or prod)
+    environment = os.environ.get("ENVIRONMENT")
     # this is the route that will be called after the user logs in
     redirect_uri = request.url_for(
         "auth",
     )
-    if (request.url.__str__()).startswith("https"):
+    # if the environment is production, then make sure to replace the http to https, else don't do anything (ie if you are in dev)
+    if environment == "prod":
         redirect_uri = redirect_uri.__str__().replace("http", "https")
+
     return await oauth.google.authorize_redirect(request, redirect_uri)
 
 

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -355,8 +355,6 @@ def test_login_endpoint_redirect_uri_dev():
 
 
 # Test the auth endpoint
-
-
 def test_auth_endpoint():
     response = client.get("/auth")
     assert response.status_code == 200

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import httpx
 from server import bot_middleware, server
 import urllib.parse
 

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -350,7 +350,7 @@ def test_login_endpoint_redirect_uri_dev():
     if os.environ.get("ENVIRONMENT") == "dev":
         redirect_uri = urllib.parse.quote_plus("http://testserver/auth")
 
-    # assert that the response url we get from the login endpoint contains the redirect_uri replaced with https
+    # assert that the response url we get from the login endpoint contains the redirect_uri is not replaced with https (we need to keep the http)
     assert response.url.__str__().__contains__("redirect_uri=" + redirect_uri)
 
 


### PR DESCRIPTION
# Summary | Résumé

The following changes were done:

- Added environment variable for production/dev environment determination
- Modified the devcontainer docker-compose to include "dev" as the environment variable value
- Changed the login route to convert the request uri to https if it is in production
- Added a couple of unit tests to test the new login logic 