### PR TITLE
Updating the unit tests to not hardcode the year

### DIFF
--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -658,7 +658,8 @@ def test_get_federal_holidays(requests_mock):
     }
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec
-        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=" + str(current_year),
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year="
+        + str(current_year),
         json=mocked_response,
     )
 
@@ -703,7 +704,8 @@ def test_api_returns_empty_list(requests_mock):
     # Mock no holidays
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec
-        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=" + str(current_year),
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year="
+        + str(current_year),
         json={"holidays": []},
     )
 
@@ -719,11 +721,15 @@ def test_leap_year_handling(requests_mock):
     requests_mock.DEFAULT_TIMEOUT = 10
 
     # Mock the current date to a date in 2024
-    with patch('integrations.google_workspace.google_calendar.datetime') as mock_datetime:
+    with patch(
+        "integrations.google_workspace.google_calendar.datetime"
+    ) as mock_datetime:
         # Configure the mock to return 2024 when .now() is called
         mock_now = datetime(2024, 6, 15)  # Any date in 2024
         mock_datetime.now.return_value = mock_now
-        mock_datetime.side_effect = lambda *args, **kwargs: datetime.datetime(*args, **kwargs)
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime.datetime(
+            *args, **kwargs
+        )
 
         # Mock the API response for 2024
         requests_mock.get(  # nosec
@@ -741,7 +747,9 @@ def test_leap_year_handling(requests_mock):
         holidays = google_calendar.get_federal_holidays()
 
         # Verify leap year is considered
-        assert "2024-02-29" in holidays, "Leap year date should be included in the holidays"
+        assert (
+            "2024-02-29" in holidays
+        ), "Leap year date should be included in the holidays"
 
 
 def test_get_utc_hour_same_zone():

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -645,6 +645,9 @@ def test_no_available_slots_within_search_limit(
 def test_get_federal_holidays(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
+
+    # get the current year
+    current_year = datetime.now().year
     # Mock the API response
     mocked_response = {
         "holidays": [
@@ -655,7 +658,7 @@ def test_get_federal_holidays(requests_mock):
     }
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec
-        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=" + str(current_year),
         json=mocked_response,
     )
 
@@ -694,10 +697,13 @@ def test_get_federal_holidays_with_different_year(requests_mock):
 def test_api_returns_empty_list(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
+
+    # get the current year
+    current_year = datetime.now().year
     # Mock no holidays
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec
-        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=" + str(current_year),
         json={"holidays": []},
     )
 
@@ -712,10 +718,14 @@ def test_api_returns_empty_list(requests_mock):
 def test_leap_year_handling(requests_mock):
     # set the timeout to 10s
     requests_mock.DEFAULT_TIMEOUT = 10
+
+    # get the curent year
+    current_year = datetime.now().year
+    
     # Mock response for a leap year with an extra day
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec
-        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=2024",
+        "https://canada-holidays.ca/api/v1/holidays?federal=true&year=" + str(current_year),
         json={
             "holidays": [
                 {

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -721,7 +721,6 @@ def test_leap_year_handling(requests_mock):
 
     # get the curent year
     current_year = datetime.now().year
-    
     # Mock response for a leap year with an extra day
     # Bandit skip security check for the requests_mock.get call
     requests_mock.get(  # nosec


### PR DESCRIPTION
# Summary | Résumé

Updating the unit tests to not have the year hard coded. Since switching to 2025, the tests broke 🫠 