### PR TITLE
Setting the jwt_token in the cookie

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -176,11 +176,9 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
 @limiter.limit("5/minute")
 async def logout(request: Request):
     request.session.pop("user", None)
-    # request.session.pop("access_token", None)
     response = RedirectResponse(url="/")
     response.delete_cookie("access_token")
     return response
-    # return RedirectResponse(url="/")
 
 
 # Login route. You will be redirected to the google login page

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -176,8 +176,11 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
 @limiter.limit("5/minute")
 async def logout(request: Request):
     request.session.pop("user", None)
-    request.session.pop("access_token", None)
-    return RedirectResponse(url="/")
+    # request.session.pop("access_token", None)
+    response = RedirectResponse(url="/")
+    response.delete_cookie("access_token")
+    return response
+    # return RedirectResponse(url="/")
 
 
 # Login route. You will be redirected to the google login page
@@ -209,8 +212,11 @@ async def auth(request: Request):
     if user_data:
         request.session["user"] = dict(user_data)
         jwt_token = create_access_token(data={"sub": user_data["email"]})
-        request.session["access_token"] = jwt_token
-    return RedirectResponse(url="/")
+        response = RedirectResponse(url="/")
+        response.set_cookie(
+            "access_token", jwt_token, httponly=True, secure=True, samesite="Strict"
+        )
+    return response
 
 
 # User route. Returns the user's first name that is currently logged into the application

--- a/app/tests/server/test_utils.py
+++ b/app/tests/server/test_utils.py
@@ -125,7 +125,7 @@ async def test_get_current_user_no_token_or_session_user(mock_request):
     with pytest.raises(HTTPException) as exc_info:
         await utils.get_current_user(mock_request)
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail == "Not authenticated"
+    assert exc_info.value.detail == "Invalid token"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/AWSRequestForm.jsx
+++ b/frontend/src/components/AWSRequestForm.jsx
@@ -28,7 +28,10 @@ const AWSRequestForm = ({ onSend }) => {
     // Fetch accounts from API
     const fetchAccounts = async () => {
       try {
-        const response = await fetch('/accounts');
+        const response = await fetch('/accounts', {
+          method: 'GET',
+          credentials: 'include', //Include cookies with requests
+        });
         const data = await response.json();
         setAccounts(data); // Assuming the API returns an array of account numbers
       } catch (error) {
@@ -63,6 +66,7 @@ const AWSRequestForm = ({ onSend }) => {
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'include', //Include cookies with requests
         body: JSON.stringify(requestData),
       });
       if (!response.ok) {

--- a/frontend/src/scenes/logout/index.jsx
+++ b/frontend/src/scenes/logout/index.jsx
@@ -14,7 +14,7 @@ const Logout = () => {
   
           if (response.ok) {
             // Clear the authentication state and redirect to the landing page
-            navigate('/');
+            //navigate('/login');
             window.location.reload(); // Refresh the session
           } else {
             console.error('Failed to log out');

--- a/frontend/src/scenes/logout/index.jsx
+++ b/frontend/src/scenes/logout/index.jsx
@@ -14,7 +14,6 @@ const Logout = () => {
   
           if (response.ok) {
             // Clear the authentication state and redirect to the landing page
-            //navigate('/login');
             window.location.reload(); // Refresh the session
           } else {
             console.error('Failed to log out');


### PR DESCRIPTION
# Summary | Résumé

Making changes to set the jwt token in the user's browser cookie. The jwt token expires after 30 minutes and gets deleted when the user logs out. 
