### PR TITLE
Skip federal holidays when automatically scheduling a retro

### DIFF
--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timedelta
-
+import requests
 import pytz
 
 from integrations.google_workspace.google_service import (
@@ -12,6 +12,7 @@ from integrations.utils.api import convert_string_to_camel_case
 
 # Get the email for the SRE bot
 SRE_BOT_EMAIL = os.environ.get("SRE_BOT_EMAIL")
+
 
 
 @handle_google_api_errors
@@ -125,6 +126,9 @@ def find_first_available_slot(
             busy_times.append((start, end))
     busy_times.sort(key=lambda x: x[0])
 
+    # get the list of Canandian federal holidays
+    federal_holidays = get_federal_holidays()
+    
     for day_offset in range(days_in_future, days_in_future + search_days_limit):
         # Calculate the start and end times of the search window for the current day
         search_date = datetime.utcnow() + timedelta(days=day_offset)
@@ -140,6 +144,10 @@ def find_first_available_slot(
             hour=19, minute=0, second=0, microsecond=0
         )  # 3 PM EST, times are in UTC
 
+        # if the day is a federal holiday, skip it
+        if search_date.date().strftime("%Y-%m-%d") in federal_holidays:
+            continue
+        
         # Attempt to find an available slot within this day's search window
         for current_time in (
             search_start + timedelta(minutes=i) for i in range(0, 121, duration_minutes)
@@ -153,3 +161,20 @@ def find_first_available_slot(
                     return current_time.astimezone(est), slot_end.astimezone(est)
 
     return None, None  # No available slot found after searching the limit
+
+def get_federal_holidays():
+    # Get the public holidays for the current year
+    # Uses Paul Craig's Public holidays api to retrieve the federal holidays 
+
+    # get today's year
+    year = datetime.now().year
+    
+    # call the api to get the public holidays
+    url = f"https://canada-holidays.ca/api/v1/holidays?federal=true&year={year}"
+    response = requests.get(url)
+    
+    # Store the observed dates of the holidays and return the list
+    holidays = []
+    for holiday in response.json()["holidays"]:
+        holidays.append(holiday["observedDate"])
+    return holidays

--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -164,7 +164,7 @@ def find_first_available_slot(
 
 def get_federal_holidays():
     # Get the public holidays for the current year
-    # Uses Paul Craig's Public holidays api to retrieve the federal holidays 
+    # Uses Paul Craig's Public holidays api to retrieve the federal holidays (https://canada-holidays.ca/api) 
 
     # get today's year
     year = datetime.now().year

--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -14,7 +14,6 @@ from integrations.utils.api import convert_string_to_camel_case
 SRE_BOT_EMAIL = os.environ.get("SRE_BOT_EMAIL")
 
 
-
 @handle_google_api_errors
 def get_freebusy(time_min, time_max, items, **kwargs):
     """Returns free/busy information for a set of calendars.
@@ -128,7 +127,7 @@ def find_first_available_slot(
 
     # get the list of Canandian federal holidays
     federal_holidays = get_federal_holidays()
-    
+
     for day_offset in range(days_in_future, days_in_future + search_days_limit):
         # Calculate the start and end times of the search window for the current day
         search_date = datetime.utcnow() + timedelta(days=day_offset)
@@ -147,7 +146,7 @@ def find_first_available_slot(
         # if the day is a federal holiday, skip it
         if search_date.date().strftime("%Y-%m-%d") in federal_holidays:
             continue
-        
+
         # Attempt to find an available slot within this day's search window
         for current_time in (
             search_start + timedelta(minutes=i) for i in range(0, 121, duration_minutes)
@@ -162,17 +161,18 @@ def find_first_available_slot(
 
     return None, None  # No available slot found after searching the limit
 
+
 def get_federal_holidays():
     # Get the public holidays for the current year
-    # Uses Paul Craig's Public holidays api to retrieve the federal holidays (https://canada-holidays.ca/api) 
+    # Uses Paul Craig's Public holidays api to retrieve the federal holidays (https://canada-holidays.ca/api)
 
     # get today's year
     year = datetime.now().year
-    
+
     # call the api to get the public holidays
     url = f"https://canada-holidays.ca/api/v1/holidays?federal=true&year={year}"
     response = requests.get(url)
-    
+
     # Store the observed dates of the holidays and return the list
     holidays = []
     for holiday in response.json()["holidays"]:

--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -171,7 +171,7 @@ def get_federal_holidays():
 
     # call the api to get the public holidays
     url = f"https://canada-holidays.ca/api/v1/holidays?federal=true&year={year}"
-    response = requests.get(url)
+    response = requests.get(url, timeout=10)
 
     # Store the observed dates of the holidays and return the list
     holidays = []

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -5,3 +5,4 @@ freezegun==1.4.0
 pytest==7.4.4
 pytest-asyncio==0.23.6
 pytest-env==0.8.2
+requests-mock==1.12.1

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -491,6 +491,9 @@ def test_no_available_slots_within_search_limit(
 
 # test that the federal holidays are correctly parsed
 def test_get_federal_holidays(requests_mock):
+    # set the timeout to 10s
+    requests_mock.DEFAULT_TIMEOUT = 10
+    
     # Mock the API response
     mocked_response = {
         "holidays": [
@@ -513,6 +516,9 @@ def test_get_federal_holidays(requests_mock):
 
 # test that holidays are correctly fetched for a different year
 def test_get_federal_holidays_with_different_year(requests_mock):
+    # set the timeout to 10s
+    requests_mock.DEFAULT_TIMEOUT = 10
+    
     # Mock the API response for a different year
     requests_mock.get(
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025",
@@ -534,6 +540,9 @@ def test_get_federal_holidays_with_different_year(requests_mock):
 
 # Test that an empty list is returned when there are no holidays
 def test_api_returns_empty_list(requests_mock):
+     # set the timeout to 10s
+    requests_mock.DEFAULT_TIMEOUT = 10
+    
     # Mock no holidays
     requests_mock.get(
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
@@ -549,6 +558,8 @@ def test_api_returns_empty_list(requests_mock):
 
 # Test that a leap year is correctly handled
 def test_leap_year_handling(requests_mock):
+    # set the timeout to 10s
+    requests_mock.DEFAULT_TIMEOUT = 10
     # Mock response for a leap year with an extra day
     requests_mock.get(
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
@@ -558,7 +569,7 @@ def test_leap_year_handling(requests_mock):
                     "observedDate": "2024-02-29"
                 }  # Assuming this is a special leap year holiday
             ]
-        },
+        }
     )
 
     # Execute

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -502,7 +502,7 @@ def test_get_federal_holidays(requests_mock):
         ]
     }
     # Bandit skip security check for the requests_mock.get call
-    requests_mock.get( # nosec
+    requests_mock.get(  # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json=mocked_response,
     )
@@ -520,7 +520,7 @@ def test_get_federal_holidays_with_different_year(requests_mock):
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock the API response for a different year
     # Bandit skip security check for the requests_mock.get call
-    requests_mock.get( # nosec
+    requests_mock.get(  # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025",
         json={"holidays": []},
     )
@@ -544,7 +544,7 @@ def test_api_returns_empty_list(requests_mock):
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock no holidays
     # Bandit skip security check for the requests_mock.get call
-    requests_mock.get( # nosec
+    requests_mock.get(  # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json={"holidays": []},
     )
@@ -562,7 +562,7 @@ def test_leap_year_handling(requests_mock):
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock response for a leap year with an extra day
     # Bandit skip security check for the requests_mock.get call
-    requests_mock.get( # nosec 
+    requests_mock.get(  # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json={
             "holidays": [

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -493,7 +493,6 @@ def test_no_available_slots_within_search_limit(
 def test_get_federal_holidays(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
-    
     # Mock the API response
     mocked_response = {
         "holidays": [
@@ -518,7 +517,6 @@ def test_get_federal_holidays(requests_mock):
 def test_get_federal_holidays_with_different_year(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
-    
     # Mock the API response for a different year
     requests_mock.get(
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025",
@@ -540,9 +538,8 @@ def test_get_federal_holidays_with_different_year(requests_mock):
 
 # Test that an empty list is returned when there are no holidays
 def test_api_returns_empty_list(requests_mock):
-     # set the timeout to 10s
+    # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
-    
     # Mock no holidays
     requests_mock.get(
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
@@ -569,7 +566,7 @@ def test_leap_year_handling(requests_mock):
                     "observedDate": "2024-02-29"
                 }  # Assuming this is a special leap year holiday
             ]
-        }
+        },
     )
 
     # Execute

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -501,7 +501,8 @@ def test_get_federal_holidays(requests_mock):
             {"observedDate": "2024-12-25"},
         ]
     }
-    requests_mock.get(
+    # Bandit skip security check for the requests_mock.get call
+    requests_mock.get( # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json=mocked_response,
     )
@@ -518,7 +519,8 @@ def test_get_federal_holidays_with_different_year(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock the API response for a different year
-    requests_mock.get(
+    # Bandit skip security check for the requests_mock.get call
+    requests_mock.get( # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025",
         json={"holidays": []},
     )
@@ -541,7 +543,8 @@ def test_api_returns_empty_list(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock no holidays
-    requests_mock.get(
+    # Bandit skip security check for the requests_mock.get call
+    requests_mock.get( # nosec
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json={"holidays": []},
     )
@@ -558,7 +561,8 @@ def test_leap_year_handling(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
     # Mock response for a leap year with an extra day
-    requests_mock.get(
+    # Bandit skip security check for the requests_mock.get call
+    requests_mock.get( # nosec 
         "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
         json={
             "holidays": [

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -44,6 +44,7 @@ def fixed_utc_now():
     # Return a fixed UTC datetime
     return datetime(2023, 4, 10, 12, 0)  # This is a Monday
 
+
 # Fixture to mock the datetime.now() function
 @pytest.fixture
 def mock_datetime_now(est_timezone):
@@ -68,10 +69,12 @@ def mock_datetime_now(est_timezone):
 def items():
     return [{"id": "calendar1"}, {"id": "calendar2"}]
 
+
 # Fixture to mock the year
 @pytest.fixture
 def mock_year():
     return 2024
+
 
 @patch(
     "integrations.google_workspace.google_calendar.DEFAULT_DELEGATED_ADMIN_EMAIL",
@@ -325,9 +328,12 @@ def test_insert_event_api_call_error(
     assert mock_os_environ_get.called
     assert not mock_handle_errors.called
 
+
 @patch("integrations.google_workspace.google_calendar.get_federal_holidays")
 @patch("integrations.google_workspace.google_calendar.datetime")
-def test_available_slot_on_first_weekday(mock_datetime, mock_federal_holidays ,fixed_utc_now, mock_year, est_timezone):
+def test_available_slot_on_first_weekday(
+    mock_datetime, mock_federal_holidays, fixed_utc_now, mock_year, est_timezone
+):
     # Mock datetime to control the flow of time in the test
     mock_datetime.utcnow.return_value = fixed_utc_now
     mock_datetime.return_value.year = 2024
@@ -347,12 +353,10 @@ def test_available_slot_on_first_weekday(mock_datetime, mock_federal_holidays ,f
             }
         }
     }
-    mock_federal_holidays.return_value = {"holidays": [
-            {"observedDate": "2024-01-01"},
-            {"observedDate": "2024-07-01"}
-        ]
+    mock_federal_holidays.return_value = {
+        "holidays": [{"observedDate": "2024-01-01"}, {"observedDate": "2024-07-01"}]
     }
-    
+
     # Expected search date is three days in the future (which should be Thursday)
     # Busy period is from 1 PM to 1:30 PM EST on the first day being checked (April 13th)
     # The function should find an available slot after the busy period
@@ -374,7 +378,9 @@ def test_available_slot_on_first_weekday(mock_datetime, mock_federal_holidays ,f
 # Test out the find_first_available_slot function when multiple busy days
 @patch("integrations.google_workspace.google_calendar.get_federal_holidays")
 @patch("integrations.google_workspace.google_calendar.datetime")
-def test_opening_exists_after_busy_days(mock_datetime, mock_federal_holidays, fixed_utc_now, est_timezone):
+def test_opening_exists_after_busy_days(
+    mock_datetime, mock_federal_holidays, fixed_utc_now, est_timezone
+):
     # Mock datetime to control the flow of time in the test
     mock_datetime.utcnow.return_value = fixed_utc_now
     mock_datetime.return_value.year = 2024
@@ -393,13 +399,10 @@ def test_opening_exists_after_busy_days(mock_datetime, mock_federal_holidays, fi
         }
     }
 
-    mock_federal_holidays.return_value = {"holidays": [
-            {"observedDate": "2024-01-01"},
-            {"observedDate": "2024-07-01"}
-        ]
+    mock_federal_holidays.return_value = {
+        "holidays": [{"observedDate": "2024-01-01"}, {"observedDate": "2024-07-01"}]
     }
 
-    
     start, end = google_calendar.find_first_available_slot(
         freebusy_response, days_in_future=3, duration_minutes=30, search_days_limit=60
     )
@@ -416,7 +419,9 @@ def test_opening_exists_after_busy_days(mock_datetime, mock_federal_holidays, fi
 # Test that weekends are skipped when searching for available slots
 @patch("integrations.google_workspace.google_calendar.get_federal_holidays")
 @patch("integrations.google_workspace.google_calendar.datetime")
-def test_skipping_weekends(mock_datetime, mock_federal_holidays, fixed_utc_now, est_timezone):
+def test_skipping_weekends(
+    mock_datetime, mock_federal_holidays, fixed_utc_now, est_timezone
+):
     mock_datetime.utcnow.return_value = fixed_utc_now
     mock_datetime.fromisoformat.side_effect = lambda d: datetime.fromisoformat(d[:-1])
     mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
@@ -430,10 +435,8 @@ def test_skipping_weekends(mock_datetime, mock_federal_holidays, fixed_utc_now, 
         }
     }
 
-    mock_federal_holidays.return_value = {"holidays": [
-            {"observedDate": "2024-01-01"},
-            {"observedDate": "2024-07-01"}
-        ]
+    mock_federal_holidays.return_value = {
+        "holidays": [{"observedDate": "2024-01-01"}, {"observedDate": "2024-07-01"}]
     }
 
     # For this test, ensure the mocked 'now' falls before a weekend, and verify that the function skips to the next weekday
@@ -473,10 +476,8 @@ def test_no_available_slots_within_search_limit(
         }
     }
 
-    mock_federal_holidays.return_value = {"holidays": [
-            {"observedDate": "2024-01-01"},
-            {"observedDate": "2024-07-01"}
-        ]
+    mock_federal_holidays.return_value = {
+        "holidays": [{"observedDate": "2024-01-01"}, {"observedDate": "2024-07-01"}]
     }
 
     start, end = google_calendar.find_first_available_slot(
@@ -495,10 +496,13 @@ def test_get_federal_holidays(requests_mock):
         "holidays": [
             {"observedDate": "2024-01-01"},
             {"observedDate": "2024-07-01"},
-            {"observedDate": "2024-12-25"}
+            {"observedDate": "2024-12-25"},
         ]
     }
-    requests_mock.get("https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024", json=mocked_response)
+    requests_mock.get(
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        json=mocked_response,
+    )
 
     # Call the function
     holidays = google_calendar.get_federal_holidays()
@@ -506,15 +510,21 @@ def test_get_federal_holidays(requests_mock):
     # Assert that the holidays are correctly parsed
     assert holidays == ["2024-01-01", "2024-07-01", "2024-12-25"]
 
+
 # test that holidays are correctly fetched for a different year
 def test_get_federal_holidays_with_different_year(requests_mock):
     # Mock the API response for a different year
-    requests_mock.get("https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025", json={"holidays": []})
+    requests_mock.get(
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2025",
+        json={"holidays": []},
+    )
 
     # Patch datetime to control the current year
-    with patch('integrations.google_workspace.google_calendar.datetime') as mock_datetime:
+    with patch(
+        "integrations.google_workspace.google_calendar.datetime"
+    ) as mock_datetime:
         mock_datetime.now.return_value = datetime(2025, 1, 1)
-        
+
         # Call the function
         holidays = google_calendar.get_federal_holidays()
 
@@ -525,7 +535,10 @@ def test_get_federal_holidays_with_different_year(requests_mock):
 # Test that an empty list is returned when there are no holidays
 def test_api_returns_empty_list(requests_mock):
     # Mock no holidays
-    requests_mock.get("https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024", json={"holidays": []})
+    requests_mock.get(
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        json={"holidays": []},
+    )
 
     # Execute
     holidays = google_calendar.get_federal_holidays()
@@ -537,11 +550,16 @@ def test_api_returns_empty_list(requests_mock):
 # Test that a leap year is correctly handled
 def test_leap_year_handling(requests_mock):
     # Mock response for a leap year with an extra day
-    requests_mock.get("https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024", json={
-        "holidays": [
-            {"observedDate": "2024-02-29"}  # Assuming this is a special leap year holiday
-        ]
-    })
+    requests_mock.get(
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        json={
+            "holidays": [
+                {
+                    "observedDate": "2024-02-29"
+                }  # Assuming this is a special leap year holiday
+            ]
+        },
+    )
 
     # Execute
     holidays = google_calendar.get_federal_holidays()


### PR DESCRIPTION
# Summary | Résumé

Adding functionality to automatically skip federal holidays when scheduling a retro. The SRE bot will basically not schedule any retros on any public holiday days. This uses Paul Craig's holiday API at https://canada-holidays.ca/