### PR TITLE
Adding a fix for forwarded messages in incident timeline

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -454,6 +454,16 @@ def handle_reaction_added(client, ack, body, logger):
                             logger.error("No incident document found for this channel.")
 
             for message in messages:
+                # get the forwarded message and get the attachments appeending the forwarded message to the original message
+                if message.get("attachments"):
+                    attachments = message["attachments"]
+                    for attachment in attachments:
+                        fallback = attachment.get("fallback")
+                        if fallback:
+                            message["text"] += (
+                                "\nForwarded Message :" + attachment["fallback"]
+                            )
+
                 # get the message ts time
                 message_ts = message["ts"]
 
@@ -520,6 +530,16 @@ def handle_reaction_removed(client, ack, body, logger):
                 return
             # get the message we want to delete
             message = messages[0]
+
+            # get the forwarded message and get the attachments appeending the forwarded message to the original message
+            if message.get("attachments"):
+                attachments = message["attachments"]
+                for attachment in attachments:
+                    fallback = attachment.get("fallback")
+                    if fallback:
+                        message["text"] += (
+                            "Forwarded Message :" + attachment["fallback"]
+                        )
 
             # get the message ts time
             message_ts = message["ts"]


### PR DESCRIPTION
# Summary | Résumé

Previously, forwarded messages were not handled properly by the incident timeline. This PR resolves this issue and now forwarded messages that have the 💾 emoji appear as such:

<img width="753" alt="Screenshot 2024-05-14 at 2 52 06 PM" src="https://github.com/cds-snc/sre-bot/assets/85905333/292fc991-7374-45db-9e51-df35b014fa99">

