### PR TITLE
Feat/standardize entity provisioning logs

### DIFF
--- a/app/modules/dev/aws_dev.py
+++ b/app/modules/dev/aws_dev.py
@@ -11,27 +11,10 @@ logger = logging.getLogger(__name__)
 
 def aws_dev_command(ack, client, body, respond):
     ack()
-    response = identity_center.synchronize(enable_groups_sync=False)
+    response = identity_center.synchronize(
+        enable_user_create=False, enable_membership_create=False
+    )
     if not response:
-        respond("No groups found.")
+        respond("Sync failed.")
     else:
-        message = ""
-        if identity_center.DRY_RUN:
-            message += "Dry run mode enabled.\n"
-        if response["users"]:
-            users_created, users_deleted = response["users"]
-            message += "Users created:\n- " + "\n- ".join(users_created) + "\n"
-            message += "Users deleted:\n- " + "\n- ".join(users_deleted) + "\n"
-        else:
-            message += "Users Sync Disabled.\n"
-        if response["groups"]:
-            groups_created, groups_deleted = response["groups"]
-            message += (
-                "Groups memberships created:\n- " + "\n- ".join(groups_created) + "\n"
-            )
-            message += (
-                "Groups memberships deleted:\n- " + "\n- ".join(groups_deleted) + "\n"
-            )
-        else:
-            message += "Groups Sync Disabled.\n"
-        respond(message)
+        respond("Sync successful.")

--- a/app/modules/provisioning/entities.py
+++ b/app/modules/provisioning/entities.py
@@ -41,6 +41,13 @@ def provision_entities(
         f"{integration_name}:{entity_name}:{operation_name}: Started processing {len(entities)} entities"
     )
     for entity in entities:
+        event = {
+            "name": "provision_entities",
+            "integration": integration_name,
+            "entity": entity_name,
+            "operation": operation_name,
+            "status": "dry_run",
+        }
         entity_string = (
             filters.get_nested_value(entity, display_key) if display_key else entity
         )
@@ -50,17 +57,19 @@ def provision_entities(
                 logger.info(
                     f"{integration_name}:{entity_name}:{operation_name}:Successful: {entity_string}"
                 )
+                event["status"] = "successful"
                 log_to_sentinel(
-                    f"{integration_name}_{entity_name}_{operation_name}_successful",
+                    event,
                     {"entity": entity},
                 )
                 provisioned_entities.append({"entity": entity, "response": response})
             else:
+                event["status"] = "failed"
                 logger.error(
                     f"{integration_name}:{entity_name}:{operation_name}:Failed: {entity_string}"
                 )
                 log_to_sentinel(
-                    f"{integration_name}_{entity_name}_{operation_name}_failed",
+                    event,
                     {"entity": entity},
                 )
         else:
@@ -68,7 +77,7 @@ def provision_entities(
                 f"{integration_name}:{entity_name}:{operation_name}:Successful:DRY_RUN: {entity_string}"
             )
             log_to_sentinel(
-                f"{integration_name}_{entity_name}_{operation_name}_dry_run",
+                event,
                 {"entity": entity},
             )
             provisioned_entities.append({"entity": entity, "response": None})

--- a/app/tests/modules/aws/test_sync_identity_center.py
+++ b/app/tests/modules/aws/test_sync_identity_center.py
@@ -80,9 +80,7 @@ def provision_entities_calls_fixture():
                                 **user,
                                 "membership_id": user["MembershipId"],
                                 "log_user_name": user["MemberId"]["UserName"],
-                                "log_group_name": target_groups[i][
-                                    "DisplayName"
-                                ],
+                                "log_group_name": target_groups[i]["DisplayName"],
                             }
                             for user in group_users[i][1]
                         ],

--- a/app/tests/modules/aws/test_sync_identity_center.py
+++ b/app/tests/modules/aws/test_sync_identity_center.py
@@ -62,6 +62,8 @@ def provision_entities_calls_fixture():
                                 **user,
                                 "user_id": user["id"],
                                 "group_id": target_groups[i]["GroupId"],
+                                "log_user_name": user["primaryEmail"],
+                                "log_group_name": target_groups[i]["DisplayName"],
                             }
                             for user in group_users[i][0]
                         ],
@@ -74,7 +76,14 @@ def provision_entities_calls_fixture():
                     call(
                         mock_identity_store.delete_group_membership,
                         [
-                            {**user, "membership_id": user["MembershipId"]}
+                            {
+                                **user,
+                                "membership_id": user["MembershipId"],
+                                "log_user_name": user["MemberId"]["UserName"],
+                                "log_group_name": target_groups[i][
+                                    "DisplayName"
+                                ],
+                            }
                             for user in group_users[i][1]
                         ],
                         execute=execute_delete,
@@ -449,6 +458,8 @@ def test_sync_users_default(
         source_users,
         source_users,
         source_users,
+        source_users,
+        target_users,
         target_users,
     ]
     mock_filters.preformat_items.side_effect = preformat_side_effects
@@ -514,6 +525,8 @@ def test_sync_users_enable_delete_true(
         source_users,
         source_users,
         source_users,
+        source_users,
+        target_users,
         target_users,
     ]
     mock_filters.compare_lists.return_value = source_users, target_users
@@ -581,6 +594,8 @@ def test_sync_users_delete_target_all_disable_delete(
         [],
         [],
         [],
+        [],
+        [],
         target_users,
     ]
     mock_entities.provision_entities.side_effect = [[], []]
@@ -639,6 +654,8 @@ def test_sync_users_delete_target_all_enable_delete(
     source_users = google_users(3)
     target_users = aws_users(6)
     mock_filters.preformat_items.side_effect = [
+        [],
+        [],
         [],
         [],
         [],


### PR DESCRIPTION
# Summary | Résumé

- Standardize logging entity provisioning events in Sentinel
- Update the aws dev command to execute sync in dry run mode