### PR TITLE
fix: remove duplicate account ID from modal

### DIFF
--- a/app/modules/aws/aws_account_health.py
+++ b/app/modules/aws/aws_account_health.py
@@ -161,7 +161,7 @@ def health_view_handler(ack: Ack, body, logger: Logger, client: WebClient):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Health check for *{account_name}*: ({account_id})",
+                    "text": f"Health check for *{account_name}*:",
                 },
             },
             {"type": "divider"},
@@ -195,7 +195,7 @@ def health_view_handler(ack: Ack, body, logger: Logger, client: WebClient):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Health check for *{account_name}*: ({account_id})",
+                    "text": f"Health check for *{account_name}*:",
                 },
             },
             {"type": "divider"},


### PR DESCRIPTION
# Summary | Résumé

Remove the duplicate account ID from the modals