### PR TITLE
fix: remove datetime format fn

### DIFF
--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -64,13 +64,13 @@ def insert_event(start, end, emails, title, **kwargs):
     """
     time_zone = kwargs.get("time_zone", "America/New_York")
     body = {
-        "start": {"dateTime": start.isoformat(), "timeZone": time_zone},
-        "end": {"dateTime": end.isoformat(), "timeZone": time_zone},
+        "start": {"dateTime": start, "timeZone": time_zone},
+        "end": {"dateTime": end, "timeZone": time_zone},
         "attendees": [{"email": email.strip()} for email in emails],
         "summary": title,
     }
     body.update({convert_to_camel_case(k): v for k, v in kwargs.items()})
-    if "delegated_user_email" in kwargs:
+    if "delegated_user_email" in kwargs and kwargs["delegated_user_email"] is not None:
         delegated_user_email = kwargs["delegated_user_email"]
     else:
         delegated_user_email = os.environ.get("SRE_BOT_EMAIL")

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -154,8 +154,8 @@ def test_insert_event_no_kwargs_no_delegated_email(
         scopes=["https://www.googleapis.com/auth/calendar.events"],
         delegated_user_email="test_email",
         body={
-            "start": {"dateTime": start.isoformat(), "timeZone": "America/New_York"},
-            "end": {"dateTime": end.isoformat(), "timeZone": "America/New_York"},
+            "start": {"dateTime": start, "timeZone": "America/New_York"},
+            "end": {"dateTime": end, "timeZone": "America/New_York"},
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
         },
@@ -193,8 +193,8 @@ def test_insert_event_with_kwargs(
         scopes=["https://www.googleapis.com/auth/calendar.events"],
         delegated_user_email="test_custom_email",
         body={
-            "start": {"dateTime": start.isoformat(), "timeZone": "Magic/Time_Zone"},
-            "end": {"dateTime": end.isoformat(), "timeZone": "Magic/Time_Zone"},
+            "start": {"dateTime": start, "timeZone": "Magic/Time_Zone"},
+            "end": {"dateTime": end, "timeZone": "Magic/Time_Zone"},
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
             **kwargs,


### PR DESCRIPTION
# Summary | Résumé

Quick fix:

the Calendar Event  insert method doesn't handle the toiso() function, it expects a string directly.