### PR TITLE
fix: stop log to sentinel from triggering Slack retries

### DIFF
--- a/app/integrations/sentinel.py
+++ b/app/integrations/sentinel.py
@@ -88,8 +88,15 @@ def post_data(customer_id, shared_key, body, log_type):
 
 
 def log_to_sentinel(event, message):
+    is_event_sent = False
     payload = {"event": event, "message": message}
-    if send_event(payload):
+
+    try:
+        is_event_sent = send_event(payload)
+    except Exception as e:
+        logging.error(e)
+
+    if is_event_sent:
         logging.info(f"Sentinel event sent: {payload}")
     else:
         logging.error(f"Sentinel event failed: {payload}")


### PR DESCRIPTION
# Summary
Update the `log_to_sentinel` method so that on failure, it logs an error but does not bubble the exception up to the caller. This is being done because a failure to log to Sentinel should not break the SRE Bot's behaviour.

The logged error will get caught by the CloudWatch metric filter and allow the SRE team to investigate.