### PR TITLE
fix: update incident channel notes for testing

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -298,7 +298,11 @@ def submit(ack, view, say, body, client, logger):
     say(text=text, channel=channel_id)
 
     # Reminder to brief up
-    text = ":rotating_light: If this is a cybersecurity incident, please initiate the briefing process for CCCS and TBS OCIO Cyber"
+    text = ":one: Is this a `cybersecurity incident`? Please initiate the briefing process for CCCS and TBS OCIO Cyber"
+    say(text=text, channel=channel_id)
+
+    # Reminder to stop planned testing
+    text = ":two: Is there active `penetration or performance testing`? Please stop it immediately"
     say(text=text, channel=channel_id)
 
     # Invite oncall to channel


### PR DESCRIPTION
# Summary
Update the messages added to a new incident channel to remind teams to stop any planned penetration or performance testing.  The notes will now look like so:

![image](https://github.com/cds-snc/sre-bot/assets/2110107/5062ad0a-d693-444b-bced-9e710f004c31)
# Related
- Closes cds-snc/platform-core-services#513