### PR TITLE
Adding JWT token and session checking api authentication

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -19,6 +19,7 @@ PyJWT==2.8.0
 PyYAML!=6.0.0,!=5.4.0,!=5.4.1
 python-dotenv==0.21.1
 python-i18n==0.3.9
+python-jose==3.3.0
 pytz==2023.4
 requests==2.32.2
 slowapi==0.1.9

--- a/app/server/utils.py
+++ b/app/server/utils.py
@@ -1,6 +1,18 @@
 import logging
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+from jose import JWTError, jwt
+from fastapi import HTTPException, status, Request
+
 
 logging.basicConfig(level=logging.INFO)
+
+SECRET_KEY = os.environ.get("SESSION_SECRET_KEY") or None
+if SECRET_KEY is None:
+    raise Exception("Missing env variables")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", 30))
 
 
 def log_ops_message(client, message):
@@ -8,3 +20,69 @@ def log_ops_message(client, message):
     logging.info(f"Ops msg: {message}")
     client.conversations_join(channel=channel_id)
     client.chat_postMessage(channel=channel_id, text=message, as_user=True)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    """
+    Generates a JSON Web Token (JWT) for authentication purposes.
+
+    Args:
+        data (dict): The data to include in the token payload.
+        expires_delta (Optional[timedelta], optional): The time duration for which the token is valid. Defaults to None.
+
+    Returns:
+        str: The encoded JWT token as a string.
+    """
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(request: Request):
+    """
+    Retrieves the current authenticated user from the request.
+
+    This asynchronous function attempts to retrieve the user information
+    from either the session token or the session user stored in the request.
+    It performs the following steps:
+    1. Checks for the presence of an access token and session user in the request.
+    2. If neither is present, raises an HTTP 401 Unauthorized exception.
+    3. Attempts to decode the access token to extract the user information.
+    4. If the token is invalid or the user information is not present in the token,
+       it raises an HTTP 401 Unauthorized exception.
+    5. Returns the user information if successfully extracted from the token.
+
+    Args:
+        request (Request): The FastAPI request object containing session data.
+
+    Raises:
+        HTTPException: If neither the access token nor the session user is present in the request.
+        HTTPException: If the access token is invalid or the user information is not found.
+
+    Returns:
+        str: The user information extracted from the token or session.
+    """
+    # we are going to get the access token and the session user from the request to double check
+    token = request.session.get("access_token")
+    session_user = request.session.get("user")
+    if not token and not session_user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user = payload.get("sub")
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    return user

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from unittest.mock import ANY, call, MagicMock, patch, PropertyMock, Mock, AsyncMock
 from server import bot_middleware, server
-from server.server import login_required
 import urllib.parse
 from slowapi.errors import RateLimitExceeded
 from starlette.responses import JSONResponse
@@ -10,7 +9,7 @@ from httpx import AsyncClient
 import os
 import pytest
 from fastapi.testclient import TestClient
-from fastapi import Request, HTTPException, status
+from fastapi import Request
 
 app = server.handler
 app.add_middleware(bot_middleware.BotMiddleware, bot=MagicMock())
@@ -552,7 +551,9 @@ async def test_auth_rate_limiting():
         with patch(
             "server.server.oauth.google.authorize_access_token", new_callable=AsyncMock
         ) as mock_auth:
-            mock_auth.return_value = {"userinfo": {"name": "Test User"}}
+            mock_auth.return_value = {
+                "userinfo": {"name": "Test User", "email": "test@test.com"}
+            }
 
             # Make 5 requests to the auth endpoint
             for _ in range(5):
@@ -569,14 +570,14 @@ async def test_auth_rate_limiting():
 async def test_user_rate_limiting():
     async with AsyncClient(app=app, base_url="http://test") as client:
         # Simulate a logged in session
-        session_data = {"user": {"given_name": "FirstName"}}
+        session_data = {"user": {"given_name": "FirstName", "email": "test@test.com"}}
         headers = {"Cookie": f"session={session_data}"}
-        # Make 5 requests to the user endpoint
-        for _ in range(5):
+        # Make 10 requests to the user endpoint
+        for _ in range(10):
             response = await client.get("/user", headers=headers)
             assert response.status_code == 200
 
-        # The 6th request should be rate limited
+        # The 11th request should be rate limited
         response = await client.get("/user", headers=headers)
         assert response.status_code == 429
         assert response.json() == {"message": "Rate limit exceeded"}
