### PR TITLE
Adding a login required decorator to secure certain api endpoings

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -254,7 +254,7 @@ def login_required(route):
 
 # Geolocate route. Returns the country, city, latitude, and longitude of the IP address.
 @handler.get("/geolocate/{ip}")
-async def geolocate(ip):
+def geolocate(ip):
     reader = maxmind.geolocate(ip)
     if isinstance(reader, str):
         raise HTTPException(status_code=404, detail=reader)

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -28,6 +28,9 @@ from sns_message_validator import (
     InvalidSignatureVersionException,
     SignatureVerificationFailureException,
 )
+from functools import wraps
+from fastapi import status
+
 
 logging.basicConfig(level=logging.INFO)
 sns_message_validator = SNSMessageValidator()
@@ -195,9 +198,63 @@ async def user(request: Request):
         return JSONResponse({"error": "Not logged in"})
 
 
+def get_current_user(request: Request):
+    """
+    Retrieves the currently logged-in user from the session.
+    Args:
+        request (Request): The HTTP request object containing session information.
+    Returns:
+        dict: The user information if the user is logged in.
+    Raises:
+        HTTPException: If the user is not authenticated.
+    """
+    # Retrieve the 'user' from the session stored in the request
+    user = request.session.get("user")
+
+    # If there is no 'user' in the session, raise an HTTP 401 Unauthorized exception
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Google login"},
+        )
+    return user
+
+
+def login_required(route):
+    """
+    A decorator to ensure that the user is logged in before accessing the route.
+    Args:
+        route (function): The route function that requires login.
+    Returns:
+        function: The decorated route function with login check.
+    """
+
+    @wraps(route)
+    async def decorated_route(*args, **kwargs):
+        """
+        The decorated route function that includes login check.
+        Args:
+            *args: Variable length argument list for the route function.
+            **kwargs: Arbitrary keyword arguments for the route function.
+        Returns:
+            The result of the original route function if the user is logged in.
+        """
+        # Get the current request from the arguments
+        request = kwargs.get("request")
+        if request:
+            # Check if the user is logged in
+            user = get_current_user(request)  # noqa: F841
+        # Call the original route function and return its result
+        return await route(*args, **kwargs)
+
+    # Return the decorated route function
+    return decorated_route
+
+
 # Geolocate route. Returns the country, city, latitude, and longitude of the IP address.
 @handler.get("/geolocate/{ip}")
-def geolocate(ip):
+async def geolocate(ip):
     reader = maxmind.geolocate(ip)
     if isinstance(reader, str):
         raise HTTPException(status_code=404, detail=reader)
@@ -360,6 +417,6 @@ def append_incident_buttons(payload, webhook_id):
 
 # Defines a route handler for `/*` essentially.
 @handler.get("/{rest_of_path:path}")
-@limiter.limit("10/minute")
+@limiter.limit("20/minute")
 async def react_app(request: Request, rest_of_path: str):
     return templates.TemplateResponse("index.html", {"request": request})


### PR DESCRIPTION
# Summary | Résumé

Adding a login required decorator so that we can secure certain API endpoints. If we add this decorator to an API endpoint, the user has to be logged in, in order to use that particular endpoint. 