### PR TITLE
fix: handle budget auto-adjustment events

### DIFF
--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -24,7 +24,10 @@ def parse(payload, client):
         blocks = format_new_iam_user(payload)
     elif isinstance(msg, str) and "API Key with value token=" in msg:
         blocks = format_api_key_detected(payload, client)
-    elif isinstance(msg, dict) and {"previousBudgetLimit", "currentBudgetLimit"} <= msg.keys():
+    elif (
+        isinstance(msg, dict)
+        and {"previousBudgetLimit", "currentBudgetLimit"} <= msg.keys()
+    ):
         logging.info(f"Budget auto-adjustment event received: {payload.Message}")
         blocks = []
     else:

--- a/app/server/event_handlers/aws.py
+++ b/app/server/event_handlers/aws.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import os
 import urllib.parse
@@ -23,6 +24,9 @@ def parse(payload, client):
         blocks = format_new_iam_user(payload)
     elif isinstance(msg, str) and "API Key with value token=" in msg:
         blocks = format_api_key_detected(payload, client)
+    elif isinstance(msg, dict) and {"previousBudgetLimit", "currentBudgetLimit"} <= msg.keys():
+        logging.info(f"Budget auto-adjustment event received: {payload.Message}")
+        blocks = []
     else:
         blocks = []
         log_ops_message(

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -18,9 +18,13 @@ def test_parse_returns_empty_block_if_no_match_and_logs_error(log_ops_message_mo
 
 
 @patch("server.event_handlers.aws.log_ops_message")
-def test_parse_returns_empty_block_if_budget_auto_adjustment_event():
+def test_parse_returns_empty_block_if_budget_auto_adjustment_event(
+    log_ops_message_mock,
+):
     client = MagicMock()
-    payload = MagicMock(Message='{"previousBudgetLimit": "1", "currentBudgetLimit": "2"}')
+    payload = MagicMock(
+        Message='{"previousBudgetLimit": "1", "currentBudgetLimit": "2"}'
+    )
     response = aws.parse(payload, client)
     assert response == []
     log_ops_message_mock.assert_not_called()

--- a/app/tests/server/event_handlers/test_aws_handler.py
+++ b/app/tests/server/event_handlers/test_aws_handler.py
@@ -17,6 +17,15 @@ def test_parse_returns_empty_block_if_no_match_and_logs_error(log_ops_message_mo
     )
 
 
+@patch("server.event_handlers.aws.log_ops_message")
+def test_parse_returns_empty_block_if_budget_auto_adjustment_event():
+    client = MagicMock()
+    payload = MagicMock(Message='{"previousBudgetLimit": "1", "currentBudgetLimit": "2"}')
+    response = aws.parse(payload, client)
+    assert response == []
+    log_ops_message_mock.assert_not_called()
+
+
 @patch("server.event_handlers.aws.format_cloudwatch_alarm")
 def test_parse_returns_blocks_if_AlarmArn_in_msg(format_cloudwatch_alarm_mock):
     client = MagicMock()


### PR DESCRIPTION
# Summary
Update the SRE bot to recognize and ignore spend budget auto-adjustment notifications.  We're receiving these now because of the historical spend budget setup on Notify production.

# Related
- https://gcdigital.slack.com/archives/C0388M21LKZ/p1709260800376949