### PR TITLE
fix: use CDS Trivy vulnerability database

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -70,7 +70,9 @@ jobs:
           log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "./Dockerfile"

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -36,7 +36,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+        uses: cds-snc/security-tools/.github/actions/docker-scan@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/sre-bot:latest"
           dockerfile_path: "Dockerfile"


### PR DESCRIPTION
# Summary
Update the Docker scan actions to use a self-hosted Trivy vulnerability database. This is being done to address the rate limiting of the publicly hosted database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597