### PR TITLE
Refactor/google drive module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,6 @@
 				"ms-python.python",
 				"ms-python.vscode-pylance",
 				"ms-python.flake8",
-				"ms-python.pylint",
 				"ms-python.mypy-type-checker",
 				"mtxr.sqltools",
 				"mtxr.sqltools-driver-pg",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "python.pylintPath": "/usr/local/py-utils/bin/pylint",
     "mypy-type-checker.cwd": "${workspaceFolder}/app",
+    "pylint.cwd": "${workspaceFolder}/app",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
     "python.pylintPath": "/usr/local/py-utils/bin/pylint",
+    "mypy-type-checker.cwd": "${workspaceFolder}/app",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,8 @@
     "python.pylintPath": "/usr/local/py-utils/bin/pylint",
     "mypy-type-checker.cwd": "${workspaceFolder}/app",
     "pylint.cwd": "${workspaceFolder}/app",
+    "pylint.path": [
+        "[\"../../usr/local/py-utils/bin/pylint\"]"
+    ],
+    "flake8.cwd": "${workspaceFolder}/app"
 }

--- a/app/commands/google_service.py
+++ b/app/commands/google_service.py
@@ -9,6 +9,7 @@ load_dotenv()
 
 SRE_DRIVE_ID = os.environ.get("SRE_DRIVE_ID")
 SRE_INCIDENT_FOLDER = os.environ.get("SRE_INCIDENT_FOLDER")
+INCIDENT_TEMPLATE = os.environ.get("INCIDENT_TEMPLATE")
 
 
 def open_modal(client, body, folders):
@@ -28,6 +29,7 @@ def open_modal(client, body, folders):
 
 
 def google_service_command(client, body, respond):
+    respond(f"Healthcheck status: {google_drive.healthcheck()}")
     folders = google_drive.list_folders_in_folder(SRE_INCIDENT_FOLDER)
     if not folders:
         respond("The folder ID is invalid. Please check the environment variables.")

--- a/app/commands/google_service.py
+++ b/app/commands/google_service.py
@@ -1,7 +1,6 @@
 """Testing new google service (will be removed)"""
 import os
 
-# from integrations.google_workspace.google_service import get_google_service
 from integrations.google_workspace import google_drive
 from dotenv import load_dotenv
 

--- a/app/commands/google_service.py
+++ b/app/commands/google_service.py
@@ -11,8 +11,9 @@ SRE_DRIVE_ID = os.environ.get("SRE_DRIVE_ID")
 SRE_INCIDENT_FOLDER = os.environ.get("SRE_INCIDENT_FOLDER")
 
 
