### PR TITLE
Adding days input variable to let user select the number of days ahead to schedule a retro

### DIFF
--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -490,10 +490,10 @@ def schedule_incident_retro(client, body, ack):
                     },
                     "label": {
                         "type": "plain_text",
-                        "text": "How many days from now should I start checking the calendar for availability?"
-                    }
+                        "text": "How many days from now should I start checking the calendar for availability?",
+                    },
                 },
-                { "type": "divider"},
+                {"type": "divider"},
                 {
                     "type": "section",
                     "text": {
@@ -529,7 +529,6 @@ def schedule_incident_retro(client, body, ack):
                         "text": "4. If no free time exists for the next 2 months, the event will not be scheduled.",
                     },
                 },
-               
             ]
         ),
     }

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -88,9 +88,10 @@ def test_schedule_event_successful(
         (datetime.utcnow() + timedelta(hours=1)).isoformat(),
     )
     book_calendar_event_mock.return_value = "https://calendar.link"
+    mock_days = 1
 
     # Call the function under test
-    event_link = google_calendar.schedule_event(event_details)
+    event_link = google_calendar.schedule_event(event_details, mock_days)
 
     # Assertions
     get_google_service_mock.assert_called_once_with(
@@ -116,9 +117,10 @@ def test_schedule_event_no_available_slots(
     # Set up the mock return values
     get_google_service_mock.return_value = google_service_mock
     find_first_available_slot_mock.return_value = (None, None)
+    mock_days = 1
 
     # Call the function under test
-    event_link = google_calendar.schedule_event(event_details)
+    event_link = google_calendar.schedule_event(event_details, mock_days)
 
     # Assertions
     assert event_link is None

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -1028,14 +1028,13 @@ def test_schedule_incident_retro_with_no_topic():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
-
 @patch("integrations.google_workspace.google_calendar.schedule_event")
 def test_save_incident_retro_success(schedule_event_mock):
     mock_client = MagicMock()
     mock_ack = MagicMock()
     schedule_event_mock.return_value = "http://example.com/event"
     body_mock = {"trigger_id": "some_trigger_id"}
-    view_mock_with_link = {"private_metadata": "event details for scheduling"}
+    view_mock_with_link = {"private_metadata": "event details for scheduling", "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}}}
 
     # Call the function
     incident_helper.save_incident_retro(
@@ -1059,7 +1058,7 @@ def test_save_incident_retro_failure(schedule_event_mock):
     mock_ack = MagicMock()
     schedule_event_mock.return_value = None
     body_mock = {"trigger_id": "some_trigger_id"}
-    view_mock_with_link = {"private_metadata": "event details for scheduling"}
+    view_mock_with_link = {"private_metadata": "event details for scheduling", "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}}}
 
     # Call the function
     incident_helper.save_incident_retro(

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -1028,13 +1028,17 @@ def test_schedule_incident_retro_with_no_topic():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
+
 @patch("integrations.google_workspace.google_calendar.schedule_event")
 def test_save_incident_retro_success(schedule_event_mock):
     mock_client = MagicMock()
     mock_ack = MagicMock()
     schedule_event_mock.return_value = "http://example.com/event"
     body_mock = {"trigger_id": "some_trigger_id"}
-    view_mock_with_link = {"private_metadata": "event details for scheduling", "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}}}
+    view_mock_with_link = {
+        "private_metadata": "event details for scheduling",
+        "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
+    }
 
     # Call the function
     incident_helper.save_incident_retro(
@@ -1058,7 +1062,10 @@ def test_save_incident_retro_failure(schedule_event_mock):
     mock_ack = MagicMock()
     schedule_event_mock.return_value = None
     body_mock = {"trigger_id": "some_trigger_id"}
-    view_mock_with_link = {"private_metadata": "event details for scheduling", "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}}}
+    view_mock_with_link = {
+        "private_metadata": "event details for scheduling",
+        "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
+    }
 
     # Call the function
     incident_helper.save_incident_retro(


### PR DESCRIPTION

# Summary | Résumé

Adding an input field to allow a user to input a number of days field to begin looking for first available time. The dialog now looks like the following:

![Screenshot 2024-04-11 at 2 18 15 PM](https://github.com/cds-snc/sre-bot/assets/85905333/81675f36-ae5d-4ed4-ac87-56a18667b6b3)
