### PR TITLE
Feat/setup user provisioning sre

### DIFF
--- a/app/integrations/slack/users.py
+++ b/app/integrations/slack/users.py
@@ -34,7 +34,7 @@ def get_user_id_from_request(body):
             return match.group(0)
 
 
-def get_user_email(client: WebClient, body):
+def get_user_email_from_body(client: WebClient, body):
     """
     Returns the user email from the body of a request, otherwise None.
       Supports the following formats:
@@ -47,6 +47,22 @@ def get_user_email(client: WebClient, body):
         user_info = client.users_info(user=user_id)
         if user_info["ok"]:
             return user_info["user"]["profile"]["email"]
+
+
+def get_user_email_from_handle(client: WebClient, user_handle: str):
+    user_handle = user_handle.lstrip("@")
+
+    users_list = client.users_list()
+
+    for member in users_list["members"]:
+        if "name" in member and member["name"] == user_handle:
+            user_id = member["id"]
+
+            user_info = client.users_info(user=user_id)
+
+            return user_info["user"]["profile"]["email"]
+
+    return None
 
 
 def get_user_locale(client: WebClient, user_id=None):

--- a/app/modules/aws/identity_center.py
+++ b/app/modules/aws/identity_center.py
@@ -277,7 +277,7 @@ def provision_aws_users(operation, users_emails):
             display_key="primaryEmail",
         )
     else:
-        target_users = users.get_users_from_integration('aws_identity_center')
+        target_users = users.get_users_from_integration("aws_identity_center")
         users_to_delete = [
             user for user in target_users if user["UserName"] in users_emails
         ]

--- a/app/modules/provisioning/users.py
+++ b/app/modules/provisioning/users.py
@@ -1,0 +1,26 @@
+"""Module for getting users from integrations."""
+from logging import getLogger
+from integrations.google_workspace import google_directory
+from integrations.aws import identity_store
+from utils import filters
+
+logger = getLogger(__name__)
+
+
+def get_users_from_integration(integration_source, **kwargs):
+    processing_filters = kwargs.get("processing_filters", [])
+    users = []
+
+    match integration_source:
+        case "google_directory":
+            logger.info("Getting Google Workspace users.")
+            users = google_directory.list_users()
+        case "aws_identity_center":
+            logger.info("Getting AWS Identity Center users.")
+            users = identity_store.list_users()
+        case _:
+            return users
+    for filter in processing_filters:
+        users = filters.filter_by_condition(users, filter)
+
+    return users

--- a/app/tests/integrations/slack/test_users.py
+++ b/app/tests/integrations/slack/test_users.py
@@ -140,13 +140,13 @@ def test_get_user_email():
         "user": {"profile": {"email": "test@example.com"}},
     }
     body = {"user_id": "U1234"}
-    assert users.get_user_email(client, body) == "test@example.com"
+    assert users.get_user_email_from_body(client, body) == "test@example.com"
 
     # Test when the user ID is not found in the request body
     body = {}
-    assert users.get_user_email(client, body) is None
+    assert users.get_user_email_from_body(client, body) is None
 
     # Test when the users_info call is not successful
     client.users_info.return_value = {"ok": False}
     body = {"user_id": "U1234"}
-    assert users.get_user_email(client, body) is None
+    assert users.get_user_email_from_body(client, body) is None

--- a/app/tests/modules/aws/test_aws.py
+++ b/app/tests/modules/aws/test_aws.py
@@ -35,6 +35,18 @@ def test_aws_command_handles_access_command(request_access_modal):
     assert request_access_modal.called_with(client, body)
 
 
+@patch("modules.aws.aws.request_user_provisioing")
+def test_aws_command_handles_provision_command(mock_request_provisioning):
+    ack = MagicMock()
+    respond = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+
+    aws.aws_command(ack, {"text": "user"}, MagicMock(), respond, client, body)
+    ack.assert_called
+    assert mock_request_provisioning.called_with(client, body)
+
+
 @patch("modules.aws.aws.request_health_modal")
 def test_aws_command_handles_health_command(request_health_modal):
     ack = MagicMock()


### PR DESCRIPTION
# Summary | Résumé

- Setup basic user provisioning slash command for the bot

(Reserved to members of SRE admin groups only)

Refactor will be required to ensure proper unit tests and more advanced features (confirmation, modals, etc.)