### PR TITLE
Make search is case insensitive

### DIFF
--- a/app/integrations/google_drive.py
+++ b/app/integrations/google_drive.py
@@ -301,7 +301,7 @@ def close_incident_document(file_id):
         "requests": [
             {
                 "replaceAllText": {
-                    "containsText": {"text": f"Status: {status}", "matchCase": "true"},
+                    "containsText": {"text": f"Status: {status}", "matchCase": "false"},
                     "replaceText": "Status: Closed",
                 }
             }


### PR DESCRIPTION
# Summary | Résumé

Make the search for the incident document status to be case insensitive, so that we can match more values. 