### PR TITLE
Fix/aws commands handler

### DIFF
--- a/app/modules/aws/aws_access_requests.py
+++ b/app/modules/aws/aws_access_requests.py
@@ -1,4 +1,4 @@
-import boto3  # noqa
+import boto3  # type: ignore
 import datetime
 import os
 import uuid

--- a/app/modules/dev/core.py
+++ b/app/modules/dev/core.py
@@ -1,0 +1,19 @@
+import os
+from . import aws_dev, google
+
+PREFIX = os.environ.get("PREFIX", "")
+
+
+def dev_command(ack, logger, respond, client, body, args):
+    ack()
+
+    if PREFIX != "dev-":
+        respond("This command is only available in the development environment.")
+        return
+    action = args.pop(0) if args else ""
+    logger.info("Dev command received: %s", action)
+    match action:
+        case "aws":
+            aws_dev.aws_dev_command(ack, client, body, respond)
+        case "google":
+            google.google_service_command(ack, client, body, respond, logger)


### PR DESCRIPTION
# Summary | Résumé

Fix test slash commands for Slack module by supporting a `test` command followed by the test name to perform.

Available in Dev only