### PR TITLE
Fix/aws integration for client & identity store

### DIFF
--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -4,7 +4,7 @@ from functools import wraps
 import boto3  # type: ignore
 from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
 from dotenv import load_dotenv
-from integrations.utils.api import convert_kwargs_to_camel_case
+from integrations.utils.api import convert_kwargs_to_pascal_case
 
 load_dotenv()
 
@@ -104,7 +104,7 @@ def execute_aws_api_call(service_name, method, paginated=False, **kwargs):
     client = assume_role_client(service_name, role_arn)
     kwargs.pop("role_arn", None)
     if kwargs:
-        kwargs = convert_kwargs_to_camel_case(kwargs)
+        kwargs = convert_kwargs_to_pascal_case(kwargs)
     api_method = getattr(client, method)
     if paginated:
         return paginator(client, method, **kwargs)

--- a/app/integrations/utils/api.py
+++ b/app/integrations/utils/api.py
@@ -1,4 +1,5 @@
 """Utilities for API integrations."""
+import re
 
 
 def convert_string_to_camel_case(snake_str):
@@ -29,5 +30,40 @@ def convert_kwargs_to_camel_case(kwargs):
         return convert_dict_to_camel_case(kwargs)
     elif isinstance(kwargs, list):
         return [convert_kwargs_to_camel_case(i) for i in kwargs]
