### PR TITLE
feat: add Slack `/sre vpn` commands

### DIFF
--- a/app/commands/helpers/vpn_helper.py
+++ b/app/commands/helpers/vpn_helper.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 
+from commands.utils import log_to_sentinel
 from integrations.aws_client_vpn import AWSClientVPN
 
 
@@ -152,6 +153,15 @@ def vpn_on(ack, view, client, body, logger):
             f"```Reason: {reason}```\n\n"
             f"This can take up to 5 minutes.  Use the following to check the status.\n"
             f"```/sre vpn status```"
+        )
+        log_to_sentinel(
+            "vpn_turned_on",
+            {
+                "vpn": vpn,
+                "duration": duration,
+                "reason": reason,
+                "slack_user": body["user"],
+            },
         )
     else:
         result = f"{get_status_icon(status)} There was an error turning on the `{vpn}` VPN.  Please contact SRE for help."

--- a/app/commands/helpers/vpn_helper.py
+++ b/app/commands/helpers/vpn_helper.py
@@ -122,7 +122,6 @@ def vpn_on(ack, view, client, body, logger):
 
     # Get inputs and validate
     errors = {}
-    user = body["user"]["id"]
     vpn = view["state"]["values"]["vpn"]["vpn"]["selected_option"]["value"]
     duration = view["state"]["values"]["duration"]["duration"]["selected_option"][
         "value"
@@ -163,9 +162,7 @@ def vpn_on(ack, view, client, body, logger):
         reason,
         body["user"],
     )
-    client.chat_postEphemeral(
-        channel=VPN_PRODUCTS[vpn]["channel_id"], text=result, user=user
-    )
+    client.chat_postMessage(channel=VPN_PRODUCTS[vpn]["channel_id"], text=result)
 
 
 def vpn_status_modal(client, body):

--- a/app/commands/helpers/vpn_helper.py
+++ b/app/commands/helpers/vpn_helper.py
@@ -14,10 +14,12 @@ help_text = """
 """
 
 # Comma separated list of products that have an AWS client VPN installed
+VPN_DURATIONS = os.environ.get("VPN_DURATIONS", "1,4,8").split(",")
 VPN_PRODUCTS = os.environ.get("VPN_PRODUCTS", "").split(",")
 
 
-def handle_webhook_command(args, client, body, respond):
+def handle_vpn_command(args, client, body, respond):
+    "Top level routing of the VPN subcommands"
     if len(args) == 0:
         respond(help_text)
         return
@@ -36,63 +38,53 @@ def handle_webhook_command(args, client, body, respond):
                 "Tapez `/sre vpn help` pour voir une liste de commandes."
             )
 
-def vpn_on(ack, view, body, logger, client, say):
-    ack()
-
-    errors = {}
-
-    print(view["state"]["values"])
-
-    product = view["state"]["values"]["product"]["product"]["selected_option"]["value"]
-    reason = view["state"]["values"]["reason"]["reason"]["value"]
-    if not product:
-        errors["product"] = "Please select a product"
-    if not reason:
-        errors["reason"] = "Please enter a reason"
-
-    if len(errors) > 0:
-        ack(response_action="errors", errors=errors)
-        return
-
 
 def vpn_on_modal(client, body):
-    vpn_products = [
-        {
-            "text": {"type": "plain_text", "text": product["name"]},
-            "value": product["id"],
-        }
-        for product in VPN_PRODUCTS
-    ]    
+    "Open the VPN on modal" 
     client.views_open(
         trigger_id=body["trigger_id"],
         view={
             "type": "modal",
-            "callback_id": "vpn_on_view",
-            "title": {"type": "plain_text", "text": "SRE - turn on AWS client VPN"},
-            "submit": {"type": "plain_text", "text": "Submit"},
+            "callback_id": "vpn_on",
+            "title": {"type": "plain_text", "text": "SRE - VPN On"},
+            "submit": {"type": "plain_text", "text": "Turn on"},
             "blocks": [
                 {
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Select the product VPN that you would like to turn on",
+                        "text": "Select the VPN you would like to turn on",
                         "emoji": True,
                     },
                 },
                 {
-                    "block_id": "product",
+                    "block_id": "vpn",
                     "type": "input",
                     "element": {
                         "type": "static_select",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Select a product",
+                            "text": "Select a VPN",
                         },
-                        "options": vpn_products,
-                        "action_id": "product",
+                        "options": get_select_options(VPN_PRODUCTS),
+                        "action_id": "vpn",
                     },
-                    "label": {"type": "plain_text", "text": "Product", "emoji": True},
-                },                
+                    "label": {"type": "plain_text", "text": "VPN", "emoji": True},
+                },
+                {
+                    "block_id": "duration",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a duration",
+                        },
+                        "options": get_select_options(VPN_DURATIONS, transform=lambda time: f"{time} hour{'' if time == '1' else 's'}"),
+                        "action_id": "duration",
+                    },
+                    "label": {"type": "plain_text", "text": "How long should it stay on?", "emoji": True},
+                },                                
                 {
                     "block_id": "reason",
                     "type": "input",
@@ -102,9 +94,47 @@ def vpn_on_modal(client, body):
                     },
                     "label": {
                         "type": "plain_text",
-                        "text": "Why is the VPN being turned on?",
+                        "text": "Why is it being turned on?",
                     },
                 },
             ],
         },
     )
+
+
+def vpn_on(ack, view, client, body, logger):
+    "VPN on modal submission handler"
+    ack()
+
+    errors = {}
+
+    user = body["user"]["id"]
+    vpn = view["state"]["values"]["vpn"]["vpn"]["selected_option"]["value"]
+    duration = view["state"]["values"]["duration"]["duration"]["selected_option"]["value"]
+    reason = view["state"]["values"]["reason"]["reason"]["value"]
+
+    if not vpn:
+        errors["vpn"] = "Please select a VPN to turn on"
+    if not reason:
+        errors["reason"] = "Please enter a reason"
+    if duration not in VPN_DURATIONS:
+        errors["duration"] = "Please select a valid duration"
+
+    if len(errors) > 0:
+        ack(response_action="errors", errors=errors)
+        return
+    
+    result = f":large_green_circle: `{vpn}` VPN turning on for `{duration} hour{'' if duration == '1' else 's'}`.  This can take a few minutes and you can check with `/sre vpn status`.\n\nThe VPN is being turned on for the following reason:\n```{reason}```"
+    logger.info("VPN On: vpn: %s, duration: %s, reason: %s, slack user: %s, ", vpn, duration, reason, body["user"])
+    client.chat_postMessage(channel=user, text=result)
+
+
+def get_select_options(options_list, transform=lambda x: x):
+    "Helper function to generate a list of select options"
+    return [
+        {
+            "text": {"type": "plain_text", "text": f"{transform(option)}", "emoji": True},
+            "value": option,
+        }
+        for option in options_list
+    ]

--- a/app/commands/helpers/vpn_helper.py
+++ b/app/commands/helpers/vpn_helper.py
@@ -1,0 +1,110 @@
+import os
+
+
+help_text = """
+\n `/sre vpn on`
+\n      - turn on the VPN 
+\n      - activer le RVP
+\n `/sre vpn off`
+\n      - turn off the VPN
+\n      - désactiver le RPV
+\n `/sre vpn status`
+\n      - get the VPN's status
+\n      - obtenir le statut du RPV
+"""
+
+# Comma separated list of products that have an AWS client VPN installed
+VPN_PRODUCTS = os.environ.get("VPN_PRODUCTS", "").split(",")
+
+
+def handle_webhook_command(args, client, body, respond):
+    if len(args) == 0:
+        respond(help_text)
+        return
+
+    action, *args = args
+    match action:
+        case "help":
+            respond(help_text)         
+        case "on":
+            vpn_on_modal(client, body)          
+        case _:
+            respond(
+                f"Unknown command: `{action}`. "
+                "Type `/sre vpn help` to see a list of commands.\n"
+                f"Commande inconnue: `{action}`. "
+                "Tapez `/sre vpn help` pour voir une liste de commandes."
+            )
+
+def vpn_on(ack, view, body, logger, client, say):
+    ack()
+
+    errors = {}
+
+    print(view["state"]["values"])
+
+    product = view["state"]["values"]["product"]["product"]["selected_option"]["value"]
+    reason = view["state"]["values"]["reason"]["reason"]["value"]
+    if not product:
+        errors["product"] = "Please select a product"
+    if not reason:
+        errors["reason"] = "Please enter a reason"
+
+    if len(errors) > 0:
+        ack(response_action="errors", errors=errors)
+        return
+
+
+def vpn_on_modal(client, body):
+    vpn_products = [
+        {
+            "text": {"type": "plain_text", "text": product["name"]},
+            "value": product["id"],
+        }
+        for product in VPN_PRODUCTS
+    ]    
+    client.views_open(
+        trigger_id=body["trigger_id"],
+        view={
+            "type": "modal",
+            "callback_id": "vpn_on_view",
+            "title": {"type": "plain_text", "text": "SRE - turn on AWS client VPN"},
+            "submit": {"type": "plain_text", "text": "Submit"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select the product VPN that you would like to turn on",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "product",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a product",
+                        },
+                        "options": vpn_products,
+                        "action_id": "product",
+                    },
+                    "label": {"type": "plain_text", "text": "Product", "emoji": True},
+                },                
+                {
+                    "block_id": "reason",
+                    "type": "input",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "reason",
+                    },
+                    "label": {
+                        "type": "plain_text",
+                        "text": "Why is the VPN being turned on?",
+                    },
+                },
+            ],
+        },
+    )

