### PR TITLE
Fix/groups sync

### DIFF
--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -9,7 +9,7 @@ from integrations.google_workspace.google_service import (
     DEFAULT_DELEGATED_ADMIN_EMAIL,
     DEFAULT_GOOGLE_WORKSPACE_CUSTOMER_ID,
 )
-from integrations.utils.api import convert_string_to_camel_case
+from integrations.utils.api import convert_string_to_camel_case, retry_request
 from utils import filters
 
 logger = getLogger(__name__)
@@ -209,35 +209,59 @@ def list_groups_with_members(
 
     groups_with_members = []
     for group in filtered_groups:
-        error_occured = False
         logger.info(f"Getting members for group: {group['email']}")
         try:
-            members = list_group_members(
-                group["email"], fields="members(email, role, type, status)"
+            members = retry_request(
+                list_group_members,
+                max_attempts=3,
+                delay=1,
+                email=group["email"],
+                fields="members(email, role, type, status)",
             )
         except Exception as e:
             logger.warning(f"Error getting members for group {group['email']}: {e}")
             continue
 
-        for member in members:
-            user_details = {}
-            try:
-                logger.info(f"Getting user details for member: {member['email']}")
-                user_details = get_user(member["email"], fields="name, primaryEmail")
-            except Exception as e:
-                logger.warning(
-                    f"Error getting user details for member {member['email']}: {e}"
-                )
-                error_occured = True
-                if not tolerate_errors:
-                    break
-            if user_details:
-                member.update(user_details)
-        if members and (not error_occured or tolerate_errors):
+        members = get_members_details(members, tolerate_errors)
+        if members:
             group.update({"members": members})
             groups_with_members.append(group)
 
     return groups_with_members
+
+
+def get_members_details(members: list[dict], tolerate_errors=False):
+    """Get user details for a list of members.
+
+    Args:
+        members (list): A list of member objects.
+        tolerate_errors (bool): Whether to tolerate errors when getting user details.
+
+    Returns:"""
+
+    error_occured = False
+    for member in members:
+        user_details = {}
+        try:
+            logger.info(f"Getting user details for member: {member['email']}")
+            user_details = retry_request(
+                get_user,
+                max_attempts=3,
+                delay=1,
+                email=member["email"],
+                fields="name, primaryEmail",
+            )
+        except Exception as e:
+            logger.warning(
+                f"Error getting user details for member {member['email']}: {e}"
+            )
+            error_occured = True
+            if not tolerate_errors:
+                break
+        if user_details:
+            member.update(user_details)
+
+    return members if not error_occured or tolerate_errors else []
 
 
 def convert_google_groups_members_to_dataframe(groups):

--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -213,9 +213,9 @@ def list_groups_with_members(
         try:
             members = retry_request(
                 list_group_members,
+                group["email"],
                 max_attempts=3,
                 delay=1,
-                email=group["email"],
                 fields="members(email, role, type, status)",
             )
         except Exception as e:
@@ -246,9 +246,9 @@ def get_members_details(members: list[dict], tolerate_errors=False):
             logger.info(f"Getting user details for member: {member['email']}")
             user_details = retry_request(
                 get_user,
+                member["email"],
                 max_attempts=3,
                 delay=1,
-                email=member["email"],
                 fields="name, primaryEmail",
             )
         except Exception as e:

--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -106,18 +106,22 @@ def handle_google_api_errors(func: Callable[..., Any]) -> Callable[..., Any]:
             logging.error(
                 f"An HTTP error occurred in function '{func.__module__}:{func.__name__}': {e}"
             )
+            raise e
         except ValueError as e:
             logging.error(
                 f"A ValueError occurred in function '{func.__module__}:{func.__name__}': {e}"
             )
+            raise e
         except RefreshError as e:
             logging.error(
                 f"A RefreshError occurred in function '{func.__module__}:{func.__name__}': {e}"
             )
+            raise e
         except Error as e:
             logging.error(
                 f"An error occurred in function '{func.__module__}:{func.__name__}': {e}"
             )
+            raise e
         except Exception as e:  # Catch-all for any other types of exceptions
             message = str(e)
             func_name = func.__name__
@@ -131,7 +135,7 @@ def handle_google_api_errors(func: Callable[..., Any]) -> Callable[..., Any]:
                 logging.error(
                     f"An unexpected error occurred in function '{func.__module__}:{func.__name__}': {e}"
                 )
-        return None
+            raise e
 
     return wrapper
 

--- a/app/integrations/utils/api.py
+++ b/app/integrations/utils/api.py
@@ -3,6 +3,8 @@
 import re
 import string
 import random
+import time
+import logging
 
 
 def convert_string_to_camel_case(snake_str):
@@ -85,3 +87,27 @@ def generate_unique_id():
     unique_id = "-".join(segments)
 
     return unique_id
+
+
+def retry_request(func, max_attempts=3, delay=1, *args, **kwargs):
+    """Retry a function up to a maximum number of attempts with a delay between each attempt.
+
+    Args:
+        func (function): The function to call.
+        max_attempts (int): The maximum number of attempts to make.
+        delay (int): The delay between each attempt in seconds.
+        *args: Positional arguments to pass to the function.
+        **kwargs: Keyword arguments to pass to the function.
+
+    Returns:
+        Any: The result of the function call.
+    """
+    for i in range(max_attempts):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if i == max_attempts - 1:
+                logging.warning(f"Error after {max_attempts} attempts: {e}")
+                raise e
+            time.sleep(delay)
+            continue

--- a/app/integrations/utils/api.py
+++ b/app/integrations/utils/api.py
@@ -89,7 +89,13 @@ def generate_unique_id():
     return unique_id
 
 
-def retry_request(func, max_attempts=3, delay=1, *args, **kwargs):
+def retry_request(
+    func,
+    *args,
+    max_attempts=3,
+    delay=1,
+    **kwargs,
+):
     """Retry a function up to a maximum number of attempts with a delay between each attempt.
 
     Args:

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -470,11 +470,12 @@ def test_insert_event_api_call_error(
     emails = ["test1@test.com", "test2@test.com"]
     title = "Test Event"
     document_id = "test_document_id"
-    google_calendar.insert_event(start, end, emails, title, document_id)
-    assert (
-        "An unexpected error occurred in function 'integrations.google_workspace.google_calendar:insert_event': API call error"
-        in caplog.text
-    )
+    with pytest.raises(Exception):
+        google_calendar.insert_event(start, end, emails, title, document_id)
+        assert (
+            "An unexpected error occurred in function 'integrations.google_workspace.google_calendar:insert_event': API call error"
+            in caplog.text
+        )
     assert not mock_convert_string_to_camel_case.called
     assert mock_os_environ_get.called
     assert not mock_handle_errors.called

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import pandas as pd
-import pytest
 from integrations.google_workspace import google_directory
 
 

--- a/app/tests/integrations/google_workspace/test_google_drive.py
+++ b/app/tests/integrations/google_workspace/test_google_drive.py
@@ -1,7 +1,7 @@
 """Unit tests for google_drive module."""
 
 from unittest.mock import patch, call
-
+import pytest
 from integrations.google_workspace import google_drive
 
 
@@ -152,9 +152,10 @@ def test_create_file_with_invalid_type_raises_value_error(
     execute_google_api_call_mock.side_effect = ValueError(
         "Invalid file_type: invalid_file_type"
     )
-    result = google_drive.create_file("name", "folder", "invalid_file_type")
+    with pytest.raises(ValueError):
+        result = google_drive.create_file("name", "folder", "invalid_file_type")
+        assert result is None
 
-    assert result is None
     mocked_logging_error.assert_called_once_with(
         "A ValueError occurred in function 'integrations.google_workspace.google_drive:create_file': Invalid file_type: invalid_file_type"
     )

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -100,7 +100,7 @@ def test_handle_google_api_errors_catches_http_error(mocked_logging_error):
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    with pytest.raises(HttpError, match="<HttpError 400 \"Bad Request\">"):
+    with pytest.raises(HttpError, match='<HttpError 400 "Bad Request">'):
         result = decorated_func()
         assert result is None
 

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -100,9 +100,10 @@ def test_handle_google_api_errors_catches_http_error(mocked_logging_error):
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(HttpError, match="<HttpError 400 \"Bad Request\">"):
+        result = decorated_func()
+        assert result is None
 
-    assert result is None
     mocked_logging_error.assert_called_once_with(
         "An HTTP error occurred in function 'mock_module:mock_func': <HttpError 400 \"Bad Request\">"
     )
@@ -115,9 +116,10 @@ def test_handle_google_api_errors_catches_value_error(mocked_logging_error):
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(ValueError, match="ValueError message"):
+        result = decorated_func()
+        assert result is None
 
-    assert result is None
     mock_func.assert_called_once()
     mocked_logging_error.assert_called_once_with(
         "A ValueError occurred in function 'mock_module:mock_func': ValueError message"
@@ -131,25 +133,30 @@ def test_handle_google_api_errors_catches_error(mocked_logging_error):
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(Error, match="Error message"):
+        result = decorated_func()
+        assert result is None
 
-    assert result is None
     mock_func.assert_called_once()
     mocked_logging_error.assert_called_once_with(
         "An error occurred in function 'mock_module:mock_func': Error message"
     )
 
 
+@patch("logging.warning")
 @patch("logging.error")
-def test_handle_google_api_errors_catches_exception(mocked_logging_error: MagicMock):
+def test_handle_google_api_errors_catches_exception(
+    mocked_logging_error: MagicMock, mocked_logging_warning: MagicMock
+):
     mock_func = MagicMock(side_effect=Exception("Exception message"))
     mock_func.__name__ = "mock_func"
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(Exception, match="Exception message"):
+        result = decorated_func()
+        assert result is None
 
-    assert result is None
     mock_func.assert_called_once()
     mocked_logging_error.assert_called_once_with(
         "An unexpected error occurred in function 'mock_module:mock_func': Exception message"
@@ -160,23 +167,24 @@ def test_handle_google_api_errors_catches_exception(mocked_logging_error: MagicM
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(Exception, match="timed out"):
+        result = decorated_func()
+        assert result is None
+
     mock_func.assert_called_once()
     mocked_logging_error.assert_called_with(
         "An unexpected error occurred in function 'mock_module:list_groups': timed out"
     )
 
-
-@patch("logging.warning")
-def test_handle_google_api_errors_catches_non_critical_error(mocked_logging_warning):
     mock_func = MagicMock(side_effect=Exception("timed out"))
     mock_func.__name__ = "get_user"
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func("arg1", "arg2", a="b")
+    with pytest.raises(Exception, match="timed out"):
+        result = decorated_func("arg1", "arg2", a="b")
+        assert result is None
 
-    assert result is None
     mock_func.assert_called_once()
     mocked_logging_warning.assert_called_once_with(
         "A non critical error occurred in function 'mock_module:get_user(arg1, arg2, a=b)': timed out"
@@ -190,9 +198,9 @@ def test_handle_google_api_errors_catches_refresh_error(mocked_logging_error):
     mock_func.__module__ = "mock_module"
     decorated_func = handle_google_api_errors(mock_func)
 
-    result = decorated_func()
+    with pytest.raises(RefreshError, match="RefreshError message"):
+        decorated_func()
 
-    assert result is None
     mock_func.assert_called_once()
     mocked_logging_error.assert_called_once_with(
         "A RefreshError occurred in function 'mock_module:mock_func': RefreshError message"

--- a/app/tests/integrations/utils/test_api.py
+++ b/app/tests/integrations/utils/test_api.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock, patch
 import pytest
 import string
 from integrations.utils.api import (
@@ -8,6 +9,7 @@ from integrations.utils.api import (
     convert_dict_to_pascale_case,
     convert_kwargs_to_pascal_case,
     generate_unique_id,
+    retry_request,
 )
 
 
@@ -249,3 +251,42 @@ def test_no_illegal_characters():
     assert not any(
         char in illegal_chars for char in unique_id.replace("-", "")
     ), "ID should not have uppercase or special characters"
+
+
+def test_retry_request_success():
+    mock_func = MagicMock(return_value="success")
+    result = retry_request(mock_func, max_attempts=3, delay=1)
+    assert result == "success"
+    mock_func.assert_called_once()
+
+
+def test_retry_request_success_after_retries():
+    mock_func = MagicMock(side_effect=[Exception("fail"), Exception("fail"), "success"])
+    result = retry_request(mock_func, max_attempts=3, delay=1)
+    assert result == "success"
+    assert mock_func.call_count == 3
+
+
+def test_retry_request_failure():
+    mock_func = MagicMock(side_effect=Exception("fail"))
+    with pytest.raises(Exception, match="fail"):
+        retry_request(mock_func, max_attempts=3, delay=1)
+    assert mock_func.call_count == 3
+
+
+@patch("time.sleep", return_value=None)
+def test_retry_request_delay(mock_sleep):
+    mock_func = MagicMock(side_effect=[Exception("fail"), "success"])
+    result = retry_request(mock_func, max_attempts=3, delay=2)
+    assert result == "success"
+    assert mock_func.call_count == 2
+    mock_sleep.assert_called_once_with(2)
+
+
+@patch("logging.warning")
+def test_retry_request_logging(mock_logging_warning):
+    mock_func = MagicMock(side_effect=Exception("fail"))
+    with pytest.raises(Exception, match="fail"):
+        retry_request(mock_func, max_attempts=3, delay=1)
+    assert mock_func.call_count == 3
+    mock_logging_warning.assert_called_once_with("Error after 3 attempts: fail")

--- a/app/tests/integrations/utils/test_api.py
+++ b/app/tests/integrations/utils/test_api.py
@@ -290,3 +290,18 @@ def test_retry_request_logging(mock_logging_warning):
         retry_request(mock_func, max_attempts=3, delay=1)
     assert mock_func.call_count == 3
     mock_logging_warning.assert_called_once_with("Error after 3 attempts: fail")
+
+
+def test_retry_request_passes_args_and_kwargs():
+    mock_func = MagicMock(return_value="success")
+    result = retry_request(
+        mock_func,
+        "arg1",
+        "arg2",
+        max_attempts=3,
+        delay=1,
+        kwarg1="kwarg1",
+        kwarg2="kwarg2",
+    )
+    assert result == "success"
+    mock_func.assert_called_once_with("arg1", "arg2", kwarg1="kwarg1", kwarg2="kwarg2")


### PR DESCRIPTION
# Summary | Résumé

## Feature:
- Introduce a `retry_request` function to retry failed calls. The default retry is set to 3. This should help deal with the timed out errors we have seen.

## Fix:
- Google Directory integration would return members without their details even if an error occurred during the get_user api call. I introduced a new, distinct function to get the members details. If a single error occurs, an empty array is return unless the tolerate error flag is set.
- The above also should fix the issue where a group sync would fail due to some of their users missing the primaryEmail key on their details since this is only possible when the get_user call succeeds.
