### PR TITLE
Feat/refactor incident helper with integrations 

### DIFF
--- a/app/integrations/google_workspace/google_docs.py
+++ b/app/integrations/google_workspace/google_docs.py
@@ -33,7 +33,7 @@ def create(title: str) -> str:
 
 
 @handle_google_api_errors
-def batch_update(document_id: str, requests: list) -> None:
+def batch_update(document_id: str, requests: list) -> dict:
     """Applies a list of updates to a document in Google Docs.
 
     Args:
@@ -41,9 +41,9 @@ def batch_update(document_id: str, requests: list) -> None:
         requests (list): A list of update requests.
 
     Returns:
-        None
+        dict: The response from the Google Docs API.
     """
-    execute_google_api_call(
+    return execute_google_api_call(
         "docs",
         "v1",
         "documents",

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -106,7 +106,7 @@ def create_folder(name, parent_folder):
         fields="id",
     )
 
-    return result["id"]
+    return result
 
 
 @handle_google_api_errors
@@ -215,15 +215,20 @@ def get_file_by_name(name, folder_id=None):
 
 
 @handle_google_api_errors
-def list_folders_in_folder(folder):
+def list_folders_in_folder(folder, query=None):
     """List all folders in a folder in Google Drive.
 
     Args:
         folder (str): The id of the folder to list.
+        query (str, optional): A query to filter the folders.
 
     Returns:
         list: A list of folders in the folder.
     """
+    base_query = f"parents in '{folder}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false"
+    if query:
+        base_query += f" and {query}"
+
     return execute_google_api_call(
         "drive",
         "v3",
@@ -234,7 +239,7 @@ def list_folders_in_folder(folder):
         supportsAllDrives=True,
         includeItemsFromAllDrives=True,
         corpora="user",
-        q=f"parents in '{folder}' and mimeType = 'application/vnd.google-apps.folder' and trashed=false",
+        q=base_query,
         fields="files(id, name)",
     )
 

--- a/app/integrations/google_workspace/google_drive.py
+++ b/app/integrations/google_workspace/google_drive.py
@@ -14,13 +14,14 @@ INCIDENT_TEMPLATE = os.environ.get("INCIDENT_TEMPLATE")
 
 
 @handle_google_api_errors
-def add_metadata(file_id, key, value):
+def add_metadata(file_id, key, value, delegated_user_email=None):
     """Add metadata to a file in Google Drive.
 
     Args:
         file_id (str): The file id of the file to add metadata to.
         key (str): The key of the metadata to add.
         value (str): The value of the metadata to add.
+        delegated_user_email (str, optional): The email address of the user to impersonate.
 
     Returns:
         dict: The updated file metadata.
@@ -30,6 +31,7 @@ def add_metadata(file_id, key, value):
         "v3",
         "files",
         "update",
+        delegated_user_email=delegated_user_email,
         fileId=file_id,
         body={"appProperties": {key: value}},
         fields="name, appProperties",
@@ -38,12 +40,13 @@ def add_metadata(file_id, key, value):
 
 
 @handle_google_api_errors
-def delete_metadata(file_id, key):
+def delete_metadata(file_id, key, delegated_user_email=None):
     """Delete metadata from a file in Google Drive.
 
     Args:
         file_id (str): The file id of the file to delete metadata from.
         key (str): The key of the metadata to delete.
+        delegated_user_email (str, optional): The email address of the user to impersonate.
 
     Returns:
         dict: The updated file metadata.
@@ -53,6 +56,7 @@ def delete_metadata(file_id, key):
         "v3",
         "files",
         "update",
+        delegated_user_email=delegated_user_email,
         fileId=file_id,
         body={"appProperties": {key: None}},
         fields="name, appProperties",
@@ -82,17 +86,19 @@ def list_metadata(file_id):
 
 
 @handle_google_api_errors
-def create_folder(name, parent_folder):
+def create_folder(name, parent_folder, fields=None):
     """Create a new folder in Google Drive.
 
     Args:
         name (str): The name of the new folder.
         parent_folder (str): The id of the parent folder.
+        fields (str, optional): The fields to include in the response.
 
     Returns:
-        str: The id of the new folder.
+        dict: A File resource representing the new folder.
+        (https://developers.google.com/drive/api/reference/rest/v3/files#File)
     """
-    result = execute_google_api_call(
+    return execute_google_api_call(
         "drive",
         "v3",
         "files",
@@ -103,14 +109,12 @@ def create_folder(name, parent_folder):
             "parents": [parent_folder],
         },
         supportsAllDrives=True,
-        fields="id",
+        fields=fields,
     )
-
-    return result
 
 
 @handle_google_api_errors
-def create_file_from_template(name, folder, template):
+def create_file_from_template(name, folder, template, fields=None):
     """Create a new file in Google Drive from a template
      (Docs, Sheets, Slides, Forms, or Sites.)
 
@@ -120,9 +124,9 @@ def create_file_from_template(name, folder, template):
         template (str): The id of the template to use.
 
     Returns:
-        str: The id of the new file.
+        dict: A File resource representing the new file with a mask of 'id'.
     """
-    result = execute_google_api_call(
+    return execute_google_api_call(
         "drive",
         "v3",
         "files",
@@ -130,10 +134,8 @@ def create_file_from_template(name, folder, template):
         fileId=template,
         body={"name": name, "parents": [folder]},
         supportsAllDrives=True,
-        fields="id",
+        fields=fields,
     )
-
-    return result["id"]
 
 
 @handle_google_api_errors

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -85,7 +85,7 @@ def handle_google_api_errors(func):
                 result, unsupported_params = result
                 if unsupported_params:
                     logging.warning(
-                        f"Unsupported parameters in '{func.__name__}' were filtered out: {', '.join(unsupported_params)}"
+                        f"Unknown parameters in '{func.__name__}' were detected: {', '.join(unsupported_params)}"
                     )
             return result
         except HttpError as e:
@@ -152,7 +152,7 @@ def execute_google_api_call(
         k: v for k, v in formatted_kwargs.items() if k in supported_params
     }
     unsupported_params = set(formatted_kwargs.keys()) - set(filtered_params.keys())
-
+    # filtered_params = kwargs
     if paginate:
         all_results = []
         request = api_method(**filtered_params)
@@ -178,8 +178,9 @@ def get_google_api_command_parameters(resource_obj, method):
         list: The names of the parameters for the API method, excluding non-parameter documentation.
     """
     api_method = getattr(resource_obj, method)
+    # Add known parameters not documented in the docstring
+    parameter_names = ["fields"]
 
-    parameter_names = []
     if hasattr(api_method, "__doc__") and api_method.__doc__:
         parsing_parameters = False
         doc_lines = api_method.__doc__.splitlines()

--- a/app/integrations/google_workspace/sheets.py
+++ b/app/integrations/google_workspace/sheets.py
@@ -1,0 +1,63 @@
+"""Google Sheets API calls."""
+
+from integrations.google_workspace.google_service import (
+    handle_google_api_errors,
+    execute_google_api_call,
+)
+
+
+@handle_google_api_errors
+def get_values(
+    spreadsheetId: str, range: str | None = None, includeGridData=None, fields=None
+):
+    """Gets the values from a Google Sheet.
+
+    Args:
+        spreadsheetId (str): The id of the Google Sheet.
+        range (str, optional): The range of the values to retrieve.
+        includeGridData (bool, optional): Whether to include grid data.
+        fields (str, optional): The fields to include in the response.
+
+    Returns:
+        dict: The response from the Google Sheets API.
+    """
+    return execute_google_api_call(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "get",
+        spreadsheetId=spreadsheetId,
+        range=range,
+        includeGridData=includeGridData,
+        fields=fields,
+    )
+
+
+def batch_update_values(
+    spreadsheetId: str,
+    range: str,
+    values: list,
+    valueInputOption: str = "USER_ENTERED",
+) -> dict:
+    """Updates values in a Google Sheet.
+
+    Args:
+        spreadsheetId (str): The id of the Google Sheet.
+        range (str): The range to update.
+        values (list): The values to update.
+        valueInputOption (str, optional): The value input option.
+
+    Returns:
+        dict: The response from the Google Sheets API.
+    """
+    return execute_google_api_call(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "batchUpdate",
+        spreadsheetId=spreadsheetId,
+        body={
+            "valueInputOption": valueInputOption,
+            "data": [{"range": range, "values": values}],
+        },
+    )

--- a/app/tests/integrations/google_workspace/test_google_drive.py
+++ b/app/tests/integrations/google_workspace/test_google_drive.py
@@ -69,10 +69,14 @@ def test_list_metadata_returns_result(execute_google_api_call_mock):
 
 @patch("integrations.google_workspace.google_drive.execute_google_api_call")
 def test_create_folder_returns_folder_id(execute_google_api_call_mock):
-    execute_google_api_call_mock.return_value = {"id": "test_folder_id"}
-    assert (
-        google_drive.create_folder("test_folder", "parent_folder") == "test_folder_id"
-    )
+    execute_google_api_call_mock.return_value = {
+        "id": "test_folder_id",
+        "name": "test_folder",
+    }
+    assert google_drive.create_folder("test_folder", "parent_folder") == {
+        "id": "test_folder_id",
+        "name": "test_folder",
+    }
     execute_google_api_call_mock.assert_called_once_with(
         "drive",
         "v3",

--- a/app/tests/integrations/google_workspace/test_google_drive.py
+++ b/app/tests/integrations/google_workspace/test_google_drive.py
@@ -17,6 +17,7 @@ def test_add_metadata_returns_result(execute_google_api_call_mock):
         "v3",
         "files",
         "update",
+        delegated_user_email=None,
         fileId="file_id",
         body={"appProperties": {"key": "value"}},
         fields="name, appProperties",
@@ -37,6 +38,7 @@ def test_delete_metadata_returns_result(execute_google_api_call_mock):
         "v3",
         "files",
         "update",
+        delegated_user_email=None,
         fileId="file_id",
         body={"appProperties": {"key": None}},
         fields="name, appProperties",
@@ -68,14 +70,39 @@ def test_list_metadata_returns_result(execute_google_api_call_mock):
 
 
 @patch("integrations.google_workspace.google_drive.execute_google_api_call")
-def test_create_folder_returns_folder_id(execute_google_api_call_mock):
+def test_create_folder_returns_folder(execute_google_api_call_mock):
     execute_google_api_call_mock.return_value = {
         "id": "test_folder_id",
         "name": "test_folder",
+        "appProperties": {},
     }
     assert google_drive.create_folder("test_folder", "parent_folder") == {
         "id": "test_folder_id",
         "name": "test_folder",
+        "appProperties": {},
+    }
+    execute_google_api_call_mock.assert_called_once_with(
+        "drive",
+        "v3",
+        "files",
+        "create",
+        body={
+            "name": "test_folder",
+            "mimeType": "application/vnd.google-apps.folder",
+            "parents": ["parent_folder"],
+        },
+        supportsAllDrives=True,
+        fields=None,
+    )
+
+
+@patch("integrations.google_workspace.google_drive.execute_google_api_call")
+def test_create_folder_calls_api_with_fields(execute_google_api_call_mock):
+    execute_google_api_call_mock.return_value = {
+        "id": "test_folder_id",
+    }
+    assert google_drive.create_folder("test_folder", "parent_folder", "id") == {
+        "id": "test_folder_id",
     }
     execute_google_api_call_mock.assert_called_once_with(
         "drive",
@@ -129,12 +156,12 @@ def test_create_file_with_invalid_type_raises_value_error(
 
 
 @patch("integrations.google_workspace.google_drive.execute_google_api_call")
-def test_create_file_from_template_returns_file_id(execute_google_api_call_mock):
+def test_create_file_from_template_returns_file(execute_google_api_call_mock):
     execute_google_api_call_mock.return_value = {"id": "test_document_id"}
     result = google_drive.create_file_from_template(
         "test_document", "folder_id", "template_id"
     )
-    assert result == "test_document_id"
+    assert result == {"id": "test_document_id"}
     execute_google_api_call_mock.assert_called_once_with(
         "drive",
         "v3",
@@ -143,7 +170,7 @@ def test_create_file_from_template_returns_file_id(execute_google_api_call_mock)
         fileId="template_id",
         body={"name": "test_document", "parents": ["folder_id"]},
         supportsAllDrives=True,
-        fields="id",
+        fields=None,
     )
 
 

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -190,7 +190,7 @@ def test_handle_google_api_errors_processes_unsupported_params(
     assert result == "test"
     mock_func.assert_called_once()
     mocked_logging_warning.assert_called_once_with(
-        "Unsupported parameters in 'mock_func' were filtered out: unsupported"
+        "Unknown parameters in 'mock_func' were detected: unsupported"
     )
 
 
@@ -440,4 +440,4 @@ Returns:
 
     result = get_google_api_command_parameters(mock_resource, "method")
 
-    assert result == ["arg1", "arg2"]
+    assert result == ["fields", "arg1", "arg2"]

--- a/app/tests/integrations/google_workspace/test_sheets.py
+++ b/app/tests/integrations/google_workspace/test_sheets.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch, MagicMock
+from integrations.google_workspace import sheets
+
+
+@patch("integrations.google_workspace.sheets.execute_google_api_call")
+def test_get_values(mock_execute_google_api_call):
+
+    spreadsheet_id = "1"
+    range = "A1:B2"
+    include_grid_data = True
+    fields = "fields"
+
+    sheets.get_values(spreadsheet_id, range, include_grid_data, fields)
+
+    mock_execute_google_api_call.assert_called_once_with(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "get",
+        spreadsheetId=spreadsheet_id,
+        range=range,
+        includeGridData=include_grid_data,
+        fields=fields,
+    )
+
+
+@patch("integrations.google_workspace.sheets.execute_google_api_call")
+def test_get_values_with_defaults(mock_execute_google_api_call):
+
+    spreadsheet_id = "1"
+
+    sheets.get_values(spreadsheet_id)
+
+    mock_execute_google_api_call.assert_called_once_with(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "get",
+        spreadsheetId=spreadsheet_id,
+        range=None,
+        includeGridData=None,
+        fields=None,
+    )
+
+
+@patch("integrations.google_workspace.sheets.execute_google_api_call")
+def test_batch_update_values(mock_execute_google_api_call):
+
+    spreadsheet_id = "1"
+    range = "A1:B2"
+    values = [["a", "b"], ["c", "d"]]
+    value_input_option = "USER_ENTERED"
+
+    sheets.batch_update_values(spreadsheet_id, range, values, value_input_option)
+
+    mock_execute_google_api_call.assert_called_once_with(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "batchUpdate",
+        spreadsheetId=spreadsheet_id,
+        body={
+            "valueInputOption": value_input_option,
+            "data": [{"range": range, "values": values}],
+        },
+    )
+
+
+@patch("integrations.google_workspace.sheets.execute_google_api_call")
+def test_batch_update_values_with_defaults(mock_execute_google_api_call):
+
+    spreadsheet_id = "1"
+    range = "A1:B2"
+    values = [["a", "b"], ["c", "d"]]
+
+    sheets.batch_update_values(spreadsheet_id, range, values)
+
+    mock_execute_google_api_call.assert_called_once_with(
+        "sheets",
+        "v4",
+        "spreadsheets.values",
+        "batchUpdate",
+        spreadsheetId=spreadsheet_id,
+        body={
+            "valueInputOption": "USER_ENTERED",
+            "data": [{"range": range, "values": values}],
+        },
+    )

--- a/app/tests/integrations/google_workspace/test_sheets.py
+++ b/app/tests/integrations/google_workspace/test_sheets.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from integrations.google_workspace import sheets
 
 


### PR DESCRIPTION
# Summary | Résumé

- Refactor the incident helper (used with `/sre incident` command) to use generic Google integrations modules instead of the catchall google_drive module (became a very large file with lots of process specific configuration)
- Introduce the Google Sheets module
- Add typing annotations when possible

Additional fixes:
- Refactoring required some updates to the execute api function, namely supporting the `fields` argument as a supported parameter in the api calls.
- Google Drive and Docs also were updated to support fields as an arg
- Delegated user email has been added to functions with write permissions so that they can possibly be executed by using the caller's identity instead of the bot's, thus inheriting their permissions in Google Workspace