### PR TITLE
Fixing up a bug where if the incident creator is in the channel, then don't invite them again 

### DIFF
--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -306,9 +306,12 @@ def submit(ack, view, say, body, client, logger):
     text = ":alphabet-yellow-question: Is someone `penetration or performance testing`? Please stop it to make your life easier."
     say(text=text, channel=channel_id)
 
+
     # Invite oncall to channel
     for user in oncall:
-        client.conversations_invite(channel=channel_id, users=user["id"])
+        # if the incident creator is also oncall, don't invite them again
+        if user is not user_id: 
+            client.conversations_invite(channel=channel_id, users=user["id"])
 
     # Invite the @security users to channel
     response = client.usergroups_users_list(usergroup=SLACK_SECURITY_USER_GROUP_ID)

--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -306,11 +306,10 @@ def submit(ack, view, say, body, client, logger):
     text = ":alphabet-yellow-question: Is someone `penetration or performance testing`? Please stop it to make your life easier."
     say(text=text, channel=channel_id)
 
-
     # Invite oncall to channel
     for user in oncall:
         # if the incident creator is also oncall, don't invite them again
-        if user is not user_id: 
+        if user is not user_id:
             client.conversations_invite(channel=channel_id, users=user["id"])
 
     # Invite the @security users to channel

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -740,7 +740,7 @@ def test_incident_submit_pulls_oncall_people_into_the_channel(
         ]
     )
 
-    
+
 @patch("commands.incident.google_drive.update_incident_list")
 @patch("commands.incident.google_drive.merge_data")
 @patch("commands.incident.google_drive.create_new_incident")

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -733,9 +733,9 @@ def test_incident_submit_pulls_oncall_people_into_the_channel(
     client.conversations_invite.assert_has_calls(
         [
             call(channel="channel_id", users="creator_user_id"),
-            call(channel="channel_id", users="on_call_user_id"),
             call(
-                channel="channel_id", users=["security_user_id_1", "security_user_id_2"]
+                channel="channel_id",
+                users=["on_call_user_id", "security_user_id_1", "security_user_id_2"],
             ),
         ]
     )
@@ -794,6 +794,61 @@ def test_incident_submit_does_not_invite_on_call_if_already_in_channel(
             call(
                 channel="channel_id", users=["security_user_id_1", "security_user_id_2"]
             ),
+        ]
+    )
+
+
+@patch("commands.incident.google_drive.update_incident_list")
+@patch("commands.incident.google_drive.merge_data")
+@patch("commands.incident.google_drive.create_new_incident")
+@patch("commands.incident.google_drive.list_metadata")
+@patch("commands.incident.opsgenie.get_on_call_users")
+@patch("commands.incident.log_to_sentinel")
+def test_incident_submit_does_not_invite_security_group_members_already_in_channel(
+    _log_to_sentinel_mock,
+    mock_get_on_call_users,
+    mock_list_metadata,
+    mock_create_new_incident,
+    mock_merge_data,
+    mock_update_incident_list,
+):
+    ack = MagicMock()
+    logger = MagicMock()
+    view = helper_generate_view()
+    say = MagicMock()
+    body = {"user": {"id": "creator_user_id"}, "trigger_id": "trigger_id", "view": view}
+    client = MagicMock()
+    client.conversations_create.return_value = {
+        "channel": {"id": "channel_id", "name": "channel_name"}
+    }
+    client.users_lookupByEmail.return_value = {
+        "ok": True,
+        "user": {
+            "id": "on_call_user_id",
+            "profile": {"display_name_normalized": "name"},
+        },
+    }
+    client.usergroups_users_list.return_value = {
+        "ok": True,
+        "users": [
+            "creator_user_id",
+            "security_user_id_2",
+        ],
+    }
+
+    mock_create_new_incident.return_value = "id"
+
+    mock_get_on_call_users.return_value = ["email"]
+    mock_list_metadata.return_value = {"appProperties": {"genie_schedule": "oncall"}}
+
+    incident.submit(ack, view, say, body, client, logger)
+    mock_get_on_call_users.assert_called_once_with("oncall")
+    client.users_lookupByEmail.assert_any_call(email="email")
+    client.usergroups_users_list(usergroup="SLACK_SECURITY_USER_GROUP_ID")
+    client.conversations_invite.assert_has_calls(
+        [
+            call(channel="channel_id", users="creator_user_id"),
+            call(channel="channel_id", users=["on_call_user_id", "security_user_id_2"]),
         ]
     )
 


### PR DESCRIPTION
# Summary | Résumé

Closes #342 

Fixing up a bug that if someone is already in a channel and the sre bot tries to invite them again, an error is generated and subsequent calls don't get executed. 