### PR TITLE
Adding opsgenie alert integration

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -35,6 +35,9 @@ def handle_incident_action_buttons(client, ack, body, logger):
             f"🙈  <@{user}> has acknowledged and ignored the incident.\n"
             f"<@{user}> a pris connaissance et ignoré l'incident."
         )
+        # if the last attachment is a preview from a link, switch the places of the last 2 attachments so that the incident buttons can be appended properly
+        if len(attachments) > 1 and attachments[-1]["thumb_url"]:
+            attachments[-2], attachments[-1] = attachments[-1], attachments[-2]
         attachments[-1] = {
             "color": "3AA3E3",
             "fallback": f"{msg}",

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -17,8 +17,29 @@ def get_on_call_users(schedule):
         return []
 
 
+def create_alert(description):
+    content = api_post_request(
+        f"https://api.opsgenie.com/v2/alerts",
+        {"name": "GenieKey", "token": OPSGENIE_KEY},
+        {"message": "Notify API Key has been compromised!", "description": description},
+    )
+    try:
+        data = json.loads(content)
+        return data["result"]
+    except Exception:
+        return "Could not issue alert to Opsgenie!"
+
+
 def api_get_request(url, auth):
     req = Request(url)
+    req.add_header("Authorization", f"{auth['name']} {auth['token']}")
+    conn = urlopen(req)  # nosec - Scheme is hardcoded to https
+    return conn.read().decode("utf-8")
+
+
+def api_post_request(url, auth, data):
+    data = json.dumps(data).encode("utf-8")
+    req = Request(url, data=data, method="POST")
     req.add_header("Authorization", f"{auth['name']} {auth['token']}")
     conn = urlopen(req)  # nosec - Scheme is hardcoded to https
     return conn.read().decode("utf-8")

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 from urllib.request import Request, urlopen
 
 # Use the integrations API Key as the Opsgenie API Key
@@ -14,7 +15,8 @@ def get_on_call_users(schedule):
     try:
         data = json.loads(content)
         return list(map(lambda x: x["name"], data["data"]["onCallParticipants"]))
-    except Exception:
+    except Exception as e:
+        logging.error(f"Could not get on call users for schedule {schedule}. Details of error: {e}")
         return []
 
 
@@ -30,8 +32,10 @@ def create_alert(description):
     )
     try:
         data = json.loads(content)
+        logging.info(f"Created opsgenie alert with result: {data['result']}")
         return data["result"]
-    except Exception:
+    except Exception as e:
+        logging.error(f"Could not create opsgenie alert. Error: {e}")
         return "Could not issue alert to Opsgenie!"
 
 

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -16,7 +16,9 @@ def get_on_call_users(schedule):
         data = json.loads(content)
         return list(map(lambda x: x["name"], data["data"]["onCallParticipants"]))
     except Exception as e:
-        logging.error(f"Could not get on call users for schedule {schedule}. Details of error: {e}")
+        logging.error(
+            f"Could not get on call users for schedule {schedule}. Details of error: {e}"
+        )
         return []
 
 

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -2,7 +2,8 @@ import json
 import os
 from urllib.request import Request, urlopen
 
-OPSGENIE_KEY = os.getenv("OPSGENIE_KEY", None)
+# Use the integrations API Key as the Opsgenie API Key
+OPSGENIE_KEY = os.getenv("OPSGENIE_INTEGRATIONS_KEY", None)
 
 
 def get_on_call_users(schedule):
@@ -17,11 +18,15 @@ def get_on_call_users(schedule):
         return []
 
 
+# Create an Opsgenie alert. This is used to notify the on-call users
 def create_alert(description):
     content = api_post_request(
         f"https://api.opsgenie.com/v2/alerts",
         {"name": "GenieKey", "token": OPSGENIE_KEY},
-        {"message": "Notify API Key has been compromised!", "description": description},
+        {
+            "message": "Notify API Key has been compromised!",
+            "description": f"{description}",
+        },
     )
     try:
         data = json.loads(content)
