### PR TITLE
Channel name is now the event title for the retro

### DIFF
--- a/app/modules/dev/aws_dev.py
+++ b/app/modules/dev/aws_dev.py
@@ -14,10 +14,7 @@ logger = logging.getLogger(__name__)
 def aws_dev_command(ack, client, body, respond):
     ack()
     response = organizations.list_organization_accounts()
-    accounts = {
-        account["Id"]: account["Name"]
-        for account in response
-    }
+    accounts = {account["Id"]: account["Name"] for account in response}
     accounts = dict(sorted(accounts.items(), key=lambda i: i[1]))
     formatted_accounts = ""
     for account in accounts.keys():

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -459,11 +459,6 @@ def schedule_incident_retro(client, body, ack):
     # get all users in a channel
     users = client.conversations_members(channel=channel_id)["members"]
 
-    # Get the channel topic
-    channel_name = client.conversations_info(channel=channel_id)["channel"]["purpose"][
-        "value"
-    ]
-
     # If for some reason the channel topic is empty, set it to "Incident Retro"
     if channel_name == "":
         channel_name = "Incident Retro"

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -830,7 +830,6 @@ def test_schedule_incident_retro_successful_no_bots():
         usergroup=SLACK_SECURITY_USER_GROUP_ID
     )
     mock_client.conversations_members.assert_called_once_with(channel="C1234567890")
-    mock_client.conversations_info.assert_called_once_with(channel="C1234567890")
 
     # Check the users_info method was called correctly
     calls = [call for call in mock_client.users_info.call_args_list]
@@ -842,7 +841,7 @@ def test_schedule_incident_retro_successful_no_bots():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -898,7 +897,6 @@ def test_schedule_incident_retro_successful_bots():
         usergroup=SLACK_SECURITY_USER_GROUP_ID
     )
     mock_client.conversations_members.assert_called_once_with(channel="C1234567890")
-    mock_client.conversations_info.assert_called_once_with(channel="C1234567890")
 
     # Check the users_info method was called correctly
     calls = [call for call in mock_client.users_info.call_args_list]
@@ -910,7 +908,7 @@ def test_schedule_incident_retro_successful_bots():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -965,7 +963,6 @@ def test_schedule_incident_retro_successful_security_group():
         usergroup=SLACK_SECURITY_USER_GROUP_ID
     )
     mock_client.conversations_members.assert_called_once_with(channel="C1234567890")
-    mock_client.conversations_info.assert_called_once_with(channel="C1234567890")
 
     # Check the users_info method was called correctly
     calls = [call for call in mock_client.users_info.call_args_list]
@@ -977,7 +974,7 @@ def test_schedule_incident_retro_successful_security_group():
     expected_data = json.dumps(
         {
             "emails": ["user2@example.com"],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1033,7 +1030,6 @@ def test_schedule_incident_retro_successful_no_security_group():
         usergroup=SLACK_SECURITY_USER_GROUP_ID
     )
     mock_client.conversations_members.assert_called_once_with(channel="C1234567890")
-    mock_client.conversations_info.assert_called_once_with(channel="C1234567890")
 
     # Check the users_info method was called correctly
     calls = [call for call in mock_client.users_info.call_args_list]
@@ -1045,7 +1041,7 @@ def test_schedule_incident_retro_successful_no_security_group():
     expected_data = json.dumps(
         {
             "emails": ["user1@example.com", "user2@example.com"],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1092,7 +1088,7 @@ def test_schedule_incident_retro_with_no_users():
     expected_data = json.dumps(
         {
             "emails": [],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1137,7 +1133,51 @@ def test_schedule_incident_retro_with_no_topic():
     expected_data = json.dumps(
         {
             "emails": [],
-            "name": "Retro Purpose",
+            "name": "incident-2024-01-12-test",
+            "incident_document": "dummy_document_id",
+            "channel_id": "C1234567890",
+        }
+    )
+    # Assertions to validate behavior when no users are present in the channel
+    assert (
+        mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
+    )
+
+def test_schedule_incident_retro_with_no_name():
+    mock_client = MagicMock()
+    mock_ack = MagicMock()
+    mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
+    mock_client.conversations_info.return_value = {
+        "channel": {"name": "", "topic": {"value": ""}, "purpose": {"value": "Retro Purpose"}}
+    }
+    mock_client.bookmarks_list.return_value = {
+        "ok": True,
+        "bookmarks": [
+            {
+                "title": "Incident report",
+                "link": "https://docs.google.com/document/d/dummy_document_id/edit",
+            }
+        ],
+    }
+    mock_client.users_info.side_effect = []
+
+    # Adjust the mock to simulate no users in the channel
+    mock_client.conversations_members.return_value = {"members": []}
+
+    body = {
+        "channel_id": "C1234567890",
+        "trigger_id": "T1234567890",
+        "channel_name": "incident-",
+        "user_id": "U12345",
+    }
+
+    incident_helper.schedule_incident_retro(mock_client, body, mock_ack)
+
+    # construct the expected data object and set the topic to a default one
+    expected_data = json.dumps(
+        {
+            "emails": [],
+            "name": "incident-",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1182,7 +1222,7 @@ def test_schedule_incident_retro_with_no_purpose():
     expected_data = json.dumps(
         {
             "emails": [],
-            "name": "Incident Retro",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1206,7 +1246,7 @@ def test_save_incident_retro_success(schedule_event_mock):
     data_to_send = json.dumps(
         {
             "emails": [],
-            "name": "Incident Retro",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1244,7 +1284,7 @@ def test_save_incident_retro_success_post_message_to_channel(schedule_event_mock
     data_to_send = json.dumps(
         {
             "emails": [],
-            "name": "Incident Retro",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }
@@ -1285,7 +1325,7 @@ def test_save_incident_retro_failure(schedule_event_mock):
     data_to_send = json.dumps(
         {
             "emails": [],
-            "name": "Incident Retro",
+            "name": "incident-2024-01-12-test",
             "incident_document": "dummy_document_id",
             "channel_id": "C1234567890",
         }

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -1143,12 +1143,17 @@ def test_schedule_incident_retro_with_no_topic():
         mock_client.views_open.call_args[1]["view"]["private_metadata"] == expected_data
     )
 
+
 def test_schedule_incident_retro_with_no_name():
     mock_client = MagicMock()
     mock_ack = MagicMock()
     mock_client.usergroups_users_list.return_value = {"users": ["U444444"]}
     mock_client.conversations_info.return_value = {
-        "channel": {"name": "", "topic": {"value": ""}, "purpose": {"value": "Retro Purpose"}}
+        "channel": {
+            "name": "",
+            "topic": {"value": ""},
+            "purpose": {"value": "Retro Purpose"},
+        }
     }
     mock_client.bookmarks_list.return_value = {
         "ok": True,


### PR DESCRIPTION
# Summary | Résumé

Making the channel name be the event title when scheduling a retro. 