### PR TITLE
Using description as calendar event title and posting notification message to Slack with event info

### DIFF
--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -129,7 +129,7 @@ def insert_event(start, end, emails, title, incident_document, **kwargs):
 
     # Create a dictionary to return the event link and the event info
     result = dict(event_link=htmllink, event_info=event_info)
-    
+
     return result
 
 

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -285,6 +285,9 @@ def submit(ack, view, say, body, client, logger):
         channel=channel_id, topic=f"Incident: {name} / {product}"
     )
 
+    # Set the description
+    client.conversations_setDescription(channel=channel_id, description=f"{name}")
+
     # Announce incident
     user_id = body["user"]["id"]
     text = (

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -586,7 +586,6 @@ def save_incident_retro(client, ack, body, view):
     result = schedule_retro.schedule_event(view["private_metadata"], days)
     
     # if we could not schedule the event, display a message to the user that the event could not be scheduled
-    #if event_link is None:
     if result is None:
         blocks = {
             "type": "modal",
@@ -636,6 +635,7 @@ def save_incident_retro(client, ack, body, view):
             ),
         }
         logging.info("Event has been scheduled successfully. Link: %s", event_link)
+
         # post the message in the channel
         client.chat_postMessage(channel=channel_id, text=event_info, unfurl_links=False)
 

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -584,7 +584,7 @@ def save_incident_retro(client, ack, body, view):
 
     # pass the data using the view["private_metadata"] to the schedule_event function
     result = schedule_retro.schedule_event(view["private_metadata"], days)
-    
+
     # if we could not schedule the event, display a message to the user that the event could not be scheduled
     if result is None:
         blocks = {
@@ -602,7 +602,9 @@ def save_incident_retro(client, ack, body, view):
                 ]
             ),
         }
-        logging.info("The event could not be scheduled since schedule_event returned None")
+        logging.info(
+            "The event could not be scheduled since schedule_event returned None"
+        )
 
     # if the event was scheduled successfully, display a message to the user that the event was scheduled and provide a link to the event
     else:

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -460,12 +460,13 @@ def schedule_incident_retro(client, body, ack):
     users = client.conversations_members(channel=channel_id)["members"]
 
     # Get the channel topic
-    channel_topic = client.conversations_info(channel=channel_id)["channel"]["topic"][
+    channel_name = client.conversations_info(channel=channel_id)["channel"]["purpose"][
         "value"
     ]
+
     # If for some reason the channel topic is empty, set it to "Incident Retro"
-    if channel_topic == "":
-        channel_topic = "Incident Retro"
+    if channel_name == "":
+        channel_name = "Incident Retro"
         logging.warning("Channel topic is empty. Setting it to 'Incident Retro'")
 
     user_emails = []
@@ -498,8 +499,9 @@ def schedule_incident_retro(client, body, ack):
     data_to_send = json.dumps(
         {
             "emails": user_emails,
-            "topic": channel_topic,
+            "name": channel_name,
             "incident_document": document_id,
+            "channel_id": channel_id,
         }
     )
 
@@ -581,9 +583,11 @@ def save_incident_retro(client, ack, body, view):
     days = int(view["state"]["values"]["number_of_days"]["number_of_days"]["value"])
 
     # pass the data using the view["private_metadata"] to the schedule_event function
-    event_link = schedule_retro.schedule_event(view["private_metadata"], days)
+    result = schedule_retro.schedule_event(view["private_metadata"], days)
+    
     # if we could not schedule the event, display a message to the user that the event could not be scheduled
-    if event_link is None:
+    #if event_link is None:
+    if result is None:
         blocks = {
             "type": "modal",
             "title": {"type": "plain_text", "text": "SRE - Schedule Retro 🗓️"},
@@ -599,8 +603,13 @@ def save_incident_retro(client, ack, body, view):
                 ]
             ),
         }
+        logging.info("The event could not be scheduled since schedule_event returned None")
+
     # if the event was scheduled successfully, display a message to the user that the event was scheduled and provide a link to the event
     else:
+        channel_id = json.loads(view["private_metadata"])["channel_id"]
+        event_link = result["event_link"]
+        event_info = result["event_info"]
         blocks = {
             "type": "modal",
             "title": {"type": "plain_text", "text": "SRE - Schedule Retro 🗓️"},
@@ -610,7 +619,7 @@ def save_incident_retro(client, ack, body, view):
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "*Successfully schduled calender event!*",
+                            "text": "*Successfully scheduled calender event!*",
                         },
                         "accessory": {
                             "type": "button",
@@ -626,9 +635,12 @@ def save_incident_retro(client, ack, body, view):
                 ]
             ),
         }
