### PR TITLE
Removing the rate limiting for the geolocate function

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -198,7 +198,6 @@ async def user(request: Request):
 # Geolocate route. Returns the country, city, latitude, and longitude of the IP address.
 # If we have a custom header of 'X-Sentinel-Source', then we skip rate limiting so that Sentinel is not rate limited
 @handler.get("/geolocate/{ip}")
-@limiter.limit("20/minute", key_func=sentinel_key_func)
 def geolocate(ip, request: Request):
     reader = maxmind.geolocate(ip)
     if isinstance(reader, str):

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -196,9 +196,8 @@ async def user(request: Request):
 
 
 # Geolocate route. Returns the country, city, latitude, and longitude of the IP address.
-# If we have a custom header of 'X-Sentinel-Source', then we skip rate limiting so that Sentinel is not rate limited
 @handler.get("/geolocate/{ip}")
-def geolocate(ip, request: Request):
+def geolocate(ip):
     reader = maxmind.geolocate(ip)
     if isinstance(reader, str):
         raise HTTPException(status_code=404, detail=reader)

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -583,31 +583,6 @@ async def test_user_rate_limiting():
 
 
 @pytest.mark.asyncio
-async def test_geolocate_rate_limiting():
-    async with AsyncClient(app=app, base_url="http://test") as client:
-        # Mock the maxmind.geolocate function
-        with patch(
-            "server.server.maxmind.geolocate",
-            return_value=("Country", "City", 12.34, 56.78),
-        ):
-            # Make 10 requests to the geolocate endpoint
-            for _ in range(20):
-                response = await client.get("/geolocate/8.8.8.8")
-                assert response.status_code == 200
-                assert response.json() == {
-                    "country": "Country",
-                    "city": "City",
-                    "latitude": 12.34,
-                    "longitude": 56.78,
-                }
-
-            # The 21th request should be rate limited
-            response = await client.get("/geolocate/8.8.8.8")
-            assert response.status_code == 429
-            assert response.json() == {"message": "Rate limit exceeded"}
-
-
-@pytest.mark.asyncio
 async def test_webhooks_rate_limiting():
     async with AsyncClient(app=app, base_url="http://test") as client:
         # Mock the webhooks.get_webhook function


### PR DESCRIPTION
# Summary | Résumé

Remove the rate limiting for this as we are getting this error message and we will need to investigate what is calling it:

```ERROR:slowapi:Skipping limit: 20 per 1 minute. Empty value found in parameters.```