+    else:
+        return kwargs
+
+
+def convert_string_to_pascal_case(snake_str):
+    """Convert a snake_case string to PascalCase."""
+    if not isinstance(snake_str, str):
+        raise TypeError("Input must be a string")
+    # Convert camelCase to snake_case
+    snake_str = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", snake_str)
+    snake_str = re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_str).lower()
+
+    components = snake_str.split("_")
+    if len(components) == 1 and components[0] != "":
+        # return components[0]
+        return snake_str[0].upper() + snake_str[1:]
+    else:
+        return "".join(x.title() for x in components)
+
+
+def convert_dict_to_pascale_case(dict):
+    """Convert all keys in a dictionary from snake_case to PascalCase."""
+    new_dict = {}
+    for k, v in dict.items():
+        new_key = convert_string_to_pascal_case(k)
+        new_dict[new_key] = convert_kwargs_to_pascal_case(v)
+    return new_dict
+
+
+def convert_kwargs_to_pascal_case(kwargs):
+    """Convert all keys in a list of dictionaries from snake_case to PascalCase."""
+    if isinstance(kwargs, dict):
+        return convert_dict_to_pascale_case(kwargs)
+    elif isinstance(kwargs, list):
+        return [convert_kwargs_to_pascal_case(i) for i in kwargs]
     else:
         return kwargs

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,170 @@
+import pytest
+
+# Google API Python Client
+
+
+# Google Discovery Directory Resource
+# Base fixtures
+@pytest.fixture
+def google_groups():
+    def _google_groups(n=3, prefix="", domain="test.com"):
+        return [
+            {
+                "id": f"{prefix}_google_group_id{i+1}",
+                "name": f"AWS-group{i+1}",
+                "email": f"{prefix}_aws-group{i+1}@{domain}",
+            }
+            for i in range(n)
+        ]
+
+    return _google_groups
+
+
+@pytest.fixture
+def google_users():
+    def _google_users(n=3, prefix="", domain="test.com"):
+        users = []
+        for i in range(n):
+            user = {
+                "id": f"{prefix}_id_{i}",
+                "primaryEmail": f"{prefix}_email_{i}@{domain}",
+                "emails": [
+                    {
+                        "address": f"{prefix}_email_{i}@{domain}",
+                        "primary": True,
+                        "type": "work",
+                    }
+                ],
+                "suspended": False,
+                "name": {
+                    "fullName": f"Given_name_{i} Family_name_{i}",
+                    "familyName": f"Family_name_{i}",
+                    "givenName": f"Given_name_{i}",
+                    "displayName": f"Given_name_{i} Family_name_{i}",
+                },
+            }
+            users.append(user)
+        return users
+
+    return _google_users
+
+
+@pytest.fixture
+def google_group_members(google_users):
+    def _google_group_members(n=3, prefix="", domain="test.com"):
+        users = google_users(n, prefix, domain)
+        return [
+            {
+                "kind": "admin#directory#member",
+                "email": user["primaryEmail"],
+                "role": "MEMBER",
+                "type": "USER",
+                "status": "ACTIVE",
+                "id": user["id"],
+            }
+            for user in users
+        ]
+
+    return _google_group_members
+
+
+# Fixture with users
+@pytest.fixture
+def google_groups_w_users(google_groups, google_users):
+    def _google_groups_w_users(n_groups=1, n_users=3, prefix="", domain="test.com"):
+        groups = google_groups(n_groups, prefix, domain)
+        users = google_users(n_users, prefix, domain)
+        for group in groups:
+            group["members"] = users
+        return groups
+
+    return _google_groups_w_users
+
+
+# AWS API fixtures
+
+
+@pytest.fixture
+def aws_users():
+    def _aws_users(n=3, prefix="", domain="test.com", store_id="d-123412341234"):
+        users = []
+        for i in range(n):
+            user = {
+                "UserName": f"{prefix}_email_{i}@{domain}",
+                "UserId": f"{prefix}_id_{i}",
+                "Name": {
+                    "FamilyName": f"Family_name_{i}",
+                    "GivenName": f"Given_name_{i}",
+                },
+                "DisplayName": f"Given_name_{i} Family_name_{i}",
+                "Emails": [
+                    {
+                        "Value": f"{prefix}_email_{i}@{domain}",
+                        "Type": "work",
+                        "Primary": True,
+                    }
+                ],
+                "IdentityStoreId": f"{store_id}",
+            }
+            users.append(user)
+        return users
+
+    return _aws_users
+
+
+@pytest.fixture
+def aws_groups():
+    def _aws_groups(n=3, prefix="", store_id="d-123412341234"):
+        return {
+            "Groups": [
+                {
+                    "GroupId": f"{prefix}_aws-group_id{i+1}",
+                    "DisplayName": f"AWS-group{i+1}",
+                    "Description": f"A group to test resolving AWS-group{i+1} memberships",
+                    "IdentityStoreId": f"{store_id}",
+                }
+                for i in range(n)
+            ]
+        }
+
+    return _aws_groups
+
+
+@pytest.fixture
+def aws_groups_memberships():
+    def _aws_groups_memberships(n=3, prefix="", store_id="d-123412341234"):
+        return {
+            "GroupMemberships": [
+                {
+                    "IdentityStoreId": f"{store_id}",
+                    "MembershipId": f"{prefix}_membership_id_{i+1}",
+                    "GroupId": f"{prefix}_aws-group_id{i+1}",
+                    "MemberId": {
+                        "UserId": f"{prefix}_id_{i}",
+                    },
+                }
+                for i in range(n)
+            ]
+        }
+
+    return _aws_groups_memberships
+
+
+@pytest.fixture
+def aws_groups_w_users(aws_groups, aws_users, aws_groups_memberships):
+    def _aws_groups_w_users(
+        n_groups=1, n_users=3, prefix="", domain="test.com", store_id="d-123412341234"
+    ):
+        groups = aws_groups(n_groups, prefix, domain, store_id)["Groups"]
+        users = aws_users(n_users, prefix, domain, store_id)
+        memberships = aws_groups_memberships(n_groups, prefix, domain, store_id)[
+            "GroupMemberships"
+        ]
+        for group, membership in zip(groups, memberships):
+            group.update(membership)
+            group["GroupMemberships"] = [
+                {**membership, "MemberId": user} for user in users
+            ]
+        return groups
+
+    return _aws_groups_w_users

--- a/app/tests/integrations/aws/test_client.py
+++ b/app/tests/integrations/aws/test_client.py
@@ -215,14 +215,14 @@ def test_assume_role_client(mock_boto3_client):
 
 @patch.dict(os.environ, {"AWS_SSO_ROLE_ARN": "test_role_arn"})
 @patch("integrations.aws.client.paginator")
