### PR TITLE
Refactor group member retrieval to use list_users for user details

### DIFF
--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -246,7 +246,8 @@ def get_members_details(members: list[dict], users: list[dict], tolerate_errors=
         user_details = None
         try:
             user_details = next(
-                (user for user in users if user["primaryEmail"] == member["email"]), None
+                (user for user in users if user["primaryEmail"] == member["email"]),
+                None,
             )
             if not user_details:
                 raise Exception("User details not found.")


### PR DESCRIPTION
# Summary | Résumé

Optimize the Google Workspace list_groups_with_members method to use list_users instead of querying the Google API for individual users' details.

Average Time to run for all AWS-* groups (67 groups as of today:
- Previous: 165.4 secs
- New: 23.6 secs