@@ -37,9 +42,11 @@ def api_get_request(url, auth):
     return conn.read().decode("utf-8")
 
 
+# Post the API request to the Opsgenie API
 def api_post_request(url, auth, data):
     data = json.dumps(data).encode("utf-8")
-    req = Request(url, data=data, method="POST")
+    req = Request(url, data=data)
+    req.add_header("Content-Type", "application/json")
     req.add_header("Authorization", f"{auth['name']} {auth['token']}")
     conn = urlopen(req)  # nosec - Scheme is hardcoded to https
     return conn.read().decode("utf-8")

--- a/app/integrations/opsgenie.py
+++ b/app/integrations/opsgenie.py
@@ -21,7 +21,7 @@ def get_on_call_users(schedule):
 # Create an Opsgenie alert. This is used to notify the on-call users
 def create_alert(description):
     content = api_post_request(
-        f"https://api.opsgenie.com/v2/alerts",
+        "https://api.opsgenie.com/v2/alerts",
         {"name": "GenieKey", "token": OPSGENIE_KEY},
         {
             "message": "Notify API Key has been compromised!",

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -54,6 +54,7 @@ def alert_on_call(product, client, api_key, github_repo):
     oncall = []
     message = ""
     private_message = ""
+    api_message_info = f"The key is *{api_key}* and the file is {github_repo}. You can see the message in #internal-sre-alerts to start an incident."
 
     # Get OpsGenie users on call and construct string
     if "genie_schedule" in folder_metadata:
@@ -65,12 +66,17 @@ def alert_on_call(product, client, api_key, github_repo):
         for user in oncall:
             # send a private message to the people on call.
             message += f"<@{user['id']}> "
-            private_message = f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \nThe key is *{api_key}* and the file is {github_repo}. You can see the message in #internal-sre-alerts to start an incident."
+            private_message = f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \n" + api_message_info
             # send the private message
             client.chat_postMessage(
                 channel=user["id"], text=private_message, as_user=True
             )
         message += "have been notified."
+
+    # create an alert in OpsGenie
+    result = opsgenie.create_alert(api_message_info)
+    message += f"\nAn alert has been created in OpsGenie with result: {result}."
+
     return message
 
 

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -256,7 +256,7 @@ def format_api_key_detected(payload, client):
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": "🙀 Notify API Key has been compromised!🔑",
+                "text": "🙀 Notify API Key has been compromised! 🔑",
             },
         },
         {
@@ -269,7 +269,7 @@ def format_api_key_detected(payload, client):
         {
             "type": "section",
             "text": {
-                "type": "plain_text",
+                "type": "mrkdwn",
                 "text": f"{on_call_message}",
             },
         },

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -41,7 +41,7 @@ def nested_get(dictionary, keys):
     return dictionary
 
 
-def alert_on_call(product, client, api_key, github_repo):
+def alert_on_call(product, client, api_key_name, github_repo):
     # get the list of folders
     folders = google_drive.list_folders()
     # get the folder id for the Product
@@ -54,7 +54,9 @@ def alert_on_call(product, client, api_key, github_repo):
     oncall = []
     message = ""
     private_message = ""
-    api_message_info = f"The key is *{api_key}* and the file is {github_repo}. You can see the message in #internal-sre-alerts to start an incident."
+
+    # Generate the opsgenie message. We don't want to expose the api key value exposed so we will just provide the name of the key.
+    opsgenie_message = f"Notify key with name {api_key_name} has been leaked and needs to be revoked. Please check Slack in #internal-sre-alerts or on-call staff can check your private messages for more detailed information. "
 
     # Get OpsGenie users on call and construct string
     if "genie_schedule" in folder_metadata:
@@ -66,19 +68,16 @@ def alert_on_call(product, client, api_key, github_repo):
         for user in oncall:
             # send a private message to the people on call.
             message += f"<@{user['id']}> "
-            private_message = (
-                f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \n"
-                + api_message_info
-            )
+            private_message = f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \nThe key name is *{api_key_name}* and it is exposed in file {github_repo}. You can see the message in #internal-sre-alerts to start an incident."
             # send the private message
             client.chat_postMessage(
                 channel=user["id"], text=private_message, as_user=True
             )
         message += "have been notified."
 
-    # create an alert in OpsGenie
-    result = opsgenie.create_alert(api_message_info)
-    message += f"\nAn alert has been created in OpsGenie with result: {result}."
+        # create an alert in OpsGenie
+        result = opsgenie.create_alert(opsgenie_message)
+        message += f"\nAn alert has been created in OpsGenie with result: {result}."
 
     return message
 
@@ -255,8 +254,12 @@ def format_api_key_detected(payload, client):
     api_key = re.search(regex, msg).groups()[0]
     github_repo = re.search(regex, msg).groups()[1]
 
+    # We don't want to send the actual api-key through Slack, but we do want the name to be given,
+    # so therefore extract the api key name by following the format of a Notify api key
+    api_key_name = api_key[7 : len(api_key) - 74]
+
     # send a private message with the api-key and github repo to the people on call.
-    on_call_message = alert_on_call("Notify", client, api_key, github_repo)
+    on_call_message = alert_on_call("Notify", client, api_key_name, github_repo)
 
     # Format the message displayed in Slack
     return [
@@ -272,7 +275,7 @@ def format_api_key_detected(payload, client):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"Notify API Key *{api_key}* has been committed in github file {github_repo}. The key needs to be revoked!",
+                "text": f"Notify API Key Name *{api_key_name}* has been committed in github file {github_repo}. The key needs to be revoked!",
             },
         },
         {

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -66,7 +66,10 @@ def alert_on_call(product, client, api_key, github_repo):
         for user in oncall:
             # send a private message to the people on call.
             message += f"<@{user['id']}> "
-            private_message = f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \n" + api_message_info
+            private_message = (
+                f"Hello {user['profile']['first_name']}!\nA Notify API key has been leaked and needs to be revoked. 🙀 \n"
+                + api_message_info
+            )
             # send the private message
             client.chat_postMessage(
                 channel=user["id"], text=private_message, as_user=True

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -265,13 +265,13 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
                     logging.info("No blocks to post, returning")
                     return
                 payload = WebhookPayload(blocks=blocks)
-                try:
-                    msg = json.loads(payload.Message)
-                except Exception:
-                    msg = payload.Message
-                # if the message is for Notify API secret, unfurl links will be set to false
-                if "API Key with value token=" in msg:
-                    payload.unfurl_links = False
+                # try:
+                #     msg = json.loads(payload.Message)
+                # except Exception:
+                #     msg = payload.Message
+                # # if the message is for Notify API secret, unfurl links will be set to false
+                # if "API Key with value token=" in msg:
+                #     payload.unfurl_links = False
 
         payload.channel = webhook["channel"]["S"]
         payload = append_incident_buttons(payload, id)

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -265,14 +265,6 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
                     logging.info("No blocks to post, returning")
                     return
                 payload = WebhookPayload(blocks=blocks)
-                # try:
-                #     msg = json.loads(payload.Message)
-                # except Exception:
-                #     msg = payload.Message
-                # # if the message is for Notify API secret, unfurl links will be set to false
-                # if "API Key with value token=" in msg:
-                #     payload.unfurl_links = False
-
         payload.channel = webhook["channel"]["S"]
         payload = append_incident_buttons(payload, id)
         try:

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -265,6 +265,13 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
                     logging.info("No blocks to post, returning")
                     return
                 payload = WebhookPayload(blocks=blocks)
+                try:
+                    msg = json.loads(payload.Message)
+                except Exception:
+                    msg = payload.Message
+                # if the message is for Notify API secret, unfurl links will be set to false
+                if "API Key with value token=" in msg:
+                    payload.unfurl_links = False
 
         payload.channel = webhook["channel"]["S"]
         payload = append_incident_buttons(payload, id)

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -202,6 +202,7 @@ def test_handle_incident_action_buttons_ignore_drop_richtext_block_no_type(
         },
     )
 
+
 # Test that the order of the ignore buttons are appended properly and the preview is moved up once the ignore button is clicked
 
 
@@ -235,7 +236,7 @@ def test_handle_incident_action_buttons_link_preview(
                     "title": "title",
                     "thumb_url": "http://blah.com/g/200/200",
                     "image_url": "http://blah.com/g/200/200",
-                }
+                },
             ],
         },
     }