--- a/app/commands/helpers/vpn_helper.py
+++ b/app/commands/helpers/vpn_helper.py
@@ -1,13 +1,12 @@
 import os
 
+from integrations.aws_client_vpn import AWSClientVPN
+
 
 help_text = """
 \n `/sre vpn on`
-\n      - turn on the VPN 
+\n      - turn on the VPN
 \n      - activer le RVP
-\n `/sre vpn off`
-\n      - turn off the VPN
-\n      - désactiver le RPV
 \n `/sre vpn status`
 \n      - get the VPN's status
 \n      - obtenir le statut du RPV
@@ -15,7 +14,13 @@ help_text = """
 
 # Comma separated list of products that have an AWS client VPN installed
 VPN_DURATIONS = os.environ.get("VPN_DURATIONS", "1,4,8").split(",")
-VPN_PRODUCTS = os.environ.get("VPN_PRODUCTS", "").split(",")
+VPN_PRODUCTS = {
+    "Notify": {
+        "channel_id": os.environ.get("VPN_NOTIFY_CHANNEL_ID"),
+        "vpn_id": os.environ.get("VPN_NOTIFY_ID"),
+        "role_arn": os.environ.get("VPN_NOTIFY_ROLE_ARN"),
+    }
+}
 
 
 def handle_vpn_command(args, client, body, respond):
@@ -27,9 +32,11 @@ def handle_vpn_command(args, client, body, respond):
     action, *args = args
     match action:
         case "help":
-            respond(help_text)         
+            respond(help_text)
         case "on":
-            vpn_on_modal(client, body)          
+            vpn_on_modal(client, body)
+        case "status":
+            vpn_status_modal(client, body)
         case _:
             respond(
                 f"Unknown command: `{action}`. "
@@ -40,7 +47,7 @@ def handle_vpn_command(args, client, body, respond):
 
 
 def vpn_on_modal(client, body):
-    "Open the VPN on modal" 
+    "Open the VPN on modal"
     client.views_open(
         trigger_id=body["trigger_id"],
         view={
@@ -53,7 +60,7 @@ def vpn_on_modal(client, body):
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Select the VPN you would like to turn on",
+                        "text": "Select the VPN to turn on",
                         "emoji": True,
                     },
                 },
@@ -66,7 +73,7 @@ def vpn_on_modal(client, body):
                             "type": "plain_text",
                             "text": "Select a VPN",
                         },
-                        "options": get_select_options(VPN_PRODUCTS),
+                        "options": get_select_options(VPN_PRODUCTS.keys()),
                         "action_id": "vpn",
                     },
                     "label": {"type": "plain_text", "text": "VPN", "emoji": True},
@@ -80,11 +87,18 @@ def vpn_on_modal(client, body):
                             "type": "plain_text",
                             "text": "Select a duration",
                         },
-                        "options": get_select_options(VPN_DURATIONS, transform=lambda time: f"{time} hour{'' if time == '1' else 's'}"),
+                        "options": get_select_options(
+                            VPN_DURATIONS,
+                            transform=lambda time: f"{time} hour{'' if time == '1' else 's'}",
+                        ),
                         "action_id": "duration",
                     },
-                    "label": {"type": "plain_text", "text": "How long should it stay on?", "emoji": True},
-                },                                
+                    "label": {
+                        "type": "plain_text",
+                        "text": "How long should it stay on?",
+                        "emoji": True,
+                    },
+                },
                 {
                     "block_id": "reason",
                     "type": "input",
@@ -106,35 +120,143 @@ def vpn_on(ack, view, client, body, logger):
     "VPN on modal submission handler"
     ack()
 
+    # Get inputs and validate
     errors = {}
-
     user = body["user"]["id"]
     vpn = view["state"]["values"]["vpn"]["vpn"]["selected_option"]["value"]
-    duration = view["state"]["values"]["duration"]["duration"]["selected_option"]["value"]
+    duration = view["state"]["values"]["duration"]["duration"]["selected_option"][
+        "value"
+    ]
     reason = view["state"]["values"]["reason"]["reason"]["value"]
-
-    if not vpn:
-        errors["vpn"] = "Please select a VPN to turn on"
+    if vpn not in VPN_PRODUCTS.keys():
+        errors["vpn"] = "Please select a VPN from the dropdown"
     if not reason:
         errors["reason"] = "Please enter a reason"
     if duration not in VPN_DURATIONS:
         errors["duration"] = "Please select a valid duration"
-
     if len(errors) > 0:
         ack(response_action="errors", errors=errors)
         return
-    
-    result = f":large_green_circle: `{vpn}` VPN turning on for `{duration} hour{'' if duration == '1' else 's'}`.  This can take a few minutes and you can check with `/sre vpn status`.\n\nThe VPN is being turned on for the following reason:\n```{reason}```"
-    logger.info("VPN On: vpn: %s, duration: %s, reason: %s, slack user: %s, ", vpn, duration, reason, body["user"])
-    client.chat_postMessage(channel=user, text=result)
+
+    # Get the VPN status and respond to the user
+    client_vpn = AWSClientVPN(
+        client_vpn_id=VPN_PRODUCTS[vpn]["vpn_id"],
+        assume_role_arn=VPN_PRODUCTS[vpn]["role_arn"],
+    )
+    status = client_vpn.turn_on()
+    if status == AWSClientVPN.STATUS_ON:
+        result = f"{get_status_icon(status)} The `{vpn}` VPN is `{status}`."
+    elif status == AWSClientVPN.STATUS_TURNING_ON:
+        result = (
+            f"{get_status_icon(status)} The `{vpn}` VPN is `{status}` for {duration} hour{'' if duration == '1' else 's'}:\n"
+            f"```{reason}```\n\n"
+            f"This can take up to 5 minutes.  Use the following to check the status.\n"
+            f"```/sre vpn status```"
+        )
+    else:
+        result = f"{get_status_icon(status)} There was an error turning on the `{vpn}` VPN.  Please contact SRE for assistance."
+    logger.info(
+        "VPN On: vpn: %s, duration: %s, reason: %s, slack user: %s, ",
+        vpn,
+        duration,
+        reason,
+        body["user"],
+    )
+    client.chat_postEphemeral(
+        channel=VPN_PRODUCTS[vpn]["channel_id"], text=result, user=user
+    )
+
+
+def vpn_status_modal(client, body):
+    "Open the VPN status modal"
+    client.views_open(
+        trigger_id=body["trigger_id"],
+        view={
+            "type": "modal",
+            "callback_id": "vpn_status",
+            "title": {"type": "plain_text", "text": "SRE - VPN Status"},
+            "submit": {"type": "plain_text", "text": "Get status"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select the VPN",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "vpn",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a VPN",
+                        },
+                        "options": get_select_options(VPN_PRODUCTS.keys()),
+                        "action_id": "vpn",
+                    },
+                    "label": {"type": "plain_text", "text": "VPN", "emoji": True},
+                },
+            ],
+        },
+    )
+
+
+def vpn_status(ack, view, client, body, logger):
+    "VPN status modal submission handler"
+    ack()
+
+    # Get inputs and validate
+    errors = {}
+    user = body["user"]["id"]
+    vpn = view["state"]["values"]["vpn"]["vpn"]["selected_option"]["value"]
+    if vpn not in VPN_PRODUCTS.keys():
+        errors["vpn"] = "Please select a VPN from the dropdown"
+    if len(errors) > 0:
+        ack(response_action="errors", errors=errors)
+        return
+
+    # Get the VPN status and respond to the user
+    client_vpn = AWSClientVPN(
+        client_vpn_id=VPN_PRODUCTS[vpn]["vpn_id"],
+        assume_role_arn=VPN_PRODUCTS[vpn]["role_arn"],
+    )
+    status = client_vpn.get_status()
+    result = f"{get_status_icon(status)} The `{vpn}` VPN is `{status}`."
+
+    logger.info(
+        "VPN status: vpn: %s, status: %s, slack user: %s, ",
+        vpn,
+        status,
+        body["user"],
+    )
+    client.chat_postEphemeral(
+        channel=VPN_PRODUCTS[vpn]["channel_id"], text=result, user=user
+    )
 
 
 def get_select_options(options_list, transform=lambda x: x):
     "Helper function to generate a list of select options"
     return [
         {
-            "text": {"type": "plain_text", "text": f"{transform(option)}", "emoji": True},
+            "text": {
+                "type": "plain_text",
+                "text": f"{transform(option)}",
+                "emoji": True,
+            },
             "value": option,
         }
         for option in options_list
     ]
+
+
+def get_status_icon(status):
+    "Helper function to get the icon for the status"
+    if status == AWSClientVPN.STATUS_ON:
+        return ":large_green_circle:"
+    elif status in [AWSClientVPN.STATUS_TURNING_ON, AWSClientVPN.STATUS_TURNING_OFF]:
+        return ":large_yellow_circle:"
+    else:
+        return ":red_circle:"

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -2,7 +2,12 @@ import os
 
 from commands import utils
 
