### PR TITLE
Adding host port and protocol to the ECS task definition

### DIFF
--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -19,7 +19,9 @@
     "name": "sre-bot",
     "portMappings": [
       {
-        "containerPort": 8000
+        "containerPort": 8000,
+        "hostPort": 8000,
+        "protocol": "tcp"
       }
     ],
     "secrets": [

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -5,7 +5,8 @@
       "capabilities": {
         "drop": [
           "ALL"
-        ]
+        ],
+        "add": null
       }
     },
     "logConfiguration": {
@@ -40,6 +41,12 @@
         "name": "nofile",
         "softLimit": 1000000
       }
-    ]
+    ],
+    "cpu": null,
+    "environment": null,
+    "essential": null,
+    "mountPoints": null,
+    "systemControls": null,
+    "volumesFrom": null
   }
 ]

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -6,7 +6,7 @@
         "drop": [
           "ALL"
         ],
-        "add": null
+        "add": [] 
       }
     },
     "logConfiguration": {
@@ -42,11 +42,11 @@
         "softLimit": 1000000
       }
     ],
-    "cpu": null,
-    "environment": null,
-    "essential": null,
-    "mountPoints": null,
-    "systemControls": null,
-    "volumesFrom": null
+    "cpu": 0,
+    "environment": [],
+    "essential": true,
+    "mountPoints": [],
+    "systemControls": [],
+    "volumesFrom": [] 
   }
 ]


### PR DESCRIPTION

# Summary | Résumé

Adding the host port and protocol to the ECS task definition so that it does not get reset in a terraform plan. 