### PR TITLE
Feat/enable provision job dry run

### DIFF
--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -135,3 +135,12 @@ def paginator(client, operation, keys=None, **kwargs):
                     results.extend(page[key])
 
     return results
+
+
+def healthcheck():
+    """Check the health of the AWS integration.
+
+    Returns:
+        bool: True if the integration is healthy, False otherwise.
+    """
+    return execute_aws_api_call("sts", "get_caller_identity") is not False

--- a/app/tests/integrations/aws/test_client.py
+++ b/app/tests/integrations/aws/test_client.py
@@ -312,3 +312,23 @@ def test_execute_aws_api_call_raises_exception_when_role_arn_not_provided(
     )
     mock_assume_role.assert_not_called()
     mock_convert_kwargs_to_pascal_case.assert_not_called()
+
+
+@patch("integrations.aws.client.execute_aws_api_call")
+def test_healtcheck_is_healthy(mock_execute_aws_api_call):
+    mock_execute_aws_api_call.return_value = {"key": "value"}
+
+    result = aws_client.healthcheck()
+
+    assert result is True
+    mock_execute_aws_api_call.assert_called_once_with("sts", "get_caller_identity")
+
+
+@patch("integrations.aws.client.execute_aws_api_call")
+def test_healtcheck_is_unhealthy(mock_execute_aws_api_call):
+    mock_execute_aws_api_call.return_value = False
+
+    result = aws_client.healthcheck()
+
+    assert result is False
+    mock_execute_aws_api_call.assert_called_once_with("sts", "get_caller_identity")

--- a/app/tests/jobs/test_scheduled_tasks.py
+++ b/app/tests/jobs/test_scheduled_tasks.py
@@ -24,13 +24,15 @@ def test_run_continuously(time_mock, threading_mock, schedule_mock):
     assert result == cease_continuous_run
 
 
+@patch("jobs.scheduled_tasks.aws_client")
 @patch("jobs.scheduled_tasks.google_drive")
 @patch("jobs.scheduled_tasks.maxmind")
 @patch("jobs.scheduled_tasks.opsgenie")
 @patch("jobs.scheduled_tasks.logging")
 def test_integration_healthchecks_healthy(
-    mock_logging, mock_opsgenie, mock_maxmind, mock_google_drive
+    mock_logging, mock_opsgenie, mock_maxmind, mock_google_drive, mock_aws_client
 ):
+    mock_aws_client.healthcheck.return_value = True
     mock_google_drive.healthcheck.return_value = True
     mock_maxmind.healthcheck.return_value = True
     mock_opsgenie.healthcheck.return_value = True
@@ -41,13 +43,15 @@ def test_integration_healthchecks_healthy(
     assert mock_logging.error.call_count == 0
 
 
+@patch("jobs.scheduled_tasks.aws_client")
 @patch("jobs.scheduled_tasks.google_drive")
 @patch("jobs.scheduled_tasks.maxmind")
 @patch("jobs.scheduled_tasks.opsgenie")
 @patch("jobs.scheduled_tasks.logging")
 def test_integration_healthchecks_unhealthy(
-    mock_logging, mock_opsgenie, mock_maxmind, mock_google_drive
+    mock_logging, mock_opsgenie, mock_maxmind, mock_google_drive, mock_aws_client
 ):
+    mock_aws_client.healthcheck.return_value = True
     mock_google_drive.healthcheck.return_value = False
     mock_maxmind.healthcheck.return_value = False
     mock_opsgenie.healthcheck.return_value = True


### PR DESCRIPTION
# Summary | Résumé

Setup AWS ID center provisioning job in DRY_RUN mode. Currently will run every 2 hours to harness logs for analysis.