-from commands.helpers import geolocate_helper, incident_helper, vpn_helper, webhook_helper
+from commands.helpers import (
+    geolocate_helper,
+    incident_helper,
+    vpn_helper,
+    webhook_helper,
+)
 
 help_text = """
 \n `/sre help`
@@ -51,7 +56,7 @@ def sre_command(ack, command, logger, respond, client, body):
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
         case "vpn":
-            vpn_helper.handle_vpn_command(args, client, body, respond)            
+            vpn_helper.handle_vpn_command(args, client, body, respond)
         case _:
             respond(
                 f"Unknown command: `{action}`. Type `/sre help` to see a list of commands. \nCommande inconnue: `{action}`. Entrez `/sre help` pour une liste des commandes valides"

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -51,7 +51,7 @@ def sre_command(ack, command, logger, respond, client, body):
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
         case "vpn":
-            vpn_helper.handle_webhook_command(args, client, body, respond)            
+            vpn_helper.handle_vpn_command(args, client, body, respond)            
         case _:
             respond(
                 f"Unknown command: `{action}`. Type `/sre help` to see a list of commands. \nCommande inconnue: `{action}`. Entrez `/sre help` pour une liste des commandes valides"

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -2,7 +2,7 @@ import os
 
 from commands import utils
 
-from commands.helpers import geolocate_helper, incident_helper, webhook_helper
+from commands.helpers import geolocate_helper, incident_helper, vpn_helper, webhook_helper
 
 help_text = """
 \n `/sre help`
@@ -14,6 +14,9 @@ help_text = """
 \n `/sre incident`
 \n      - lists incident commands
 \n      - lister les commandes d'incidents
+\n `/sre vpn`
+\n      - lists VPN commands
+\n      - lister les commandes du RPV
 \n `/sre webhooks`
 \n      - lists webhook commands
 \n      - lister les commandes de liens de rappel HTTP
@@ -47,6 +50,8 @@ def sre_command(ack, command, logger, respond, client, body):
             webhook_helper.handle_webhook_command(args, client, body, respond)
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
+        case "vpn":
+            vpn_helper.handle_webhook_command(args, client, body, respond)            
         case _:
             respond(
                 f"Unknown command: `{action}`. Type `/sre help` to see a list of commands. \nCommande inconnue: `{action}`. Entrez `/sre help` pour une liste des commandes valides"

--- a/app/integrations/aws_client_vpn.py
+++ b/app/integrations/aws_client_vpn.py
@@ -6,79 +6,172 @@ from botocore.exceptions import ClientError
 
 AWS_REGION = os.environ.get("AWS_REGION", "ca-central-1")
 
+
 class AWSClientVPN:
-    def __init__(self, client_vpn_id, region_name=AWS_REGION):
-        self.client = boto3.client('ec2', region_name=region_name)
+    """
+    Manage an account's client VPN endpoint.
+    """
+
+    STATUS_ON = "on"
+    STATUS_OFF = "off"
+    STATUS_TURNING_ON = "turning-on"
+    STATUS_TURNING_OFF = "turning-off"
+    STATUS_ERROR = "error"
+
+    def __init__(self, client_vpn_id, assume_role_arn, region_name=AWS_REGION):
+        """
+        Initializes the AWSClientVPN class with the client VPN ID and an boto3 `ec2`
+        client that has assumed the role required to manage the account's client VPN.
+        """
+        logging.info(
+            f"Initializing AWSClientVPN for client_vpn_id: {client_vpn_id} with assume_role_arn: {assume_role_arn}"
+        )
         self.client_vpn_id = client_vpn_id
 
+        client = boto3.client("sts")
+        response = client.assume_role(
+            RoleArn=assume_role_arn, RoleSessionName="SREBot_Client_VPN_Role"
+        )
+        session = boto3.Session(
+            aws_access_key_id=response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+            aws_session_token=response["Credentials"]["SessionToken"],
+        )
+        self.client = session.client("ec2", region_name=region_name)
+
     def get_status(self):
+        """
+        Returns the status of the client VPN endpoint.
+        """
         status = "error"
-        response = self.client.describe_client_vpn_endpoints(ClientVpnEndpointIds=[self.client_vpn_id])
-        
-        if response['ClientVpnEndpoints']:
-            statusCode = response['ClientVpnEndpoints'][0]['Status']['Code']
+        response = self.client.describe_client_vpn_endpoints(
+            ClientVpnEndpointIds=[self.client_vpn_id]
+        )
+
+        if response["ClientVpnEndpoints"]:
+            statusCode = response["ClientVpnEndpoints"][0]["Status"]["Code"]
             if statusCode == "available":
-                status = "on"
+                status = self.STATUS_ON
             else:
-                response = self.client.describe_client_vpn_target_networks(ClientVpnEndpointId=self.client_vpn_id)
+                response = self.client.describe_client_vpn_target_networks(
+                    ClientVpnEndpointId=self.client_vpn_id
+                )
                 if response["ClientVpnTargetNetworks"]:
-                    networkStatus = [network["Status"].get("Code") for network in response["ClientVpnTargetNetworks"] if "Status" in network]
+                    networkStatus = [
+                        network["Status"].get("Code")
+                        for network in response["ClientVpnTargetNetworks"]
+                        if "Status" in network
+                    ]
                     if "associating" in networkStatus:
-                        status = "turning-on"
+                        status = self.STATUS_TURNING_ON
                     elif "disassociating" in networkStatus:
-                        status = "turning-off"
-                    else:
-                        status = "off"
-        else:
-            logging.
+                        status = self.STATUS_TURNING_OFF
+                else:
+                    status = self.STATUS_OFF
+
+        logging.info(f"Client VPN status: {status}")
+        logging.info(f"Client VPN response: {response}")
         return status
 
-
     def turn_on(self):
-        status = self.get_status()
-        if status in ["on", "turning-on"]:
-            print("VPN is already on")
-            return
+        """
+        Creates an association for the client VPN for all subnets that have an authorization rule.
+        It identifies the subnets by the authorization rule's destination CIDR.  Any client VPN
+        authorization rule for a single IP address `/32` is ignored.
 