-def open_modal(client, body):
-    folders = list_folders()
+def open_modal(client, body, folders):
+    if not folders:
+        return
     folder_names = [i["name"] for i in folders]
     blocks = [
         {"type": "section", "text": {"type": "mrkdwn", "text": f"*{name}*"}}
@@ -26,9 +27,9 @@ def open_modal(client, body):
     client.views_open(trigger_id=body["trigger_id"], view=view)
 
 
-def google_service_command(client, body):
-    open_modal(client, body)
-
-
-def list_folders():
-    return google_drive.list_folders_in_folder(SRE_INCIDENT_FOLDER)
+def google_service_command(client, body, respond):
+    folders = google_drive.list_folders_in_folder(SRE_INCIDENT_FOLDER)
+    if not folders:
+        respond("The folder ID is invalid. Please check the environment variables.")
+        return
+    open_modal(client, body, folders)

--- a/app/commands/google_service.py
+++ b/app/commands/google_service.py
@@ -1,7 +1,8 @@
 """Testing new google service (will be removed)"""
 import os
 
-from integrations.google_workspace.google_service import get_google_service
+# from integrations.google_workspace.google_service import get_google_service
+from integrations.google_workspace import google_drive
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -30,20 +31,4 @@ def google_service_command(client, body):
 
 
 def list_folders():
-    service = get_google_service("drive", "v3")
-    results = (
-        service.files()
-        .list(
-            pageSize=25,
-            supportsAllDrives=True,
-            includeItemsFromAllDrives=True,
-            corpora="drive",
-            q="parents in '{}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false and not name contains '{}'".format(
-                SRE_INCIDENT_FOLDER, "Templates"
-            ),
-            driveId=SRE_DRIVE_ID,
-            fields="nextPageToken, files(id, name)",
-        )
-        .execute()
-    )
-    return results.get("files", [])
+    return google_drive.list_folders_in_folder(SRE_INCIDENT_FOLDER)

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -21,6 +21,8 @@ help_text = """
 \n      - show the version of the SRE Bot
 \n      - montre la version du bot SRE"""
 
+PREFIX = os.environ.get("PREFIX", "")
+
 
 def sre_command(ack, command, logger, respond, client, body):
     ack()
@@ -48,7 +50,11 @@ def sre_command(ack, command, logger, respond, client, body):
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
         case "google-service":
-            google_service.google_service_command(client, body)
+            if PREFIX == "dev-":
+                google_service.google_service_command(client, body)
+            else:
+                respond("This command is only available in the dev environment.")
+            return
         case _:
             respond(
                 f"Unknown command: `{action}`. Type `/sre help` to see a list of commands. \nCommande inconnue: `{action}`. Entrez `/sre help` pour une liste des commandes valides"

--- a/app/commands/sre.py
+++ b/app/commands/sre.py
@@ -49,9 +49,9 @@ def sre_command(ack, command, logger, respond, client, body):
             webhook_helper.handle_webhook_command(args, client, body, respond)
         case "version":
             respond(f"SRE Bot version: {os.environ.get('GIT_SHA', 'unknown')}")
-        case "google-service":
+        case "google":
             if PREFIX == "dev-":
-                google_service.google_service_command(client, body)
+                google_service.google_service_command(client, body, respond)
             else:
                 respond("This command is only available in the dev environment.")
             return

--- a/app/integrations/google_workspace/google_docs.py
+++ b/app/integrations/google_workspace/google_docs.py
@@ -1,0 +1,4 @@
+"""Google Docs module.
+
+This module provides functions to create and manipulate Google Docs.
+"""

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -1,0 +1,220 @@
+"""
+Google Drive Module.
+
+This module provides functionalities to interact with Google Drive. It includes functions to add metadata to a file, create a new folder, create a new document from a template, and copy a file to a new folder.
+
+Functions:
+    add_metadata(file_id: str, key: str, value: str) -> dict:
+        Adds metadata to a file in Google Drive and returns the updated file metadata.
+
+    create_new_folder(name: str, parent_folder: str) -> str:
+        Creates a new folder in Google Drive and returns the id of the new folder.
+
+    create_new_document_from_template(name: str, folder: str, template: str) -> str:
+        Creates a new document in Google Drive from a template (Docs, Sheets, Slides, Forms, or Sites) and returns the id of the new document.
+
+    copy_file_to_folder(file_id: str, name: str, parent_folder_id: str, destination_folder_id: str) -> str:
+        Copies a file to a new folder in Google Drive and returns the id of the new file.
+"""
+from integrations.google_workspace.google_service import (
+    get_google_service,
+    handle_google_api_errors,
+)
+
+
+@handle_google_api_errors
+def add_metadata(file_id, key, value):
+    """Add metadata to a file in Google Drive.
+
+    Args:
+        file_id (str): The file id of the file to add metadata to.
+        key (str): The key of the metadata to add.
+        value (str): The value of the metadata to add.
+
+    Returns:
+        dict: The updated file metadata.
+    """
+    # pylint: disable=no-member
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .update(
+            fileId=file_id,
+            body={"appProperties": {key: value}},
+            fields="name, appProperties",
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    # pylint: enable=no-member
+
+    return result
+
+
+@handle_google_api_errors
+def delete_metadata(file_id, key):
+    """Delete metadata from a file in Google Drive.
+
+    Args:
+        file_id (str): The file id of the file to delete metadata from.
+        key (str): The key of the metadata to delete.
+
+    Returns:
+        dict: The updated file metadata.
+    """
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .update(
+            fileId=file_id,
+            body={"appProperties": {key: None}},
+            fields="name, appProperties",
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    return result
+
+
+@handle_google_api_errors
+def create_folder(name, parent_folder):
+    """Create a new folder in Google Drive.
+
+    Args:
+        name (str): The name of the new folder.
+        parent_folder (str): The id of the parent folder.
+
+    Returns:
+        str: The id of the new folder.
+    """
+    # pylint: disable=no-member
+    service = get_google_service("drive", "v3")
+    results = (
+        service.files()
+        .create(
+            body={
+                "name": name,
+                "mimeType": "application/vnd.google-apps.folder",
+                "parents": [parent_folder],
+            },
+            supportsAllDrives=True,
+            fields="id",
+        )
+        .execute()
+    )
+    # pylint: enable=no-member
+
+    return results["id"]
+
+
+@handle_google_api_errors
+def create_new_file_from_template(name, folder, template):
+    """Create a new file in Google Drive from a template
+     (Docs, Sheets, Slides, Forms, or Sites.)
+
+    Args:
+        name (str): The name of the new file.
+        folder (str): The id of the folder to create the file in.
+        template (str): The id of the template to use.
+
+    Returns:
+        str: The id of the new file.
+    """
+    # pylint: disable=no-member
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .copy(
+            fileId=template,
+            body={"name": name, "parents": [folder]},
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+    # pylint: enable=no-member
+    return result["id"]
+
+
+@handle_google_api_errors
+def create_new_file(name, folder, file_type):
+    """Create a new file in Google Drive.
+        Options for 'file_type' are:
+
+            - "document": Google Docs
+            - "spreadsheet": Google Sheets
+            - "presentation": Google Slides
+            - "form": Google Forms
+            - "site": Google Sites
+
+    Args:
+        name (str): The name of the new file.
+        folder (str): The id of the folder to create the file in.
+        file_type (str): The type of the new file.
+
+    Returns:
+        str: The id of the new file.
+    """
+
+    mime_type = {
+        "document": "application/vnd.google-apps.document",
+        "spreadsheet": "application/vnd.google-apps.spreadsheet",
+        "presentation": "application/vnd.google-apps.presentation",
+        "form": "application/vnd.google-apps.form",
+        "site": "application/vnd.google-apps.site",
+    }
+
+    if file_type not in mime_type:
+        raise ValueError(f"Invalid file_type: {file_type}")
+
+    mime_type_value = mime_type[file_type]
+
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .create(
+            body={"name": name, "parents": [folder], "mimeType": mime_type_value},
+            supportsAllDrives=True,
+            fields="id",
+        )
+        .execute()
+    )
+    return result["id"]
+
+
+@handle_google_api_errors
+def copy_file_to_folder(file_id, name, parent_folder_id, destination_folder_id):
+    """Copy a file to a new folder in Google Drive.
+
+    Args:
+        file_id (str): The id of the file to copy.
+        name (str): The name of the new file.
+        parent_folder_id (str): The id of the parent folder.
+        destination_folder_id (str): The id of the destination folder.
+
+    Returns:
+        str: The id of the new file.
+    """
+    service = get_google_service("drive", "v3")
+    copied_file = (
+        service.files()
+        .copy(
+            fileId=file_id,
+            body={"name": name, "parents": [parent_folder_id]},
+            supportsAllDrives=True,
+            fields="id",
+        )
+        .execute()
+    )
+    # move the copy to the new folder
+    updated_file = (
+        service.files()
+        .update(
+            fileId=copied_file["id"],
+            addParents=destination_folder_id,
+            removeParents=parent_folder_id,
+            supportsAllDrives=True,
+            fields="id",
+        )
+        .execute()
+    )
+    return updated_file["id"]

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -77,6 +77,25 @@ def delete_metadata(file_id, key):
 
 
 @handle_google_api_errors
+def list_metadata(file_id):
+    """List metadata of a file in Google Drive.
+
+    Args:
+        file_id (str): The file id of the file to list metadata from.
+
+    Returns:
+        dict: The file metadata.
+    """
+    service = get_google_service("drive", "v3")
+    result = (
+        service.files()
+        .get(fileId=file_id, fields="name, appProperties", supportsAllDrives=True)
+        .execute()
+    )
+    return result
+
+
+@handle_google_api_errors
 def create_folder(name, parent_folder):
     """Create a new folder in Google Drive.
 
@@ -203,6 +222,34 @@ def get_file_by_name(name, folder):
             q="trashed=false and name='{}'".format(name),
             driveId=folder,
             fields="files(appProperties, id, name)",
+        )
+        .execute()
+    )
+    return results.get("files", [])
+
+
+@handle_google_api_errors
+def list_folders_in_folder(folder):
+    """List all folders in a folder in Google Drive.
+
+    Args:
+        folder (str): The id of the folder to list.
+
+    Returns:
+        list: A list of folders in the folder.
+    """
+    service = get_google_service("drive", "v3")
+    results = (
+        service.files()
+        .list(
+            pageSize=25,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            corpora="user",
+            q="parents in '{}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false".format(
+                folder
+            ),
+            fields="nextPageToken, files(id, name)",
         )
         .execute()
     )

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -16,10 +16,14 @@ Functions:
     copy_file_to_folder(file_id: str, name: str, parent_folder_id: str, destination_folder_id: str) -> str:
         Copies a file to a new folder in Google Drive and returns the id of the new file.
 """
+import os
 from integrations.google_workspace.google_service import (
     get_google_service,
     handle_google_api_errors,
 )
+
+SRE_INCIDENT_FOLDER = os.environ.get("SRE_INCIDENT_FOLDER")
+INCIDENT_TEMPLATE = os.environ.get("INCIDENT_TEMPLATE")
 
 
 @handle_google_api_errors
@@ -89,7 +93,7 @@ def list_metadata(file_id):
     service = get_google_service("drive", "v3")
     result = (
         service.files()
-        .get(fileId=file_id, fields="name, appProperties", supportsAllDrives=True)
+        .get(fileId=file_id, fields="id, name, appProperties", supportsAllDrives=True)
         .execute()
     )
     return result
@@ -293,3 +297,17 @@ def copy_file_to_folder(file_id, name, parent_folder_id, destination_folder_id):
         .execute()
     )
     return updated_file["id"]
+
+
+@handle_google_api_errors
+def healthcheck():
+    """Check the health of the Google Drive API.
+
+    Returns:
+        bool: True if the API is healthy, False otherwise.
+    """
+    healthy = False
+    metadata = list_metadata(INCIDENT_TEMPLATE)
+    healthy = "id" in metadata
+
+    return healthy

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -182,6 +182,34 @@ def create_new_file(name, folder, file_type):
 
 
 @handle_google_api_errors
+def get_file_by_name(name, folder):
+    """Get a file by name in Google Drive.
+
+    Args:
+        name (str): The name of the file to get.
+        folder (str): The id of the folder to search in.
+
+    Returns:
+        list: A list of files that match the name.
+    """
+    service = get_google_service("drive", "v3")
+    results = (
+        service.files()
+        .list(
+            pageSize=1,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            corpora="drive",
+            q="trashed=false and name='{}'".format(name),
+            driveId=folder,
+            fields="files(appProperties, id, name)",
+        )
+        .execute()
+    )
+    return results.get("files", [])
+
+
+@handle_google_api_errors
 def copy_file_to_folder(file_id, name, parent_folder_id, destination_folder_id):
     """Copy a file to a new folder in Google Drive.
 

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -308,6 +308,7 @@ def healthcheck():
     """
     healthy = False
     metadata = list_metadata(INCIDENT_TEMPLATE)
-    healthy = "id" in metadata
+    if metadata is not None:
+        healthy = "id" in metadata
 
     return healthy

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -260,20 +260,28 @@ def list_folders_in_folder(folder):
         list: A list of folders in the folder.
     """
     service = get_google_service("drive", "v3")
-    results = (
-        service.files()
-        .list(
-            pageSize=25,
-            supportsAllDrives=True,
-            includeItemsFromAllDrives=True,
-            corpora="user",
-            q="parents in '{}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false".format(
-                folder
-            ),
-            fields="nextPageToken, files(id, name)",
+    page_token = None
+    all_files = []
+    while True:
+        results = (
+            service.files()
+            .list(
+                pageSize=25,
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+                corpora="user",
+                q="parents in '{}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false".format(
+                    folder
+                ),
+                fields="nextPageToken, files(id, name)",
+                pageToken=page_token,
+            )
+            .execute()
         )
-        .execute()
-    )
+        all_files.extend(results.get('files', []))
+        page_token = results.get('nextPageToken')
+        if not page_token:
+            break
     return results.get("files", [])
 
 

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -7,14 +7,32 @@ Functions:
     add_metadata(file_id: str, key: str, value: str) -> dict:
         Adds metadata to a file in Google Drive and returns the updated file metadata.
 
-    create_new_folder(name: str, parent_folder: str) -> str:
+    delete_metadata(file_id: str, key: str) -> dict:
+        Deletes metadata from a file in Google Drive and returns the updated file metadata.
+
+    list_metadata(file_id: str) -> dict:
+        Lists metadata of a file in Google Drive and returns the file metadata.
+
+    create_folder(name: str, parent_folder: str) -> str:
         Creates a new folder in Google Drive and returns the id of the new folder.
 
-    create_new_document_from_template(name: str, folder: str, template: str) -> str:
+    create_file_from_template(name: str, folder: str, template: str) -> str:
         Creates a new document in Google Drive from a template (Docs, Sheets, Slides, Forms, or Sites) and returns the id of the new document.
+
+    create_file(name: str, folder: str, file_type: str) -> str:
+        Creates a new file in Google Drive and returns the id of the new file.
+
+    get_file_by_name(name: str, folder: str) -> list:
+        Gets a file by name in Google Drive and returns a list of files that match the name.
+
+    list_folders_in_folder(folder: str) -> list:
+        Lists all folders in a folder in Google Drive and returns a list of folders in the folder.
 
     copy_file_to_folder(file_id: str, name: str, parent_folder_id: str, destination_folder_id: str) -> str:
         Copies a file to a new folder in Google Drive and returns the id of the new file.
+
+    healthcheck() -> bool:
+        Checks the health of the Google Drive API and returns True if the API is healthy, False otherwise.
 """
 import os
 from integrations.google_workspace.google_service import (
@@ -22,7 +40,6 @@ from integrations.google_workspace.google_service import (
     handle_google_api_errors,
 )
 
-SRE_INCIDENT_FOLDER = os.environ.get("SRE_INCIDENT_FOLDER")
 INCIDENT_TEMPLATE = os.environ.get("INCIDENT_TEMPLATE")
 
 
@@ -131,7 +148,7 @@ def create_folder(name, parent_folder):
 
 
 @handle_google_api_errors
-def create_new_file_from_template(name, folder, template):
+def create_file_from_template(name, folder, template):
     """Create a new file in Google Drive from a template
      (Docs, Sheets, Slides, Forms, or Sites.)
 
@@ -159,7 +176,7 @@ def create_new_file_from_template(name, folder, template):
 
 
 @handle_google_api_errors
-def create_new_file(name, folder, file_type):
+def create_file(name, folder, file_type):
     """Create a new file in Google Drive.
         Options for 'file_type' are:
 

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -278,11 +278,11 @@ def list_folders_in_folder(folder):
             )
             .execute()
         )
-        all_files.extend(results.get('files', []))
-        page_token = results.get('nextPageToken')
+        all_files.extend(results.get("files", []))
+        page_token = results.get("nextPageToken")
         if not page_token:
             break
-    return results.get("files", [])
+    return all_files
 
 
 @handle_google_api_errors

--- a/app/integrations/google_workspace/google_meet.py
+++ b/app/integrations/google_workspace/google_meet.py
@@ -1,4 +1,11 @@
-"""Google Meet integration."""
+"""Google Meet Module.
+
+This module provides a function to start a Google Meet session.
+
+Functions:
+    create_google_meet(title: str) -> str:
+        Starts a Google Meet session and returns the URL of the session.
+"""
 import re
 from datetime import datetime
 

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -68,10 +68,10 @@ def handle_google_api_errors(func):
         try:
             return func(*args, **kwargs)
         except HttpError as e:
-            print(f"An HTTP error occurred: {e}")
+            print(f"An HTTP error occurred in function {func.__name__}: {e}")
             return None
         except Error as e:
-            print(f"An error occurred: {e}")
+            print(f"An error occurred in function {func.__name__}: {e}")
             return None
 
     return wrapper

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -70,6 +70,9 @@ def handle_google_api_errors(func):
         except HttpError as e:
             logging.error(f"An HTTP error occurred in function '{func.__name__}': {e}")
             return None
+        except ValueError as e:
+            logging.error(f"A ValueError occurred in function '{func.__name__}': {e}")
+            return None
         except Error as e:
             logging.error(f"An error occurred in function '{func.__name__}': {e}")
             return None

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -68,10 +68,10 @@ def handle_google_api_errors(func):
         try:
             return func(*args, **kwargs)
         except HttpError as e:
-            print(f"An HTTP error occurred in function {func.__name__}: {e}")
+            print(f"An HTTP error occurred in function '{func.__name__}': {e}")
             return None
         except Error as e:
-            print(f"An error occurred in function {func.__name__}: {e}")
+            print(f"An error occurred in function '{func.__name__}': {e}")
             return None
 
     return wrapper

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -68,10 +68,10 @@ def handle_google_api_errors(func):
         try:
             return func(*args, **kwargs)
         except HttpError as e:
-            print(f"An HTTP error occurred in function '{func.__name__}': {e}")
+            logging.error(f"An HTTP error occurred in function '{func.__name__}': {e}")
             return None
         except Error as e:
-            print(f"An error occurred in function '{func.__name__}': {e}")
+            logging.error(f"An error occurred in function '{func.__name__}': {e}")
             return None
 
     return wrapper

--- a/app/main.py
+++ b/app/main.py
@@ -26,11 +26,6 @@ def main(bot):
     APP_TOKEN = os.environ.get("APP_TOKEN")
     PREFIX = os.environ.get("PREFIX", "")
 
-    # Register Google Service command for dev purposes only
-    if os.getenv('PREFIX') == 'dev-':
-        bot.command(f"/{PREFIX}google-service")(google_service.google_service_command)
-        bot.view("google_service_view")(google_service.open_modal)
-
     # Register Roles commands
     bot.command(f"/{PREFIX}talent-role")(role.role_command)
     bot.view("role_view")(role.role_view_handler)
@@ -98,6 +93,11 @@ def main(bot):
         scheduled_tasks.init(bot)
         stop_run_continuously = scheduled_tasks.run_continuously()
         server_app.add_event_handler("shutdown", lambda: stop_run_continuously.set())
+
+    # Register Google Service command for dev purposes only
+    if PREFIX == "dev-":
+        bot.command(f"/{PREFIX}google-service")(google_service.google_service_command)
+        bot.view("google_service_view")(google_service.open_modal)
 
 
 def get_bot():

--- a/app/main.py
+++ b/app/main.py
@@ -26,9 +26,10 @@ def main(bot):
     APP_TOKEN = os.environ.get("APP_TOKEN")
     PREFIX = os.environ.get("PREFIX", "")
 
-    # Register Google Service command
-    bot.command(f"/{PREFIX}google-service")(google_service.google_service_command)
-    bot.view("google_service_view")(google_service.open_modal)
+    # Register Google Service command for dev purposes only
+    if os.getenv('PREFIX') == 'dev-':
+        bot.command(f"/{PREFIX}google-service")(google_service.google_service_command)
+        bot.view("google_service_view")(google_service.open_modal)
 
     # Register Roles commands
     bot.command(f"/{PREFIX}talent-role")(role.role_command)

--- a/app/main.py
+++ b/app/main.py
@@ -96,7 +96,7 @@ def main(bot):
 
     # Register Google Service command for dev purposes only
     if PREFIX == "dev-":
-        bot.command(f"/{PREFIX}google-service")(google_service.google_service_command)
+        bot.command(f"/{PREFIX}google")(google_service.google_service_command)
         bot.view("google_service_view")(google_service.open_modal)
 
 

--- a/app/mypy.ini
+++ b/app/mypy.ini
@@ -1,0 +1,2 @@
+[mypy-google.oauth2.service_account]
+ignore_missing_imports = True

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -130,6 +130,18 @@ def test_list_folders_returns_folder_names(get_google_service_mock):
     ]
 
 
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_list_folders_iterates_over_pages(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.list.return_value.execute.side_effect = [
+        {"files": [{"name": "test_folder"}], "nextPageToken": "token"},
+        {"files": [{"name": "test_folder2"}]},
+    ]
+    assert google_drive.list_folders_in_folder("parent_folder") == [
+        {"name": "test_folder"},
+        {"name": "test_folder2"},
+    ]
+
+
 @patch("integrations.google_workspace.google_drive.list_metadata")
 def test_healthcheck_healthy(list_metadata_mock):
     list_metadata_mock.return_value = {"id": "test_doc"}

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -1,0 +1,87 @@
+"""Unit tests for google_drive module."""
+import pytest
+from unittest.mock import patch
+
+import integrations.google_workspace.google_drive as google_drive
+
+# Constants for the test
+START_HEADING = "Detailed Timeline"
+END_HEADING = "Trigger"
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_add_metadata_returns_result(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.update.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
+    result = google_drive.add_metadata("file_id", "key", "value")
+    assert result == {"name": "test_folder", "appProperties": {"key": "value"}}
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_delete_metadata_returns_result(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.update.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {},
+    }
+    result = google_drive.delete_metadata("file_id", "key")
+    get_google_service_mock.return_value.files.return_value.update.assert_called_once_with(
+        fileId="file_id",
+        body={"appProperties": {"key": None}},
+        fields="name, appProperties",
+        supportsAllDrives=True,
+    )
+    assert result == {"name": "test_folder", "appProperties": {}}
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_create_folder_returns_folder_id(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
+        "id": "test_folder_id"
+    }
+    result = google_drive.create_folder("test_folder", "parent_folder")
+    assert result == "test_folder_id"
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_create_new_file_with_valid_type_returns_file_id(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
+        "id": "test_document_id"
+    }
+    result = google_drive.create_new_file("test_document", "folder_id", "document")
+    assert result == "test_document_id"
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_create_new_file_with_invalid_type_raises_value_error(get_google_service_mock):
+    with pytest.raises(ValueError) as e:
+        google_drive.create_new_file("test_document", "folder_id", "invalid_type")
+    assert "Invalid file_type: invalid_type" in str(e.value)
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_create_new_file_from_template_returns_file_id(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.copy.return_value.execute.return_value = {
+        "id": "test_document_id"
+    }
+    result = google_drive.create_new_file_from_template(
+        "test_document", "folder_id", "template_id"
+    )
+    assert result == "test_document_id"
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_copy_file_to_folder_returns_file_id(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.copy.return_value.execute.return_value = {
+        "id": "file_id"
+    }
+    get_google_service_mock.return_value.files.return_value.update.return_value.execute.return_value = {
+        "id": "updated_file_id"
+    }
+    assert (
+        google_drive.copy_file_to_folder(
+            "file_id", "name", "parent_folder", "destination_folder"
+        )
+        == "updated_file_id"
+    )

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -36,6 +36,16 @@ def test_delete_metadata_returns_result(get_google_service_mock):
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
+def test_list_metadata_returns_result(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.get.return_value.execute.return_value = {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
+    result = google_drive.list_metadata("file_id")
+    assert result == {"name": "test_folder", "appProperties": {"key": "value"}}
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
 def test_create_folder_returns_folder_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
         "id": "test_folder_id"
@@ -105,3 +115,13 @@ def test_copy_file_to_folder_returns_file_id(get_google_service_mock):
         )
         == "updated_file_id"
     )
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
+def test_list_folders_returns_folder_names(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
+        "files": [{"name": "test_folder"}]
+    }
+    assert google_drive.list_folders_in_folder("parent_folder") == [{"name": "test_folder"}]
+
+

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -54,7 +54,7 @@ def test_create_folder_returns_folder_id(get_google_service_mock):
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
-def test_create_new_file_with_valid_type_returns_file_id(get_google_service_mock):
+def test_create_file_with_valid_type_returns_file_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
         "id": "test_document_id"
     }
@@ -62,15 +62,21 @@ def test_create_new_file_with_valid_type_returns_file_id(get_google_service_mock
     assert result == "test_document_id"
 
 
+@patch("logging.error")
 @patch("integrations.google_workspace.google_drive.get_google_service")
-def test_create_new_file_with_invalid_type_raises_value_error(get_google_service_mock):
-    with pytest.raises(ValueError) as e:
-        google_drive.create_file("test_document", "folder_id", "invalid_type")
-    assert "Invalid file_type: invalid_type" in str(e.value)
+def test_create_file_with_invalid_type_raises_value_error(
+    get_google_service_mock, mocked_logging_error
+):
+    result = google_drive.create_file("name", "folder", "invalid_file_type")
+
+    assert result is None
+    mocked_logging_error.assert_called_once_with(
+        "A ValueError occurred in function 'create_file': Invalid file_type: invalid_file_type"
+    )
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
-def test_create_new_file_from_template_returns_file_id(get_google_service_mock):
+def test_create_file_from_template_returns_file_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.copy.return_value.execute.return_value = {
         "id": "test_document_id"
     }

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -122,6 +122,18 @@ def test_list_folders_returns_folder_names(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
         "files": [{"name": "test_folder"}]
     }
-    assert google_drive.list_folders_in_folder("parent_folder") == [{"name": "test_folder"}]
+    assert google_drive.list_folders_in_folder("parent_folder") == [
+        {"name": "test_folder"}
+    ]
 
 
+@patch("integrations.google_workspace.google_drive.list_metadata")
+def test_healthcheck_healthy(list_metadata_mock):
+    list_metadata_mock.return_value = {"id": "test_doc"}
+    assert google_drive.healthcheck() is True
+
+
+@patch("integrations.google_workspace.google_drive.list_metadata")
+def test_healthcheck_unhealthy(list_metadata_mock):
+    list_metadata_mock.return_value = None
+    assert google_drive.healthcheck() is False

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -41,8 +41,10 @@ def test_list_metadata_returns_result(get_google_service_mock):
         "name": "test_folder",
         "appProperties": {"key": "value"},
     }
-    result = google_drive.list_metadata("file_id")
-    assert result == {"name": "test_folder", "appProperties": {"key": "value"}}
+    assert google_drive.list_metadata("file_id") == {
+        "name": "test_folder",
+        "appProperties": {"key": "value"},
+    }
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
@@ -50,8 +52,9 @@ def test_create_folder_returns_folder_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
         "id": "test_folder_id"
     }
-    result = google_drive.create_folder("test_folder", "parent_folder")
-    assert result == "test_folder_id"
+    assert (
+        google_drive.create_folder("test_folder", "parent_folder") == "test_folder_id"
+    )
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
@@ -59,14 +62,14 @@ def test_create_new_file_with_valid_type_returns_file_id(get_google_service_mock
     get_google_service_mock.return_value.files.return_value.create.return_value.execute.return_value = {
         "id": "test_document_id"
     }
-    result = google_drive.create_new_file("test_document", "folder_id", "document")
+    result = google_drive.create_file("test_document", "folder_id", "document")
     assert result == "test_document_id"
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
 def test_create_new_file_with_invalid_type_raises_value_error(get_google_service_mock):
     with pytest.raises(ValueError) as e:
-        google_drive.create_new_file("test_document", "folder_id", "invalid_type")
+        google_drive.create_file("test_document", "folder_id", "invalid_type")
     assert "Invalid file_type: invalid_type" in str(e.value)
 
 
@@ -75,7 +78,7 @@ def test_create_new_file_from_template_returns_file_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.copy.return_value.execute.return_value = {
         "id": "test_document_id"
     }
-    result = google_drive.create_new_file_from_template(
+    result = google_drive.create_file_from_template(
         "test_document", "folder_id", "template_id"
     )
     assert result == "test_document_id"

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -4,10 +4,6 @@ from unittest.mock import patch
 
 import integrations.google_workspace.google_drive as google_drive
 
-# Constants for the test
-START_HEADING = "Detailed Timeline"
-END_HEADING = "Trigger"
-
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
 def test_add_metadata_returns_result(get_google_service_mock):

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -1,5 +1,4 @@
 """Unit tests for google_drive module."""
-import pytest
 from unittest.mock import patch
 
 import integrations.google_workspace.google_drive as google_drive

--- a/app/tests/integrations/google_workspace/test_google_drive_module.py
+++ b/app/tests/integrations/google_workspace/test_google_drive_module.py
@@ -72,6 +72,26 @@ def test_create_new_file_from_template_returns_file_id(get_google_service_mock):
 
 
 @patch("integrations.google_workspace.google_drive.get_google_service")
+def test_get_file_by_name_returns_object(get_google_service_mock):
+    get_google_service_mock.return_value.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {
+                "name": "test_document",
+                "id": "test_document_id",
+                "appProperties": {},
+            },
+        ]
+    }
+    assert google_drive.get_file_by_name("test_file_name", "folder_id") == [
+        {
+            "name": "test_document",
+            "id": "test_document_id",
+            "appProperties": {},
+        }
+    ]
+
+
+@patch("integrations.google_workspace.google_drive.get_google_service")
 def test_copy_file_to_folder_returns_file_id(get_google_service_mock):
     get_google_service_mock.return_value.files.return_value.copy.return_value.execute.return_value = {
         "id": "file_id"

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -54,26 +54,32 @@ def test_get_google_service_raises_exception_if_credentials_json_is_invalid(
         assert "Invalid credentials JSON" in str(e.value)
 
 
-def test_handle_google_api_errors_catches_http_error():
+def test_handle_google_api_errors_catches_http_error(capfd):
     mock_resp = MagicMock()
     mock_resp.status = "400"
     mock_func = MagicMock(side_effect=HttpError(resp=mock_resp, content=b""))
+    mock_func.__name__ = "mock_func"
     decorated_func = handle_google_api_errors(mock_func)
 
     result = decorated_func()
 
     assert result is None
     mock_func.assert_called_once()
+    out, err = capfd.readouterr()
+    assert "An HTTP error occurred in function mock_func:" in out
 
 
-def test_handle_google_api_errors_catches_error():
+def test_handle_google_api_errors_catches_error(capfd):
     mock_func = MagicMock(side_effect=Error())
+    mock_func.__name__ = "mock_func"
     decorated_func = handle_google_api_errors(mock_func)
 
     result = decorated_func()
 
     assert result is None
     mock_func.assert_called_once()
+    out, err = capfd.readouterr()
+    assert "An error occurred in function mock_func:" in out
 
 
 def test_handle_google_api_errors_passes_through_return_value():

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -66,7 +66,7 @@ def test_handle_google_api_errors_catches_http_error(capfd):
     assert result is None
     mock_func.assert_called_once()
     out, err = capfd.readouterr()
-    assert "An HTTP error occurred in function mock_func:" in out
+    assert "An HTTP error occurred in function 'mock_func':" in out
 
 
 def test_handle_google_api_errors_catches_error(capfd):
@@ -79,7 +79,7 @@ def test_handle_google_api_errors_catches_error(capfd):
     assert result is None
     mock_func.assert_called_once()
     out, err = capfd.readouterr()
-    assert "An error occurred in function mock_func:" in out
+    assert "An error occurred in function 'mock_func':" in out
 
 
 def test_handle_google_api_errors_passes_through_return_value():


### PR DESCRIPTION
# Summary | Résumé

Fixed: 
- .devcontainer.json configuration and vscode settings for codespaces setup 
- make the new dev test commands available in dev only
- update google_meet module docstring

Refactor the Google Drive integration:
_Note: none of the changes below affect the app in production for the moment_

- split the functions using the different endpoints into each their distinct module (google_drive, google_docs, google
- streamline the functions and make them reusable in different contexts
   - e.g.: single function to create a new file, taking the file type as an argument instead of two separate functions
- add a google api error handler wrapper function

## TODO: Add the remaining functions to their respective modules and update the imports in the various commands:
1. get_timeline_section: Uses the Docs endpoint. This function should get a section with a start/end heading instead of using const. The implementation function needs to be adjusted.
2. merge_data: Uses Docs and is specific to an incident. This function should be moved to the incident helper.
3. replace_text_between_headings: Uses Docs and seems specific to the incident command. This function should be moved to the incident helper.
4. create_incident: This function should be moved to the incident helper.
5. close_incident_document: This function should be moved to the incident helper.
6. update_incident_list: This function should be moved to the incident helper.
7. update_spreadsheet_close_incident: This function should be moved to the incident helper.

