### PR TITLE
Close incident command 

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -16,6 +16,9 @@ help_text = """
 \n `/sre incident roles`
 \n      - manages roles in an incident channel
 \n      - gérer les rôles dans un canal d'incident
+\n `/sre incident close`
+\n      - close the incident, archive the channel and update the incident spreadsheet and document 
+\n      - clôturer l'incident, archiver le canal et mettre à jour la feuille de calcul et le document de l'incident
 \n `/sre incident stale`
 \n      - lists all incidents older than 14 days with no activity
 \n      - lister tous les incidents plus vieux que 14 jours sans activité
@@ -38,6 +41,8 @@ def handle_incident_command(args, client, body, respond, ack):
             list_folders(client, body, ack)
         case "roles":
             manage_roles(client, body, ack, respond)
+        case "close":
+            close_incident(client, body, ack, respond)
         case "stale":
             stale_incidents(client, body, ack)
         case _:
@@ -267,6 +272,30 @@ def save_incident_roles(client, ack, view):
         channel=metadata["channel_id"],
     )
 
+
+def close_incident(client, body, ack, respond):
+    ack()
+    # get the current chanel
+    channel_id = body["channel"]["id"]
+
+    # update the incident document
+    
+    # update the spreadsheet with status "Closed
+    
+    # archive the channel 
+    client.conversations_archive(channel=channel_id)
+    
+    # update the document and the spreadsheet 
+    action = body["actions"][0]["value"]
+    user = body["user"]["id"]
+    if action == "ignore":
+        msg = f"<@{user}> has delayed archiving this channel for 14 days."
+        client.chat_update(
+            channel=channel_id, text=msg, ts=body["message_ts"], attachments=[]
+        )
+    elif action == "archive":
+        client.conversations_archive(channel=channel_id)
+    pass
 
 def stale_incidents(client, body, ack):
     ack()

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -1,5 +1,6 @@
 import json
 import re
+import logging
 from integrations import google_drive
 from commands.utils import get_stale_channels
 
@@ -290,6 +291,8 @@ def close_incident(client, body, ack):
     # Update the document status to "Closed" if we can get the document
     if document_id != "":
         google_drive.close_incident_document(document_id)
+    else:
+        logging.warning("No incident document found for this channel.")
 
     # Update the spreadsheet with the current incident with status = closed
     google_drive.update_spreadsheet_close_incident(return_channel_name(channel_name))

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -469,6 +469,7 @@ def extract_google_doc_id(url):
     # Regular expression pattern to match Google Docs ID
     pattern = r"/d/([a-zA-Z0-9_-]+)/"
 
+    # Search in the given text for all occurences of pattern
     match = re.search(pattern, url)
     if match:
         return match.group(1)
@@ -477,6 +478,7 @@ def extract_google_doc_id(url):
 
 
 def return_channel_name(input_str):
+    # return the channel name without the incident- prefix and appending a # to the channel name
     prefix = "incident-"
     if input_str.startswith(prefix):
         return "#" + input_str[len(prefix) :]

--- a/app/commands/incident.py
+++ b/app/commands/incident.py
@@ -328,6 +328,9 @@ def submit(ack, view, say, body, client, logger):
     text = "Run `/sre incident roles` to assign roles to the incident"
     say(text=text, channel=channel_id)
 
+    text = "Run `/sre incident close` to update the status of the incident document and incident spreadsheet to closed and to archive the channel"
+    say(text=text, channel=channel_id)
+
 
 def generate_success_modal(body):
     locale = body["view"]["blocks"][0]["elements"][0]["value"]

--- a/app/integrations/google_drive.py
+++ b/app/integrations/google_drive.py
@@ -296,6 +296,7 @@ def close_incident_document(file_id):
     # List of possible statuses to be replaced
     possible_statuses = ["In Progress", "Open", "Ready to be Reviewed", "Reviewed"]
 
+    # Replace all possible statuses with "Closed"
     changes = {
         "requests": [
             {
@@ -307,6 +308,7 @@ def close_incident_document(file_id):
             for status in possible_statuses
         ]
     }
+    # Execute the batchUpdate request
     service = get_google_service("docs", "v1")
     result = (
         service.documents()
@@ -348,8 +350,8 @@ def update_incident_list(document_link, name, slug, product, channel_url):
 
 
 def update_spreadsheet_close_incident(channel_name):
+    # Find the row in the spreadsheet with the channel_name and update it's status to Closed
     # Read the data from the sheet
-    print("Channel name: ", channel_name)
     service = get_google_service("sheets", "v4")
     sheet_name = "Sheet1"
     result = (

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -515,44 +515,44 @@ def test_conversations_archive_fail(
 
 
 def test_return_channel_name_with_prefix():
-    """Test the function with a string that includes the prefix."""
+    # Test the function with a string that includes the prefix.
     assert incident_helper.return_channel_name("incident-abc123") == "#abc123"
 
 
 def test_return_channel_name_without_prefix():
-    """Test the function with a string that does not include the prefix."""
+    # Test the function with a string that does not include the prefix.
     assert incident_helper.return_channel_name("general") == "general"
 
 
 def test_return_channel_name_empty_string():
-    """Test the function with an empty string."""
+    # Test the function with an empty string.
     assert incident_helper.return_channel_name("") == ""
 
 
 def test_return_channel_name_prefix_only():
-    """Test the function with a string that is only the prefix."""
+    # Test the function with a string that is only the prefix.
     assert incident_helper.return_channel_name("incident-") == "#"
 
 
 def test_extract_google_doc_id_valid_url():
-    """Test the function with a valid Google Docs URL."""
+    # Test the function with a valid Google Docs URL.
     url = "https://docs.google.com/document/d/1XWvE5s_OeB_12345/edit"
     assert incident_helper.extract_google_doc_id(url) == "1XWvE5s_OeB_12345"
 
 
 def test_extract_google_doc_id_invalid_url():
-    """Test the function with an invalid URL."""
+    # Test the function with an invalid URL.
     url = "https://www.example.com/page"
     assert incident_helper.extract_google_doc_id(url) is None
 
 
 def test_extract_google_doc_id_url_with_no_id():
-    """Test the function with a Google Docs URL that has no ID."""
+    # Test the function with a Google Docs URL that has no ID.
     url = "https://docs.google.com/document/d/"
     assert incident_helper.extract_google_doc_id(url) is None
 
 
 def test_extract_google_doc_id_empty_string():
-    """Test the function with an empty string."""
+    # Test the function with an empty string.
     url = ""
     assert incident_helper.extract_google_doc_id(url) is None

--- a/app/tests/intergrations/test_google_drive.py
+++ b/app/tests/intergrations/test_google_drive.py
@@ -215,6 +215,8 @@ def test_update_spreadsheet(get_google_service_mock):
         ["Channel B", "Detail 2", "In Progress"],
         ["Channel C", "Detail 3", "Reviewed"],
     ]
+
+    # get the return values from the mock
     get_google_service_mock.return_value.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {
         "values": mock_values
     }

--- a/app/tests/intergrations/test_google_drive.py
+++ b/app/tests/intergrations/test_google_drive.py
@@ -80,6 +80,17 @@ def test_create_new_google_doc_file(get_google_service_mock):
 
 
 @patch("integrations.google_drive.get_google_service")
+def test_update_incident_file(get_google_service_mock):
+    # test that incident doc's status is
+    get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
+        "id": "google_doc_id"
+    }
+    assert (
+        google_drive.create_new_docs_file("name", "parent_folder_id") == "google_doc_id"
+    )
+
+
+@patch("integrations.google_drive.get_google_service")
 def test_create_new_google_sheets_file(get_google_service_mock):
     # test that a new google sheets is successfully created
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
@@ -183,3 +194,33 @@ def test_update_incident_list(get_google_service_mock):
         )
         is True
     )
+
+
+@patch("integrations.google_drive.get_google_service")
+def test_close_incident_document(get_google_service_mock):
+    # Define a mock response for the batchUpdate call
+    get_google_service_mock.return_value.documents.return_value.batchUpdate.return_value.execute.return_value = {
+        "status": "success"
+    }
+
+    # Assert that the function returns the correct response
+    assert google_drive.close_incident_document("file_id") == {"status": "success"}
+
+
+@patch("integrations.google_drive.get_google_service")
+def test_update_spreadsheet(get_google_service_mock):
+    # Define a mock response for the get values call
+    mock_values = [
+        ["Channel A", "Detail 1", "Open"],
+        ["Channel B", "Detail 2", "In Progress"],
+        ["Channel C", "Detail 3", "Reviewed"],
+    ]
+    get_google_service_mock.return_value.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {
+        "values": mock_values
+    }
+
+    # Define a channel name to search for
+    channel_name = "Channel B"
+
+    # assert that the function returns the correct response
+    assert google_drive.update_spreadsheet_close_incident(channel_name) is True


### PR DESCRIPTION
# Summary | Résumé

Closes #355 

A new command for the SRE bot that closes an incident channel. To run it, you need to go to the incident channel and type ```/sre incident close```
Once this is done, the incident document is updated to "Closed", the incident spreadsheet for that particular channel is also updated to "Closed" and the channel is archived. 