-        response = self.client.describe_client_vpn_authorization_rules(ClientVpnEndpointId=self.client_vpn_id)
-        if response['AuthorizationRules']:
-            subnets_cidrs = [subnet['DestinationCidr'] for subnet in response['AuthorizationRules'] if not subnet['DestinationCidr'].endswith('/32')]
-            
+        The result of this method is that the client VPN will begin associating subnets which
+        can take up to 5 minutes before it completes.
+        """
+        status = self.get_status()
+        if status in [self.STATUS_ON, self.STATUS_TURNING_ON]:
+            logging.info(f"Client VPN is already on or turning on: {status}")
+            return status
+
+        status = self.STATUS_ERROR
+        response = self.client.describe_client_vpn_authorization_rules(
+            ClientVpnEndpointId=self.client_vpn_id
+        )
+        logging.info(
+            f"Client VPN describe_client_vpn_authorization_rules response: {response}"
+        )
+
+        if response["AuthorizationRules"]:
+            subnets_cidrs = [
+                subnet["DestinationCidr"]
+                for subnet in response["AuthorizationRules"]
+                if not subnet["DestinationCidr"].endswith("/32")
+            ]
+
             if subnets_cidrs:
                 response = self.client.describe_subnets(
-                    Filters=[
-                        {'Name': 'cidr-block', 'Values': subnets_cidrs}
-                    ]
+                    Filters=[{"Name": "cidr-block", "Values": subnets_cidrs}]
                 )
+                logging.info(f"Client VPN describe_subnets response: {response}")
+
                 if response["Subnets"]:
-                    subnet_ids = [subnet['SubnetId'] for subnet in response["Subnets"]]
+                    subnet_ids = [subnet["SubnetId"] for subnet in response["Subnets"]]
                     for id in subnet_ids:
                         try:
                             response = self.client.associate_client_vpn_target_network(
-                                ClientVpnEndpointId=self.client_vpn_id,
-                                SubnetId=id
+                                ClientVpnEndpointId=self.client_vpn_id, SubnetId=id
+                            )
+                            logging.info(
+                                f"Client VPN associate_client_vpn_target_network response: {response}"
                             )
                         except ClientError as error:
-                            if error.response['Error']['Code'] != 'InvalidClientVpnDuplicateAssociation':
-                               raise error
-    
+                            if (
+                                error.response["Error"]["Code"]
+                                == "InvalidClientVpnDuplicateAssociation"
+                            ):
+                                logging.info(
+                                    f"Client VPN associate_client_vpn_target_network already associated: {error}"
+                                )
+                            else:
+                                logging.error(
+                                    f"Client VPN associate_client_vpn_target_network error: {error}"
+                                )
+                                raise error
+                    status = self.STATUS_TURNING_ON
+
+        logging.info(f"Client VPN turn_on status: {status}")
+        return status
 
     def turn_off(self):
-        response = self.client.describe_client_vpn_target_networks(ClientVpnEndpointId=self.client_vpn_id)
+        status = self.get_status()
+        if status in [self.STATUS_OFF, self.STATUS_TURNING_OFF]:
+            logging.info(f"Client VPN is already off or turning off: {status}")
+            return status
+
+        status = self.STATUS_ERROR
+        response = self.client.describe_client_vpn_target_networks(
+            ClientVpnEndpointId=self.client_vpn_id
+        )
+        logging.info(
+            f"Client VPN describe_client_vpn_target_networks response: {response}"
+        )
+
         if response["ClientVpnTargetNetworks"]:
-            association_ids = [association['AssociationId'] for association in response["ClientVpnTargetNetworks"] if association['Status']['Code'] == 'associated']
+            association_ids = [
+                association["AssociationId"]
+                for association in response["ClientVpnTargetNetworks"]
+                if association["Status"]["Code"] == "associated"
+            ]
 
             if association_ids:
                 for id in association_ids:
                     try:
                         response = self.client.disassociate_client_vpn_target_network(
-                            ClientVpnEndpointId=self.client_vpn_id,
-                            AssociationId=id
+                            ClientVpnEndpointId=self.client_vpn_id, AssociationId=id
                         )
-                        print(response)
+                        logging.info(
+                            f"Client VPN disassociate_client_vpn_target_network response: {response}"
+                        )
                     except ClientError as error:
-                        print(error)
+                        logging.error(
+                            f"Client VPN disassociate_client_vpn_target_network error: {error}"
+                        )
+                        raise error
+                status = self.STATUS_TURNING_OFF
 
-
-vpn = AWSClientVPN("cvpn-endpoint-010b27fdb479d5e19")
-print(vpn.turn_off())
+        logging.info(f"Client VPN turn_off status: {status}")
+        return status

--- a/app/integrations/aws_client_vpn.py
+++ b/app/integrations/aws_client_vpn.py
@@ -1,0 +1,84 @@
+import boto3
+import logging
+import os
+
+from botocore.exceptions import ClientError
+
+AWS_REGION = os.environ.get("AWS_REGION", "ca-central-1")
+
+class AWSClientVPN:
+    def __init__(self, client_vpn_id, region_name=AWS_REGION):
+        self.client = boto3.client('ec2', region_name=region_name)
+        self.client_vpn_id = client_vpn_id
+
+    def get_status(self):
+        status = "error"
+        response = self.client.describe_client_vpn_endpoints(ClientVpnEndpointIds=[self.client_vpn_id])
+        
+        if response['ClientVpnEndpoints']:
+            statusCode = response['ClientVpnEndpoints'][0]['Status']['Code']
+            if statusCode == "available":
+                status = "on"
+            else:
+                response = self.client.describe_client_vpn_target_networks(ClientVpnEndpointId=self.client_vpn_id)
+                if response["ClientVpnTargetNetworks"]:
+                    networkStatus = [network["Status"].get("Code") for network in response["ClientVpnTargetNetworks"] if "Status" in network]
+                    if "associating" in networkStatus:
+                        status = "turning-on"
+                    elif "disassociating" in networkStatus:
+                        status = "turning-off"
+                    else:
+                        status = "off"
+        else:
+            logging.
+        return status
+
+
+    def turn_on(self):
+        status = self.get_status()
+        if status in ["on", "turning-on"]:
+            print("VPN is already on")
+            return
+
+        response = self.client.describe_client_vpn_authorization_rules(ClientVpnEndpointId=self.client_vpn_id)
+        if response['AuthorizationRules']:
+            subnets_cidrs = [subnet['DestinationCidr'] for subnet in response['AuthorizationRules'] if not subnet['DestinationCidr'].endswith('/32')]
+            
+            if subnets_cidrs:
+                response = self.client.describe_subnets(
+                    Filters=[
+                        {'Name': 'cidr-block', 'Values': subnets_cidrs}
+                    ]
+                )
+                if response["Subnets"]:
+                    subnet_ids = [subnet['SubnetId'] for subnet in response["Subnets"]]
+                    for id in subnet_ids:
+                        try:
+                            response = self.client.associate_client_vpn_target_network(
+                                ClientVpnEndpointId=self.client_vpn_id,
+                                SubnetId=id
+                            )
+                        except ClientError as error:
+                            if error.response['Error']['Code'] != 'InvalidClientVpnDuplicateAssociation':
+                               raise error
+    
+
+    def turn_off(self):
+        response = self.client.describe_client_vpn_target_networks(ClientVpnEndpointId=self.client_vpn_id)
+        if response["ClientVpnTargetNetworks"]:
+            association_ids = [association['AssociationId'] for association in response["ClientVpnTargetNetworks"] if association['Status']['Code'] == 'associated']
+
+            if association_ids:
+                for id in association_ids:
+                    try:
+                        response = self.client.disassociate_client_vpn_target_network(
+                            ClientVpnEndpointId=self.client_vpn_id,
+                            AssociationId=id
+                        )
+                        print(response)
+                    except ClientError as error:
+                        print(error)
+
+
+vpn = AWSClientVPN("cvpn-endpoint-010b27fdb479d5e19")
+print(vpn.turn_off())

--- a/app/jobs/client_vpn_turn_off.py
+++ b/app/jobs/client_vpn_turn_off.py
@@ -1,0 +1,28 @@
+import datetime
+import logging
+
+from integrations.aws_client_vpn import AWSClientVPN
+
+logging.basicConfig(level=logging.INFO)
+
+
+def client_vpn_turn_off():
+    """
+    Turn off expired client VPN sessions.
+    """
+    logging.info("Looking for expired client VPN sessions")
+
+    client_vpn = AWSClientVPN()
+    vpn_sessions = client_vpn.get_vpn_sessions()
+    for session in vpn_sessions:
+        logging.info("Found VPN session %s", session)
+        remaining_seconds = (
+            float(session["expires_at"]["N"]) - datetime.datetime.now().timestamp()
+        )
+        if remaining_seconds < 0:
+            logging.info("Session %s has expired, turning off", session["SK"]["S"])
+            AWSClientVPN(
+                name=session["SK"]["S"],
+                vpn_id=session["vpn_id"]["S"],
+                assume_role_arn=session["assume_role_arn"]["S"],
+            ).turn_off()

--- a/app/jobs/scheduled_tasks.py
+++ b/app/jobs/scheduled_tasks.py
@@ -1,3 +1,4 @@
+from jobs.client_vpn_turn_off import client_vpn_turn_off
 from jobs.revoke_aws_sso_access import revoke_aws_sso_access
 from jobs.notify_stale_incident_channels import notify_stale_incident_channels
 import threading
@@ -17,6 +18,7 @@ def init(bot):
 
     schedule.every(10).seconds.do(revoke_aws_sso_access, client=bot.client)
     schedule.every(5).minutes.do(scheduler_heartbeat)
+    schedule.every(5).minutes.do(client_vpn_turn_off)
 
 
 def scheduler_heartbeat():

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,7 @@ def main(bot):
 
     # VPN events
     bot.view("vpn_on")(vpn_helper.vpn_on)
+    bot.view("vpn_status")(vpn_helper.vpn_status)
 
     SocketModeHandler(bot, APP_TOKEN).connect()
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt import App
 from dotenv import load_dotenv
 from commands import atip, aws, incident, sre, role
-from commands.helpers import incident_helper, webhook_helper
+from commands.helpers import incident_helper, vpn_helper, webhook_helper
 from server import bot_middleware, server
 
 from jobs import scheduled_tasks
@@ -68,6 +68,9 @@ def main(bot):
     bot.action("toggle_webhook")(webhook_helper.toggle_webhook)
     bot.action("reveal_webhook")(webhook_helper.reveal_webhook)
     bot.action("next_page")(webhook_helper.next_page)
+
+    # VPN events
+    bot.view("vpn_on")(vpn_helper.vpn_on)
 
     SocketModeHandler(bot, APP_TOKEN).connect()
 

--- a/app/tests/commands/helpers/test_vpn_helper.py
+++ b/app/tests/commands/helpers/test_vpn_helper.py
@@ -1,0 +1,475 @@
+from commands.helpers import vpn_helper
+
+
+from unittest.mock import call, MagicMock, patch
+
+
+def test_handle_vpn_empty_command():
+    respond = MagicMock()
+    vpn_helper.handle_vpn_command([], MagicMock(), MagicMock(), respond)
+    respond.assert_called_once_with(vpn_helper.help_text)
+
+
+def test_handle_vpn_unknown_command():
+    respond = MagicMock()
+    vpn_helper.handle_vpn_command(["foobar"], MagicMock(), MagicMock(), respond)
+    respond.assert_called_once_with(
+        "Unknown command: `foobar`. Type `/sre vpn help` to see a list of commands.\nCommande inconnue: `foobar`. Tapez `/sre vpn help` pour voir une liste de commandes."
+    )
+
+
+def test_handle_vpn_help_command():
+    client = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    vpn_helper.handle_vpn_command(
+        ["help"],
+        client,
+        body,
+        respond,
+    )
+    respond.assert_called_once_with(vpn_helper.help_text)
+
+
+@patch("commands.helpers.vpn_helper.vpn_on_modal")
+def test_handle_vpn_on_command(mock_vpn_on_modal):
+    client = MagicMock()
+    body = MagicMock()
+    vpn_helper.handle_vpn_command(["on"], client, body, MagicMock())
+    mock_vpn_on_modal.assert_called_with(client, body)
+
+
+@patch("commands.helpers.vpn_helper.vpn_status_modal")
+def test_handle_vpn_status_command(mock_vpn_status_modal):
+    client = MagicMock()
+    body = MagicMock()
+    vpn_helper.handle_vpn_command(["status"], client, body, MagicMock())
+    mock_vpn_status_modal.assert_called_with(client, body)
+
+
+@patch("commands.helpers.vpn_helper.VPN_PRODUCTS", {"vpn1": "", "vpn2": ""})
+def test_vpn_on_modal():
+    client = MagicMock()
+    body = {"trigger_id": "trigger_id"}
+    vpn_helper.vpn_on_modal(client, body)
+    client.views_open.assert_called_with(
+        trigger_id="trigger_id",
+        view={
+            "type": "modal",
+            "callback_id": "vpn_on",
+            "title": {"type": "plain_text", "text": "SRE - VPN On"},
+            "submit": {"type": "plain_text", "text": "Turn on"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select the VPN to turn on",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "vpn",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a VPN",
+                        },
+                        "options": [
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "vpn1",
+                                    "emoji": True,
+                                },
+                                "value": "vpn1",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "vpn2",
+                                    "emoji": True,
+                                },
+                                "value": "vpn2",
+                            },
+                        ],
+                        "action_id": "vpn",
+                    },
+                    "label": {"type": "plain_text", "text": "VPN", "emoji": True},
+                },
+                {
+                    "block_id": "duration",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a duration",
+                        },
+                        "options": [
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "1 hour",
+                                    "emoji": True,
+                                },
+                                "value": "1",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "4 hours",
+                                    "emoji": True,
+                                },
+                                "value": "4",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "8 hours",
+                                    "emoji": True,
+                                },
+                                "value": "8",
+                            },
+                        ],
+                        "action_id": "duration",
+                    },
+                    "label": {
+                        "type": "plain_text",
+                        "text": "How long should it stay on?",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "reason",
+                    "type": "input",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "reason",
+                    },
+                    "label": {
+                        "type": "plain_text",
+                        "text": "Why is it being turned on?",
+                    },
+                },
+            ],
+        },
+    )
+
+
+@patch(
+    "commands.helpers.vpn_helper.VPN_PRODUCTS",
+    {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
+)
+@patch("commands.helpers.vpn_helper.AWSClientVPN")
+def test_vpn_on(mock_aws_client_vpn):
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+                "duration": {"duration": {"selected_option": {"value": "1"}}},
+                "reason": {"reason": {"value": "because"}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    client_vpn = MagicMock()
+    mock_aws_client_vpn.return_value = client_vpn
+    mock_aws_client_vpn.STATUS_TURNING_ON = "turning-on"
+    client_vpn.turn_on.return_value = "turning-on"
+
+    vpn_helper.vpn_on(ack, view, client, body, logger)
+
+    ack.assert_called_once_with()
+    mock_aws_client_vpn.assert_called_with(
+        name="vpn1",
+        reason="because",
+        duration="1",
+        vpn_id="vpn-123",
+        assume_role_arn="test/role-name",
+    )
+    mock_aws_client_vpn().turn_on.assert_called_with()
+    client.chat_postMessage.assert_called_with(
+        channel="456",
+        text=":beach-ball: The `vpn1` VPN is `turning-on` for 1 hour:\n```Reason: because```\n\nThis can take up to 5 minutes.  Use the following to check the status.\n```/sre vpn status```",
+    )
+
+
+@patch(
+    "commands.helpers.vpn_helper.VPN_PRODUCTS",
+    {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
+)
+@patch("commands.helpers.vpn_helper.AWSClientVPN")
+def test_vpn_on_error(mock_aws_client_vpn):
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+                "duration": {"duration": {"selected_option": {"value": "1"}}},
+                "reason": {"reason": {"value": "because"}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    client_vpn = MagicMock()
+    mock_aws_client_vpn.return_value = client_vpn
+    mock_aws_client_vpn.STATUS_ERROR = "error"
+    client_vpn.turn_on.return_value = "error"
+
+    vpn_helper.vpn_on(ack, view, client, body, logger)
+
+    ack.assert_called_once_with()
+    mock_aws_client_vpn.assert_called_with(
+        name="vpn1",
+        reason="because",
+        duration="1",
+        vpn_id="vpn-123",
+        assume_role_arn="test/role-name",
+    )
+    mock_aws_client_vpn().turn_on.assert_called_with()
+    client.chat_postMessage.assert_called_with(
+        channel="456",
+        text=":red: There was an error turning on the `vpn1` VPN.  Please contact SRE for help.",
+    )
+
+
+def test_vpn_on_validation_error():
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+                "duration": {"duration": {"selected_option": {"value": "2"}}},
+                "reason": {"reason": {"value": ""}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+
+    vpn_helper.vpn_on(ack, view, client, body, logger)
+
+    ack.assert_has_calls(
+        [
+            call(),
+            call(
+                response_action="errors",
+                errors={
+                    "vpn": "Please select a VPN from the dropdown",
+                    "reason": "Please enter a reason",
+                    "duration": "Please select a valid duration",
+                },
+            ),
+        ]
+    )
+
+
+@patch("commands.helpers.vpn_helper.VPN_PRODUCTS", {"vpn1": "", "vpn2": ""})
+def test_vpn_status_modal():
+    client = MagicMock()
+    body = {"trigger_id": "trigger_id"}
+    vpn_helper.vpn_status_modal(client, body)
+    client.views_open.assert_called_with(
+        trigger_id="trigger_id",
+        view={
+            "type": "modal",
+            "callback_id": "vpn_status",
+            "title": {"type": "plain_text", "text": "SRE - VPN Status"},
+            "submit": {"type": "plain_text", "text": "Get status"},
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select the VPN",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "block_id": "vpn",
+                    "type": "input",
+                    "element": {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a VPN",
+                        },
+                        "options": [
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "vpn1",
+                                    "emoji": True,
+                                },
+                                "value": "vpn1",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "vpn2",
+                                    "emoji": True,
+                                },
+                                "value": "vpn2",
+                            },
+                        ],
+                        "action_id": "vpn",
+                    },
+                    "label": {"type": "plain_text", "text": "VPN", "emoji": True},
+                },
+            ],
+        },
+    )
+
+
+@patch(
+    "commands.helpers.vpn_helper.VPN_PRODUCTS",
+    {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
+)
+@patch("commands.helpers.vpn_helper.AWSClientVPN")
+def test_vpn_status_vpn_off(mock_aws_client_vpn):
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    client_vpn = MagicMock()
+    mock_aws_client_vpn.return_value = client_vpn
+    client_vpn.get_status.return_value = {"status": "off"}
+
+    vpn_helper.vpn_status(ack, view, client, body, logger)
+
+    ack.assert_called_once_with()
+    mock_aws_client_vpn.assert_called_with(
+        name="vpn1",
+        vpn_id="vpn-123",
+        assume_role_arn="test/role-name",
+    )
+    mock_aws_client_vpn().get_status.assert_called_with()
+    client.chat_postEphemeral.assert_called_with(
+        channel="456", text=":red: The `vpn1` VPN is `off`", user="user"
+    )
+
+
+@patch(
+    "commands.helpers.vpn_helper.VPN_PRODUCTS",
+    {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
+)
+@patch("commands.helpers.vpn_helper.AWSClientVPN")
+def test_vpn_status_vpn_turning_on(mock_aws_client_vpn):
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    client_vpn = MagicMock()
+    mock_aws_client_vpn.return_value = client_vpn
+    mock_aws_client_vpn.STATUS_TURNING_ON = "turning-on"
+    client_vpn.get_status.return_value = {
+        "status": "turning-on",
+        "session": {"duration": {"N": "4"}, "reason": {"S": "because"}},
+    }
+
+    vpn_helper.vpn_status(ack, view, client, body, logger)
+
+    ack.assert_called_once_with()
+    mock_aws_client_vpn.assert_called_with(
+        name="vpn1",
+        vpn_id="vpn-123",
+        assume_role_arn="test/role-name",
+    )
+    mock_aws_client_vpn().get_status.assert_called_with()
+    client.chat_postEphemeral.assert_called_with(
+        channel="456",
+        text=":beach-ball: The `vpn1` VPN is `turning-on` for 4 hours:\n```Reason: because```",
+        user="user",
+    )
+
+
+@patch(
+    "commands.helpers.vpn_helper.VPN_PRODUCTS",
+    {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
+)
+@patch("commands.helpers.vpn_helper.AWSClientVPN")
+@patch("commands.helpers.vpn_helper.datetime")
+def test_vpn_status_vpn_on(mock_datetime, mock_aws_client_vpn):
+    ack = MagicMock()
+    view = {
+        "state": {
+            "values": {
+                "vpn": {"vpn": {"selected_option": {"value": "vpn1"}}},
+            }
+        }
+    }
+    body = {"user": {"id": "user"}}
+    logger = MagicMock()
+    client = MagicMock()
+    client_vpn = MagicMock()
+    mock_aws_client_vpn.return_value = client_vpn
+    mock_aws_client_vpn.STATUS_ON = "on"
+    client_vpn.get_status.return_value = {
+        "status": "on",
+        "session": {
+            "duration": {"N": "4"},
+            "reason": {"S": "because"},
+            "expires_at": {"N": "1640092800"},
+        },
+    }
+    mock_datetime.datetime.now.return_value.timestamp.return_value = 1640081000
+
+    vpn_helper.vpn_status(ack, view, client, body, logger)
+
+    ack.assert_called_once_with()
+    mock_aws_client_vpn.assert_called_with(
+        name="vpn1",
+        vpn_id="vpn-123",
+        assume_role_arn="test/role-name",
+    )
+    mock_aws_client_vpn().get_status.assert_called_with()
+    client.chat_postEphemeral.assert_called_with(
+        channel="456",
+        text=":green: The `vpn1` VPN is `on` for 3 hours 16 minutes:\n```Reason: because```",
+        user="user",
+    )
+
+
+def test_get_select_options():
+    options = ["1", "4", "8"]
+    transform = lambda x: "hour" if x == "1" else "hours"  # noqa: E731
+    assert vpn_helper.get_select_options(options, transform=transform) == [
+        {"text": {"type": "plain_text", "text": "hour", "emoji": True}, "value": "1"},
+        {"text": {"type": "plain_text", "text": "hours", "emoji": True}, "value": "4"},
+        {"text": {"type": "plain_text", "text": "hours", "emoji": True}, "value": "8"},
+    ]
+
+
+def test_get_status_icon():
+    assert vpn_helper.get_status_icon("turning-on") == ":beach-ball:"
+    assert vpn_helper.get_status_icon("on") == ":green:"
+    assert vpn_helper.get_status_icon("off") == ":red:"
+    assert vpn_helper.get_status_icon("error") == ":red:"
+
+
+def test_pluralize():
+    assert vpn_helper.pluralize(1, "hour") == "1 hour"
+    assert vpn_helper.pluralize(2, "hour") == "2 hours"

--- a/app/tests/commands/helpers/test_vpn_helper.py
+++ b/app/tests/commands/helpers/test_vpn_helper.py
@@ -164,7 +164,8 @@ def test_vpn_on_modal():
     {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
 )
 @patch("commands.helpers.vpn_helper.AWSClientVPN")
-def test_vpn_on(mock_aws_client_vpn):
+@patch("commands.helpers.vpn_helper.log_to_sentinel")
+def test_vpn_on(mock_log_to_sentinel, mock_aws_client_vpn):
     ack = MagicMock()
     view = {
         "state": {
@@ -198,6 +199,15 @@ def test_vpn_on(mock_aws_client_vpn):
         channel="456",
         text=":beach-ball: The `vpn1` VPN is `turning-on` for 1 hour:\n```Reason: because```\n\nThis can take up to 5 minutes.  Use the following to check the status.\n```/sre vpn status```",
     )
+    mock_log_to_sentinel.assert_called_with(
+        "vpn_turned_on",
+        {
+            "vpn": "vpn1",
+            "duration": "1",
+            "reason": "because",
+            "slack_user": {"id": "user"},
+        },
+    )
 
 
 @patch(
@@ -205,7 +215,8 @@ def test_vpn_on(mock_aws_client_vpn):
     {"vpn1": {"vpn_id": "vpn-123", "role_arn": "test/role-name", "channel_id": "456"}},
 )
 @patch("commands.helpers.vpn_helper.AWSClientVPN")
-def test_vpn_on_error(mock_aws_client_vpn):
+@patch("commands.helpers.vpn_helper.log_to_sentinel")
+def test_vpn_on_error(mock_log_to_sentinel, mock_aws_client_vpn):
     ack = MagicMock()
     view = {
         "state": {
@@ -239,6 +250,7 @@ def test_vpn_on_error(mock_aws_client_vpn):
         channel="456",
         text=":red: There was an error turning on the `vpn1` VPN.  Please contact SRE for help.",
     )
+    mock_log_to_sentinel.assert_not_called()
 
 
 def test_vpn_on_validation_error():

--- a/app/tests/commands/test_sre.py
+++ b/app/tests/commands/test_sre.py
@@ -108,6 +108,18 @@ def test_sre_command_with_webhooks_argument(command_runner):
     command_runner.assert_called_once_with([], clientMock, body, respond)
 
 
+@patch("commands.sre.vpn_helper.handle_vpn_command")
+def test_sre_command_with_vpn_argument(command_runner):
+    command_runner.return_value = "vpn command help"
+    clientMock = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    sre.sre_command(
+        MagicMock(), {"text": "vpn"}, MagicMock(), respond, clientMock, body
+    )
+    command_runner.assert_called_once_with([], clientMock, body, respond)
+
+
 def test_sre_command_with_unknown_argument():
     respond = MagicMock()
     sre.sre_command(

--- a/app/tests/intergrations/test_aws_client_vpn.py
+++ b/app/tests/intergrations/test_aws_client_vpn.py
@@ -1,0 +1,605 @@
+from unittest.mock import call, MagicMock, patch
+
+from integrations.aws_client_vpn import AWSClientVPN
+
+mock_boto3 = MagicMock()
+AWS_REGION = "test-region"
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_init_with_assume_role_arn():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "test-access-key-id",
+            "SecretAccessKey": "test-secret-access-key",
+            "SessionToken": "test-session-token",
+        }
+    }
+    sts_client = mock_boto3.client.return_value
+    sts_client.assume_role.return_value = assume_role_response
+
+    vpn = AWSClientVPN(
+        name="TestVPN",
+        vpn_id="vpn-123",
+        assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
+    )
+    assert vpn.name == "TestVPN"
+    assert vpn.vpn_id == "vpn-123"
+    assert vpn.assume_role_arn == "arn:aws:iam::123456789012:role/TestRole"
+    assert hasattr(vpn, "client_ec2")
+    sts_client.assume_role.assert_called_once_with(
+        RoleArn="arn:aws:iam::123456789012:role/TestRole",
+        RoleSessionName="SREBot_Client_VPN_Role",
+    )
+    mock_boto3.Session.assert_called_once_with(
+        aws_access_key_id="test-access-key-id",
+        aws_secret_access_key="test-secret-access-key",
+        aws_session_token="test-session-token",
+    )
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_init_without_assume_role_arn():
+    vpn = AWSClientVPN(name="TestVPN", vpn_id="vpn-123")
+    assert vpn.name == "TestVPN"
+    assert vpn.vpn_id == "vpn-123"
+    assert vpn.assume_role_arn == ""
+    assert not hasattr(vpn, "client_ec2")
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_status_available():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    mock_client_ec2.describe_client_vpn_endpoints.return_value = {
+        "ClientVpnEndpoints": [{"Status": {"Code": "available"}}]
+    }
+    vpn.get_vpn_sesssion = MagicMock(return_value={"session_info": "mocked_session"})
+
+    status = vpn.get_status()
+
+    mock_client_ec2.describe_client_vpn_endpoints.assert_called_once_with(
+        ClientVpnEndpointIds=["vpn-123"]
+    )
+    assert status["status"] == vpn.STATUS_ON
+    assert status["session"] == {"session_info": "mocked_session"}
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_status_associating():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    mock_client_ec2.describe_client_vpn_endpoints.return_value = {
+        "ClientVpnEndpoints": [{"Status": {"Code": "pending-association"}}]
+    }
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {
+        "ClientVpnTargetNetworks": [{"Status": {"Code": "associating"}}]
+    }
+    vpn.get_vpn_sesssion = MagicMock(return_value={"session_info": "mocked_session"})
+
+    status = vpn.get_status()
+
+    mock_client_ec2.describe_client_vpn_target_networks.assert_called_once_with(
+        ClientVpnEndpointId="vpn-123"
+    )
+    assert status["status"] == vpn.STATUS_TURNING_ON
+    assert status["session"] == {"session_info": "mocked_session"}
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_status_no_endpoints():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    mock_client_ec2.describe_client_vpn_endpoints.return_value = {}
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {}
+    vpn.get_vpn_sesssion = MagicMock(return_value=None)
+
+    status = vpn.get_status()
+
+    assert status["status"] == vpn.STATUS_ERROR
+    assert status["session"] is None
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_status_disassociating():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    mock_client_ec2.describe_client_vpn_endpoints.return_value = {
+        "ClientVpnEndpoints": [{"Status": {"Code": "pending-disassociation"}}]
+    }
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {
+        "ClientVpnTargetNetworks": [{"Status": {"Code": "disassociating"}}]
+    }
+    vpn.get_vpn_sesssion = MagicMock(return_value={"session_info": "mocked_session"})
+
+    status = vpn.get_status()
+
+    assert status["status"] == vpn.STATUS_TURNING_OFF
+    assert status["session"] == {"session_info": "mocked_session"}
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_on_already_on():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_ON})
+    vpn.put_vpn_session = MagicMock()
+
+    status = vpn.turn_on()
+
+    assert status == vpn.STATUS_ON
+    vpn.put_vpn_session.assert_called_once()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_on_turning_on():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_TURNING_ON})
+    vpn.put_vpn_session = MagicMock()
+
+    status = vpn.turn_on()
+
+    assert status == vpn.STATUS_TURNING_ON
+    vpn.put_vpn_session.assert_called_once()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_on_no_authorization_rules():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_ERROR})
+    mock_client_ec2.describe_client_vpn_authorization_rules.return_value = {}
+
+    vpn.put_vpn_session = MagicMock()
+
+    status = vpn.turn_on()
+
+    assert status == vpn.STATUS_ERROR
+    assert not vpn.put_vpn_session.called
+    assert not mock_client_ec2.describe_subnets.called
+    assert (
+        not mock_client_ec2.associate_client_vpn_target_networkdescribe_subnets.called
+    )
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_on_associating_subnets():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_OFF})
+    mock_client_ec2.describe_client_vpn_authorization_rules.return_value = {
+        "AuthorizationRules": [
+            {"DestinationCidr": "10.0.1.0/24"},
+            {"DestinationCidr": "10.0.2.0/24"},
+            {"DestinationCidr": "10.0.0.2/32"},
+        ]
+    }
+    mock_client_ec2.describe_subnets.return_value = {
+        "Subnets": [{"SubnetId": "subnet-123"}, {"SubnetId": "subnet-456"}]
+    }
+    mock_client_ec2.associate_client_vpn_target_network.return_value = {}
+
+    vpn.put_vpn_session = MagicMock()
+
+    status = vpn.turn_on()
+
+    assert status == vpn.STATUS_TURNING_ON
+    mock_client_ec2.describe_client_vpn_authorization_rules.assert_called_once_with(
+        ClientVpnEndpointId="vpn-123"
+    )
+    mock_client_ec2.describe_subnets.assert_called_once_with(
+        Filters=[{"Name": "cidr-block", "Values": ["10.0.1.0/24", "10.0.2.0/24"]}]
+    )
+    mock_client_ec2.associate_client_vpn_target_network.assert_has_calls(
+        [
+            call(
+                ClientVpnEndpointId="vpn-123",
+                SubnetId="subnet-123",
+            ),
+            call(
+                ClientVpnEndpointId="vpn-123",
+                SubnetId="subnet-456",
+            ),
+        ]
+    )
+
+    vpn.put_vpn_session.assert_called_once()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_on_associating_error():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_OFF})
+    mock_client_ec2.describe_client_vpn_authorization_rules.return_value = {
+        "AuthorizationRules": [{"DestinationCidr": "10.0.0.0/16"}]
+    }
+    mock_client_ec2.describe_subnets.return_value = {
+        "Subnets": [{"SubnetId": "subnet-123"}]
+    }
+    error_response = {"Error": {"Code": "InvalidClientVpnDuplicateAssociation"}}
+    mock_client_ec2.associate_client_vpn_target_network.side_effect = Exception(
+        error_response
+    )
+
+    vpn.put_vpn_session = MagicMock()
+
+    try:
+        vpn.turn_on()
+    except Exception as e:
+        assert str(e) == str(error_response)
+    assert not vpn.put_vpn_session.called
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_off_already_off():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_OFF})
+
+    status = vpn.turn_off()
+
+    assert status == vpn.STATUS_OFF
+    mock_client_ec2.describe_client_vpn_target_networks.assert_not_called()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_off_turning_off():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_TURNING_OFF})
+
+    status = vpn.turn_off()
+
+    assert status == vpn.STATUS_TURNING_OFF
+    mock_client_ec2.describe_client_vpn_target_networks.assert_not_called()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_off_no_associated_networks():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_ERROR})
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {}
+
+    vpn.delete_vpn_session = MagicMock()
+
+    status = vpn.turn_off()
+
+    assert status == vpn.STATUS_ERROR
+    assert not vpn.delete_vpn_session.called
+    mock_client_ec2.describe_client_vpn_target_networks.assert_called_once_with(
+        ClientVpnEndpointId="vpn-123"
+    )
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_off_associating_networks():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_ON})
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {
+        "ClientVpnTargetNetworks": [
+            {"AssociationId": "assoc-123", "Status": {"Code": "associated"}},
+            {"AssociationId": "assoc-456", "Status": {"Code": "associated"}},
+            {"AssociationId": "assoc-789", "Status": {"Code": "pending-association"}},
+        ]
+    }
+    mock_client_ec2.disassociate_client_vpn_target_network.return_value = {}
+
+    vpn.delete_vpn_session = MagicMock()
+
+    status = vpn.turn_off()
+
+    assert status == vpn.STATUS_TURNING_OFF
+    mock_client_ec2.describe_client_vpn_target_networks.assert_called_once_with(
+        ClientVpnEndpointId="vpn-123"
+    )
+    mock_client_ec2.disassociate_client_vpn_target_network.assert_has_calls(
+        [
+            call(
+                ClientVpnEndpointId="vpn-123",
+                AssociationId="assoc-123",
+            ),
+            call(
+                ClientVpnEndpointId="vpn-123",
+                AssociationId="assoc-456",
+            ),
+        ]
+    )
+    vpn.delete_vpn_session.assert_called_once()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_turn_off_disassociation_error():
+    mock_client_ec2 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = mock_client_ec2
+
+    vpn = AWSClientVPN(
+        vpn_id="vpn-123", assume_role_arn="arn:aws:iam::123456789012:role/TestRole"
+    )
+    vpn.get_status = MagicMock(return_value={"status": vpn.STATUS_ON})
+    mock_client_ec2.describe_client_vpn_target_networks.return_value = {
+        "ClientVpnTargetNetworks": [
+            {"AssociationId": "assoc-123", "Status": {"Code": "associated"}}
+        ]
+    }
+    error_response = {"Error": {"Code": "DisassociateError"}}
+    mock_client_ec2.disassociate_client_vpn_target_network.side_effect = Exception(
+        error_response
+    )
+
+    vpn.delete_vpn_session = MagicMock()
+
+    try:
+        vpn.turn_off()
+    except Exception as e:
+        assert str(e) == str(error_response)
+    assert not vpn.delete_vpn_session.called
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_vpn_session_with_name():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    vpn = AWSClientVPN(name="test", vpn_id="vpn-123")
+    mock_client_ddb.get_item.return_value = {"Item": {"session_info": "mocked_session"}}
+
+    session = vpn.get_vpn_sesssion()
+
+    assert session == {"session_info": "mocked_session"}
+    mock_client_ddb.get_item.assert_called_once_with(
+        TableName=vpn.DYNAMODB_TABLE,
+        Key={
+            "PK": {"S": "vpn_session"},
+            "SK": {"S": "test"},
+        },
+    )
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_vpn_session_without_name():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    vpn = AWSClientVPN(name="", vpn_id="vpn-123")
+    mock_client_ddb.get_item.return_value = {}
+
+    session = vpn.get_vpn_sesssion()
+
+    assert session is None
+    mock_client_ddb.get_item.assert_not_called()
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_vpn_sessions():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    mock_items = [{"session_info": "session1"}, {"session_info": "session2"}]
+    mock_client_ddb.query.return_value = {"Items": mock_items}
+
+    vpn = AWSClientVPN()
+    sessions = vpn.get_vpn_sessions()
+
+    assert sessions == mock_items
+    mock_client_ddb.query.assert_called_once_with(
+        TableName=vpn.DYNAMODB_TABLE,
+        KeyConditionExpression="PK = :pk",
+        ExpressionAttributeValues={":pk": {"S": "vpn_session"}},
+    )
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_get_vpn_sessions_no_items():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    mock_client_ddb.query.return_value = {}
+
+    vpn = AWSClientVPN()
+    sessions = vpn.get_vpn_sessions()
+
+    assert sessions is None
+
+
+@patch("integrations.aws_client_vpn.datetime")
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_put_vpn_session_create_session(mock_datetime):
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+    mock_datetime.datetime.now.return_value.timestamp.return_value = 1640082800
+    mock_datetime.datetime.now.return_value.__add__.return_value.timestamp.return_value = (
+        1640086400
+    )
+
+    vpn = AWSClientVPN(
+        name="test",
+        vpn_id="vpn-123",
+        reason="foobar",
+        duration="1",
+        assume_role_arn="arn:test",
+    )
+    vpn.get_vpn_sesssion = MagicMock(return_value=None)
+
+    mock_client_ddb.put_item.return_value = {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+
+    response = vpn.put_vpn_session()
+
+    mock_client_ddb.put_item.assert_called_once_with(
+        TableName=vpn.DYNAMODB_TABLE,
+        Item={
+            "PK": {"S": "vpn_session"},
+            "SK": {"S": "test"},
+            "reason": {"S": "foobar"},
+            "duration": {"N": "1"},
+            "vpn_id": {"S": "vpn-123"},
+            "assume_role_arn": {"S": "arn:test"},
+            "created_at": {"N": "1640082800"},
+            "expires_at": {"N": "1640086400"},
+        },
+    )
+    mock_datetime.timedelta.assert_called_once_with(hours=float(vpn.duration))
+
+    assert response
+
+
+@patch("integrations.aws_client_vpn.datetime")
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_put_vpn_session_update_session(mock_datetime):
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+    mock_datetime.datetime.now.return_value.timestamp.return_value = 1640082800
+    mock_datetime.datetime.now.return_value.__add__.return_value.timestamp.return_value = (
+        1640097200
+    )
+
+    vpn = AWSClientVPN(
+        name="test",
+        vpn_id="vpn-123",
+        reason="foobar",
+        duration="4",
+        assume_role_arn="arn:test",
+    )
+    vpn.get_vpn_sesssion = MagicMock(return_value={"existing_session": "data"})
+
+    mock_client_ddb.update_item.return_value = {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+
+    response = vpn.put_vpn_session()
+
+    mock_client_ddb.update_item.assert_called_once_with(
+        TableName=vpn.DYNAMODB_TABLE,
+        Key={
+            "PK": {"S": "vpn_session"},
+            "SK": {"S": "test"},
+        },
+        UpdateExpression="set reason = :reason, #dur = :duration, created_at = :created_at, expires_at = :expires_at, vpn_id = :vpn_id, assume_role_arn = :assume_role_arn",
+        ExpressionAttributeValues={
+            ":reason": {"S": "foobar"},
+            ":duration": {"N": "4"},
+            ":created_at": {"N": "1640082800"},
+            ":expires_at": {"N": "1640097200"},
+            ":vpn_id": {"S": "vpn-123"},
+            ":assume_role_arn": {"S": "arn:test"},
+        },
+        ExpressionAttributeNames={"#dur": "duration"},
+    )
+    mock_datetime.timedelta.assert_called_once_with(hours=float(vpn.duration))
+
+    assert response
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_delete_vpn_session_with_session():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    vpn = AWSClientVPN(name="test", vpn_id="vpn-123", assume_role_arn="arn:test")
+    vpn.get_vpn_sesssion = MagicMock(return_value={"session_key": "session_value"})
+
+    mock_client_ddb.delete_item.return_value = {
+        "ResponseMetadata": {"HTTPStatusCode": 200}
+    }
+
+    response = vpn.delete_vpn_session()
+
+    mock_client_ddb.delete_item.assert_called_once_with(
+        TableName=vpn.DYNAMODB_TABLE,
+        Key={"PK": {"S": "vpn_session"}, "SK": {"S": "test"}},
+    )
+    assert response
+
+
+@patch("integrations.aws_client_vpn.boto3", mock_boto3)
+@patch("integrations.aws_client_vpn.AWS_REGION", AWS_REGION)
+def test_delete_vpn_session_without_session():
+    mock_client_ddb = MagicMock()
+    mock_boto3.client.return_value = mock_client_ddb
+
+    vpn = AWSClientVPN(name="test", vpn_id="vpn-123", assume_role_arn="arn:test")
+    vpn.get_vpn_sesssion = MagicMock(return_value=None)
+
+    response = vpn.delete_vpn_session()
+    mock_client_ddb.delete_item.assert_not_called()
+    assert response

--- a/app/tests/jobs/test_client_vpn_turn_off.py
+++ b/app/tests/jobs/test_client_vpn_turn_off.py
@@ -1,0 +1,81 @@
+from unittest.mock import call, patch, MagicMock
+from jobs import client_vpn_turn_off
+
+
+@patch("jobs.client_vpn_turn_off.datetime.datetime")
+@patch("jobs.client_vpn_turn_off.AWSClientVPN")
+def test_client_vpn_turn_off_expired_session(mock_aws_client_vpn, mock_datetime):
+    mock_session = {
+        "SK": {"S": "some_session"},
+        "vpn_id": {"S": "some_vpn_id"},
+        "assume_role_arn": {"S": "some_assume_role_arn"},
+        "expires_at": {"N": "1640092800"},
+    }
+    mock_vpn_sessions = [mock_session]
+
+    mock_aws_client_vpn_instance = MagicMock()
+    mock_aws_client_vpn_instance.get_vpn_sessions.return_value = mock_vpn_sessions
+    mock_aws_client_vpn.return_value = mock_aws_client_vpn_instance
+
+    mock_datetime.now.return_value.timestamp.return_value = 1640093800
+
+    client_vpn_turn_off.client_vpn_turn_off()
+    assert mock_aws_client_vpn.call_count == 2
+    mock_aws_client_vpn.assert_has_calls(
+        [
+            call(),
+            call().get_vpn_sessions(),
+            call(
+                name=mock_session["SK"]["S"],
+                vpn_id=mock_session["vpn_id"]["S"],
+                assume_role_arn=mock_session["assume_role_arn"]["S"],
+            ),
+            call().turn_off(),
+        ]
+    )
+
+
+@patch("jobs.client_vpn_turn_off.datetime.datetime")
+@patch("jobs.client_vpn_turn_off.AWSClientVPN")
+def test_client_vpn_turn_off_valid_session(mock_aws_client_vpn, mock_datetime):
+    mock_session = {
+        "SK": {"S": "some_session"},
+        "vpn_id": {"S": "some_vpn_id"},
+        "assume_role_arn": {"S": "some_assume_role_arn"},
+        "expires_at": {"N": "1640092800"},
+    }
+    mock_vpn_sessions = [mock_session]
+
+    mock_aws_client_vpn_instance = MagicMock()
+    mock_aws_client_vpn_instance.get_vpn_sessions.return_value = mock_vpn_sessions
+    mock_aws_client_vpn.return_value = mock_aws_client_vpn_instance
+
+    mock_datetime.now.return_value.timestamp.return_value = 1640082800
+
+    client_vpn_turn_off.client_vpn_turn_off()
+    assert mock_aws_client_vpn.call_count == 1
+    mock_aws_client_vpn.assert_has_calls(
+        [
+            call(),
+            call().get_vpn_sessions(),
+        ]
+    )
+
+
+@patch("jobs.client_vpn_turn_off.datetime.datetime")
+@patch("jobs.client_vpn_turn_off.AWSClientVPN")
+def test_client_vpn_turn_off_no_session(mock_aws_client_vpn, mock_datetime):
+    mock_vpn_sessions = []
+    mock_aws_client_vpn_instance = MagicMock()
+    mock_aws_client_vpn_instance.get_vpn_sessions.return_value = mock_vpn_sessions
+    mock_aws_client_vpn.return_value = mock_aws_client_vpn_instance
+
+    client_vpn_turn_off.client_vpn_turn_off()
+    assert mock_aws_client_vpn.call_count == 1
+    assert mock_datetime.now.call_count == 0
+    mock_aws_client_vpn.assert_has_calls(
+        [
+            call(),
+            call().get_vpn_sessions(),
+        ]
+    )

--- a/app/tests/jobs/test_scheduled_tasks.py
+++ b/app/tests/jobs/test_scheduled_tasks.py
@@ -1,6 +1,6 @@
 from jobs import scheduled_tasks
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 
 @patch("jobs.scheduled_tasks.schedule")
@@ -10,6 +10,12 @@ def test_init(schedule_mock):
     schedule_mock.every().day.at.assert_called_once_with("16:00")
     schedule_mock.every().day.at.return_value.do.assert_called_once_with(
         scheduled_tasks.notify_stale_incident_channels, client=bot.client
+    )
+    schedule_mock.every().minutes.do.assert_has_calls(
+        [
+            call(scheduled_tasks.scheduler_heartbeat),
+            call(scheduled_tasks.client_vpn_turn_off),
+        ]
     )
 
 

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -42,6 +42,9 @@ def test_main_invokes_socket_handler(
     mock_app.action.assert_any_call("toggle_webhook")
     mock_app.action.assert_any_call("reveal_webhook")
 
+    mock_app.view.assert_any_call("vpn_on")
+    mock_app.view.assert_any_call("vpn_status")
+
     mock_socket_mode_handler.assert_called_once_with(
         mock_app, os.environ.get("APP_TOKEN")
     )


### PR DESCRIPTION
# Summary
Adds Slack `/sre vpn` commands that can be used to interact with a product's AWS client VPN:
1. `/sre vpn on`: 
   - Turns on the VPN and post to the product's Slack channel that the VPN is turning on.
   - If the VPN is already on, updates the session with the new duration specified.  This can be used to extend existing sessions.
2. `/sre vpn status`:
   - Retrieves the status of the client VPN, including the remaining session length.

The command includes a scheduled job that will check ever `5 minutes` for client VPN sessions that have expired and disassociate their subnets if they have.  This is being done to save costs.

## Screenshots
### Turning on
![image](https://github.com/cds-snc/sre-bot/assets/2110107/4b0811d8-dc3d-4b4f-950d-f315ead4f764)

### On
![image](https://github.com/cds-snc/sre-bot/assets/2110107/0d1ffa37-5ce9-44f5-ac4d-0d91dea2ba6d)

### Turning off
![image](https://github.com/cds-snc/sre-bot/assets/2110107/c8ea04b9-a6fb-4e0b-982a-1e0760d12183)

# Notes
Before this can merge, the following needs to happen:
- [ ] create AWS client VPN in Notify prod.
- [ ] update the SRE Bot's secrets (AWS and Codespaces) with the following environment vars:
   - `VPN_NOTIFY_CHANNEL_ID`: Slack channel to post VPN `on` messages into.
   - `VPN_NOTIFY_ID`: client VPN ID
   - `VPN_NOTIFY_ROLE_ARN`: the IAM role in Notify prod that will be assumed by the SRE bot to manage the VPN.
- [ ] update the SRE bot's task role to allow it to cross-account assume `VPN_NOTIFY_ROLE_ARN`.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508
- https://github.com/cds-snc/notification-terraform/pull/1069