### PR TITLE
Allow guests to modify calendar events

### DIFF
--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -69,6 +69,7 @@ def insert_event(start, end, emails, title, **kwargs):
         "end": {"dateTime": end, "timeZone": time_zone},
         "attendees": [{"email": email.strip()} for email in emails],
         "summary": title,
+        "guestsCanModify": True,
     }
     body.update({convert_string_to_camel_case(k): v for k, v in kwargs.items()})
     if "delegated_user_email" in kwargs and kwargs["delegated_user_email"] is not None:

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -168,6 +168,7 @@ def test_insert_event_no_kwargs_no_delegated_email(
             "end": {"dateTime": end, "timeZone": "America/New_York"},
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
+            "guestsCanModify": True,
         },
         calendarId="primary",
     )
@@ -209,6 +210,7 @@ def test_insert_event_with_kwargs(
             "end": {"dateTime": end, "timeZone": "Magic/Time_Zone"},
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
+            "guestsCanModify": True,
             **kwargs,
         },
         calendarId="primary",


### PR DESCRIPTION
# Summary | Résumé

This PR allows anyone to reschedule the calendar event if required. Previously, guests were not allowed this. 