### PR TITLE
Disable a webhook 

### DIFF
--- a/app/models/webhooks.py
+++ b/app/models/webhooks.py
@@ -84,6 +84,15 @@ def revoke_webhook(id):
     return response
 
 
+# function to return the status of the webhook (ie if it is active or not). If active, return True, else return False
+def is_active(id):
+    response = client.get_item(TableName=table, Key={"id": {"S": id}})
+    if "Item" in response:
+        return response["Item"]["active"]["BOOL"]
+    else:
+        return False
+
+
 def toggle_webhook(id):
     response = client.update_item(
         TableName=table,

--- a/app/modules/sre/webhook_helper.py
+++ b/app/modules/sre/webhook_helper.py
@@ -320,7 +320,7 @@ def toggle_webhook(ack, body, logger, client):
     channel = hook["channel"]["S"]
 
     webhooks.toggle_webhook(id)
-    message = f"Webhook {name} has been {'enabled' if hook['active']['BOOL'] else 'disabled'} by <@{username}>"
+    message = f"Webhook {name} has been {'disabled' if hook['active']['BOOL'] else 'enabled'} by <@{username}>"
     logger.info(message)
     client.chat_postMessage(
         channel=channel,

--- a/app/tests/models/test_webhooks.py
+++ b/app/tests/models/test_webhooks.py
@@ -166,6 +166,46 @@ def test_revoke_webhook(client_mock):
 
 
 @patch("models.webhooks.client")
+def test_is_active_returns_true(client_mock):
+    client_mock.get_item.return_value = {
+        "Item": {
+            "id": {"S": "test_id"},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": "test_created_at"},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+            "invocation_count": {"N": "0"},
+            "acknowledged_count": {"N": "0"},
+        }
+    }
+    assert webhooks.is_active("test_id") is True
+
+
+@patch("models.webhooks.client")
+def test_is_active_returns_false(client_mock):
+    client_mock.get_item.return_value = {
+        "Item": {
+            "id": {"S": "test_id"},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": "test_created_at"},
+            "active": {"BOOL": False},
+            "user_id": {"S": "test_user_id"},
+            "invocation_count": {"N": "0"},
+            "acknowledged_count": {"N": "0"},
+        }
+    }
+    assert webhooks.is_active("test_id") is False
+
+
+@patch("models.webhooks.client")
+def test_is_active_not_found(client_mock):
+    client_mock.get_item.return_value = {}
+    assert webhooks.is_active("test_id") is False
+
+
+@patch("models.webhooks.client")
 @patch("models.webhooks.get_webhook")
 def test_toggle_webhook(get_webhook_mock, client_mock):
     client_mock.update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}

--- a/app/tests/modules/sre/test_webhook_helper.py
+++ b/app/tests/modules/sre/test_webhook_helper.py
@@ -505,11 +505,11 @@ def test_toggle_webhook(list_all_webhooks_mock, toggle_webhook_mock, get_webhook
     webhook_helper.toggle_webhook(ack, body, logger, client)
     ack.assert_called()
     toggle_webhook_mock.assert_called_with("id")
-    logger.info.assert_called_with("Webhook name has been enabled by <@username>")
+    logger.info.assert_called_with("Webhook name has been disabled by <@username>")
     client.chat_postMessage.assert_called_with(
         channel="channel",
         user="user_id",
-        text="Webhook name has been enabled by <@username>",
+        text="Webhook name has been disabled by <@username>",
     )
     list_all_webhooks_mock.assert_called_with(
         client, body, 0, webhook_helper.MAX_BLOCK_SIZE, "all", update=True


### PR DESCRIPTION
# Summary | Résumé

The following changes were made:
1. Properly disabled a webhook. 
2. The message that now appears shows properly when disabling a webhook (ie it says Webhook disabled by user) and when enabled now says Webhook enabled by user. It was reverse prevously.
3. If a webhook is disabled, you will not be able to use it to send messages.
4. Unit tests were added and changed. 

Part of this PR closes #436 