### PR TITLE
Adding logic that the security team does not get automatically added when creating a test incident

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -342,7 +342,9 @@ def submit(ack, view, say, body, client, logger):
 
     # Get users from the @security group
     response = client.usergroups_users_list(usergroup=SLACK_SECURITY_USER_GROUP_ID)
-    if response.get("ok"):
+
+    # if we are testing, ie PREFIX is "dev" then don't add the security group users since we don't want to spam them
+    if response.get("ok") and PREFIX == "":
         for security_user in response["users"]:
             if security_user != user_id:
                 users_to_invite.append(security_user)


### PR DESCRIPTION

# Summary | Résumé

Added logic so that the Security team + Calvin does not get automatically added when we are testing creation of an incident. 