### PR TITLE
fix: update pickle string scope

### DIFF
--- a/scripts/google_pickle_string/get_google_pickle_string.py
+++ b/scripts/google_pickle_string/get_google_pickle_string.py
@@ -3,7 +3,7 @@ import pickle
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 SCOPES = [
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/docs",
     "https://www.googleapis.com/auth/spreadsheets",
 ]

--- a/scripts/google_pickle_string/requirements.txt
+++ b/scripts/google_pickle_string/requirements.txt
@@ -1,4 +1,3 @@
-
-google-api-python-client
-google-auth-httplib2
-google-auth-oauthlib
+google-api-python-client==2.109.0
+google-auth-httplib2==0.1.1
+google-auth-oauthlib==1.1.0


### PR DESCRIPTION
# Summary
Update the pickle string scope to be all Google Drive items.  This is being done as we're relying on the explicit permissions of the SRE Bot Google user to grant access to the bot.