+        logging.info("Event has been scheduled successfully. Link: %s", event_link)
+        # post the message in the channel
+        client.chat_postMessage(channel=channel_id, text=event_info, unfurl_links=False)
+
     # Open the modal and log that the event was scheduled successfully
     client.views_open(trigger_id=body["trigger_id"], view=blocks)
-    logging.info("Event has been scheduled successfully. Link: %s", event_link)
 
 
 # We just need to handle the action here and record who clicked on it

--- a/app/modules/incident/schedule_retro.py
+++ b/app/modules/incident/schedule_retro.py
@@ -18,7 +18,6 @@ def schedule_event(event_details, days):
     time_min = (now + timedelta(days=days)).isoformat() + "Z"
     time_max = (now + timedelta(days=(60 + days))).isoformat() + "Z"
 
-    print("EVENT DETAILS: ", event_details)
     # Construct the items array
     items = []
     emails = json.loads(event_details).get("emails")
@@ -69,4 +68,4 @@ def schedule_event(event_details, days):
         incident_document,
         **event_config,
     )
-    return result  # Return the HTML link and event info
+    return result # Return the HTML link and event info

--- a/app/modules/incident/schedule_retro.py
+++ b/app/modules/incident/schedule_retro.py
@@ -18,10 +18,11 @@ def schedule_event(event_details, days):
     time_min = (now + timedelta(days=days)).isoformat() + "Z"
     time_max = (now + timedelta(days=(60 + days))).isoformat() + "Z"
 
+    print("EVENT DETAILS: ", event_details)
     # Construct the items array
     items = []
     emails = json.loads(event_details).get("emails")
-    incident_name = json.loads(event_details).get("topic")
+    incident_name = json.loads(event_details).get("name")
     for email in emails:
         email = email.strip()
         items.append({"id": email})
@@ -60,7 +61,7 @@ def schedule_event(event_details, days):
         },
     }
 
-    event_link = insert_event(
+    result = insert_event(
         first_available_start.isoformat(),
         first_available_end.isoformat(),
         emails,
@@ -68,5 +69,4 @@ def schedule_event(event_details, days):
         incident_document,
         **event_config,
     )
-
-    return event_link
+    return result  # Return the HTML link and event info

--- a/app/modules/incident/schedule_retro.py
+++ b/app/modules/incident/schedule_retro.py
@@ -68,4 +68,4 @@ def schedule_event(event_details, days):
         incident_document,
         **event_config,
     )
-    return result # Return the HTML link and event info
+    return result  # Return the HTML link and event info

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -165,7 +165,17 @@ def test_insert_event_no_kwargs_no_delegated_email(
     mock_execute_google_api_call,
     mock_os_environ_get,
 ):
-    mock_execute_google_api_call.return_value = {"htmlLink": "test_link"}
+    mock_execute_google_api_call.return_value = {
+        "htmlLink": "test_link",
+        "start": {
+            "dateTime": "2024-07-25T13:30:00-04:00",
+            "timeZone": "America/New_York",
+        },
+        "end": {
+            "dateTime": "2024-07-25T14:00:00-04:00",
+            "timeZone": "America/New_York",
+        },
+    }
     mock_unique_id.return_value = "abc-123-de4"
     start = datetime.now()
     end = start
