### PR TITLE
More logging to indicate if a bookmark does not exist in an incident channel

### DIFF
--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -306,13 +306,18 @@ def close_incident(client, body, ack):
             if response["bookmarks"][item]["title"] == "Incident report":
                 document_id = extract_google_doc_id(response["bookmarks"][item]["link"])
     else:
-        logging.warning("No incident document found for channel %s", channel_name)
+        logging.warning(
+            "No bookmark link for the incident document found for channel %s",
+            channel_name,
+        )
 
     # Update the document status to "Closed" if we can get the document
     if document_id != "":
         google_drive.close_incident_document(document_id)
     else:
-        logging.warning("No incident document found for this channel.")
+        logging.warning(
+            "Could not close the incident document - the document was not found."
+        )
 
     # Update the spreadsheet with the current incident with status = closed
     google_drive.update_spreadsheet_close_incident(return_channel_name(channel_name))

--- a/app/commands/helpers/incident_helper.py
+++ b/app/commands/helpers/incident_helper.py
@@ -305,6 +305,8 @@ def close_incident(client, body, ack):
         for item in range(len(response["bookmarks"])):
             if response["bookmarks"][item]["title"] == "Incident report":
                 document_id = extract_google_doc_id(response["bookmarks"][item]["link"])
+    else:
+        logging.warning("No incident document found for channel %s", channel_name)
 
     # Update the document status to "Closed" if we can get the document
     if document_id != "":

--- a/app/tests/commands/helpers/test_incident_helper.py
+++ b/app/tests/commands/helpers/test_incident_helper.py
@@ -486,6 +486,33 @@ def test_close_incident_no_bookmarks(
     mock_update_spreadsheet.assert_called_once_with("#2024-01-12-test")
 
 
+@patch("commands.helpers.incident_helper.google_drive.close_incident_document")
+@patch(
+    "commands.helpers.incident_helper.google_drive.update_spreadsheet_close_incident"
+)
+@patch("commands.helpers.incident_helper.extract_google_doc_id", return_value=None)
+def test_close_incident_no_bookmarks_error(
+    mock_extract_id, mock_update_spreadsheet, mock_close_document
+):
+    mock_client = MagicMock()
+    mock_ack = MagicMock()
+
+    # Mock client.bookmarks_list to return no bookmarks
+    mock_client.bookmarks_list.return_value = {"ok": False, "error": "not_in_channel"}
+
+    # Call close_incident
+    incident_helper.close_incident(
+        mock_client,
+        {"channel_id": "C12345", "channel_name": "incident-2024-01-12-test"},
+        mock_ack,
+    )
+
+    # Assertions to ensure that document update functions are not called as there are no bookmarks
+    mock_extract_id.assert_not_called()
+    mock_close_document.assert_not_called()
+    mock_update_spreadsheet.assert_called_once_with("#2024-01-12-test")
+
+
 # Test that the channel that the command is ran in,  is not an incident channel.
 def test_close_incident_not_incident_channel():
     mock_client = MagicMock()


### PR DESCRIPTION
# Summary | Résumé

Added more error logging to indicate if a bookmark is not listed in an incident channel. 