@@ -256,7 +257,7 @@ def test_handle_incident_action_buttons_link_preview(
                     "color": "3AA3E3",
                     "fallback": "🙈  <@user_id> has acknowledged and ignored the incident.\n<@user_id> a pris connaissance et ignoré l'incident.",
                     "text": "🙈  <@user_id> has acknowledged and ignored the incident.\n<@user_id> a pris connaissance et ignoré l'incident.",
-                }
+                },
             ],
         },
     )

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -202,6 +202,65 @@ def test_handle_incident_action_buttons_ignore_drop_richtext_block_no_type(
         },
     )
 
+# Test that the order of the ignore buttons are appended properly and the preview is moved up once the ignore button is clicked
+
+
+@patch("commands.incident.webhooks.increment_acknowledged_count")
+@patch("commands.incident.log_to_sentinel")
+def test_handle_incident_action_buttons_link_preview(
+    _log_to_sentinel_mock, increment_acknowledged_count_mock
+):
+    client = MagicMock()
+    ack = MagicMock()
+    logger = MagicMock()
+    body = {
+        "actions": [
+            {
+                "name": "ignore-incident",
+                "value": "incident_id",
+                "type": "button",
+            }
+        ],
+        "channel": {"id": "channel_id"},
+        "user": {"id": "user_id"},
+        "original_message": {
+            "attachments": [
+                {
+                    "color": "3AA3E3",
+                    "fallback": "foo",
+                    "text": "bar",
+                },
+                {
+                    "text": "test",
+                    "title": "title",
+                    "thumb_url": "http://blah.com/g/200/200",
+                    "image_url": "http://blah.com/g/200/200",
+                }
+            ],
+        },
+    }
+    incident.handle_incident_action_buttons(client, ack, body, logger)
+    increment_acknowledged_count_mock.assert_called_with("incident_id")
+    client.api_call.assert_called_with(
+        "chat.update",
+        json={
+            "channel": "channel_id",
+            "attachments": [
+                {
+                    "text": "test",
+                    "title": "title",
+                    "thumb_url": "http://blah.com/g/200/200",
+                    "image_url": "http://blah.com/g/200/200",
+                },
+                {
+                    "color": "3AA3E3",
+                    "fallback": "🙈  <@user_id> has acknowledged and ignored the incident.\n<@user_id> a pris connaissance et ignoré l'incident.",
+                    "text": "🙈  <@user_id> has acknowledged and ignored the incident.\n<@user_id> a pris connaissance et ignoré l'incident.",
+                }
+            ],
+        },
+    )
+
 
 @patch("commands.incident.google_drive.list_folders")
 def test_incident_open_modal_calls_ack(mock_list_folders):

