### PR TITLE
fix: add detailed payload logging for debugging

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -375,6 +375,9 @@ def handle_webhook(id: str, payload: WebhookPayload | str, request: Request):
         if webhooks.is_active(id):
             webhooks.increment_invocation_count(id)
             if isinstance(payload, str):
+                logging.info(
+                    f"Received message: {payload}"
+                )  # log the full message for debugging
                 try:
                     payload = AwsSnsPayload.parse_raw(payload)
                     sns_message_validator.validate_message(message=payload.dict())


### PR DESCRIPTION
# Summary | Résumé

Adding more detailed logging to debug the payload errors generated by the Upptime status notification