### PR TITLE
Feat/sync single group

### DIFF
--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -296,6 +296,10 @@ def list_groups_with_memberships(
     """Retrieves groups with their members from the AWS Identity Center (identitystore)
 
     Args:
+        group_members (bool): Include group members in the response. Default is True.
+        members_details (bool): Include the details of the members. Default is True.
+        include_empty_groups (bool): Include groups without members. Default is True.
+        groups_filters (list): A list of filters to apply to the groups. Default is None.
         **kwargs: Additional keyword arguments for the API call. (passed to list_groups)
 
     Returns:
@@ -309,6 +313,7 @@ def list_groups_with_memberships(
     if groups_filters is not None:
         for groups_filter in groups_filters:
             groups = filters.filter_by_condition(groups, groups_filter)
+    logger.info(f"Founds {len(groups)} groups in AWS Identity Store.")
     if not group_members:
         return groups
 

--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -1,5 +1,6 @@
 """Google Directory module to interact with the Google Workspace Directory API."""
 
+from logging import getLogger
 from integrations.google_workspace.google_service import (
     handle_google_api_errors,
     execute_google_api_call,
@@ -8,6 +9,8 @@ from integrations.google_workspace.google_service import (
 )
 from integrations.utils.api import convert_string_to_camel_case
 from utils import filters
+
+logger = getLogger(__name__)
 
 
 @handle_google_api_errors
@@ -181,8 +184,10 @@ def list_groups_with_members(
     if not groups:
         return []
 
-    for filter in groups_filters:
-        groups = filters.filter_by_condition(groups, filter)
+    if groups_filters is not None:
+        for groups_filter in groups_filters:
+            groups = filters.filter_by_condition(groups, groups_filter)
+    logger.info(f"Found {len(groups)} groups.")
     if not group_members:
         return groups
 

--- a/app/modules/aws/identity_center.py
+++ b/app/modules/aws/identity_center.py
@@ -28,20 +28,26 @@ def synchronize(**kwargs):
     enable_membership_create = kwargs.pop("enable_membership_create", True)
     enable_membership_delete = kwargs.pop("enable_membership_delete", False)
     query = kwargs.pop("query", "email:aws-*")
+    pre_processing_filters = kwargs.pop("pre_processing_filters", [])
 
     users_sync_status = None
     groups_sync_status = None
 
     source_groups_filters = [lambda group: "AWS-" in group["name"]]
     source_groups = groups.get_groups_from_integration(
-        "google_groups", query=query, post_processing_filters=source_groups_filters
+        "google_groups",
+        query=query,
+        pre_processing_filters=pre_processing_filters,
+        post_processing_filters=source_groups_filters,
     )
     source_users = filters.get_unique_nested_dicts(source_groups, "members")
     logger.info(
         f"synchronize:Found {len(source_groups)} Groups and {len(source_users)} Users from Source"
     )
 
-    target_groups = groups.get_groups_from_integration("aws_identity_center")
+    target_groups = groups.get_groups_from_integration(
+        "aws_identity_center", pre_processing_filters=pre_processing_filters
+    )
     target_users = identity_store.list_users()
 
     logger.info(

--- a/app/tests/modules/aws/test_sync_identity_center.py
+++ b/app/tests/modules/aws/test_sync_identity_center.py
@@ -217,8 +217,13 @@ def test_synchronize_sync_users_and_groups_with_defaults(
 
     assert mock_groups.get_groups_from_integration.call_count == 2
     assert mock_groups.get_groups_from_integration.call_args_list == [
-        call("google_groups", query="email:aws-*", post_processing_filters=ANY),
-        call("aws_identity_center"),
+        call(
+            "google_groups",
+            query="email:aws-*",
+            pre_processing_filters=[],
+            post_processing_filters=ANY,
+        ),
+        call("aws_identity_center", pre_processing_filters=[]),
     ]
 
     assert mock_identity_store.list_users.call_count == 2
@@ -284,9 +289,12 @@ def test_synchronize_sync_skip_users_if_false(
     assert mock_groups.get_groups_from_integration.call_count == 2
 
     google_groups_call = call(
-        "google_groups", query="email:aws-*", post_processing_filters=ANY
+        "google_groups",
+        query="email:aws-*",
+        pre_processing_filters=[],
+        post_processing_filters=ANY,
     )
-    aws_identity_center_call = call("aws_identity_center")
+    aws_identity_center_call = call("aws_identity_center", pre_processing_filters=[])
     assert mock_groups.get_groups_from_integration.call_args_list == [
         google_groups_call,
         aws_identity_center_call,
@@ -351,9 +359,12 @@ def test_synchronize_sync_skip_groups_false_if_false(
     assert mock_groups.get_groups_from_integration.call_count == 2
 
     google_groups_call = call(
-        "google_groups", query="email:aws-*", post_processing_filters=ANY
+        "google_groups",
+        query="email:aws-*",
+        pre_processing_filters=[],
+        post_processing_filters=ANY,
     )
-    aws_identity_center_call = call("aws_identity_center")
+    aws_identity_center_call = call("aws_identity_center", pre_processing_filters=[])
     assert mock_groups.get_groups_from_integration.call_args_list == [
         google_groups_call,
         aws_identity_center_call,
@@ -419,9 +430,12 @@ def test_synchronize_sync_skip_users_and_groups_if_false(
     assert mock_groups.get_groups_from_integration.call_count == 2
 
     google_groups_call = call(
-        "google_groups", query="email:aws-*", post_processing_filters=ANY
+        "google_groups",
+        query="email:aws-*",
+        pre_processing_filters=[],
+        post_processing_filters=ANY,
     )
-    aws_identity_center_call = call("aws_identity_center")
+    aws_identity_center_call = call("aws_identity_center", pre_processing_filters=[])
     assert mock_groups.get_groups_from_integration.call_args_list == [
         google_groups_call,
         aws_identity_center_call,


### PR DESCRIPTION
# Summary | Résumé

Introduce support for optional args in `/aws groups sync` command. Args are treated as group names and only groups from source and target containing these args in their names will be synched