### PR TITLE
Add a scheduling button to the Stale channel notificaiton

### DIFF
--- a/app/jobs/notify_stale_incident_channels.py
+++ b/app/jobs/notify_stale_incident_channels.py
@@ -15,7 +15,7 @@ def notify_stale_incident_channels(client):
         Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver."""
     attachments = [
         {
-            "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?",
+            "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver le canal maintenant ou planifier une rétro?",
             "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
             "callback_id": "archive_channel",
             "color": "#3AA3E3",

--- a/app/jobs/notify_stale_incident_channels.py
+++ b/app/jobs/notify_stale_incident_channels.py
@@ -11,11 +11,11 @@ def notify_stale_incident_channels(client):
     channels = slack_channels.get_stale_channels(
         client, pattern=INCIDENT_CHANNELS_PATTERN
     )
-    text = """👋  Hi! There have been no updates in this incident channel for 14 days! Consider archiving it.\n
-        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Vous pouvez considérer l'archiver."""
+    text = """👋  Hi! There have been no updates in this incident channel for 14 days! Consider scheduling a retro or archiving it.\n
+        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver."""
     attachments = [
         {
-            "text": "Would you like to archive the channel now? | Voulez-vous archiver ce canal maintenant?",
+            "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?", 
             "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
             "callback_id": "archive_channel",
             "color": "#3AA3E3",
@@ -23,14 +23,21 @@ def notify_stale_incident_channels(client):
             "actions": [
                 {
                     "name": "archive",
-                    "text": "Yes | Oui",
+                    "text": "Archive channel | Canal d'archives",
                     "type": "button",
                     "value": "archive",
                     "style": "danger",
                 },
                 {
+                    "name": "schedule_retro",
+                    "text": "Schedule Retro | Calendrier rétro",
+                    "type": "button",
+                    "value": "schedule_retro",
+                    "style": "primary",
+                },
+                {
                     "name": "ignore",
-                    "text": "No | Non",
+                    "text": "Ignore | Ignorer",
                     "type": "button",
                     "value": "ignore",
                 },
@@ -40,5 +47,6 @@ def notify_stale_incident_channels(client):
     for channel in channels:
         log_to_sentinel("sent_stale_channel_notification", {"channel": channel})
         client.chat_postMessage(
-            channel=channel["id"], text=text, attachments=attachments
+            #channel=channel["id"], text=text, attachments=attachments
+            channel="C06TVP0V5AR", text=text, attachments=attachments
         )

--- a/app/jobs/notify_stale_incident_channels.py
+++ b/app/jobs/notify_stale_incident_channels.py
@@ -15,7 +15,7 @@ def notify_stale_incident_channels(client):
         Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver."""
     attachments = [
         {
-            "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?", 
+            "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?",
             "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
             "callback_id": "archive_channel",
             "color": "#3AA3E3",
@@ -47,6 +47,5 @@ def notify_stale_incident_channels(client):
     for channel in channels:
         log_to_sentinel("sent_stale_channel_notification", {"channel": channel})
         client.chat_postMessage(
-            #channel=channel["id"], text=text, attachments=attachments
-            channel="C06TVP0V5AR", text=text, attachments=attachments
+            channel=channel["id"], text=text, attachments=attachments
         )

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -135,13 +135,14 @@ def archive_channel_action(client, body, ack):
     # get the current chanel id and name and make up the body with those 2 values
     channel_info = {
         "channel_id": channel_id,
-        "channel_name": channel_name, 
+        "channel_name": channel_name,
         "user_id": user,
-        "trigger_id": body["trigger_id"],
     }
-        
+
     if action == "ignore":
-        msg = f"<@{user}> has delayed scheduling and archiving this channel for 14 days."
+        msg = (
+            f"<@{user}> has delayed scheduling and archiving this channel for 14 days."
+        )
         client.chat_update(
             channel=channel_id, text=msg, ts=body["message_ts"], attachments=[]
         )
@@ -152,6 +153,7 @@ def archive_channel_action(client, body, ack):
         # log the event to sentinel
         log_to_sentinel("incident_channel_archived", body)
     elif action == "schedule_retro":
+        channel_info["trigger_id"] = body["trigger_id"]
         schedule_incident_retro(client, channel_info, ack)
         # log the event to sentinel
         log_to_sentinel("incident_retro_scheduled", body)

--- a/app/tests/jobs/test_notify_stale_incident_channels.py
+++ b/app/tests/jobs/test_notify_stale_incident_channels.py
@@ -14,7 +14,7 @@ def test_notify_stale_incident_channels(_log_to_sentinel_mock, get_stale_channel
         text="👋  Hi! There have been no updates in this incident channel for 14 days! Consider scheduling a retro or archiving it.\n\n        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver.",
         attachments=[
             {
-                "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?", 
+                "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?",
                 "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
                 "callback_id": "archive_channel",
                 "color": "#3AA3E3",
@@ -31,7 +31,7 @@ def test_notify_stale_incident_channels(_log_to_sentinel_mock, get_stale_channel
                         "name": "schedule_retro",
                         "text": "Schedule Retro | Calendrier rétro",
                         "type": "button",
-                        "value": "archive",
+                        "value": "schedule_retro",
                         "style": "primary",
                     },
                     {

--- a/app/tests/jobs/test_notify_stale_incident_channels.py
+++ b/app/tests/jobs/test_notify_stale_incident_channels.py
@@ -11,10 +11,10 @@ def test_notify_stale_incident_channels(_log_to_sentinel_mock, get_stale_channel
     notify_stale_incident_channels.notify_stale_incident_channels(client)
     client.chat_postMessage.assert_called_once_with(
         channel="channel_id",
-        text="👋  Hi! There have been no updates in this incident channel for 14 days! Consider archiving it.\n\n        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Vous pouvez considérer l'archiver.",
+        text="👋  Hi! There have been no updates in this incident channel for 14 days! Consider scheduling a retro or archiving it.\n\n        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver.",
         attachments=[
             {
-                "text": "Would you like to archive the channel now? | Voulez-vous archiver ce canal maintenant?",
+                "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?", 
                 "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
                 "callback_id": "archive_channel",
                 "color": "#3AA3E3",
@@ -22,14 +22,21 @@ def test_notify_stale_incident_channels(_log_to_sentinel_mock, get_stale_channel
                 "actions": [
                     {
                         "name": "archive",
-                        "text": "Yes | Oui",
+                        "text": "Archive channel | Canal d'archives",
                         "type": "button",
                         "value": "archive",
                         "style": "danger",
                     },
                     {
+                        "name": "schedule_retro",
+                        "text": "Schedule Retro | Calendrier rétro",
+                        "type": "button",
+                        "value": "archive",
+                        "style": "primary",
+                    },
+                    {
                         "name": "ignore",
-                        "text": "No | Non",
+                        "text": "Ignore | Ignorer",
                         "type": "button",
                         "value": "ignore",
                     },

--- a/app/tests/jobs/test_notify_stale_incident_channels.py
+++ b/app/tests/jobs/test_notify_stale_incident_channels.py
@@ -14,7 +14,7 @@ def test_notify_stale_incident_channels(_log_to_sentinel_mock, get_stale_channel
         text="👋  Hi! There have been no updates in this incident channel for 14 days! Consider scheduling a retro or archiving it.\n\n        Bonjour! Il n'y a pas eu de mise à jour dans ce canal d'incident depuis 14 jours. Pensez à planifier une rétro ou à l'archiver.",
         attachments=[
             {
-                "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver la chaîne maintenant ou programmer une rétro?",
+                "text": "Would you like to archive the channel now or schedule a retro? | Souhaitez-vous archiver le canal maintenant ou planifier une rétro?",
                 "fallback": "You are unable to archive the channel | Vous ne pouvez pas archiver ce canal",
                 "callback_id": "archive_channel",
                 "color": "#3AA3E3",

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -93,7 +93,7 @@ def test_archive_channel_action_ignore(mock_log_to_sentinel):
     client = MagicMock()
     body = {
         "actions": [{"value": "ignore"}],
-        "channel": {"id": "channel_id"},
+        "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
         "message_ts": "message_ts",
         "user": {"id": "user_id"},
     }
@@ -136,6 +136,28 @@ def test_archive_channel_action_archive(
     mock_log_to_sentinel.assert_called_once_with("incident_channel_archived", body)
 
 
+@patch("modules.incident.incident_helper.log_to_sentinel")
+def test_archive_channel_action_schedule_incident(
+    mock_log_to_sentinel
+):
+    client = MagicMock()
+    body = {
+        "actions": [{"value": "schedule_retro"}],
+        "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
+        "message_ts": "message_ts",
+        "user": {"id": "user_id"},
+    }
+    channel_info = {
+            "channel_id": "channel_id",
+            "channel_name": "channel_name",
+            "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
+            "user_id": "user_id",
+        }
+    ack = MagicMock()
+    incident_helper.schedule_incident_retro(client, channel_info, ack)
+    assert ack.call_count == 1
+    
+    
 @patch("modules.incident.incident_helper.google_drive.delete_metadata")
 @patch("modules.incident.incident_helper.view_folder_metadata")
 def test_delete_folder_metadata(view_folder_metadata_mock, delete_metadata_mock):

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -137,27 +137,19 @@ def test_archive_channel_action_archive(
 
 
 @patch("modules.incident.incident_helper.log_to_sentinel")
-def test_archive_channel_action_schedule_incident(
-    mock_log_to_sentinel
-):
+def test_archive_channel_action_schedule_incident(mock_log_to_sentinel):
     client = MagicMock()
-    body = {
-        "actions": [{"value": "schedule_retro"}],
-        "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
-        "message_ts": "message_ts",
-        "user": {"id": "user_id"},
-    }
     channel_info = {
-            "channel_id": "channel_id",
-            "channel_name": "channel_name",
-            "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
-            "user_id": "user_id",
-        }
+        "channel_id": "channel_id",
+        "channel_name": "channel_name",
+        "channel": {"id": "channel_id", "name": "incident-2024-01-12-test"},
+        "user_id": "user_id",
+    }
     ack = MagicMock()
     incident_helper.schedule_incident_retro(client, channel_info, ack)
     assert ack.call_count == 1
-    
-    
+
+
 @patch("modules.incident.incident_helper.google_drive.delete_metadata")
 @patch("modules.incident.incident_helper.view_folder_metadata")
 def test_delete_folder_metadata(view_folder_metadata_mock, delete_metadata_mock):


### PR DESCRIPTION
# Summary | Résumé

Change the Stale notification message to now include a button to schedule a retro. The new layout looks like this:

![Screenshot 2024-04-11 at 5 01 18 PM](https://github.com/cds-snc/sre-bot/assets/85905333/60cf2c09-37ee-45cf-b208-bcd4f9227302)

It might be too verbose or too big - any suggestions on how to improve it will be appreciated. Also, not sure about the French translations 😬 