### PR TITLE
Feat/list group members safeguard

### DIFF
--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -257,10 +257,14 @@ def list_groups_with_memberships(**kwargs):
     for filter in groups_filters:
         groups = filters.filter_by_condition(groups, filter)
 
+    groups_with_memberships = []
     for group in groups:
         group["GroupMemberships"] = list_group_memberships(group["GroupId"])
-        if group["GroupMemberships"] and members_details:
-            for membership in group["GroupMemberships"]:
-                membership["MemberId"] = describe_user(membership["MemberId"]["UserId"])
-
-    return groups
+        if group["GroupMemberships"]:
+            if members_details:
+                for membership in group["GroupMemberships"]:
+                    membership["MemberId"] = describe_user(
+                        membership["MemberId"]["UserId"]
+                    )
+            groups_with_memberships.append(group)
+    return groups_with_memberships

--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -246,7 +246,7 @@ def list_groups_with_memberships(**kwargs):
         **kwargs: Additional keyword arguments for the API call. (passed to list_groups)
 
     Returns:
-        list: A list of group objects with their members.
+        list: A list of group objects with their members. Any group without members will not be included.
     """
     members_details = kwargs.pop("members_details", True)
     groups_filters = kwargs.pop("filters", [])

--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -230,6 +230,7 @@ def list_group_memberships(group_id, **kwargs):
     response = execute_aws_api_call(
         "identitystore",
         "list_group_memberships",
+        paginated=True,
         GroupId=group_id,
         **kwargs,
     )

--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -231,10 +231,11 @@ def list_group_memberships(group_id, **kwargs):
         "identitystore",
         "list_group_memberships",
         paginated=True,
+        keys=["GroupMemberships"],
         GroupId=group_id,
         **kwargs,
     )
-    return response["GroupMemberships"] if response else []
+    return response if response else []
 
 
 @handle_aws_api_errors

--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -150,7 +150,7 @@ def list_groups_with_members(**kwargs):
     """List all groups in the Google Workspace domain with their members.
 
     Returns:
