### PR TITLE
Fix/get user timeout

### DIFF
--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -203,16 +203,26 @@ def list_groups_with_members(
     groups_with_members = []
     for group in groups:
         logger.info(f"Getting members for group: {group['email']}")
-        members = list_group_members(
-            group["email"], fields="members(email, role, type, status)"
-        )
+        try:
+            members = list_group_members(
+                group["email"], fields="members(email, role, type, status)"
+            )
+        except Exception as e:
+            logger.warning(f"Error getting members for group {group['email']}: {e}")
+            continue
         if members and members_details:
             detailed_members = []
-            for member in members:
-                logger.info(f"Getting user details for member: {member['email']}")
-                detailed_members.append(
-                    get_user(member["email"], fields="name, primaryEmail")
+            try:
+                for member in members:
+                    logger.info(f"Getting user details for member: {member['email']}")
+                    detailed_members.append(
+                        get_user(member["email"], fields="name, primaryEmail")
+                    )
+                group["members"] = detailed_members
+                groups_with_members.append(group)
+            except Exception as e:
+                logger.warning(
+                    f"Error getting user details for group {member['email']}: {e}"
                 )
-            group["members"] = detailed_members
-            groups_with_members.append(group)
+                continue
     return groups_with_members

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -14,6 +14,7 @@ google-api-core==2.19.2
 google-auth==2.33.0
 httpx==0.27.2
 itsdangerous==2.2.0
+pandas==2.2.3
 PyJWT==2.9.0
 PyYAML!=6.0.0,!=5.4.0,!=5.4.1
 python-dotenv==0.21.1

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -396,6 +396,33 @@ def test_list_groups_with_members_filtered(
 @patch("integrations.google_workspace.google_directory.list_groups")
 @patch("integrations.google_workspace.google_directory.list_group_members")
 @patch("integrations.google_workspace.google_directory.get_user")
+def test_list_groups_with_members_error_in_list_group_members(
+    mock_get_user,
+    mock_list_group_members,
+    mock_list_groups,
+    google_groups,
+    google_group_members,
+    google_users,
+    google_groups_w_users
+):
+    groups = google_groups(2)
+    group_members = [Exception("Error fetching group members"), google_group_members(2)]
+    users = google_users(2)
+
+    mock_list_groups.return_value = groups
+    mock_list_group_members.side_effect = group_members
+    mock_get_user.side_effect = users
+
+    # Only the second group should be processed
+    expected_groups_with_users = [groups[1]]
+    expected_groups_with_users[0]["members"] = users
+
+    assert google_directory.list_groups_with_members() == expected_groups_with_users
+
+
+@patch("integrations.google_workspace.google_directory.list_groups")
+@patch("integrations.google_workspace.google_directory.list_group_members")
+@patch("integrations.google_workspace.google_directory.get_user")
 def test_list_groups_with_members_without_details(
     mock_get_user,
     mock_list_group_members,
@@ -435,6 +462,29 @@ def test_list_groups_with_members_without_members_enabled(
 
     mock_list_group_members.assert_not_called()
     mock_get_user.assert_not_called()
+
+
+@patch("integrations.google_workspace.google_directory.list_groups")
+@patch("integrations.google_workspace.google_directory.list_group_members")
+@patch("integrations.google_workspace.google_directory.get_user")
+def test_list_groups_with_members_error_in_get_user(
+    mock_get_user,
+    mock_list_group_members,
+    mock_list_groups,
+    google_groups,
+    google_group_members,
+    google_users,
+):
+    groups = google_groups(2)
+    group_members = [google_group_members(2), google_group_members(2)]
+    users = [Exception("Error fetching user details"), google_users(1)[0]]
+
+    mock_list_groups.return_value = groups
+    mock_list_group_members.side_effect = group_members
+    mock_get_user.side_effect = users
+
+    # No groups should be processed due to error in get_user
+    assert google_directory.list_groups_with_members() == []
 
 
 @patch("integrations.google_workspace.google_directory.list_groups")


### PR DESCRIPTION
# Summary | Résumé

Update the Google list groups with users to handle cases where an API time out error breaks the sync job.

Add a tolerate error flag to continue processing users (set to default False)