### PR TITLE
Fixing dynamodb local v2.0 change plus creating dynamodb tables at startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
+	'postCreateCommand': '.devcontainer/maxmind-create.sh && .devcontainer/dynamodb-create.sh',
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,11 +20,12 @@ services:
         VARIANT: "3.11"
         INSTALL_NODE: "true"
         NODE_VERSION: "lts/*"
+        LICENSE_KEY: '${MAXMIND_KEY}'
     volumes:
       - ..:/workspace:cached
     command: sleep infinity
     environment:
-      AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
-      AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+      AWS_ACCESS_KEY_ID: 'AWSACCESSKEYID'
+      AWS_SECRET_ACCESS_KEY: 'AWSSECRETACCESSKEY'
       SHELL: /bin/zsh
       ENVIRONMENT: 'dev'


### PR DESCRIPTION
# Summary | Résumé

Making the dynamodb creation of the databases work, plus fixing a new change that AWS introduced that the access key's and id can't no longer contain special characters since dynamodb local v2.0. Information regarding the proceeding can be found here:

- https://www.agiliztech.com/2023/07/12/amazon-dynamodb-local-v20-whats-new/#:~:text=Updated%20Access%20Key%20ID%20convention&text=The%20new%20convention%20specifies%20that,only%20allows%20letters%20and%20numbers.
- https://repost.aws/articles/ARc4hEkF9CRgOrw8kSMe6CwQ/troubleshooting-the-access-key-id-or-security-token-is-invalid-error-after-upgrading-dynamodb-local-to-version-2-0-0-1-23-0-or-greater