@@ -631,94 +632,3 @@ async def test_react_app_rate_limiting():
         response = await client.get("/some-path")
         assert response.status_code == 429
         assert response.json() == {"message": "Rate limit exceeded"}
-
-
-def test_get_current_user_authenticated():
-    # Create a mock request object with a session containing a user
-    mock_request = MagicMock(spec=Request)
-    mock_request.session = {"user": {"username": "testuser"}}
-
-    # Call the function with the mock request
-    result = server.get_current_user(mock_request)
-
-    # Assert the result is the user
-    assert result == {"username": "testuser"}
-
-
-def test_get_current_user_not_authenticated():
-    # Create a mock request object with an empty session
-    mock_request = MagicMock(spec=Request)
-    mock_request.session = {}
-
-    # Call the function and assert it raises HTTPException
-    with pytest.raises(HTTPException) as exc_info:
-        server.get_current_user(mock_request)
-
-    # Assert the exception details
-    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-    assert exc_info.value.detail == "Not authenticated"
-    assert exc_info.value.headers["WWW-Authenticate"] == "Google login"
-
-
-def test_get_current_user_no_session():
-    # Create a mock request object with no session attribute
-    mock_request = MagicMock(spec=Request)
-    del mock_request.session
-
-    # Call the function and assert it raises HTTPException
-    with pytest.raises(AttributeError):
-        server.get_current_user(mock_request)
-
-
-def test_get_current_user_missing_user_in_session():
-    # Create a mock request object with a session missing the 'user' key
-    mock_request = MagicMock(spec=Request)
-    mock_request.session = {"some_other_key": "some_value"}
-
-    # Call the function and assert it raises HTTPException
-    with pytest.raises(HTTPException) as exc_info:
-        server.get_current_user(mock_request)
-
-    # Assert the exception details
-    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-    assert exc_info.value.detail == "Not authenticated"
-    assert exc_info.value.headers["WWW-Authenticate"] == "Google login"
-
-
-# Mock route handler to test the decorator
-@login_required
-async def mock_route_handler(request: Request):
-    return {"message": "Success"}
-
-
-@pytest.mark.asyncio
-@patch("server.server.get_current_user")
-async def test_login_required_user_logged_in(mock_get_current_user):
-    # Mock the request object with a session containing a user
-    mock_request = MagicMock(spec=Request)
-    mock_request.session = {"user": {"username": "testuser"}}
-
-    # Patch get_current_user to return the user
-    mock_get_current_user.return_value = {"username": "testuser"}
-
-    # Call the decorated function
-    response = await mock_route_handler(request=mock_request)
-
-    # Assert the result is the success message
-    assert response == {"message": "Success"}
-
-
-@pytest.mark.asyncio
-async def test_get_current_user_session_not_user():
-    # Mock the request object with no session attribute
-    mock_request = MagicMock(spec=Request)
-    mock_request.session = {"some_message": "blah blah blah"}
-
-    # Call the function and assert it raises HTTPException
-    with pytest.raises(HTTPException) as exc_info:
-        server.get_current_user(mock_request)
-
-    # Assert the exception details
-    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-    assert exc_info.value.detail == "Not authenticated"
-    assert exc_info.value.headers["WWW-Authenticate"] == "Google login"

--- a/app/tests/server/test_utils.py
+++ b/app/tests/server/test_utils.py
@@ -1,6 +1,11 @@
+import pytest
 from server import utils
+from jose import jwt, JWTError
 from integrations.slack import users as slack_users
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock, patch
+from fastapi import Request, HTTPException
+from datetime import timedelta, datetime
+from server.utils import create_access_token, SECRET_KEY, ALGORITHM
 
 
 def test_log_ops_message():
@@ -37,3 +42,145 @@ def test_get_user_locale_without_locale():
     user_id = MagicMock()
     client.users_info.return_value = {"ok": False}
     assert slack_users.get_user_locale(client, user_id) == "en-US"