-@patch("integrations.aws.client.convert_kwargs_to_camel_case")
+@patch("integrations.aws.client.convert_kwargs_to_pascal_case")
 @patch("integrations.aws.client.assume_role_client")
 def test_execute_aws_api_call_non_paginated(
-    mock_assume_role_client, mock_convert_kwargs_to_camel_case, mock_paginator
+    mock_assume_role_client, mock_convert_kwargs_to_pascal_case, mock_paginator
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_camel_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
     mock_method = MagicMock()
     mock_method.return_value = {"key": "value"}
     mock_client.some_method = mock_method
@@ -234,20 +234,20 @@ def test_execute_aws_api_call_non_paginated(
     mock_assume_role_client.assert_called_once_with("service_name", "test_role_arn")
     mock_method.assert_called_once_with(arg1="value1")
     assert result == {"key": "value"}
-    mock_convert_kwargs_to_camel_case.assert_called_once_with({"arg1": "value1"})
+    mock_convert_kwargs_to_pascal_case.assert_called_once_with({"arg1": "value1"})
     mock_paginator.assert_not_called()
 
 
 @patch.dict(os.environ, {"AWS_SSO_ROLE_ARN": "test_role_arn"})
-@patch("integrations.aws.client.convert_kwargs_to_camel_case")
+@patch("integrations.aws.client.convert_kwargs_to_pascal_case")
 @patch("integrations.aws.client.assume_role_client")
 @patch("integrations.aws.client.paginator")
 def test_execute_aws_api_call_paginated(
-    mock_paginator, mock_assume_role_client, mock_convert_kwargs_to_camel_case
+    mock_paginator, mock_assume_role_client, mock_convert_kwargs_to_pascal_case
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_camel_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
     mock_paginator.return_value = ["value1", "value2", "value3"]
 
     result = aws_client.execute_aws_api_call(
@@ -260,14 +260,14 @@ def test_execute_aws_api_call_paginated(
 
 
 @patch("integrations.aws.client.paginator")
-@patch("integrations.aws.client.convert_kwargs_to_camel_case")
+@patch("integrations.aws.client.convert_kwargs_to_pascal_case")
 @patch("integrations.aws.client.assume_role_client")
 def test_execute_aws_api_call_with_role_arn(
-    mock_assume_role_client, mock_convert_kwargs_to_camel_case, mock_paginator
+    mock_assume_role_client, mock_convert_kwargs_to_pascal_case, mock_paginator
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_camel_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
     mock_method = MagicMock()
     mock_method.return_value = {"key": "value"}
     mock_client.some_method = mock_method
@@ -284,10 +284,10 @@ def test_execute_aws_api_call_with_role_arn(
 
 @patch.dict(os.environ, {"AWS_SSO_ROLE_ARN": "test_role_arn"})
 @patch("integrations.aws.client.paginator")
-@patch("integrations.aws.client.convert_kwargs_to_camel_case")
+@patch("integrations.aws.client.convert_kwargs_to_pascal_case")
 @patch("integrations.aws.client.assume_role_client")
 def test_execute_aws_api_call_raises_exception_assume_role_on_error(
-    mock_assume_role, mock_convert_kwargs_to_camel_case, mock_paginator
+    mock_assume_role, mock_convert_kwargs_to_pascal_case, mock_paginator
 ):
     with pytest.raises(ValueError):
         aws_client.execute_aws_api_call(None, "some_method", role_arn="test_role_arn")
@@ -296,15 +296,15 @@ def test_execute_aws_api_call_raises_exception_assume_role_on_error(
         aws_client.execute_aws_api_call("service_name", None, role_arn="test_role_arn")
 
     mock_assume_role.assert_not_called()
-    mock_convert_kwargs_to_camel_case.assert_not_called()
+    mock_convert_kwargs_to_pascal_case.assert_not_called()
     mock_paginator.assert_not_called()
 
 
 @patch.dict(os.environ, clear=True)
-@patch("integrations.aws.client.convert_kwargs_to_camel_case")
+@patch("integrations.aws.client.convert_kwargs_to_pascal_case")
 @patch("integrations.aws.client.assume_role_client")
 def test_execute_aws_api_call_raises_exception_when_role_arn_not_provided(
-    mock_assume_role, mock_convert_kwargs_to_camel_case
+    mock_assume_role, mock_convert_kwargs_to_pascal_case
 ):
     with pytest.raises(ValueError) as exc_info:
         aws_client.execute_aws_api_call("service_name", "some_method", arg1="value1")
@@ -314,4 +314,4 @@ def test_execute_aws_api_call_raises_exception_when_role_arn_not_provided(
         == "role_arn must be provided either as a keyword argument or as the AWS_SSO_ROLE_ARN environment variable"
     )
     mock_assume_role.assert_not_called()
-    mock_convert_kwargs_to_camel_case.assert_not_called()
+    mock_convert_kwargs_to_pascal_case.assert_not_called()

--- a/app/tests/integrations/utils/test_api.py
+++ b/app/tests/integrations/utils/test_api.py
@@ -3,7 +3,35 @@ from integrations.utils.api import (
     convert_string_to_camel_case,
     convert_dict_to_camel_case,
     convert_kwargs_to_camel_case,
+    convert_string_to_pascal_case,
+    convert_dict_to_pascale_case,
+    convert_kwargs_to_pascal_case,
 )
+
+
+@pytest.fixture
+def kwargs():
+    return [
+        {
+            "snake_case": "value",
+            "another_snake_case": "another_value",
+            "camelCase": "camel_value",
+            "nested_dict": {
+                "nested_snake_case": "nested_value",
+                "nested_camelCase": "nested_camel_value",
+                "nested_nested_dict": {
+                    "nested_nested_snake_case": "nested_nested_value",
+                    "nested_nested_camelCase": "nested_nested_camel_value",
+                },
+            },
+            "nested_list": [
+                {
+                    "nested_list_snake_case": "nested_list_value",
+                    "nested_list_camelCase": "nested_list_camel_value",
+                }
+            ],
+        }
+    ]
 
 
 def test_convert_string_to_camel_case():
@@ -26,21 +54,9 @@ def test_convert_string_to_camel_case_with_non_string_input():
         convert_string_to_camel_case(123)
 
 
-def test_convert_dict_to_camel_case():
-    dict = {
-        "snake_case": "value",
-        "another_snake_case": "another_value",
-        "camelCase": "camel_value",
-        "nested_dict": {
-            "nested_snake_case": "nested_value",
-            "nested_camelCase": "nested_camel_value",
-            "nested_nested_dict": {
-                "nested_nested_snake_case": "nested_nested_value",
-                "nested_nested_camelCase": "nested_nested_camel_value",
-            },
-        },
-    }
-
+def test_convert_dict_to_camel_case(kwargs):
+    kwargs[0].pop("nested_list")
+    dict = kwargs[0]
     expected = {
         "snakeCase": "value",
         "anotherSnakeCase": "another_value",
@@ -67,28 +83,7 @@ def test_convert_dict_to_camel_case_with_non_string_keys():
         convert_dict_to_camel_case(dict)
 
 
-def test_convert_kwargs_to_camel_case():
-    kwargs = [
-        {
-            "snake_case": "value",
-            "another_snake_case": "another_value",
-            "camelCase": "camel_value",
-            "nested_dict": {
-                "nested_snake_case": "nested_value",
-                "nested_camelCase": "nested_camel_value",
-                "nested_nested_dict": {
-                    "nested_nested_snake_case": "nested_nested_value",
-                    "nested_nested_camelCase": "nested_nested_camel_value",
-                },
-            },
-            "nested_list": [
-                {
-                    "nested_list_snake_case": "nested_list_value",
-                    "nested_list_camelCase": "nested_list_camel_value",
-                }
-            ],
-        }
-    ]
+def test_convert_kwargs_to_camel_case(kwargs):
     expected = [
         {
             "snakeCase": "value",
@@ -126,3 +121,93 @@ def test_convert_kwargs_to_camel_case_with_non_dict_non_list_kwargs():
 def test_convert_kwargs_to_camel_case_with_nested_list():
     kwargs = [{"key": ["value1", "value2"]}]
     assert convert_kwargs_to_camel_case(kwargs) == [{"key": ["value1", "value2"]}]
+
+
+def test_convert_string_to_pascal_case():
+    assert convert_string_to_pascal_case("snake_case") == "SnakeCase"
+    assert (
+        convert_string_to_pascal_case("longer_snake_case_string")
+        == "LongerSnakeCaseString"
+    )
+    assert convert_string_to_pascal_case("alreadyPascalCase") == "AlreadyPascalCase"
+    assert convert_string_to_pascal_case("singleword") == "Singleword"
+    assert convert_string_to_pascal_case("with_numbers_123") == "WithNumbers123"
+
+
+def test_convert_string_to_pascal_case_with_empty_string():
+    assert convert_string_to_pascal_case("") == ""
+
+
+def test_convert_string_to_pascal_case_with_non_string_input():
+    with pytest.raises(TypeError):
+        convert_string_to_pascal_case(123)
+
+
+def test_convert_dict_to_pascal_case(kwargs):
+    kwargs[0].pop("nested_list")
+    dict = kwargs[0]
+
+    expected = {
+        "SnakeCase": "value",
+        "AnotherSnakeCase": "another_value",
+        "CamelCase": "camel_value",
+        "NestedDict": {
+            "NestedSnakeCase": "nested_value",
+            "NestedCamelCase": "nested_camel_value",
+            "NestedNestedDict": {
+                "NestedNestedSnakeCase": "nested_nested_value",
+                "NestedNestedCamelCase": "nested_nested_camel_value",
+            },
+        },
+    }
+    assert convert_dict_to_pascale_case(dict) == expected
+
+
+def test_convert_dict_to_pascal_case_with_empty_dict():
+    assert convert_dict_to_pascale_case({}) == {}
+
+
+def test_convert_dict_to_pascal_case_with_non_string_keys():
+    dict = {1: "value", 2: "another_value"}
+    with pytest.raises(TypeError):
+        convert_dict_to_pascale_case(dict)
+
+
+def test_convert_kwargs_to_pascal_case(kwargs):
+    expected = [
+        {
+            "SnakeCase": "value",
+            "AnotherSnakeCase": "another_value",
+            "CamelCase": "camel_value",
+            "NestedDict": {
+                "NestedSnakeCase": "nested_value",
+                "NestedCamelCase": "nested_camel_value",
+                "NestedNestedDict": {
+                    "NestedNestedSnakeCase": "nested_nested_value",
+                    "NestedNestedCamelCase": "nested_nested_camel_value",
+                },
+            },
+            "NestedList": [
+                {
+                    "NestedListSnakeCase": "nested_list_value",
+                    "NestedListCamelCase": "nested_list_camel_value",
+                }
+            ],
+        }
+    ]
+    assert convert_kwargs_to_pascal_case(kwargs) == expected
+
+
+def test_convert_kwargs_to_pascal_case_with_empty_list():
+    assert convert_kwargs_to_pascal_case([]) == []
+
+
+def test_convert_kwargs_to_pascal_case_with_non_dict_non_list_kwargs():
+    assert convert_kwargs_to_pascal_case("string") == "string"
+    assert convert_kwargs_to_pascal_case(123) == 123
+    assert convert_kwargs_to_pascal_case(True) is True
+
+
+def test_convert_kwargs_to_pascal_case_with_nested_list():
+    kwargs = [{"key": ["value1", "value2"]}]
+    assert convert_kwargs_to_pascal_case(kwargs) == [{"Key": ["value1", "value2"]}]


### PR DESCRIPTION
# Summary | Résumé

- Add functions to handle conversion of snake case to pascal case
- Fix client to convert kwargs with pascal case (instead of camel case like Google client)
- Add functions to handle groups, groups memberships, users and grouping of the 3 objects together
- Add global fixtures to handle Google and AWS API in tests