### PR TITLE
Fixing up stale incidents not displaying

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -292,7 +292,6 @@ def stale_incidents(client, body, ack):
     )
 
     stale_channels = get_stale_channels(client)
-    print("stale_channels", stale_channels)
 
     blocks = {
         "type": "modal",

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -281,7 +281,7 @@ def stale_incidents(client, body, ack):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "Loading stale incident list ...",
+                    "text": "Loading stale incident list ...(this may take a minute)",
                 },
             }
         ],
@@ -292,6 +292,7 @@ def stale_incidents(client, body, ack):
     )
 
     stale_channels = get_stale_channels(client)
+    print("stale_channels", stale_channels)
 
     blocks = {
         "type": "modal",

--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -6,15 +6,36 @@ from integrations.sentinel import send_event
 logging.basicConfig(level=logging.INFO)
 
 
+# Get all incident channels
 def get_incident_channels(client):
     channels = []
-    response = client.conversations_list(
-        exclude_archived=True, limit=1000, types="public_channel"
-    )
-    if response["ok"]:
-        channels = list(
-            filter(lambda x: x["name"].startswith("incident-20"), response["channels"])
+    cursor = None
+
+    # Execute while the next_cursor is not empty. We need to iterate through the collection limiting to a max of 100 channels
+    # at a time. The cursor is used to keep track of the current position in the collection. This is due to Slack's pagination
+    # and the way it hanles retrieval of channels.
+    while True:
+        response = client.conversations_list(
+            exclude_archived=True, limit=100, types="public_channel", cursor=cursor
         )
+
+        # if we did not get a successful response, break out of the loop
+        if not response.get("ok"):
+            break
+
+        # filter the channels to only include incident channels
+        for channel in response.get("channels", []):
+            if channel["name"].startswith("incident-20"):
+                channels.append(channel)
+
+        # get the next cursor
+        cursor = response.get("response_metadata", {}).get("next_cursor")
+
+        # if the cursor is empty, break out of the loop
+        if not cursor:
+            break
+
+    # return the list of incident channels
     return channels
 
 

--- a/app/tests/commands/test_utils.py
+++ b/app/tests/commands/test_utils.py
@@ -15,12 +15,48 @@ def test_get_incident_channels():
                 "name": "incident-2022-channel",
             },
         ],
+        "response_metadata": {"next_cursor": ""},
     }
     assert utils.get_incident_channels(client) == [
         {
             "name": "incident-2022-channel",
         },
     ]
+
+
+# Test get_incident_channels with multiple pages of results
+def test_get_incident_channels_with_multiple_pages():
+    client = MagicMock()
+
+    # Define mock responses
+    mock_response_page_1 = {
+        "ok": True,
+        "channels": [
+            {"name": "incident-2021-alpha"},
+            {"name": "general"},
+            {"name": "incident-2020-beta"},
+        ],
+        "response_metadata": {"next_cursor": "cursor123"},
+    }
+    mock_response_page_2 = {
+        "ok": True,
+        "channels": [{"name": "random"}, {"name": "incident-2022-gamma"}],
+        "response_metadata": {"next_cursor": ""},
+    }
+
+    # Set the side_effect of the conversations_list method
+    client.conversations_list.side_effect = [mock_response_page_1, mock_response_page_2]
+
+    # Call the function
+    result = utils.get_incident_channels(client)
+
+    # Verify results
+    expected_channels = [
+        {"name": "incident-2021-alpha"},
+        {"name": "incident-2020-beta"},
+        {"name": "incident-2022-gamma"},
+    ]
+    assert result == expected_channels
 
 
 def test_get_messages_in_time_period():


### PR DESCRIPTION
# Summary | Résumé

The command /sre incident stale was not working as it was not listing all the stale incidents. This was a weird bug/result due to the way the Slack API was handling limits and channels. In order to get all the channels, you had to get a smaller subset of results and then iterate through the collection. Now all stale incidents are obtained and shown in the command. Stale incidents are defined as having no activity for more than 14 days. 

<img width="587" alt="Screenshot 2024-01-11 at 7 01 51 PM" src="https://github.com/cds-snc/sre-bot/assets/85905333/4166bda2-8a3c-4a18-b71f-ad9d7edbe2f0">
