### PR TITLE
Feat: bump devcontainer image and simplify build steps

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,41 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3/.devcontainer/base.Dockerfile
+
 ARG VARIANT="3.11"
 FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT}
 
-# Install additional packages if necessary
-COPY .devcontainer/apt-packages.txt ./
+# Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && xargs apt-get -y install --no-install-recommends <apt-packages.txt \
+    && apt-get -y install --no-install-recommends \
     && apt-get autoremove -y && apt-get clean -y
 
-# Setup aliases and autocomplete if still needed
+# Install Checkov
+RUN pip3 install --upgrade requests setuptools \
+    && pip3 install --upgrade botocore checkov
+
+COPY .devcontainer/apt-packages.txt ./
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && xargs apt-get -y install --no-install-recommends <apt-packages.txt
+
+# Setup aliases and autocomplete
 RUN echo "\n\
-    alias ll='ls -la'" >> /home/vscode/.zshrc
+    complete -C /usr/bin/aws_completer aws\n\
+    complete -C /usr/local/bin/terraform terraform\n\
+    complete -C /usr/local/bin/terraform terragrunt\n\
+    alias tf='terraform'\n\
+    alias tg='terragrunt'\n\
+    alias ll='la -la'" >> /home/vscode/.zshrc
+
+# Setup AWS Credentials
+RUN mkdir -p /home/vscode/.aws 
+
+RUN echo "\n\
+    [default]\n\
+    aws_access_key_id=foo\n\
+    aws_secret_access_key=bar\n\
+    " >> /home/vscode/.aws/credentials
+
+RUN echo "\n\
+    [default]\n\
+    region=ca-central-1\n\
+    output=json\n\
+    " >> /home/vscode/.aws/config

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Setup aliases and autocomplete
 RUN echo "\n\
-    complete -C /usr/bin/aws_completer aws\n\
+    complete -C /usr/local/bin/aws_completer aws\n\
     complete -C /usr/local/bin/terraform terraform\n\
     complete -C /usr/local/bin/terraform terragrunt\n\
     alias tf='terraform'\n\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3.11"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT}
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,10 +8,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     && apt-get autoremove -y && apt-get clean -y
 
-# Install Checkov
-RUN pip3 install --upgrade requests setuptools \
-    && pip3 install --upgrade botocore checkov
-
 COPY .devcontainer/apt-packages.txt ./
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && xargs apt-get -y install --no-install-recommends <apt-packages.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,46 +1,13 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/python-3/.devcontainer/base.Dockerfile
-
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3.11"
 FROM mcr.microsoft.com/devcontainers/python:1-${VARIANT}
 
-# Install packages
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
-    && apt-get autoremove -y && apt-get clean -y
-
-# Install Nodejs
-RUN apt-get -y install nodejs \
-    npm
-
-# Install Checkov
-RUN pip3 install --upgrade requests setuptools \
-    && pip3 install --upgrade botocore checkov
-
+# Install additional packages if necessary
 COPY .devcontainer/apt-packages.txt ./
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && xargs apt-get -y install --no-install-recommends <apt-packages.txt
+    && xargs apt-get -y install --no-install-recommends <apt-packages.txt \
+    && apt-get autoremove -y && apt-get clean -y
 
-# Setup aliases and autocomplete
+# Setup aliases and autocomplete if still needed
 RUN echo "\n\
-    complete -C /usr/bin/aws_completer aws\n\
-    complete -C /usr/local/bin/terraform terraform\n\
-    complete -C /usr/local/bin/terraform terragrunt\n\
-    alias tf='terraform'\n\
-    alias tg='terragrunt'\n\
-    alias ll='la -la'" >> /home/vscode/.zshrc
-
-# Setup AWS Credentials
-RUN mkdir -p /home/vscode/.aws 
-
-RUN echo "\n\
-    [default]\n\
-    aws_access_key_id=foo\n\
-    aws_secret_access_key=bar\n\
-    " >> /home/vscode/.aws/credentials
-
-RUN echo "\n\
-    [default]\n\
-    region=ca-central-1\n\
-    output=json\n\
-    " >> /home/vscode/.aws/config
+    alias ll='ls -la'" >> /home/vscode/.zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,14 +17,20 @@
 				"redhat.vscode-yaml",
 				"timonwong.shellcheck",
 				"hashicorp.terraform",
-				"github.copilot"
+				"github.copilot",
+				"ms-python.black-formatter"
 			],
 			"settings": {
-				"python.pythonPath": "/usr/local/bin/python",
+				// "python.pythonPath": "/usr/local/bin/python",
 				"python.languageServer": "Pylance",
 				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
 				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
 				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"mypy-type-checker.cwd": "${workspaceFolder}/app",
+				"flake8.cwd": "${workspaceFolder}/app",
+				"python.analysis.extraPaths": [
+					"${workspaceFolder}/app"
+				],
 				"[python]": {
 					"editor.formatOnSave": true
 				},
@@ -43,7 +49,7 @@
 		"ghcr.io/devcontainers/features/aws-cli:1": {
 			"version": "2.2.29"
 		},
-		"docker-in-docker": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest",
 			"moby": true
 		},
