### PR TITLE
Send message to user if the close incident command is not ran from an incident channel

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -288,15 +288,17 @@ def close_incident(client, body, ack):
     # get the current chanel id and name
     channel_id = body["channel_id"]
     channel_name = body["channel_name"]
+    print("Channel name is " + channel_name)
 
-    if not channel_name.startswith("incident-"): 
+    if not channel_name.startswith("incident-"):
+        print("Does not start with incident")
         user_id = body["user_id"]
         client.chat_postEphemeral(
-            text = f"Channel {channel_name} is not an incident channel. Please use the command in an incident channel.",
+            text=f"Channel {channel_name} is not an incident channel. Please use this command in an incident channel.",
             channel=channel_id,
-            user = user_id
+            user=user_id,
         )
-        return 
+        return
 
     # get and update the incident document
     document_id = ""

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -288,10 +288,8 @@ def close_incident(client, body, ack):
     # get the current chanel id and name
     channel_id = body["channel_id"]
     channel_name = body["channel_name"]
-    print("Channel name is " + channel_name)
 
     if not channel_name.startswith("incident-"):
-        print("Does not start with incident")
         user_id = body["user_id"]
         client.chat_postEphemeral(
             text=f"Channel {channel_name} is not an incident channel. Please use this command in an incident channel.",

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -486,6 +486,35 @@ def test_close_incident_no_bookmarks(
     mock_update_spreadsheet.assert_called_once_with("#2024-01-12-test")
 
 
+# Test that the channel that the command is ran in,  is not an incident channel.
+def test_close_incident_not_incident_channel():
+    mock_client = MagicMock()
+    mock_ack = MagicMock()
+
+    # Mock the response of the private message to have been posted as expected
+    mock_client.chat_postEphemeral.return_value = {"ok": True}
+
+    # Call close_incident
+    incident_helper.close_incident(
+        mock_client,
+        {
+            "channel_id": "C12345",
+            "user_id": "12345",
+            "channel_name": "some-other-channel",
+        },
+        mock_ack,
+    )
+
+    # Assert that ack was called
+    mock_ack.assert_called_once()
+
+    # Assert that the private message was posted as expected with the expected text
+    expected_text = "Channel some-other-channel is not an incident channel. Please use this command in an incident channel."
+    mock_client.chat_postEphemeral.assert_called_once_with(
+        channel="C12345", user="12345", text=expected_text
+    )
+
+
 @patch("commands.helpers.incident_helper.google_drive.close_incident_document")
 @patch(
     "commands.helpers.incident_helper.google_drive.update_spreadsheet_close_incident"


### PR DESCRIPTION
# Summary | Résumé

Send a message visible only to the user if the ```/sre incident close`` command is not ran in an incident channel. If it is not ran in an incident channel, the message will be as follows:

![Screenshot 2024-01-18 at 9 54 00 AM](https://github.com/cds-snc/sre-bot/assets/85905333/5fb3a494-affe-4ded-bf6e-dfeb85ec9fd4)
