### PR TITLE
Use Notify API endpoint to automatically revoke a key

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -53,3 +53,5 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
           NOTIFY_TEST_KEY: ${{ secrets.NOTIFY_TEST_KEY }}
+          NOTIFY_SRE_USER_NAME: ${{ secrets.NOTIFY_SRE_USER_NAME }}
+          NOTIFY_SRE_CLIENT_SECRET: ${{ secrets.NOTIFY_SRE_CLIENT_SECRET }}

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -55,3 +55,4 @@ jobs:
           NOTIFY_TEST_KEY: ${{ secrets.NOTIFY_TEST_KEY }}
           NOTIFY_SRE_USER_NAME: ${{ secrets.NOTIFY_SRE_USER_NAME }}
           NOTIFY_SRE_CLIENT_SECRET: ${{ secrets.NOTIFY_SRE_CLIENT_SECRET }}
+          NOTIFY_OPS_CHANNEL_ID: ${{ secrets.NOTIFY_OPS_CHANNEL_ID }}

--- a/app/integrations/notify.py
+++ b/app/integrations/notify.py
@@ -77,7 +77,7 @@ def revoke_api_key(api_key, api_type, github_repo, source):
     url = os.getenv("NOTIFY_API_URL")
 
     if url is None:
-        logging.error("NOTIFY_API_URL usmissing")
+        logging.error("NOTIFY_API_URL is missing")
         return False
 
     # append the revoke-endpoint to the url

--- a/app/integrations/notify.py
+++ b/app/integrations/notify.py
@@ -1,0 +1,97 @@
+import os
+import jwt
+import time
+import calendar
+import logging
+import requests
+import json
+
+
+# generate the epoch seconds for the jwt token
+def epoch_seconds():
+    return calendar.timegm(time.gmtime())
+
+
+def create_jwt_token(secret, client_id):
+    """
+    Generate a JWT Token for the Notify API
+
+    Tokens have a header consisting of:
+    {
+        "typ": "JWT",
+        "alg": "HS256"
+    }
+
+    Parameters:
+    secret: Application signing secret
+    client_id: Identifier for the client
+
+    Claims are:
+    iss: identifier for the client
+    iat: epoch seconds for the token (UTC)
+
+    Returns a JWT token for this request
+    """
+    assert secret, "Missing secret key"
+    assert client_id, "Missing client id"
+
+    headers = {"typ": "JWT", "alg": "HS256"}
+
+    claims = {"iss": client_id, "iat": epoch_seconds()}
+    t = jwt.encode(payload=claims, key=secret, headers=headers)
+    if isinstance(t, str):
+        return t
+    else:
+        return t.decode()
+
+
+# Function to create the authorization header for the Notify API
+def create_authorization_header():
+    # get the client_id and secret from the environment variables
+    client_id = os.getenv("SRE_USER_NAME")
+    secret = os.getenv("SRE_CLIENT_SECRET")
+
+    if client_id is None or secret is None:
+        logging.error("SRE_USER_NAME or SRE_CLIENT_SECRET is missing")
+
+    # Create the jwt token and return the authorization header
+    token = create_jwt_token(secret=secret, client_id=client_id)
+    return "Authorization", "Bearer {}".format(token)
+
+
+# Function to post an api call to Notify
+def post_event(url, payload):
+    header = create_authorization_header()
+    response = requests.post(url, data=json.dumps(payload), headers=header)
+    return response
+
+# Function to revoke an api key by calling Notify's revoke api endpoint
+
+
+def revoke_api_key(api_key, api_key_name, github_repo):
+    # get the url and jwt_token
+    url = os.getenv("NOTIFY_API_URL")
+
+    if url is None:
+        logging.error("NOTIFY_API_URL usmissing")
+        return False
+
+    # append the revoke-endpoint to the url
+    url = url + "/sre-tools/api-key-revoke"
+
+    # generate the payload
+    payload = {
+        "token": api_key,
+        "type": api_key_name,
+        "url": github_repo,
+        "source": "content",
+    }
+
+    # post the event (ie call the api)
+    response = post_event(url, payload)
+    if response.status_code == 200:
+        logging.info(f"API key {api_key_name} has been revoked")
+        return True
+    else:
+        logging.error(f"API key {api_key_name} could not be revoked. Response code: {response.status_code}")
+        return False

--- a/app/integrations/notify.py
+++ b/app/integrations/notify.py
@@ -67,7 +67,7 @@ def post_event(url, payload):
     header = {header_key: header_value, "Content-Type": "application/json"}
 
     # Post the response
-    response = requests.post(url, data=json.dumps(payload), headers=header)
+    response = requests.post(url, data=json.dumps(payload), headers=header, timeout=60)
     return response
 
 

