### PR TITLE
Adding logic to properly translate Slack usernames to the incident timeline

### DIFF
--- a/app/commands/utils.py
+++ b/app/commands/utils.py
@@ -223,3 +223,15 @@ def extract_google_doc_id(url):
         return match.group(1)
     else:
         return None
+
+
+# Function to replace the user id with the user handle in a message:w
+def replace_user_id_with_handle(user_handle, message):
+    if not user_handle or not message:
+        logging.error("User handle or message is empty or None")
+        return None
+
+    user_id_pattern = r"<@\w+>"
+    if re.search(user_id_pattern, message):
+        message = re.sub(user_id_pattern, user_handle, message)
+    return message

--- a/app/tests/commands/test_incident.py
+++ b/app/tests/commands/test_incident.py
@@ -985,12 +985,44 @@ def test_handle_reaction_added_adding_new_message_to_timeline():
     mock_client.users_profile_get.assert_called_once()
 
 
+def test_handle_reaction_added_adding_new_message_to_timeline_user_handle():
+    logger = MagicMock()
+    mock_client = MagicMock()
+    mock_client.conversations_info.return_value = {"channel": {"name": "incident-123"}}
+    mock_client.conversations_history.return_value = {
+        "ok": True,
+        "messages": [
+            {
+                "type": "message",
+                "user": "U123ABC456",
+                "text": "<U123ABC456> says Sample test message",
+                "ts": "1512085950.000216",
+            }
+        ],
+    }
+    body = {
+        "event": {
+            "reaction": "floppy_disk",
+            "item": {"channel": "C123456", "ts": "123456"},
+        }
+    }
+
+    incident.handle_reaction_added(mock_client, lambda: None, body, logger)
+
+    # Make assertion that the function calls the correct functions
+    mock_client.conversations_history.assert_called_once()
+    mock_client.bookmarks_list.assert_called_once()
+    mock_client.users_profile_get.assert_called_once()
+
+
 def test_handle_reaction_removed_successful_message_removal():
     # Mock the client and logger
     logger = MagicMock()
     mock_client = MagicMock()
     mock_client.conversations_info.return_value = {"channel": {"name": "incident-123"}}
-    mock_client.users_profile_get.return_value = {"profile": {"real_name": "John Doe"}}
+    mock_client.users_profile_get.return_value = {
+        "profile": {"real_name": "John Doe", "display_name": "John"}
+    }
     mock_client.bookmarks_list.return_value = {
         "ok": True,
         "bookmarks": [{"title": "Incident report", "link": "http://example.com"}],
@@ -1011,6 +1043,45 @@ def test_handle_reaction_removed_successful_message_removal():
                 "type": "message",
                 "user": "U123ABC456",
                 "text": "Sample test message",
+                "ts": "1512085950.000216",
+            }
+        ],
+    }
+
+    incident.handle_reaction_removed(mock_client, lambda: None, body, logger)
+    mock_client.conversations_history.assert_called_once()
+    mock_client.bookmarks_list.assert_called_once()
+    mock_client.users_profile_get.assert_called_once()
+
+
+def test_handle_reaction_removed_successful_message_removal_user_id():
+    # Mock the client and logger
+    logger = MagicMock()
+    mock_client = MagicMock()
+    mock_client.conversations_info.return_value = {"channel": {"name": "incident-123"}}
+    mock_client.users_profile_get.return_value = {
+        "profile": {"real_name": "John Doe", "display_name": "John"}
+    }
+    mock_client.bookmarks_list.return_value = {
+        "ok": True,
+        "bookmarks": [{"title": "Incident report", "link": "http://example.com"}],
+    }
+    mock_client.get_timeline_section.return_value = "Sample test message"
+    mock_client.replace_text_between_headings.return_value = True
+
+    body = {
+        "event": {
+            "reaction": "floppy_disk",
+            "item": {"channel": "C123456", "ts": "123456"},
+        }
+    }
+    mock_client.conversations_history.return_value = {
+        "ok": True,
+        "messages": [
+            {
+                "type": "message",
+                "user": "U123ABC456",
+                "text": "<U123ABC456> says Sample test message",
                 "ts": "1512085950.000216",
             }
         ],

--- a/app/tests/commands/test_utils.py
+++ b/app/tests/commands/test_utils.py
@@ -277,3 +277,44 @@ def test_extract_googe_doc_id_empty_string():
 
 def test_extract_googe_doc_id_none_input():
     assert utils.extract_google_doc_id(None) is None
+
+
+def test_replace_user_id_with_valid_handle():
+    assert (
+        utils.replace_user_id_with_handle("@user", "Hello <@U12345>, how are you?")
+        == "Hello @user, how are you?"
+    )
+
+
+def test_replace_user_id_with_no_pattern_in_message():
+    assert (
+        utils.replace_user_id_with_handle("@user", "Hello user, how are you?")
+        == "Hello user, how are you?"
+    )
+
+
+def test_replace_user_id_with_empty_handle():
+    assert (
+        utils.replace_user_id_with_handle("", "Hello <@U12345>, how are you?") is None
+    )
+
+
+def test_replace_user_id_with_empty_message():
+    assert utils.replace_user_id_with_handle("@user", "") is None
+
+
+def test_replace_user_id_with_none_handle():
+    assert (
+        utils.replace_user_id_with_handle(None, "Hello <@U12345>, how are you?") is None
+    )
+
+
+def test_replace_user_id_with_none_message():
+    assert utils.replace_user_id_with_handle("@user", None) is None
+
+
+def test_replace_multiple_user_ids_in_message():
+    assert (
+        utils.replace_user_id_with_handle("@user", "Hi <@U12345>, meet <@U67890>")
+        == "Hi @user, meet @user"
+    )


### PR DESCRIPTION
# Summary | Résumé

Added logic to replace the user ids properly when tagging someone in Slack using @user_name. 

Now instead of "Hi <@U12345>, meet <@U67890> and <@U54321>", it will be written in the document as "Hi @user, meet @user and @user"


![Screenshot 2024-02-05 at 4 20 56 PM](https://github.com/cds-snc/sre-bot/assets/85905333/60a33c79-20f9-4737-953a-21599fe4b77a)
