### PR TITLE
Add updating the spreadsheet, incident document to closed when clicking Yes on stale incident notificaiton

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -3,7 +3,6 @@ import re
 import logging
 from integrations import google_drive
 from commands.utils import get_stale_channels, log_to_sentinel
-from jobs.notify_stale_incident_channels import notify_stale_incident_channels
 
 help_text = """
 \n `/sre incident create-folder <folder_name>`
@@ -47,8 +46,6 @@ def handle_incident_command(args, client, body, respond, ack):
             close_incident(client, body, ack)
         case "stale":
             stale_incidents(client, body, ack)
-        case "notify":
-            notify_stale_incident_channels(client)
         case _:
             respond(
                 f"Unknown command: {action}. Type `/sre incident help` to see a list of commands."

--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -55,7 +55,7 @@ def get_messages_in_time_period(client, channel_id, time_delta):
 
 
 def get_stale_channels(client):
-    STALE_PERIOD = timedelta(days=14)
+    STALE_PERIOD = timedelta(days=1)
     now = datetime.now()
     stale_channels = []
     channels = list(

--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -55,7 +55,7 @@ def get_messages_in_time_period(client, channel_id, time_delta):
 
 
 def get_stale_channels(client):
-    STALE_PERIOD = timedelta(days=1)
+    STALE_PERIOD = timedelta(days=14)
     now = datetime.now()
     stale_channels = []
     channels = list(

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -107,6 +107,7 @@ def test_archive_channel_action_ignore(mock_log_to_sentinel):
         "incident_channel_archive_delayed", body
     )
 
+
 @patch("commands.helpers.incident_helper.google_drive.close_incident_document")
 @patch(
     "commands.helpers.incident_helper.google_drive.update_spreadsheet_close_incident"
@@ -116,7 +117,9 @@ def test_archive_channel_action_ignore(mock_log_to_sentinel):
     return_value="dummy_document_id",
 )
 @patch("commands.helpers.incident_helper.log_to_sentinel")
-def test_archive_channel_action_archive(mock_log_to_sentinel, mock_extract_id, mock_update_spreadsheet, mock_close_document):
+def test_archive_channel_action_archive(
+    mock_log_to_sentinel, mock_extract_id, mock_update_spreadsheet, mock_close_document
+):
     client = MagicMock()
     body = {
         "actions": [{"value": "archive"}],
@@ -128,11 +131,12 @@ def test_archive_channel_action_archive(mock_log_to_sentinel, mock_extract_id, m
     incident_helper.archive_channel_action(client, body, ack)
     assert ack.call_count == 2
     mock_log_to_sentinel.assert_called_once_with(
-    "incident_channel_archived", 
-    {
-        "channel_id": "channel_id", "channel_name": "incident-2024-01-12-test",
-    }
-)
+        "incident_channel_archived",
+        {
+            "channel_id": "channel_id",
+            "channel_name": "incident-2024-01-12-test",
+        },
+    )
 
 
 @patch("commands.helpers.incident_helper.google_drive.delete_metadata")

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -107,21 +107,32 @@ def test_archive_channel_action_ignore(mock_log_to_sentinel):
         "incident_channel_archive_delayed", body
     )
 
-
+@patch("commands.helpers.incident_helper.google_drive.close_incident_document")
+@patch(
+    "commands.helpers.incident_helper.google_drive.update_spreadsheet_close_incident"
+)
+@patch(
+    "commands.helpers.incident_helper.extract_google_doc_id",
+    return_value="dummy_document_id",
+)
 @patch("commands.helpers.incident_helper.log_to_sentinel")
-def test_archive_channel_action_archive(mock_log_to_sentinel):
+def test_archive_channel_action_archive(mock_log_to_sentinel, mock_extract_id, mock_update_spreadsheet, mock_close_document):
     client = MagicMock()
     body = {
         "actions": [{"value": "archive"}],
-        "channel": {"id": "channel_id"},
+        "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
         "message_ts": "message_ts",
         "user": {"id": "user_id"},
     }
     ack = MagicMock()
     incident_helper.archive_channel_action(client, body, ack)
-    ack.assert_called_once()
-    client.conversations_archive(channel="channel_id")
-    mock_log_to_sentinel.assert_called_once_with("incident_channel_archived", body)
+    assert ack.call_count == 2
+    mock_log_to_sentinel.assert_called_once_with(
+    "incident_channel_archived", 
+    {
+        "channel_id": "channel_id", "channel_name": "incident-2024-01-12-test",
+    }
+)
 
 
 @patch("commands.helpers.incident_helper.google_drive.delete_metadata")


### PR DESCRIPTION
# Summary | Résumé

Added functionality to the stale incident notification below to do the following:

![Screenshot 2024-01-17 at 2 55 31 PM](https://github.com/cds-snc/sre-bot/assets/85905333/3f2744d3-de34-4d57-8e1a-a04a858df28f)

Now when you click on Yes, the following things happen:
- Incident document status is updated to Closed
- The incident's status in the incident spreadsheet is flaged to Closed
- The channel is archived. 