### PR TITLE
Fix circular reference of alarms

### DIFF
--- a/.github/workflows/ci_container.yml
+++ b/.github/workflows/ci_container.yml
@@ -31,9 +31,3 @@ jobs:
           -t sre-bot:latest \
           -t $REGISTRY/sre-bot:$GITHUB_SHA-`date '+%Y-%m-%d'` \
           -t $REGISTRY/sre-bot:latest .
-
-      - name: Dive into container
-        uses: cds-snc/dive-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_NAME: sre-bot:latest

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "sre_bot_error" {
   name           = local.error_logged
-  pattern        = "?ERROR ?Error"
+  pattern        = "?ERROR:slack_bolt.App"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "sre_bot_error" {
 
 resource "aws_cloudwatch_log_metric_filter" "sre_bot_warning" {
   name           = local.warning_logged
-  pattern        = "?WARNING ?Warning"
+  pattern        = "?WARNING:slack_bolt.App"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé

Changing the alarms to pick up on Errors logged from the sre bot application and not all errors. If you do all errors, it picks up from the alarm name when it is alerting. 