### PR TITLE
Changing the notify api key to a variable in order to stop alerting

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -52,3 +52,4 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
+          NOTIFY_TEST_KEY: ${{ secrets.NOTIFY_TEST_KEY }}

--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -36,7 +36,7 @@ def handle_incident_action_buttons(client, ack, body, logger):
             f"<@{user}> a pris connaissance et ignoré l'incident."
         )
         # if the last attachment is a preview from a link, switch the places of the last 2 attachments so that the incident buttons can be appended properly
-        if len(attachments) > 1 and attachments[-1]["thumb_url"]:
+        if len(attachments) > 1 and attachments[-1]["app_unfurl_url"]:
             attachments[-2], attachments[-1] = attachments[-1], attachments[-2]
         attachments[-1] = {
             "color": "3AA3E3",

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -234,6 +234,7 @@ def test_handle_incident_action_buttons_link_preview(
                 {
                     "text": "test",
                     "title": "title",
+                    "app_unfurl_url": "http://blah.com",
                     "thumb_url": "http://blah.com/g/200/200",
                     "image_url": "http://blah.com/g/200/200",
                 },
@@ -250,6 +251,7 @@ def test_handle_incident_action_buttons_link_preview(
                 {
                     "text": "test",
                     "title": "title",
+                    "app_unfurl_url": "http://blah.com",
                     "thumb_url": "http://blah.com/g/200/200",
                     "image_url": "http://blah.com/g/200/200",
                 },

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -1,6 +1,7 @@
 from server.event_handlers import aws
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 
@@ -338,12 +339,14 @@ def mock_new_iam_user():
 
 # Mock the message returned from AWS when a API key has been compromised
 def mock_api_key_detected():
+    # get the test key. Put it in a variable not to trigger the alarming of the key when committing the file in gitub
+    NOTIFY_TEST_KEY = os.getenv("NOTIFY_TEST_KEY", None)
     return MagicMock(
         Type="Notification",
         MessageId="1e5f5647g-adb5-5d6f-ab5e-c2e508881361",
         TopicArn="arn:aws:sns:ca-central-1:412578375350:test-sre-bot",
         Subject="API Key detected",
-        Message="API Key with value token='gcntfy-api-key-blah-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' has been detected in url='https://github.com/blah'! This key needs to be revoked asap.",
+        Message=f"API Key with value token='{NOTIFY_TEST_KEY}' has been detected in url='https://github.com/blah'! This key needs to be revoked asap.",
         Timestamp="2023-09-25T20:50:37.868Z",
         SignatureVersion="1",
         Signature="EXAMPLEO0OA1HN4MIHrtym3N6SWqvotsY4EcG+Ty/wrfZcxpQ3mximWM7ZfoYlzZ8NBh4s1XTPuqbl5efK64TEuPgNWBMKsm5Gc2d8H6hoDpLqAOELGl2/xlvWf2CovLH/KPj8xrSwAgOS9jL4r/EEMdXYb705YMMBudu78gooatU9EpVl+1I2MCP2AW0ZJWrcSwYMqxo9yo7H6coyBRlmTxP97PlELXoqXLfufsfFBjZ0eFycndG5A0YHeue82uLF5fIHGpcTjqNzLF0PXuJoS9xVkGx3X7p+dzmRE4rp/swGyKCqbXvgldPRycuj7GSk3r8HLSfzjqHyThnDqMECA==",


### PR DESCRIPTION
# Summary | Résumé

Changing the API key to a variable in order to stop the constant fake alerting. Also fixed a bug where the preview was messing up with the Incident/Acknowledge & Ignore buttons. 