@@ -54,9 +60,9 @@
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "16.20.0"
 		},
-		"terraform": {
-			"version": "1.3.3",
-			"terragrunt": "0.31.1"
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.11.0",
+			"installPath": "/usr/local/bin/python"
 		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,9 +59,6 @@
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "16.20.0"
-		},
-		"ghcr.io/devcontainers/features/python:1": {
-			"version": "3.11.9"
 		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,11 +40,6 @@
 			}
 		}
 	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": ".devcontainer/maxmind-create.sh && .devcontainer/dynamodb-create.sh",
-	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {
 			"version": "2.2.29"
@@ -60,5 +55,10 @@
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "16.20.0"
 		}
-	}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": ".devcontainer/maxmind-create.sh && .devcontainer/dynamodb-create.sh",
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,8 +61,7 @@
 			"version": "16.20.0"
 		},
 		"ghcr.io/devcontainers/features/python:1": {
-			"version": "3.11.0",
-			"installPath": "/usr/local/bin/python"
+			"version": "3.11.9"
 		}
 	}
 }

--- a/.devcontainer/maxmind-create.sh
+++ b/.devcontainer/maxmind-create.sh
@@ -1,5 +1,9 @@
+#!/bin/bash
+S3_BUCKET=$GEO_DB_BUCKET
 mkdir -p /workspace/app/geodb/
-wget -O "/workspace/app/geodb/GeoLite2-City.tar.gz" "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_KEY&suffix=tar.gz"
+DESTINATION="/workspace/app/geodb/GeoLite2-City.tar.gz"
+S3_OBJECT_KEY="GeoLite2-City.tar.gz"
+aws s3 cp "s3://${S3_BUCKET}/${S3_OBJECT_KEY}" $DESTINATION
 tar -xzvf /workspace/app/geodb/GeoLite2-City.tar.gz -C /workspace/app/geodb/
 cp /workspace/app/geodb/GeoLite2-City_*/GeoLite2-City.mmdb /workspace/app/geodb/GeoLite2-City.mmdb
 rm -fr /workspace/app/geodb/GeoLite2-City_*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "mypy-type-checker.cwd": "${workspaceFolder}/app",
-    "flake8.cwd": "${workspaceFolder}/app",
-    "python.analysis.extraPaths": [
-        "${workspaceFolder}/app"]
-}

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,9 +1,9 @@
-.PHONY: dev setup fmt install lint test fmt-ci lint-ci install-dev run
+.PHONY: dev dev-setup fmt install lint test fmt-ci lint-ci install-dev run
 
 dev:
 	PREFIX="dev-" python3 -m uvicorn main:server_app --reload
 
-setup:
+dev-setup: # Requires to be signed in to AWS
 	pip3 install --user -r requirements_dev.txt
 	pip3 install --user -r requirements.txt
 	sh ../.devcontainer/maxmind-create.sh

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,7 +1,13 @@
-.PHONY: dev fmt install lint test fmt-ci lint-ci install-dev run
+.PHONY: dev setup fmt install lint test fmt-ci lint-ci install-dev run
 
 dev:
 	PREFIX="dev-" python3 -m uvicorn main:server_app --reload
+
+setup:
+	pip3 install --user -r requirements_dev.txt
+	pip3 install --user -r requirements.txt
+	sh ../.devcontainer/maxmind-create.sh
+	sh ../.devcontainer/dynamodb-create.sh
 
 fmt:
 	black . $(ARGS) --target-version py311

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,9 +1,9 @@
 arrow==1.3.0
 Authlib==1.3.0
 Jinja2==3.1.4
-awscli==1.32.113
 aws-sns-message-validator==0.0.5
-boto3==1.34.113
+boto3==1.34.25
+botocore==1.34.25
 fastapi==0.111.0
 geoip2==4.8.0
 google-api-python-client==2.130.0

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -1,7 +1,9 @@
 black==24.3.0
+checkov==3.2.133
 coverage==6.5.0
 flake8==6.1.0
 freezegun==1.5.1
+setuptools==70.0.0
 pytest==7.4.4
 pytest-asyncio==0.23.7
 pytest-env==0.8.2


### PR DESCRIPTION
# Summary | Résumé

 - Update the to most recent version of devcontainers image
 - Remove optional install steps from Dockerfile to speed up build (moved to features and requirements files instead)
 - point aws_completer to path matching the features installed location
 - Make db and maxmind create scripts callable once logged in AWS (fetch DB file from S3 bucket instead of calling the API each time)
 - Move vscode settings to devcontainer.json file
 - Add dev-setup command to go through each steps needed to run the dev server