### PR TITLE
Display a message as to who archived a channel when using the close incident command

### DIFF
--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -302,9 +302,9 @@ def close_incident(client, body, ack):
     # get the current chanel id and name
     channel_id = body["channel_id"]
     channel_name = body["channel_name"]
+    user_id = body["user_id"]
 
     if not channel_name.startswith("incident-"):
-        user_id = body["user_id"]
         try:
             response = client.chat_postEphemeral(
                 text=f"Channel {channel_name} is not an incident channel. Please use this command in an incident channel.",
@@ -351,6 +351,12 @@ def close_incident(client, body, ack):
     if not response["ok"]:
         logging.error(
             "Could not archive the channel %s - %s", channel_name, response["error"]
+        )
+    else:
+        # post a message that the channel has been archived by the user
+        client.chat_postMessage(
+            channel=channel_id,
+            text=f"<@{user_id}> has archived this channel 👋",
         )
 
 


### PR DESCRIPTION
# Summary | Résumé

Display a message as to who archived a channel when using the incident close command or when the stale incident message pops up and the user selects the option to archive the channel. The message will look like:

![Screenshot 2024-03-26 at 4 00 14 PM](https://github.com/cds-snc/sre-bot/assets/85905333/e34cf858-f73d-462b-9c5a-7fbe2196fc2f)