--- a/app/integrations/notify.py
+++ b/app/integrations/notify.py
@@ -48,11 +48,11 @@ def create_jwt_token(secret, client_id):
 # Function to create the authorization header for the Notify API
 def create_authorization_header():
     # get the client_id and secret from the environment variables
-    client_id = os.getenv("SRE_USER_NAME")
-    secret = os.getenv("SRE_CLIENT_SECRET")
+    client_id = os.getenv("NOTIFY_SRE_USER_NAME")
+    secret = os.getenv("NOTIFY_SRE_CLIENT_SECRET")
 
     if client_id is None or secret is None:
-        logging.error("SRE_USER_NAME or SRE_CLIENT_SECRET is missing")
+        logging.error("NOTIFY_SRE_USER_NAME or NOTIFY_SRE_CLIENT_SECRET is missing")
 
     # Create the jwt token and return the authorization header
     token = create_jwt_token(secret=secret, client_id=client_id)
@@ -68,7 +68,7 @@ def post_event(url, payload):
 # Function to revoke an api key by calling Notify's revoke api endpoint
 
 
-def revoke_api_key(api_key, api_key_name, github_repo):
+def revoke_api_key(api_key, api_key_type, github_repo, source):
     # get the url and jwt_token
     url = os.getenv("NOTIFY_API_URL")
 
@@ -82,16 +82,16 @@ def revoke_api_key(api_key, api_key_name, github_repo):
     # generate the payload
     payload = {
         "token": api_key,
-        "type": api_key_name,
+        "type": api_key_type,
         "url": github_repo,
-        "source": "content",
+        "source": source,
     }
 
     # post the event (ie call the api)
     response = post_event(url, payload)
     if response.status_code == 200:
-        logging.info(f"API key {api_key_name} has been revoked")
+        logging.info(f"API key {api_key} has been successfully revoked")
         return True
     else:
-        logging.error(f"API key {api_key_name} could not be revoked. Response code: {response.status_code}")
+        logging.error(f"API key {api_key} could not be revoked. Response code: {response.status_code}")
         return False

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,6 +12,7 @@ google-auth-oauthlib==0.8.0
 httpx==0.25.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
+PyJWT==2.8.0
 PyYAML!=6.0.0,!=5.4.0,!=5.4.1
 python-dotenv==0.21.1
 python-i18n==0.3.9

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -1,6 +1,7 @@
 black==22.12.0
 coverage==6.5.0
 flake8==6.1.0
