### PR TITLE
Feat/handle filters in list groups members

### DIFF
--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -94,7 +94,8 @@ def execute_aws_api_call(service_name, method, paginated=False, **kwargs):
         ValueError: If the role_arn is not provided.
     """
 
-    role_arn = kwargs.get("role_arn", os.environ.get("AWS_SSO_ROLE_ARN", None))
+    role_arn = kwargs.pop("role_arn", os.environ.get("AWS_SSO_ROLE_ARN", None))
+    keys = kwargs.pop("keys", None)
     if role_arn is None:
         raise ValueError(
             "role_arn must be provided either as a keyword argument or as the AWS_SSO_ROLE_ARN environment variable"
@@ -102,12 +103,11 @@ def execute_aws_api_call(service_name, method, paginated=False, **kwargs):
     if service_name is None or method is None:
         raise ValueError("The AWS service name and method must be provided")
     client = assume_role_client(service_name, role_arn)
-    kwargs.pop("role_arn", None)
     if kwargs:
         kwargs = convert_kwargs_to_pascal_case(kwargs)
     api_method = getattr(client, method)
     if paginated:
-        return paginator(client, method, **kwargs)
+        return paginator(client, method, keys, **kwargs)
     else:
         return api_method(**kwargs)
 

--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -7,6 +7,7 @@ from integrations.google_workspace.google_service import (
     DEFAULT_GOOGLE_WORKSPACE_CUSTOMER_ID,
 )
 from integrations.utils.api import convert_string_to_camel_case
+from utils import filters
 
 
 @handle_google_api_errors
@@ -151,11 +152,15 @@ def list_groups_with_members(**kwargs):
     Returns:
         list: A list of group objects with members.
     """
-    members_details = kwargs.get("members_details", True)
-    kwargs.pop("members_details", None)
+    members_details = kwargs.pop("members_details", True)
     groups = list_groups(**kwargs)
+    groups_filters = kwargs.pop("filters", [])
     if not groups:
         return []
+
+    for filter in groups_filters:
+        groups = filters.filter_by_condition(groups, filter)
+
     for group in range(len(groups)):
         members = list_group_members(groups[group]["email"])
         if members and members_details:

--- a/app/tests/integrations/aws/test_client.py
+++ b/app/tests/integrations/aws/test_client.py
@@ -222,7 +222,7 @@ def test_execute_aws_api_call_non_paginated(
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"Arg1": "value1"}
     mock_method = MagicMock()
     mock_method.return_value = {"key": "value"}
     mock_client.some_method = mock_method
@@ -232,7 +232,7 @@ def test_execute_aws_api_call_non_paginated(
     )
 
     mock_assume_role_client.assert_called_once_with("service_name", "test_role_arn")
-    mock_method.assert_called_once_with(arg1="value1")
+    mock_method.assert_called_once_with(Arg1="value1")
     assert result == {"key": "value"}
     mock_convert_kwargs_to_pascal_case.assert_called_once_with({"arg1": "value1"})
     mock_paginator.assert_not_called()
