### PR TITLE
Fix/aws groups sync

### DIFF
--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -208,8 +208,12 @@ def delete_group_membership(membership_id, **kwargs):
     """
     kwargs = resolve_identity_store_id(kwargs)
     kwargs.update({"MembershipId": membership_id})
+    params = {
+        "IdentityStoreId": kwargs.get("IdentityStoreId"),
+        "MembershipId": membership_id,
+    }
     response = execute_aws_api_call(
-        "identitystore", "delete_group_membership", **kwargs
+        "identitystore", "delete_group_membership", **params
     )
     del response["ResponseMetadata"]
     return response == {}
@@ -266,6 +270,7 @@ def list_groups_with_memberships(**kwargs):
     """
     members_details = kwargs.pop("members_details", True)
     groups_filters = kwargs.pop("filters", [])
+    include_empty_groups = kwargs.pop("include_empty_groups", True)
     groups = list_groups(**kwargs)
 
     if not groups:
@@ -282,5 +287,6 @@ def list_groups_with_memberships(**kwargs):
                     membership["MemberId"] = describe_user(
                         membership["MemberId"]["UserId"]
                     )
+        if group["GroupMemberships"] or include_empty_groups:
             groups_with_memberships.append(group)
     return groups_with_memberships

--- a/app/modules/aws/identity_center.py
+++ b/app/modules/aws/identity_center.py
@@ -62,6 +62,7 @@ def synchronize(**kwargs):
             enable_membership_delete,
             **kwargs,
         )
+    logger.info("synchronize:Sync Completed")
 
     return {
         "users": users_sync_status,

--- a/app/tests/integrations/aws/test_identity_store.py
+++ b/app/tests/integrations/aws/test_identity_store.py
@@ -741,6 +741,13 @@ def test_list_groups_with_memberships(
     users = aws_users(2, prefix="test-", domain="test.com")
     expected_output = [
         {
+            "Description": "A group to test resolving AWS-group1 memberships",
+            "DisplayName": "test-group-name1",
+            "GroupId": "test-aws-group_id1",
+            "GroupMemberships": [],
+            "IdentityStoreId": "d-123412341234",
+        },
+        {
             "GroupId": "test-aws-group_id2",
             "DisplayName": "test-group-name2",
             "Description": "A group to test resolving AWS-group2 memberships",
@@ -826,7 +833,7 @@ def test_list_groups_with_memberships_empty_groups(
 @patch("integrations.aws.identity_store.list_groups")
 @patch("integrations.aws.identity_store.list_group_memberships")
 @patch("integrations.aws.identity_store.describe_user")
-def test_list_groups_with_memberships_empty_groups_memberships(
+def test_list_groups_with_memberships_empty_groups_memberships_with_flag(
     mock_describe_user, mock_list_group_memberships, mock_list_groups, aws_groups
 ):
     groups = aws_groups(2, prefix="test-")
@@ -834,7 +841,7 @@ def test_list_groups_with_memberships_empty_groups_memberships(
     groups_memberships = [[], []]
     mock_list_groups.return_value = groups
     mock_list_group_memberships.side_effect = groups_memberships
-    result = identity_store.list_groups_with_memberships()
+    result = identity_store.list_groups_with_memberships(include_empty_groups=False)
     assert result == expected_output
     assert mock_list_group_memberships.call_count == 2
     assert mock_describe_user.call_count == 0
@@ -863,6 +870,13 @@ def test_list_groups_with_memberships_filtered(
     users = aws_users(2, prefix="test-", domain="test.com")
 
     expected_output = [
+        {
+            "Description": "A group to test resolving AWS-group1 memberships",
+            "DisplayName": "test-group-name1",
+            "GroupId": "test-aws-group_id1",
+            "GroupMemberships": [],
+            "IdentityStoreId": "d-123412341234",
+        },
         {
             "GroupId": "test-aws-group_id2",
             "DisplayName": "test-group-name2",

--- a/app/tests/modules/aws/test_sync_identity_center.py
+++ b/app/tests/modules/aws/test_sync_identity_center.py
@@ -216,6 +216,7 @@ def test_synchronize_sync_users_and_groups_with_defaults(
     logger_calls = [
         call("synchronize:Found 1 Groups and 3 Users from Source"),
         call("synchronize:Found 1 Groups and 3 Users from Target"),
+        call("synchronize:Sync Completed"),
     ]
     assert mock_logger.info.call_args_list == logger_calls
 
@@ -292,9 +293,10 @@ def test_synchronize_sync_skip_users_if_false(
         in mock_sync_identity_center_groups.call_args_list
     )
 
-    assert mock_logger.info.call_count == 2
+    assert mock_logger.info.call_count == 3
     logger_calls = [call("synchronize:Found 3 Groups and 6 Users from Source")]
     logger_calls.append(call("synchronize:Found 3 Groups and 6 Users from Target"))
+    logger_calls.append(call("synchronize:Sync Completed"))
     assert mock_logger.info.call_args_list == logger_calls
 
 
@@ -358,9 +360,10 @@ def test_synchronize_sync_skip_groups_false_if_false(
         in mock_sync_identity_center_users.call_args_list
     )
 
-    assert mock_logger.info.call_count == 2
+    assert mock_logger.info.call_count == 3
     logger_calls = [call("synchronize:Found 3 Groups and 6 Users from Source")]
     logger_calls.append(call("synchronize:Found 3 Groups and 6 Users from Target"))
+    logger_calls.append(call("synchronize:Sync Completed"))
     assert mock_logger.info.call_args_list == logger_calls
 
 
@@ -420,9 +423,10 @@ def test_synchronize_sync_skip_users_and_groups_if_false(
 
     assert mock_sync_identity_center_users.call_count == 0
     assert mock_sync_identity_center_groups.call_count == 0
-    assert mock_logger.info.call_count == 2
+    assert mock_logger.info.call_count == 3
     logger_calls = [call("synchronize:Found 3 Groups and 6 Users from Source")]
     logger_calls.append(call("synchronize:Found 3 Groups and 6 Users from Target"))
+    logger_calls.append(call("synchronize:Sync Completed"))
     assert mock_logger.info.call_args_list == logger_calls
 
 


### PR DESCRIPTION
# Summary | Résumé

Small fixes to ensure the proper deletion of group memberships and finding all target empty groups to ensure processing even if the group hasn't members yet.