### PR TITLE
Refactor/module secret

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,8 @@ from functools import partial
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt import App
 from dotenv import load_dotenv
-from commands import atip, aws, incident, secret, sre, role, google_service
+from commands import atip, aws, incident, sre, role, google_service
+from modules import secret
 from commands.helpers import incident_helper, webhook_helper
 from server import bot_middleware, server
 
@@ -61,9 +62,7 @@ def main(bot):
     bot.view("view_save_incident_roles")(incident_helper.save_incident_roles)
 
     # Register Secret command
-    bot.command(f"/{PREFIX}secret")(secret.secret_command)
-    bot.action("secret_change_locale")(secret.handle_change_locale_button)
-    bot.view("secret_view")(secret.secret_view_handler)
+    secret.register(bot)
 
     # Register SRE events
     bot.command(f"/{PREFIX}sre")(sre.sre_command)

--- a/app/modules/secret/__init__.py
+++ b/app/modules/secret/__init__.py
@@ -1,0 +1,1 @@
+from .secret import register  # noqa: F401

--- a/app/modules/secret/secret.py
+++ b/app/modules/secret/secret.py
@@ -1,3 +1,4 @@
+import os
 import i18n
 import requests
 import time
@@ -7,6 +8,14 @@ i18n.load_path.append("./commands/locales/")
 
 i18n.set("locale", "en-US")
 i18n.set("fallback", "en-US")
+
+PREFIX = os.environ.get("PREFIX", "")
+
+
+def register(bot):
+    bot.command(f"/{PREFIX}secret")(secret_command)
+    bot.action("secret_change_locale")(handle_change_locale_button)
+    bot.view("secret_view")(secret_view_handler)
 
 
 def secret_command(client, ack, command, body):

--- a/app/tests/modules/test_secret.py
+++ b/app/tests/modules/test_secret.py
@@ -1,10 +1,10 @@
-from commands import secret
+from modules.secret import secret
 
 from unittest.mock import MagicMock, patch
 
 
-@patch("commands.secret.generate_secret_command_modal_view")
-@patch("commands.secret.get_user_locale")
+@patch("modules.secret.secret.generate_secret_command_modal_view")
+@patch("modules.secret.secret.get_user_locale")
 def test_secret_command(mock_get_user_locale, mock_generate_secret_command_modal_view):
     client = MagicMock()
     ack = MagicMock()
@@ -31,8 +31,8 @@ def test_secret_command(mock_get_user_locale, mock_generate_secret_command_modal
     )
 
 
-@patch("commands.secret.requests")
-@patch("commands.secret.time")
+@patch("modules.secret.secret.requests")
+@patch("modules.secret.secret.time")
 def test_secret_view_handler_with_succesfull_request(mock_time, mock_requests):
     ack = MagicMock()
     client = MagicMock()
@@ -89,8 +89,8 @@ def test_secret_view_handler_with_succesfull_request(mock_time, mock_requests):
     )
 
 
-@patch("commands.secret.requests")
-@patch("commands.secret.time")
+@patch("modules.secret.secret.requests")
+@patch("modules.secret.secret.time")
 def test_secret_view_handler_with_failed_request(mock_time, mock_requests):
     ack = MagicMock()
     client = MagicMock()
@@ -147,7 +147,7 @@ def test_secret_view_handler_with_failed_request(mock_time, mock_requests):
     )
 
 
-@patch("commands.secret.generate_secret_command_modal_view")
+@patch("modules.secret.secret.generate_secret_command_modal_view")
 def test_handle_change_locale_button(mock_generate_secret_command_modal_view):
     ack = MagicMock()
     client = MagicMock()


### PR DESCRIPTION
# Summary | Résumé

Small change to refactor the bot's structure:
- moved the secret.py code in its own module
- added a command register function
- setup the init file with the register function
- updated main.py to call the register function to make the code more readable
   - also makes module more self contained as new commands could be supported without modifying main