@@ -247,7 +247,7 @@ def test_execute_aws_api_call_paginated(
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"Arg1": "value1"}
     mock_paginator.return_value = ["value1", "value2", "value3"]
 
     result = aws_client.execute_aws_api_call(
@@ -255,7 +255,10 @@ def test_execute_aws_api_call_paginated(
     )
 
     mock_assume_role_client.assert_called_once_with("service_name", "test_role_arn")
-    mock_paginator.assert_called_once_with(mock_client, "some_method", arg1="value1")
+    mock_paginator.assert_called_once_with(
+        mock_client, "some_method", None, Arg1="value1"
+    )
+    mock_convert_kwargs_to_pascal_case.assert_called_once_with({"arg1": "value1"})
     assert result == ["value1", "value2", "value3"]
 
 
@@ -267,7 +270,7 @@ def test_execute_aws_api_call_with_role_arn(
 ):
     mock_client = MagicMock()
     mock_assume_role_client.return_value = mock_client
-    mock_convert_kwargs_to_pascal_case.return_value = {"arg1": "value1"}
+    mock_convert_kwargs_to_pascal_case.return_value = {"Arg1": "value1"}
     mock_method = MagicMock()
     mock_method.return_value = {"key": "value"}
     mock_client.some_method = mock_method
@@ -277,9 +280,10 @@ def test_execute_aws_api_call_with_role_arn(
     )
 
     mock_assume_role_client.assert_called_once_with("service_name", "test_role_arn")
-    mock_method.assert_called_once_with(arg1="value1")
+    mock_method.assert_called_once_with(Arg1="value1")
     assert result == {"key": "value"}
     mock_paginator.assert_not_called()
+    mock_convert_kwargs_to_pascal_case.assert_called_once_with({"arg1": "value1"})
 
 
 @patch.dict(os.environ, {"AWS_SSO_ROLE_ARN": "test_role_arn"})

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -1,5 +1,4 @@
 """Unit tests for google_directory module."""
-import json
 from unittest.mock import patch
 from integrations.google_workspace import google_directory
 
@@ -358,7 +357,9 @@ def test_list_groups_with_members_filtered(
     mock_filter_by_condition.return_value = groups[:2]
     filters = [lambda group: "test-" in group["name"]]
 
-    assert google_directory.list_groups_with_members(filters=filters) == groups_with_users
+    assert (
+        google_directory.list_groups_with_members(filters=filters) == groups_with_users
+    )
     assert mock_filter_by_condition.called_once_with(groups, filters)
     assert mock_list_group_members.call_count == 2
     assert mock_get_user.call_count == 2

--- a/app/tests/utils/test_filters.py
+++ b/app/tests/utils/test_filters.py
@@ -210,7 +210,7 @@ def test_compare_list_with_complex_values_match_mode(
 
     target_values = aws_groups(5)
     target = {
-        "values": target_values["Groups"],
+        "values": target_values,
         "key": "DisplayName",
     }
 

--- a/app/utils/filters.py
+++ b/app/utils/filters.py
@@ -6,11 +6,32 @@ logger = logging.getLogger(__name__)
 
 
 def filter_by_condition(list, condition):
-    """Filter a list by a condition, keeping only the items that satisfy the condition."""
+    """Filter a list by a condition, keeping only the items that satisfy the condition.
+        Examples:
+
+        filter_by_condition([1, 2, 3, 4, 5], lambda x: x % 2 == 0)
+        Output: [2, 4]
+
+    Args:
+        list (list): The list to filter.
+        condition (function): The condition to apply to the items in the list.
+
+    Returns:
+        list: A list containing the items that satisfy the condition.
+    """
     return [item for item in list if condition(item)]
 
 
 def get_nested_value(dictionary, key):
+    """Get a nested value from a dictionary using a dot-separated key.
+
+    Args:
+        dictionary (dict): The dictionary to search.
+        key (str): The dot-separated key to search for.
+
+    Returns:
+        The value of the nested key in the dictionary, or None if the key is not found.
+    """
     if key in dictionary:
         return dictionary[key]
     try:
@@ -21,25 +42,30 @@ def get_nested_value(dictionary, key):
 
 
 def compare_lists(source, target, mode="sync", **kwargs):
-    """
-    Compare two lists and return specific elements based on the comparison.
+    """Compares two lists and returns specific elements based on the comparison mode and keys provided.
 
     Args:
-        `source (dict)`: Source system data. Must contain the keys 'values' (list) and 'key' (string).
-        `target (dict)`: Target system data. Must contain the keys 'values' (list) and 'key' (string).
-        `mode (str)`: The mode of operation. 'sync' for sync operation and 'match' for match operation.
+        `source (dict)`: Source data with `values` (list) and `key` (string).
+        `target (dict)`: Target data with `values` (list) and `key` (string).
+        `mode (str)`: Operation mode - `sync` or `match`.
 
-        **kwargs: Additional keyword arguments. Supported arguments are:
+        **kwargs: Additional arguments:
 
         - `filters (list)`: List of filters to apply to the users.
         - `enable_delete (bool)`: Enable the deletion of users in the target system.
         - `delete_target_all (bool)`: Mark all target system users for deletion.
 
-    Returns:
-        `tuple`:
-            In `sync` mode, a tuple containing the elements to add and the elements to remove in the target system.
+         In `sync` mode (default), the function returns:
 
-            In `match` mode, a tuple containing the elements that match between the source and target lists.
+            1. Elements in the source list but not in the target list (to be added to the target).
+            2. Elements in the target list but not in the source list (to be removed from the target).
+
+        In `match` mode, the function returns:
+
+            1. Elements present in both the source and target lists.
+
+    Returns:
+        tuple: Contains the elements as per the operation mode.
     """
     source_key = source.get("key", None)
     target_key = target.get("key", None)


### PR DESCRIPTION
# Summary | Résumé

- Simplify docs on filters functions
- Fix unit tests to use proper values
- Update conftest fixtures to generate expected data format
- Fix aws paginator to receive keys properly
- Add support to AWS and Google list groups with members for improved performance when required: 
    - instead of getting all groups from the integration and then call list memberships on each of them, only perform the operation on the subset needed.