-        list: A list of group objects with members.
+        list: A list of group objects with members. Any group without members will not be included.
     """
     members_details = kwargs.pop("members_details", True)
     groups = list_groups(**kwargs)
@@ -161,14 +161,13 @@ def list_groups_with_members(**kwargs):
     for filter in groups_filters:
         groups = filters.filter_by_condition(groups, filter)
 
-    for group in range(len(groups)):
-        members = list_group_members(groups[group]["email"])
+    groups_with_members = []
+    for group in groups:
+        members = list_group_members(group["email"])
         if members and members_details:
-            groups[group]["members"] = members
-
-            for member in range(len(groups[group]["members"])):
-                groups[group]["members"][member] = get_user(
-                    groups[group]["members"][member]["email"]
-                )
-
-    return groups
+            detailed_members = []
+            for member in members:
+                detailed_members.append(get_user(member["email"]))
+            group["members"] = detailed_members
+            groups_with_members.append(group)
+    return groups_with_members

--- a/app/tests/integrations/aws/test_identity_store.py
+++ b/app/tests/integrations/aws/test_identity_store.py
@@ -614,22 +614,20 @@ def test_delete_group_membership_resource_not_found(
 @patch.dict(os.environ, {"AWS_SSO_INSTANCE_ID": "test_instance_id"})
 @patch("integrations.aws.identity_store.execute_aws_api_call")
 def test_list_group_memberships(mock_execute_aws_api_call):
-    mock_execute_aws_api_call.return_value = mock_execute_aws_api_call.return_value = {
-        "GroupMemberships": [
-            {
-                "IdentityStoreId": "test_instance_id",
-                "MembershipId": "Membership1",
-                "GroupId": "test_group_id",
-                "MemberId": {"UserId": "User1"},
-            },
-            {
-                "IdentityStoreId": "test_instance_id",
-                "MembershipId": "Membership2",
-                "GroupId": "test_group_id",
-                "MemberId": {"UserId": "User2"},
-            },
-        ],
-    }
+    mock_execute_aws_api_call.return_value = [
+        {
+            "IdentityStoreId": "test_instance_id",
+            "MembershipId": "Membership1",
+            "GroupId": "test_group_id",
+            "MemberId": {"UserId": "User1"},
+        },
+        {
+            "IdentityStoreId": "test_instance_id",
+            "MembershipId": "Membership2",
+            "GroupId": "test_group_id",
+            "MemberId": {"UserId": "User2"},
+        },
+    ]
 
     result = identity_store.list_group_memberships("test_group_id")
 
@@ -637,6 +635,7 @@ def test_list_group_memberships(mock_execute_aws_api_call):
         "identitystore",
         "list_group_memberships",
         paginated=True,
+        keys=["GroupMemberships"],
         GroupId="test_group_id",
         IdentityStoreId="test_instance_id",
     )
@@ -660,22 +659,20 @@ def test_list_group_memberships(mock_execute_aws_api_call):
 @patch.dict(os.environ, {"AWS_SSO_INSTANCE_ID": "test_instance_id"})
 @patch("integrations.aws.identity_store.execute_aws_api_call")
 def test_list_group_memberships_with_custom_id(mock_execute_aws_api_call):
-    mock_execute_aws_api_call.return_value = {
-        "GroupMemberships": [
-            {
-                "IdentityStoreId": "test_instance_id",
-                "MembershipId": "Membership1",
-                "GroupId": "test_group_id",
-                "MemberId": {"UserId": "User1"},
-            },
-            {
-                "IdentityStoreId": "test_instance_id",
-                "MembershipId": "Membership2",
-                "GroupId": "test_group_id",
-                "MemberId": {"UserId": "User2"},
-            },
-        ],
-    }
+    mock_execute_aws_api_call.return_value = [
+        {
+            "IdentityStoreId": "test_instance_id",
+            "MembershipId": "Membership1",
+            "GroupId": "test_group_id",
+            "MemberId": {"UserId": "User1"},
+        },
+        {
+            "IdentityStoreId": "test_instance_id",
+            "MembershipId": "Membership2",
+            "GroupId": "test_group_id",
+            "MemberId": {"UserId": "User2"},
+        },
+    ]
     result = identity_store.list_group_memberships(
         "test_group_id", IdentityStoreId="custom_instance_id"
     )
@@ -684,6 +681,7 @@ def test_list_group_memberships_with_custom_id(mock_execute_aws_api_call):
         "identitystore",
         "list_group_memberships",
         paginated=True,
+        keys=["GroupMemberships"],
         GroupId="test_group_id",
         IdentityStoreId="custom_instance_id",
     )

--- a/app/tests/integrations/aws/test_identity_store.py
+++ b/app/tests/integrations/aws/test_identity_store.py
@@ -721,13 +721,6 @@ def test_list_groups_with_memberships(
     users = aws_users(2, prefix="test-", domain="test.com")
     expected_output = [
         {
-            "GroupId": "test-aws-group_id1",
-            "DisplayName": "test-group-name1",
-            "Description": "A group to test resolving AWS-group1 memberships",
-            "IdentityStoreId": "d-123412341234",
-            "GroupMemberships": [],
-        },
-        {
             "GroupId": "test-aws-group_id2",
             "DisplayName": "test-group-name2",
             "Description": "A group to test resolving AWS-group2 memberships",
@@ -817,22 +810,7 @@ def test_list_groups_with_memberships_empty_groups_memberships(
     mock_describe_user, mock_list_group_memberships, mock_list_groups, aws_groups
 ):
     groups = aws_groups(2, prefix="test-")
-    expected_output = [
-        {
-            "GroupId": "test-aws-group_id1",
-            "DisplayName": "test-group-name1",
-            "Description": "A group to test resolving AWS-group1 memberships",
-            "IdentityStoreId": "d-123412341234",
-            "GroupMemberships": [],
-        },
-        {
-            "GroupId": "test-aws-group_id2",
-            "DisplayName": "test-group-name2",
-            "Description": "A group to test resolving AWS-group2 memberships",
-            "IdentityStoreId": "d-123412341234",
-            "GroupMemberships": [],
-        },
-    ]
+    expected_output = []
     groups_memberships = [[], []]
     mock_list_groups.return_value = groups
     mock_list_group_memberships.side_effect = groups_memberships
@@ -865,13 +843,6 @@ def test_list_groups_with_memberships_filtered(
     users = aws_users(2, prefix="test-", domain="test.com")
 
     expected_output = [
-        {
-            "GroupId": "test-aws-group_id1",
-            "DisplayName": "test-group-name1",
-            "Description": "A group to test resolving AWS-group1 memberships",
-            "IdentityStoreId": "d-123412341234",
-            "GroupMemberships": [],
-        },
         {
             "GroupId": "test-aws-group_id2",
             "DisplayName": "test-group-name2",

--- a/app/tests/integrations/aws/test_identity_store.py
+++ b/app/tests/integrations/aws/test_identity_store.py
@@ -636,6 +636,7 @@ def test_list_group_memberships(mock_execute_aws_api_call):
     mock_execute_aws_api_call.assert_called_once_with(
         "identitystore",
         "list_group_memberships",
+        paginated=True,
         GroupId="test_group_id",
         IdentityStoreId="test_instance_id",
     )
@@ -682,6 +683,7 @@ def test_list_group_memberships_with_custom_id(mock_execute_aws_api_call):
     mock_execute_aws_api_call.assert_called_once_with(
         "identitystore",
         "list_group_memberships",
+        paginated=True,
         GroupId="test_group_id",
         IdentityStoreId="custom_instance_id",
     )

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -319,7 +319,7 @@ def test_list_groups_with_members(
     users = google_users(2)
     groups_with_users = google_groups_w_users(2, 2)
 
-    groups_with_users[0].pop("members", None)
+    groups_with_users.remove(groups_with_users[0])
 
     mock_list_groups.return_value = groups
     mock_list_group_members.side_effect = group_members
@@ -349,7 +349,7 @@ def test_list_groups_with_members_filtered(
     users = google_users(2)
 
     groups_with_users = google_groups_w_users(4, 2, group_prefix="test-")[:2]
-    groups_with_users[0].pop("members", None)
+    groups_with_users.remove(groups_with_users[0])
 
     mock_list_groups.return_value = groups
     mock_list_group_members.side_effect = group_members
@@ -389,10 +389,7 @@ def test_list_groups_with_members_without_details(
     mock_list_group_members.side_effect = group_members
     mock_get_user.side_effect = users
 
-    assert (
-        google_directory.list_groups_with_members(members_details=False)
-        == groups_with_users
-    )
+    assert google_directory.list_groups_with_members(members_details=False) == []
 
 
 @patch("integrations.google_workspace.google_directory.list_groups")


### PR DESCRIPTION
# Summary | Résumé

- Update list groups memberships functions to return only groups with actual members.

This is intended as a safeguard against deletion of users or groups membership in the context of the provisioning module.

TODO: Refactor the list groups with members and members details as a generic function instead so that error handling can better be performed in multiple contexts.