+
+
+def test_create_access_token_with_expires_delta():
+    data = {"sub": "testuser"}
+    expires = timedelta(minutes=10)
+    token = create_access_token(data, expires)
+    decoded_data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    assert decoded_data["sub"] == "testuser"
+    assert "exp" in decoded_data
+    expected_exp = datetime.utcnow() + expires
+    assert abs(decoded_data["exp"] - int(expected_exp.timestamp())) < 5
+
+
+def test_create_access_token_with_default_expiration():
+    data = {"sub": "testuser"}
+    token = create_access_token(data)
+    decoded_data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    assert decoded_data["sub"] == "testuser"
+    assert "exp" in decoded_data
+    expected_exp = datetime.utcnow() + timedelta(minutes=30)
+    assert abs(decoded_data["exp"] - int(expected_exp.timestamp())) < 5
+
+
+def test_create_access_token_invalid_secret():
+    data = {"sub": "testuser"}
+    token = create_access_token(data)
+    with pytest.raises(JWTError):
+        jwt.decode(token, "wrong_secret_key", algorithms=[ALGORITHM])
+
+
+# Helper function to decode token safely
+def decode_token(token):
+    return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+
+
+def test_create_access_token_no_expiration():
+    data = {"sub": "testuser"}
+    token = create_access_token(data, expires_delta=None)
+    decoded_data = decode_token(token)
+    assert decoded_data["sub"] == "testuser"
+    assert "exp" in decoded_data
+
+
+def test_create_access_token_data_integrity():
+    data = {"sub": "testuser", "role": "admin"}
+    token = create_access_token(data)
+    decoded_data = decode_token(token)
+    assert decoded_data["sub"] == "testuser"
+    assert decoded_data["role"] == "admin"
+    assert "exp" in decoded_data
+
+
+def test_create_access_token_negative_expiration():
+    data = {"sub": "testuser"}
+    expires = timedelta(minutes=-10)
+    token = create_access_token(data, expires)
+    with pytest.raises(JWTError):
+        decode_token(token)
+
+
+def test_create_access_token_large_expiration():
+    data = {"sub": "testuser"}
+    expires = timedelta(days=365)
+    token = create_access_token(data, expires)
+    decoded_data = decode_token(token)
+    assert decoded_data["sub"] == "testuser"
+    assert "exp" in decoded_data
+    expected_exp = datetime.utcnow() + expires
+    assert abs(decoded_data["exp"] - int(expected_exp.timestamp())) < 5
+
+
+@pytest.fixture
+def mock_request():
+    request = AsyncMock(Request)
+    request.session = {}
+    return request
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_no_token_or_session_user(mock_request):
+    with pytest.raises(HTTPException) as exc_info:
+        await utils.get_current_user(mock_request)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Not authenticated"
+
+
+@pytest.mark.asyncio
+@patch("server.utils.jwt.decode")
+async def test_get_current_user_invalid_token(mock_jwt_decode, mock_request):
+    mock_request.session = {"access_token": "invalid_token"}
+    mock_jwt_decode.side_effect = JWTError()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await utils.get_current_user(mock_request)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid token"
+
+
+@pytest.mark.asyncio
+@patch("server.utils.jwt.decode")
+async def test_get_current_user_valid_token_no_user(mock_jwt_decode, mock_request):
+    mock_request.session = {"access_token": "valid_token"}
+    mock_jwt_decode.return_value = {"sub": None}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await utils.get_current_user(mock_request)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid token"
+
+
+@pytest.mark.asyncio
+@patch("server.utils.jwt.decode")
+async def test_get_current_user_valid_token(mock_jwt_decode, mock_request):
+    mock_request.session = {"access_token": "valid_token"}
+    mock_jwt_decode.return_value = {"sub": "testuser"}
+
+    user = await utils.get_current_user(mock_request)
+    assert user == "testuser"
+
+
+@pytest.mark.asyncio
+@patch("server.utils.jwt.decode")
+async def test_get_current_user_no_token_but_session_user(
+    mock_jwt_decode, mock_request
+):
+    with patch("server.utils.jwt.decode") as mock_jwt_decode:
+        mock_request.session = {"user": {"email": "testuser@example.com"}}
+        mock_jwt_decode.return_value = {"sub": "testuser"}
+        user = await utils.get_current_user(mock_request)
+        assert user == "testuser"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_token_and_session_user(mock_request):
+    with patch("server.utils.jwt.decode") as mock_jwt_decode:
+        mock_request.session = {
+            "access_token": "valid_token",
+            "user": {"email": "testuser@example.com"},
+        }
+        mock_jwt_decode.return_value = {"sub": "testuser"}
+        user = await utils.get_current_user(mock_request)
+        assert user == "testuser"


### PR DESCRIPTION
# Summary | Résumé

Adding JWT token that would expire after 30 minutes so that we can secure some of the endpoints. In order to request access, you the session user + JWT token will be checked. 