### PR TITLE
fix: import needs to import the incident module

### DIFF
--- a/app/modules/incident/incident_alert.py
+++ b/app/modules/incident/incident_alert.py
@@ -1,5 +1,5 @@
 from integrations.sentinel import log_to_sentinel
-from modules import incident
+from modules.incident import incident
 from models import webhooks
 
 


### PR DESCRIPTION
# Summary | Résumé

Need to import the modules.incident.incident to properly resolve the functions.

Probably should rename the main incident module as core to avoid such import issues.