--- a/app/tests/intergrations/test_opsgenie.py
+++ b/app/tests/intergrations/test_opsgenie.py
@@ -79,9 +79,10 @@ def test_api_post_request(urlopen_mock, request_mock):
     )
     request_mock.assert_called_once_with(
         "test_url",
-        data=b'{"message": "Notify API Key has been compromised!", "description": "test_description"}'
+        data=b'{"message": "Notify API Key has been compromised!", "description": "test_description"}',
     )
     request_mock.return_value.add_header.assert_called_with(
-        "Authorization", "GenieKey OPSGENIE_KEY",
+        "Authorization",
+        "GenieKey OPSGENIE_KEY",
     )
     urlopen_mock.assert_called_once_with(request_mock.return_value)

--- a/app/tests/intergrations/test_opsgenie.py
+++ b/app/tests/intergrations/test_opsgenie.py
@@ -16,10 +16,30 @@ def test_get_on_call_users(api_get_request_mock):
     )
 
 
+@patch("integrations.opsgenie.api_post_request")
+@patch("integrations.opsgenie.OPSGENIE_KEY", "OPSGENIE_KEY")
+def test_create_alert(api_post_request_mock):
+    description = "test_description"
+    api_post_request_mock.return_value = '{"result": "Request will be processed", "took": 0.302, "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120"}'
+    assert opsgenie.create_alert(description) == "Request will be processed"
+    api_post_request_mock.assert_called_once_with(
+        "https://api.opsgenie.com/v2/alerts",
+        {"name": "GenieKey", "token": "OPSGENIE_KEY"},
+        {"message": "Notify API Key has been compromised!", "description": description},
+    )
+
+
 @patch("integrations.opsgenie.api_get_request")
 def test_get_on_call_users_with_exception(api_get_request_mock):
     api_get_request_mock.return_value = "{]"
     assert opsgenie.get_on_call_users("test_schedule") == []
