### PR TITLE
feat: refactor list groups with members to use list_users

### DIFF
--- a/app/integrations/google_next/directory.py
+++ b/app/integrations/google_next/directory.py
@@ -192,7 +192,9 @@ def list_groups_with_members(
         members = get_members_details(members, users)
         if members:
             group.update({"members": members})
-            if any(member.get("error") for member in members) and not group.get("error"):
+            if any(member.get("error") for member in members) and not group.get(
+                "error"
+            ):
                 group["error"] = "Error getting members details."
             groups_with_members.append(group)
     return groups_with_members

--- a/app/integrations/google_next/directory.py
+++ b/app/integrations/google_next/directory.py
@@ -37,7 +37,7 @@ def list_users(
     service: Resource,
     customer: str | None = None,
     **kwargs,
-):
+) -> list[dict]:
     """List all users in the Google Workspace domain.
 
     Args:
@@ -90,7 +90,7 @@ def list_groups(
     service: Resource,
     customer: str | None = None,
     **kwargs,
-):
+) -> list[dict]:
     """List all groups in the Google Workspace domain. A query can be provided to filter the results (e.g. query="email:prefix-*" will filter for all groups where the email starts with 'prefix-').
 
     Args:
@@ -156,7 +156,7 @@ def list_groups_with_members(
         list: A list of group objects with members and their details.
     """
 
-    groups = list_groups(
+    groups: list[dict] = list_groups(
         service,
         query=query,
         fields="groups(email, name, directMembersCount, description)",
@@ -165,7 +165,7 @@ def list_groups_with_members(
     if len(groups) == 0:
         return []
 
-    users = list_users(service)
+    users: list[dict] = list_users(service)
 
     if groups_filters is not None:
         for groups_filter in groups_filters:
@@ -192,6 +192,8 @@ def list_groups_with_members(
         members = get_members_details(members, users)
         if members:
             group.update({"members": members})
+            if any(member.get("error") for member in members) and not group.get("error"):
+                group["error"] = "Error getting members details."
             groups_with_members.append(group)
     return groups_with_members
 
@@ -208,13 +210,14 @@ def get_members_details(members: list[dict], users: list[dict]):
     """
 
     for member in members:
-        logger.info(f"Getting user details for member: {member}")
+        logger.info(f"Getting user details for member: {member['email']}")
         user_details = next(
             (user for user in users if user["primaryEmail"] == member["email"]), None
         )
         if user_details:
             member.update(user_details)
         else:
-            raise ValueError(f"User not found: {member['email']}")
+            member["error"] = "User details not found"
+            logger.warning(f"User details not found for member: {member['email']}")
 
     return members

--- a/app/integrations/google_next/service.py
+++ b/app/integrations/google_next/service.py
@@ -121,12 +121,9 @@ def execute_google_api_call(
     """Execute a Google API call on a resource.
 
     Args:
-        service_name (str): The name of the Google service.
-        version (str): The version of the Google service.
+        service (Resource): The Google service resource.
         resource_path (str): The path to the resource, which can include nested resources separated by dots.
         method (str): The method to call on the resource.
-        scopes (list, optional): The scopes for the Google service.
-        delegated_user_email (str, optional): The email address of the user to impersonate.
         paginate (bool, optional): Whether to paginate the API call.
         **kwargs: Additional keyword arguments for the API call.
 

--- a/app/tests/integrations/google_next/test_directory.py
+++ b/app/tests/integrations/google_next/test_directory.py
@@ -310,7 +310,6 @@ def test_list_groups_with_members_updates_group_with_group_error(
     mock_list_users.side_effect = users
     mock_retry_request.side_effect = [Exception("Exception"), group_members[1]]
     mock_get_members_details.side_effect = [
-        
         [
             {
                 "id": "test_member_id2",
@@ -537,4 +536,6 @@ def test_get_members_details_returns_members_with_error(
             call("Getting user details for member: email2"),
         ]
     )
-    mock_logger.warning.assert_called_once_with("User details not found for member: email1")
+    mock_logger.warning.assert_called_once_with(
+        "User details not found for member: email1"
+    )


### PR DESCRIPTION
# Summary | Résumé

Update the Google Next `list_users` method than we used with the refactored version in the Google Workspace integration.