### PR TITLE
Fixing a bug where the person closing the incident was not displaying

### DIFF
--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -344,6 +344,12 @@ def close_incident(client, body, ack):
     # Update the spreadsheet with the current incident with status = closed
     google_drive.update_spreadsheet_close_incident(return_channel_name(channel_name))
 
+    # Need to post the message before the channe is archived so that the message can be delivered.
+    client.chat_postMessage(
+        channel=channel_id,
+        text=f"<@{user_id}> has archived this channel 👋",
+    )
+
     # archive the channel
     response = client.conversations_archive(channel=channel_id)
 
@@ -353,11 +359,8 @@ def close_incident(client, body, ack):
             "Could not archive the channel %s - %s", channel_name, response["error"]
         )
     else:
-        # post a message that the channel has been archived by the user
-        client.chat_postMessage(
-            channel=channel_id,
-            text=f"<@{user_id}> has archived this channel 👋",
-        )
+        # Log the message that the user has archived the channel.
+        logging.info(f"<@{user_id}> has archived this channel")
 
 
 def stale_incidents(client, body, ack):

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -360,7 +360,9 @@ def close_incident(client, body, ack):
         )
     else:
         # Log the message that the user has archived the channel.
-        logging.info(f"<@{user_id}> has archived this channel")
+        logging.info(
+            "Channel %s has been archived by %s", channel_name, f"<@{user_id}>"
+        )
 
 
 def stale_incidents(client, body, ack):


### PR DESCRIPTION
# Summary | Résumé

Totally my fault here - at the last minute I decided to change the logic to make the code better thus breaking the intention and functionality of the code. The issue was that the message has to be sent before the channel is archived otherwise, the message would fail. As a result, I had to move the code that posts the message before the archiving action. 