@@ -173,7 +183,10 @@ def test_insert_event_no_kwargs_no_delegated_email(
     title = "Test Event"
     document_id = "test_document_id"
     result = google_calendar.insert_event(start, end, emails, title, document_id)
-    assert result == "test_link"
+    assert result == {
+        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.", 
+        "event_link": "test_link",
+    }
     mock_execute_google_api_call.assert_called_once_with(
         "calendar",
         "v3",
@@ -187,6 +200,7 @@ def test_insert_event_no_kwargs_no_delegated_email(
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
             "guestsCanModify": True,
+            "guestsCanInviteOthers": True,
             "attachments": [
                 {
                     "fileUrl": f"https://docs.google.com/document/d/{document_id}",
@@ -219,7 +233,17 @@ def test_insert_event_with_kwargs(
     mock_execute_google_api_call,
     mock_os_environ_get,
 ):
-    mock_execute_google_api_call.return_value = {"htmlLink": "test_link"}
+    mock_execute_google_api_call.return_value = {
+        "htmlLink": "test_link",
+        "start": {
+            "dateTime": "2024-07-25T13:30:00-04:00",
+            "timeZone": "America/New_York",
+        },
+        "end": {
+            "dateTime": "2024-07-25T14:00:00-04:00",
+            "timeZone": "America/New_York",
+        },
+    }
     mock_unique_id.return_value = "abc-123-de4"
     mock_convert_string_to_camel_case.side_effect = (
         lambda x: x
@@ -251,7 +275,10 @@ def test_insert_event_with_kwargs(
     result = google_calendar.insert_event(
         start, end, emails, title, document_id, **kwargs
     )
-    assert result == "test_link"
+    assert result == {
+        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
+        "event_link": "test_link",
+    }
     mock_execute_google_api_call.assert_called_once_with(
         "calendar",
         "v3",
@@ -265,6 +292,7 @@ def test_insert_event_with_kwargs(
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
             "guestsCanModify": True,
+            "guestsCanInviteOthers": True,
             **kwargs,
         },
         calendarId="primary",
@@ -287,7 +315,17 @@ def test_insert_event_with_no_document(
     mock_execute_google_api_call,
     mock_os_environ_get,
 ):
-    mock_execute_google_api_call.return_value = {"htmlLink": "test_link"}
+    mock_execute_google_api_call.return_value = {
+        "htmlLink": "test_link",
+        "start": {
+            "dateTime": "2024-07-25T13:30:00-04:00",
+            "timeZone": "America/New_York",
+        },
+        "end": {
+            "dateTime": "2024-07-25T14:00:00-04:00",
+            "timeZone": "America/New_York",
+        },
+    }
     mock_unique_id.return_value = "abc-123-de4"
     mock_convert_string_to_camel_case.side_effect = (
         lambda x: x
@@ -312,7 +350,10 @@ def test_insert_event_with_no_document(
     result = google_calendar.insert_event(
         start, end, emails, title, document_id, **kwargs
     )
-    assert result == "test_link"
+    assert result == {
+        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
+        "event_link": "test_link",
+    }
     mock_execute_google_api_call.assert_called_once_with(
         "calendar",
         "v3",
@@ -326,6 +367,7 @@ def test_insert_event_with_no_document(
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
             "guestsCanModify": True,
+            "guestsCanInviteOthers": True,
             **kwargs,
         },
         calendarId="primary",
@@ -348,7 +390,17 @@ def test_insert_event_google_hangout_link_created(
     mock_execute_google_api_call,
     mock_os_environ_get,
 ):
-    mock_execute_google_api_call.return_value = {"htmlLink": "test_link"}
+    mock_execute_google_api_call.return_value = {
+        "htmlLink": "test_link",
+        "start": {
+            "dateTime": "2024-07-25T13:30:00-04:00",
+            "timeZone": "America/New_York",
+        },
+        "end": {
+            "dateTime": "2024-07-25T14:00:00-04:00",
+            "timeZone": "America/New_York",
+        },
+    }
     mock_unique_id.return_value = "abc-123-de4"
     start = datetime.now()
     end = start
@@ -356,7 +408,10 @@ def test_insert_event_google_hangout_link_created(
     title = "Test Event"
     document_id = "test_document_id"
     result = google_calendar.insert_event(start, end, emails, title, document_id)
-    assert result == "test_link"
+    assert result == {
+        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
+        "event_link": "test_link",
+    }
     mock_execute_google_api_call.assert_called_once_with(
         "calendar",
         "v3",
@@ -370,6 +425,7 @@ def test_insert_event_google_hangout_link_created(
             "attendees": [{"email": email.strip()} for email in emails],
             "summary": title,
             "guestsCanModify": True,
+            "guestsCanInviteOthers": True,
             "attachments": [
                 {
                     "fileUrl": f"https://docs.google.com/document/d/{document_id}",

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -184,7 +184,7 @@ def test_insert_event_no_kwargs_no_delegated_email(
     document_id = "test_document_id"
     result = google_calendar.insert_event(start, end, emails, title, document_id)
     assert result == {
-        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.", 
+        "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
         "event_link": "test_link",
     }
     mock_execute_google_api_call.assert_called_once_with(

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -583,7 +583,7 @@ def test_incident_submit_creates_channel_sets_description(
     client.conversations_setDescription.assert_called_once_with(
         channel="channel_id", description="name"
     )
-    
+
 
 @patch("modules.incident.incident.google_drive.update_incident_list")
 @patch("modules.incident.incident.google_drive.merge_data")

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -562,6 +562,34 @@ def test_incident_submit_creates_channel_sets_topic_and_announces_channel(
 @patch("modules.incident.incident.google_drive.create_new_incident")
 @patch("modules.incident.incident.google_drive.list_metadata")
 @patch("modules.incident.incident.log_to_sentinel")
+def test_incident_submit_creates_channel_sets_description(
+    _log_to_sentinel_mock,
+    _mock_list_metadata,
+    _mock_create_new_incident,
+    _mock_merge_data,
+    _mock_update_incident_list,
+):
+    ack = MagicMock()
+    logger = MagicMock()
+    view = helper_generate_view()
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    client = MagicMock()
+    client.conversations_create.return_value = {
+        "channel": {"id": "channel_id", "name": "channel_name"}
+    }
+    incident.submit(ack, view, say, body, client, logger)
+    client.conversations_create.assert_called_once_with(name=f"incident-{DATE}-name")
+    client.conversations_setDescription.assert_called_once_with(
+        channel="channel_id", description="name"
+    )
+    
+
+@patch("modules.incident.incident.google_drive.update_incident_list")
+@patch("modules.incident.incident.google_drive.merge_data")
+@patch("modules.incident.incident.google_drive.create_new_incident")
+@patch("modules.incident.incident.google_drive.list_metadata")
+@patch("modules.incident.incident.log_to_sentinel")
 def test_incident_submit_adds_creator_to_channel(
     _log_to_sentinel_mock,
     _mock_list_metadata,

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -795,8 +795,10 @@ def test_schedule_incident_retro_successful_no_bots():
     mock_client.usergroups_users_list.return_value = {"users": ["U34333"]}
     mock_client.conversations_members.return_value = {"members": ["U12345", "U67890"]}
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"},
-                    "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "topic": {"value": "Retro Topic"},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -858,8 +860,10 @@ def test_schedule_incident_retro_successful_bots():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"},
-                    "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "topic": {"value": "Retro Topic"},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -924,8 +928,10 @@ def test_schedule_incident_retro_successful_security_group():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"},
-                    "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "topic": {"value": "Retro Topic"},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user2@example.com"}}},
@@ -989,8 +995,10 @@ def test_schedule_incident_retro_successful_no_security_group():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"},
-                    "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "topic": {"value": "Retro Topic"},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -1052,8 +1060,10 @@ def test_schedule_incident_retro_with_no_users():
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"},
-                    "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "topic": {"value": "Retro Topic"},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.users_info.side_effect = []
     mock_client.bookmarks_list.return_value = {
@@ -1080,7 +1090,12 @@ def test_schedule_incident_retro_with_no_users():
 
     # construct the expected data object
     expected_data = json.dumps(
-        {"emails": [], "name": "Retro Purpose", "incident_document": "dummy_document_id", "channel_id": "C1234567890"}
+        {
+            "emails": [],
+            "name": "Retro Purpose",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
     )
     # Assertions to validate behavior when no users are present in the channel
     assert (
@@ -1092,7 +1107,9 @@ def test_schedule_incident_retro_with_no_topic():
     mock_client = MagicMock()
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
-    mock_client.conversations_info.return_value = {"channel": {"topic": {"value": ""}, "purpose": {"value": "Retro Purpose"}}}
+    mock_client.conversations_info.return_value = {
+        "channel": {"topic": {"value": ""}, "purpose": {"value": "Retro Purpose"}}
+    }
     mock_client.bookmarks_list.return_value = {
         "ok": True,
         "bookmarks": [
@@ -1130,11 +1147,14 @@ def test_schedule_incident_retro_with_no_topic():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
+
 def test_schedule_incident_retro_with_no_purpose():
     mock_client = MagicMock()
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
-    mock_client.conversations_info.return_value = {"channel": {"topic": {"value": ""}, "purpose": {"value": ""}}}
+    mock_client.conversations_info.return_value = {
+        "channel": {"topic": {"value": ""}, "purpose": {"value": ""}}
+    }
     mock_client.bookmarks_list.return_value = {
         "ok": True,
         "bookmarks": [
@@ -1172,12 +1192,16 @@ def test_schedule_incident_retro_with_no_purpose():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
+
 @patch("modules.incident.schedule_retro.schedule_event")
 def test_save_incident_retro_success(schedule_event_mock):
     mock_client = MagicMock()
     mock_ack = MagicMock()
-    #schedule_event_mock.return_value = "http://example.com/event"
-    schedule_event_mock.return_value = {"event_link": "http://example.com/event", "event_info": "event_info"}
+    # schedule_event_mock.return_value = "http://example.com/event"
+    schedule_event_mock.return_value = {
+        "event_link": "http://example.com/event",
+        "event_info": "event_info",
+    }
     body_mock = {"trigger_id": "some_trigger_id"}
     data_to_send = json.dumps(
         {
@@ -1188,7 +1212,7 @@ def test_save_incident_retro_success(schedule_event_mock):
         }
     )
     view_mock_with_link = {
-        "private_metadata": data_to_send, 
+        "private_metadata": data_to_send,
         "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
     }
 
@@ -1212,7 +1236,10 @@ def test_save_incident_retro_success(schedule_event_mock):
 def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock):
     mock_client = MagicMock()
     mock_ack = MagicMock()
-    schedule_event_mock.return_value = {"event_link": "http://example.com/event", "event_info": "event_info"}
+    schedule_event_mock.return_value = {
+        "event_link": "http://example.com/event",
+        "event_info": "event_info",
+    }
     body_mock = {"trigger_id": "some_trigger_id"}
     data_to_send = json.dumps(
         {
@@ -1223,7 +1250,7 @@ def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock
         }
     )
     view_mock_with_link = {
-        "private_metadata": data_to_send, 
+        "private_metadata": data_to_send,
         "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
     }
 
@@ -1236,12 +1263,10 @@ def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock
     mock_ack.assert_called_once()  # Ensure ack() was called
     mock_client.views_open.assert_called_once()  # Ensure the modal was opened
 
-   # Verify that the chat message was sent to the channel 
+    # Verify that the chat message was sent to the channel
     mock_client.chat_postMessage.assert_called_once()
     mock_client.chat_postMessage.assert_any_call(
-        channel="C1234567890",
-        text="event_info",
-        unfurl_links=False 
+        channel="C1234567890", text="event_info", unfurl_links=False
     )
 
     # Verify the modal content for success
@@ -1249,6 +1274,7 @@ def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock
         mock_client.views_open.call_args[1]["view"]["blocks"][0]["text"]["text"]
         == "*Successfully scheduled calender event!*"
     )
+
 
 @patch("modules.incident.schedule_retro.schedule_event")
 def test_save_incident_retro_failure(schedule_event_mock):

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -795,7 +795,8 @@ def test_schedule_incident_retro_successful_no_bots():
     mock_client.usergroups_users_list.return_value = {"users": ["U34333"]}
     mock_client.conversations_members.return_value = {"members": ["U12345", "U67890"]}
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"}}
+        "channel": {"topic": {"value": "Retro Topic"},
+                    "purpose": {"value": "Retro Purpose"}}
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -839,8 +840,9 @@ def test_schedule_incident_retro_successful_no_bots():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "topic": "Retro Topic",
+            "name": "Retro Purpose",
             "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
         }
     )
     assert (
@@ -856,7 +858,8 @@ def test_schedule_incident_retro_successful_bots():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"}}
+        "channel": {"topic": {"value": "Retro Topic"},
+                    "purpose": {"value": "Retro Purpose"}}
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -903,8 +906,9 @@ def test_schedule_incident_retro_successful_bots():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "topic": "Retro Topic",
+            "name": "Retro Purpose",
             "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
         }
     )
     assert (
@@ -920,7 +924,8 @@ def test_schedule_incident_retro_successful_security_group():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"}}
+        "channel": {"topic": {"value": "Retro Topic"},
+                    "purpose": {"value": "Retro Purpose"}}
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user2@example.com"}}},
@@ -966,8 +971,9 @@ def test_schedule_incident_retro_successful_security_group():
     expected_data = json.dumps(
         {
             "emails": ["user2@example.com"],
-            "topic": "Retro Topic",
+            "name": "Retro Purpose",
             "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
         }
     )
     assert (
@@ -983,7 +989,8 @@ def test_schedule_incident_retro_successful_no_security_group():
         "members": ["U12345", "U67890", "U54321"]
     }
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"}}
+        "channel": {"topic": {"value": "Retro Topic"},
+                    "purpose": {"value": "Retro Purpose"}}
     }
     mock_client.users_info.side_effect = [
         {"user": {"profile": {"email": "user1@example.com"}}},
@@ -1030,8 +1037,9 @@ def test_schedule_incident_retro_successful_no_security_group():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "topic": "Retro Topic",
+            "name": "Retro Purpose",
             "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
         }
     )
     assert (
@@ -1044,7 +1052,8 @@ def test_schedule_incident_retro_with_no_users():
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
     mock_client.conversations_info.return_value = {
-        "channel": {"topic": {"value": "Retro Topic"}}
+        "channel": {"topic": {"value": "Retro Topic"},
+                    "purpose": {"value": "Retro Purpose"}}
     }
     mock_client.users_info.side_effect = []
     mock_client.bookmarks_list.return_value = {
@@ -1071,7 +1080,7 @@ def test_schedule_incident_retro_with_no_users():
 
     # construct the expected data object
     expected_data = json.dumps(
-        {"emails": [], "topic": "Retro Topic", "incident_document": "dummy_document_id"}
+        {"emails": [], "name": "Retro Purpose", "incident_document": "dummy_document_id", "channel_id": "C1234567890"}
     )
     # Assertions to validate behavior when no users are present in the channel
     assert (
@@ -1083,7 +1092,7 @@ def test_schedule_incident_retro_with_no_topic():
     mock_client = MagicMock()
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
-    mock_client.conversations_info.return_value = {"channel": {"topic": {"value": ""}}}
+    mock_client.conversations_info.return_value = {"channel": {"topic": {"value": ""}, "purpose": {"value": "Retro Purpose"}}}
     mock_client.bookmarks_list.return_value = {
         "ok": True,
         "bookmarks": [
@@ -1111,8 +1120,9 @@ def test_schedule_incident_retro_with_no_topic():
     expected_data = json.dumps(
         {
             "emails": [],
-            "topic": "Incident Retro",
+            "name": "Retro Purpose",
             "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
         }
     )
     # Assertions to validate behavior when no users are present in the channel
@@ -1120,15 +1130,65 @@ def test_schedule_incident_retro_with_no_topic():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
+def test_schedule_incident_retro_with_no_purpose():
+    mock_client = MagicMock()
+    mock_ack = MagicMock()
+    mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
+    mock_client.conversations_info.return_value = {"channel": {"topic": {"value": ""}, "purpose": {"value": ""}}}
+    mock_client.bookmarks_list.return_value = {
+        "ok": True,
+        "bookmarks": [
+            {
+                "title": "Incident report",
+                "link": "https://docs.google.com/document/d/dummy_document_id/edit",
+            }
+        ],
+    }
+    mock_client.users_info.side_effect = []
+
+    # Adjust the mock to simulate no users in the channel
+    mock_client.conversations_members.return_value = {"members": []}
+
+    body = {
+        "channel_id": "C1234567890",
+        "trigger_id": "T1234567890",
+        "channel_name": "incident-2024-01-12-test",
+        "user_id": "U12345",
+    }
+
+    incident_helper.schedule_incident_retro(mock_client, body, mock_ack)
+
+    # construct the expected data object and set the topic to a default one
+    expected_data = json.dumps(
+        {
+            "emails": [],
+            "name": "Incident Retro",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
+    )
+    # Assertions to validate behavior when no users are present in the channel
+    assert (
+        mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
+    )
 
 @patch("modules.incident.schedule_retro.schedule_event")
 def test_save_incident_retro_success(schedule_event_mock):
     mock_client = MagicMock()
     mock_ack = MagicMock()
-    schedule_event_mock.return_value = "http://example.com/event"
+    #schedule_event_mock.return_value = "http://example.com/event"
+    schedule_event_mock.return_value = {"event_link": "http://example.com/event", "event_info": "event_info"}
     body_mock = {"trigger_id": "some_trigger_id"}
+    data_to_send = json.dumps(
+        {
+            "emails": [],
+            "name": "Incident Retro",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
+    )
     view_mock_with_link = {
-        "private_metadata": "event details for scheduling",
+        "private_metadata": data_to_send, 
         "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
     }
 
@@ -1144,9 +1204,51 @@ def test_save_incident_retro_success(schedule_event_mock):
     # Verify the modal content for success
     assert (
         mock_client.views_open.call_args[1]["view"]["blocks"][0]["text"]["text"]
-        == "*Successfully schduled calender event!*"
+        == "*Successfully scheduled calender event!*"
     )
 
+
+@patch("modules.incident.schedule_retro.schedule_event")
+def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock):
+    mock_client = MagicMock()
+    mock_ack = MagicMock()
+    schedule_event_mock.return_value = {"event_link": "http://example.com/event", "event_info": "event_info"}
+    body_mock = {"trigger_id": "some_trigger_id"}
+    data_to_send = json.dumps(
+        {
+            "emails": [],
+            "name": "Incident Retro",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
+    )
+    view_mock_with_link = {
+        "private_metadata": data_to_send, 
+        "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
+    }
+
+    # Call the function
+    incident_helper.save_incident_retro(
+        mock_client, mock_ack, body_mock, view_mock_with_link
+    )
+
+    # Assertions
+    mock_ack.assert_called_once()  # Ensure ack() was called
+    mock_client.views_open.assert_called_once()  # Ensure the modal was opened
+
+   # Verify that the chat message was sent to the channel 
+    mock_client.chat_postMessage.assert_called_once()
+    mock_client.chat_postMessage.assert_any_call(
+        channel="C1234567890",
+        text="event_info",
+        unfurl_links=False 
+    )
+
+    # Verify the modal content for success
+    assert (
+        mock_client.views_open.call_args[1]["view"]["blocks"][0]["text"]["text"]
+        == "*Successfully scheduled calender event!*"
+    )
 
 @patch("modules.incident.schedule_retro.schedule_event")
 def test_save_incident_retro_failure(schedule_event_mock):
@@ -1154,8 +1256,16 @@ def test_save_incident_retro_failure(schedule_event_mock):
     mock_ack = MagicMock()
     schedule_event_mock.return_value = None
     body_mock = {"trigger_id": "some_trigger_id"}
+    data_to_send = json.dumps(
+        {
+            "emails": [],
+            "name": "Incident Retro",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
+    )
     view_mock_with_link = {
-        "private_metadata": "event details for scheduling",
+        "private_metadata": data_to_send,
         "state": {"values": {"number_of_days": {"number_of_days": {"value": "1"}}}},
     }
 

--- a/app/tests/modules/incident/test_schedule_retro.py
+++ b/app/tests/modules/incident/test_schedule_retro.py
@@ -64,7 +64,7 @@ def test_schedule_event_successful(
         mock_datetime_now.now,  # use the fixture here
         mock_datetime_now.now + timedelta(hours=1),
     )
-    insert_event_mock.return_value = {"event_link": "https://calendar.link", "event_info": "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Calendar meeting details at: https://calendar.link"}
+    insert_event_mock.return_value = {"event_link": "https://calendar.link", "event_info": "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details."}
     mock_days = 1
 
     # Parse event details
@@ -103,7 +103,7 @@ def test_schedule_event_successful(
     )
 
     assert result["event_link"] == "https://calendar.link"
-    assert result["event_info"] == "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Calendar meeting details at: https://calendar.link"
+    assert result["event_info"] == "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details."
 
 
 # Test out the schedule_event function when no available slots are found

--- a/app/tests/modules/incident/test_schedule_retro.py
+++ b/app/tests/modules/incident/test_schedule_retro.py
@@ -64,7 +64,10 @@ def test_schedule_event_successful(
         mock_datetime_now.now,  # use the fixture here
         mock_datetime_now.now + timedelta(hours=1),
     )
-    insert_event_mock.return_value = {"event_link": "https://calendar.link", "event_info": "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details."}
+    insert_event_mock.return_value = {
+        "event_link": "https://calendar.link",
+        "event_info": "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details.",
+    }
     mock_days = 1
 
     # Parse event details
@@ -103,7 +106,10 @@ def test_schedule_event_successful(
     )
 
     assert result["event_link"] == "https://calendar.link"
-    assert result["event_info"] == "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details."
+    assert (
+        result["event_info"]
+        == "Retro has been scheduled for Monday, April 10, 2023 at 10:00 AM EDT. Check your calendar for more details."
+    )
 
 
 # Test out the schedule_event function when no available slots are found


### PR DESCRIPTION
# Summary | Résumé

The following changes have been made to the calendar event functionality:

- The description when you create an incident is now part of the description of the incident channel
- The description above is taken as the title of the calendar invite
- After a calendar invite is created, it is posted in the channel with event details:


![Uploading Screenshot 2024-07-18 at 10.26.14 AM.png…]()