+
+
+@patch("integrations.opsgenie.api_post_request")
+def test_create_alert_with_exception(api_post_request_mock):
+    description = "test_description"
+    api_post_request_mock.return_value = "{]"
+    assert opsgenie.create_alert(description) == "Could not issue alert to Opsgenie!"
 
 
 @patch("integrations.opsgenie.Request")
@@ -36,6 +56,32 @@ def test_api_get_request(urlopen_mock, request_mock):
     )
 
     request_mock.assert_called_once_with("test_url")
+    request_mock.return_value.add_header.assert_called_once_with(
+        "Authorization", "GenieKey OPSGENIE_KEY"
+    )
+    urlopen_mock.assert_called_once_with(request_mock.return_value)
+
+
+@patch("integrations.opsgenie.Request")
+@patch("integrations.opsgenie.urlopen")
+def test_api_post_request(urlopen_mock, request_mock):
+    urlopen_mock.return_value.read.return_value.decode.return_value = '{"result": "Request will be processed", "took": 0.302, "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120"}'
+    assert (
+        opsgenie.api_post_request(
+            "test_url",
+            {"name": "GenieKey", "token": "OPSGENIE_KEY"},
+            {
+                "message": "Notify API Key has been compromised!",
+                "description": "test_description",
+            },
+        )
+        == '{"result": "Request will be processed", "took": 0.302, "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120"}'
+    )
+    request_mock.assert_called_once_with(
+        "test_url",
+        data=b'{"message": "Notify API Key has been compromised!", "description": "test_description"}',
+        method="POST",
+    )
     request_mock.return_value.add_header.assert_called_once_with(
         "Authorization", "GenieKey OPSGENIE_KEY"
     )

--- a/app/tests/intergrations/test_opsgenie.py
+++ b/app/tests/intergrations/test_opsgenie.py
@@ -79,10 +79,9 @@ def test_api_post_request(urlopen_mock, request_mock):
     )
     request_mock.assert_called_once_with(
         "test_url",
-        data=b'{"message": "Notify API Key has been compromised!", "description": "test_description"}',
-        method="POST",
+        data=b'{"message": "Notify API Key has been compromised!", "description": "test_description"}'
     )
