### PR TITLE
Increasing memory and number of tasks to 2 for SRE bot

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_service" "main" {
   name             = "sre-bot-service"
   cluster          = aws_ecs_cluster.sre-bot.id
   task_definition  = aws_ecs_task_definition.sre-bot.arn
-  desired_count    = 1
+  desired_count    = 2
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   propagate_tags   = "SERVICE"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "fargate_cpu" {
 
 variable "fargate_memory" {
   type    = number
-  default = 512
+  default = 1024
 }
 
 variable "google_oauth_pickle_string" {


### PR DESCRIPTION
# Summary | Résumé

We have had recently had memory spikes that had killed the SRE bot. I am scaling the SRE bot to increase the number of ECS tasks and the memory of the container. 