+freezegun==1.2.2
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-env==0.8.2

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -240,7 +240,7 @@ def format_api_key_detected(payload, client):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"Notify API Key Name * {api_key_name} * has been committed in github file {github_repo}.
+                "text": f"Notify API Key Name * {api_key_name} * was committed in github file {github_repo}."
             },
         },
         {

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -243,7 +243,7 @@ def format_api_key_detected(payload, client):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"Notify API Key Name {api_key_name} was committed in github file {github_repo} and {api_key}.",
+                "text": f"Notify API Key Name {api_key_name} was committed in github file {github_repo}.",
             },
         },
         {

--- a/app/tests/intergrations/test_notify.py
+++ b/app/tests/intergrations/test_notify.py
@@ -1,39 +1,43 @@
 import jwt
 import os
+import pytest
 from integrations import notify
 from unittest.mock import patch
+from freezegun import freeze_time
+
 
 # helper function to decode the token for testing
-
-
 def decode_token(token, secret):
-    return jwt.decode(token, key=secret, options={"verify_signature": True}, algorithms=["HS256"])
+    return jwt.decode(
+        token, key=secret, options={"verify_signature": True}, algorithms=["HS256"]
+    )
 
 
-@patch("integrations.notify.create_jwt_token")
-def test_create_jwt_token_secret_missing(jwt_token_mock):
-    assert notify.create_jwt_token(secret=None, client_id="client_id") == "Missing secret key"
-    jwt_token_mock.assert_called_once_with(secret=None, client_id="client_id")
+# Test that an exception is raised if the secret is missing
+def test_create_jwt_token_secret_missing():
+    with pytest.raises(AssertionError) as err:
+        notify.create_jwt_token(None, "client_id")
+    assert str(err.value) == "Missing secret key"
 
 
-@patch("integrations.notify.create_jwt_token")
-def test_create_jwt_token_client_id_missing(jwt_token_mock):
-    assert notify.create_jwt_token(secret="secret", client_id=None) == "Missing client id"
-    jwt_token_mock.assert_called_once_with(secret="secret", client_id=None)
+# Test that an exception is raised if the client_id is missing
+def test_create_jwt_token_client_id_missing():
+    with pytest.raises(AssertionError) as err:
+        notify.create_jwt_token("secret", None)
+    assert str(err.value) == "Missing client id"
 
 
-@patch("integrations.notify.create_jwt_token")
-def test_create_jwt_token_contains_correct_headers(jwt_token_mock):
-    token = notify.create_jwt_token(secret="secret", client_id="client_id")
-    assert jwt_token_mock.called_once_with(secret="secret", client_id="client_id")
+# Test that the token is created correctly and the type and alg headers are set correctly
+def test_create_jwt_token_contains_correct_headers():
+    token = notify.create_jwt_token("secret", "client_id")
     headers = jwt.get_unverified_header(token)
     assert headers["typ"] == "JWT"
     assert headers["alg"] == "HS256"
 
 
-@patch("integrations.notify.create_jwt_token")
-def test_create_jwt_token_contains_correct_headers(jwt_token_mock):
-    token = notify.create_jwt_token(secret="secret", client_id="client_id")
+# Test that the claims headers are set correctly
+def test_create_jwt_token_contains_correct_claims_headers():
+    token = notify.create_jwt_token("secret", "client_id")
     decoded_token = decode_token(token, "secret")
     assert decoded_token["iss"] == "client_id"
     assert "iat" in decoded_token
@@ -41,42 +45,37 @@ def test_create_jwt_token_contains_correct_headers(jwt_token_mock):
     assert "pay" not in decoded_token
 
 
+# Test that the correct iat time in epoch seconds is set correctly
 @freeze_time("2020-01-01 00:00:00")
-@patch("integrations.notify.create_jwt_token")
-def test_token_contains_correct_iat(jwt_token_mock):
-    token = notify.create_jwt_token(secret="secret", client_id="client_id")
+def test_token_contains_correct_iat():
+    token = notify.create_jwt_token("secret", "client_id")
     decoded_token = decode_token(token, "secret")
     assert decoded_token["iat"] == 1577836800
 
 
-@patch.dict(
-    os.environ, {"SRE_USER_NAME": None, "SRE_CLIENT_SECRET": "foo"}, clear=True
-)
-@patch("integrations.notify.create_authorization_header")
-def test_authorization_header_missing_client_id(header_mock):
-    assert notify.create_authorization_header() == "SRE_USER_NAME or SRE_CLIENT_SECRET is missing"
-    header_mock.assert_called_once()
-
-
-@patch.dict(
-    os.environ, {"SRE_USER_NAME": "foo", "SRE_CLIENT_SECRET": None}, clear=True
-)
-@patch("integrations.notify.create_authorization_header")
-def test_authorization_header_missing_secret(header_mock):
-    assert notify.create_authorization_header() == "SRE_USER_NAME or SRE_CLIENT_SECRET is missing"
-    header_mock.assert_called_once()
-
-
+# Test that an assertion error is raised if the NOTIFY_SRE_USER_NAME is missing
+@patch.dict(os.environ, {"NOTIFY_SRE_USER_NAME": "", "NOTIFY_SRE_CLIENT_SECRET": "foo"})
 @patch("integrations.notify.create_jwt_token")
-@patch("integrations.notify.create_authorization_header")
-def test_successful_creation_of_header(self, mock_header, mock_jwt_token):
+def test_authorization_header_missing_client_id(jwt_token_mock):
+    with pytest.raises(AssertionError) as err:
+        notify.create_authorization_header()
+    assert str(err.value) == "NOTIFY_SRE_USER_NAME is missing"
+
+
+# Test that an assertion error is raised if the NOTIFY_SRE_CLIENT_SECRET is missing
+@patch.dict(os.environ, {"NOTIFY_SRE_USER_NAME": "foo", "NOTIFY_SRE_CLIENT_SECRET": ""})
+@patch("integrations.notify.create_jwt_token")
+def test_authorization_header_missing_secret(jwt_token_mock):
+    with pytest.raises(AssertionError) as err:
+        notify.create_authorization_header()
+    assert str(err.value) == "NOTIFY_SRE_CLIENT_SECRET is missing"
+
+
+# Test that the authorization header is created correctly and the correct header is generated
+@patch("integrations.notify.create_jwt_token")
+def test_successful_creation_of_header(mock_jwt_token):
     mock_jwt_token.return_value = "mocked_jwt_token"
     header_key, header_value = notify.create_authorization_header()
 
-    # Check if the JWT token function was called with the right arguments
-    mock_jwt_token.assert_called_with(secret="test_secret", client_id="test_user")
-
-    # Assert the function returns the correct format of the authorization header
-    self.assertEqual(header_key, "Authorization")
-    self.assertEqual(header_value, "Bearer mocked_jwt_token")
-
+    assert header_key == "Authorization"
+    assert header_value == "Bearer mocked_jwt_token"

--- a/app/tests/intergrations/test_notify.py
+++ b/app/tests/intergrations/test_notify.py
@@ -80,9 +80,3 @@ def test_successful_creation_of_header(self, mock_header, mock_jwt_token):
     self.assertEqual(header_key, "Authorization")
     self.assertEqual(header_value, "Bearer mocked_jwt_token")
 
-    result = notify.create_authorization_header()
-    assert result
-
-    assert notify.create_authorization_header.
-    assert notify.create_authorization_header == ("Authorization, "Bearer foo")
-    return "Authorization", "Bearer {}".format(token)

--- a/app/tests/intergrations/test_notify.py
+++ b/app/tests/intergrations/test_notify.py
@@ -1,0 +1,88 @@
+import jwt
+import os
+from integrations import notify
+from unittest.mock import patch
+
+# helper function to decode the token for testing
+
+
+def decode_token(token, secret):
+    return jwt.decode(token, key=secret, options={"verify_signature": True}, algorithms=["HS256"])
+
+
+@patch("integrations.notify.create_jwt_token")
+def test_create_jwt_token_secret_missing(jwt_token_mock):
+    assert notify.create_jwt_token(secret=None, client_id="client_id") == "Missing secret key"
+    jwt_token_mock.assert_called_once_with(secret=None, client_id="client_id")
+
+
+@patch("integrations.notify.create_jwt_token")
+def test_create_jwt_token_client_id_missing(jwt_token_mock):
+    assert notify.create_jwt_token(secret="secret", client_id=None) == "Missing client id"
+    jwt_token_mock.assert_called_once_with(secret="secret", client_id=None)
+
+
+@patch("integrations.notify.create_jwt_token")
+def test_create_jwt_token_contains_correct_headers(jwt_token_mock):
+    token = notify.create_jwt_token(secret="secret", client_id="client_id")
+    assert jwt_token_mock.called_once_with(secret="secret", client_id="client_id")
+    headers = jwt.get_unverified_header(token)
+    assert headers["typ"] == "JWT"
+    assert headers["alg"] == "HS256"
+
+
+@patch("integrations.notify.create_jwt_token")
+def test_create_jwt_token_contains_correct_headers(jwt_token_mock):
+    token = notify.create_jwt_token(secret="secret", client_id="client_id")
+    decoded_token = decode_token(token, "secret")
+    assert decoded_token["iss"] == "client_id"
+    assert "iat" in decoded_token
+    assert "req" not in decoded_token
+    assert "pay" not in decoded_token
+
+
+@freeze_time("2020-01-01 00:00:00")
+@patch("integrations.notify.create_jwt_token")
+def test_token_contains_correct_iat(jwt_token_mock):
+    token = notify.create_jwt_token(secret="secret", client_id="client_id")
+    decoded_token = decode_token(token, "secret")
+    assert decoded_token["iat"] == 1577836800
+
+
+@patch.dict(
+    os.environ, {"SRE_USER_NAME": None, "SRE_CLIENT_SECRET": "foo"}, clear=True
+)
+@patch("integrations.notify.create_authorization_header")
+def test_authorization_header_missing_client_id(header_mock):
+    assert notify.create_authorization_header() == "SRE_USER_NAME or SRE_CLIENT_SECRET is missing"
+    header_mock.assert_called_once()
+
+
+@patch.dict(
+    os.environ, {"SRE_USER_NAME": "foo", "SRE_CLIENT_SECRET": None}, clear=True
+)
+@patch("integrations.notify.create_authorization_header")
+def test_authorization_header_missing_secret(header_mock):
+    assert notify.create_authorization_header() == "SRE_USER_NAME or SRE_CLIENT_SECRET is missing"
+    header_mock.assert_called_once()
+
+
+@patch("integrations.notify.create_jwt_token")
+@patch("integrations.notify.create_authorization_header")
+def test_successful_creation_of_header(self, mock_header, mock_jwt_token):
+    mock_jwt_token.return_value = "mocked_jwt_token"
+    header_key, header_value = notify.create_authorization_header()
+
+    # Check if the JWT token function was called with the right arguments
+    mock_jwt_token.assert_called_with(secret="test_secret", client_id="test_user")
+
+    # Assert the function returns the correct format of the authorization header
+    self.assertEqual(header_key, "Authorization")
+    self.assertEqual(header_value, "Bearer mocked_jwt_token")
+
+    result = notify.create_authorization_header()
+    assert result
+
+    assert notify.create_authorization_header.
+    assert notify.create_authorization_header == ("Authorization, "Bearer foo")
+    return "Authorization", "Bearer {}".format(token)


### PR DESCRIPTION
# Summary | Résumé

Uses the Notify API endpoint to automatically revoke an API key that has been compromised.  Right now, when an API key has been compromised, the API endpoint will be called and the key will be automatically revoked. 

I left the code in the opsgenie integration so that we will have the ability to create an alert if needed in the future.

We will just have to wait to merge this PR when prod credentials are generated and we can update them in the env. variables here.  