### PR TITLE
fix: remove wrong AWS credentials config step

### DIFF
--- a/.github/workflows/refresh_geodb.yml
+++ b/.github/workflows/refresh_geodb.yml
@@ -10,13 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_S3_BACKUP_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_S3_BACKUP_SECRET_ACCESS_KEY }}
-        aws-region: ca-central-1
-
     - name: Configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@master
       with:


### PR DESCRIPTION
# Summary | Résumé

remove old config step to use OIDC one instead