### PR TITLE
Adding workflow to notify the #sre-tech-ops channel when new PR is created

### DIFF
--- a/.github/workflows/pr_notify_slack.yml
+++ b/.github/workflows/pr_notify_slack.yml
@@ -1,0 +1,27 @@
+name: PR Slack Notify
+
+on:
+  pull_request:
+    types: [review_requested]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  pr_slack_notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack message
+        if: ${{ github.event.requested_team.name == 'Internal SRE'}}
+        env:
+          SLACK_SRE_CHANNEL_WEBHOOK_URL: ${{ secrets.SLACK_SRE_CHANNEL_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO_NAME: ${{ github.repository }}
+          PR_CREATOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+            curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Review requested*: <$PR_URL|PR> - $PR_TITLE by $PR_CREATOR in $REPO_NAME.\"}" \
+            $SLACK_SRE_CHANNEL_WEBHOOK_URL


### PR DESCRIPTION
# Summary | Résumé

Workflow to post to the #sre-tech-ops channel whenever a new PR is created in the repo and the reviewers are internal-sre. The workflow will post to the channel with information similar to the following:

![Screenshot 2024-06-19 at 4 32 48 PM](https://github.com/cds-snc/sre-bot/assets/85905333/18b23396-d43c-40c0-ba01-ad70f2b7d917)