-    request_mock.return_value.add_header.assert_called_once_with(
-        "Authorization", "GenieKey OPSGENIE_KEY"
+    request_mock.return_value.add_header.assert_called_with(
+        "Authorization", "GenieKey OPSGENIE_KEY",
     )
     urlopen_mock.assert_called_once_with(request_mock.return_value)

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -197,7 +197,7 @@ def test_format_api_key_detected_extracts_the_api_key_and_inserts_it_into_blocks
     client = MagicMock()
     payload = mock_api_key_detected()
     response = aws.format_api_key_detected(payload, client)
-    assert "gcntfy-api-key-blah" in response[2]["text"]["text"]
+    assert "api-key-blah" in response[2]["text"]["text"]
 
 
 @patch("server.event_handlers.aws.alert_on_call")
@@ -343,7 +343,7 @@ def mock_api_key_detected():
         MessageId="1e5f5647g-adb5-5d6f-ab5e-c2e508881361",
         TopicArn="arn:aws:sns:ca-central-1:412578375350:test-sre-bot",
         Subject="API Key detected",
-        Message="API Key with value token='gcntfy-api-key-blah' has been detected in url='https://github.com/blah'! This key needs to be revoked asap.",
+        Message="API Key with value token='gcntfy-api-key-blah-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' has been detected in url='https://github.com/blah'! This key needs to be revoked asap.",
         Timestamp="2023-09-25T20:50:37.868Z",
         SignatureVersion="1",
         Signature="EXAMPLEO0OA1HN4MIHrtym3N6SWqvotsY4EcG+Ty/wrfZcxpQ3mximWM7ZfoYlzZ8NBh4s1XTPuqbl5efK64TEuPgNWBMKsm5Gc2d8H6hoDpLqAOELGl2/xlvWf2CovLH/KPj8xrSwAgOS9jL4r/EEMdXYb705YMMBudu78gooatU9EpVl+1I2MCP2AW0ZJWrcSwYMqxo9yo7H6coyBRlmTxP97PlELXoqXLfufsfFBjZ0eFycndG5A0YHeue82uLF5fIHGpcTjqNzLF0PXuJoS9xVkGx3X7p+dzmRE4rp/swGyKCqbXvgldPRycuj7GSk3r8HLSfzjqHyThnDqMECA==",

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -226,9 +226,11 @@ def test_format_api_key_detected_extracts_the_on_call_message_and_inserts_it_int
 @patch("integrations.google_drive.get_google_service")
 @patch("commands.incident.google_drive.list_folders")
 @patch("commands.incident.google_drive.list_metadata")
+@patch("integrations.opsgenie.create_alert")
 @patch("integrations.opsgenie.get_on_call_users")
 def test_alert_on_call_returns_message(
     get_on_call_users_mock,
+    create_alert_mock,
     list_metadata_mock,
     google_list_folders_mock,
     get_google_service_mock,
@@ -249,8 +251,12 @@ def test_alert_on_call_returns_message(
         "name": "Notify",
         "appProperties": {"genie_schedule": "test_schedule"},
     }
+    create_alert_mock.return_value = "test result"
     response = aws.alert_on_call(product, client, api_key, github_repo)
-    assert "test on-call staff have been notified" in response
+    assert (
+        "test on-call staff have been notified.\nAn alert has been created in OpsGenie with result: test result."
+        in response
+    )
 
 
 def mock_abuse_alert():

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -184,6 +184,7 @@ def test_handle_webhook_with_Notification_payload(
     parse_mock.return_value = ["foo", "bar"]
     get_webhook_mock.return_value = {"channel": {"S": "channel"}}
     payload = '{"Type": "Notification"}'
+    # payload = '{"Type": "Notification", "Message: "foo"}'
     response = client.post("/hook/id", json=payload)
     assert response.status_code == 200
     assert response.json() == {"ok": True}

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -184,7 +184,6 @@ def test_handle_webhook_with_Notification_payload(
     parse_mock.return_value = ["foo", "bar"]
     get_webhook_mock.return_value = {"channel": {"S": "channel"}}
     payload = '{"Type": "Notification"}'
-    # payload = '{"Type": "Notification", "Message: "foo"}'
     response = client.post("/hook/id", json=payload)
     assert response.status_code == 200
     assert response.json() == {"ok": True}


### PR DESCRIPTION
# Summary | Résumé

Adding opsgenie alert integration for the sre bot. Whenever a secret is detected, the SRE bot will send an alert to Opsgenie:

![Screenshot 2023-10-27 at 4 01 11 PM](https://github.com/cds-snc/sre-bot/assets/85905333/71b609f7-b698-478d-a210-b535bdf06db1)

Also fixed an error that was appending the ignore and incident buttons twice when a url preview was crawled by Slack.
