### PR TITLE
chore: log the archive incident channel actions

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -1,7 +1,7 @@
 import json
 
 from integrations import google_drive
-from commands.utils import get_stale_channels
+from commands.utils import get_stale_channels, log_to_sentinel
 
 help_text = """
 \n `/sre incident create-folder <folder_name>`
@@ -108,8 +108,10 @@ def archive_channel_action(client, body, ack):
         client.chat_update(
             channel=channel_id, text=msg, ts=body["message_ts"], attachments=[]
         )
+        log_to_sentinel(f"incident_channel_archive_delayed: {body}")
     elif action == "archive":
         client.conversations_archive(channel=channel_id)
+        log_to_sentinel(f"incident_channel_archived: {body}")
 
 
 def delete_folder_metadata(client, body, ack):

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -108,10 +108,10 @@ def archive_channel_action(client, body, ack):
         client.chat_update(
             channel=channel_id, text=msg, ts=body["message_ts"], attachments=[]
         )
-        log_to_sentinel(f"incident_channel_archive_delayed: {body}")
+        log_to_sentinel("incident_channel_archive_delayed", body)
     elif action == "archive":
         client.conversations_archive(channel=channel_id)
-        log_to_sentinel(f"incident_channel_archived: {body}")
+        log_to_sentinel("incident_channel_archived", body)
 
 
 def delete_folder_metadata(client, body, ack):

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -85,7 +85,7 @@ def test_add_folder_metadata():
     client.views_update.assert_called_once_with(view_id="bar", view=ANY)
 
 
-@patch("commands.utils.log_to_sentinel")
+@patch("commands.helpers.incident_helper.log_to_sentinel")
 def test_archive_channel_action_ignore(mock_log_to_sentinel):
     client = MagicMock()
     body = {
@@ -103,10 +103,12 @@ def test_archive_channel_action_ignore(mock_log_to_sentinel):
         ts="message_ts",
         attachments=[],
     )
-    mock_log_to_sentinel.assert_called_once_with(f"incident_channel_archive_delayed: {body}")
+    mock_log_to_sentinel.assert_called_once_with(
+        "incident_channel_archive_delayed", body
+    )
 
 
-@patch("commands.utils.log_to_sentinel")
+@patch("commands.helpers.incident_helper.log_to_sentinel")
 def test_archive_channel_action_archive(mock_log_to_sentinel):
     client = MagicMock()
     body = {
@@ -119,7 +121,7 @@ def test_archive_channel_action_archive(mock_log_to_sentinel):
     incident_helper.archive_channel_action(client, body, ack)
     ack.assert_called_once()
     client.conversations_archive(channel="channel_id")
-    mock_log_to_sentinel.assert_called_once_with(f"incident_channel_archived: {body}")
+    mock_log_to_sentinel.assert_called_once_with("incident_channel_archived", body)
 
 
 @patch("commands.helpers.incident_helper.google_drive.delete_metadata")

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -85,7 +85,8 @@ def test_add_folder_metadata():
     client.views_update.assert_called_once_with(view_id="bar", view=ANY)
 
 
-def test_archive_channel_action_ignore():
+@patch("commands.utils.log_to_sentinel")
+def test_archive_channel_action_ignore(mock_log_to_sentinel):
     client = MagicMock()
     body = {
         "actions": [{"value": "ignore"}],
@@ -102,9 +103,11 @@ def test_archive_channel_action_ignore():
         ts="message_ts",
         attachments=[],
     )
+    mock_log_to_sentinel.assert_called_once_with(f"incident_channel_archive_delayed: {body}")
 
 
-def test_archive_channel_action_archive():
+@patch("commands.utils.log_to_sentinel")
+def test_archive_channel_action_archive(mock_log_to_sentinel):
     client = MagicMock()
     body = {
         "actions": [{"value": "archive"}],
@@ -116,6 +119,7 @@ def test_archive_channel_action_archive():
     incident_helper.archive_channel_action(client, body, ack)
     ack.assert_called_once()
     client.conversations_archive(channel="channel_id")
+    mock_log_to_sentinel.assert_called_once_with(f"incident_channel_archived: {body}")
 
 
 @patch("commands.helpers.incident_helper.google_drive.delete_metadata")


### PR DESCRIPTION
# Summary
Update the archive channel action to log the request details to Sentinel.