### PR TITLE
Adding backstage catalog config file so that we can inject github data into Backstage

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sre-bot
+  annotations:
+    github.com/project-slug: cds-snc/sre-bot
+spec:
+  type: other
+  lifecycle: unknown


### PR DESCRIPTION
# Summary | Résumé

Add backstage config file to the sre-bot to be able to ingest github data into Backstage.