### PR TITLE
Unit test changes due to changes in httpx module

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,7 +12,6 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==0.8.0
 google-api-core==2.23.0
 google-auth==2.36.0
-httpx==0.27.2
 itsdangerous==2.2.0
 pandas==2.2.3
 PyJWT==2.10.1

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -3,6 +3,7 @@ checkov==3.2.334
 coverage==6.5.0
 flake8==6.1.0
 freezegun==1.5.1
+httpx==0.28.1
 setuptools==70.3.0
 pytest==8.3.4
 pytest-asyncio==0.24.0

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -5,7 +5,6 @@ from server.server import AccessRequest
 import urllib.parse
 from slowapi.errors import RateLimitExceeded
 from starlette.responses import JSONResponse
-# from httpx import AsyncClient
 from starlette.types import Scope
 from starlette.datastructures import Headers, MutableHeaders
 import os

--- a/app/tests/server/test_server.py
+++ b/app/tests/server/test_server.py
@@ -20,6 +20,7 @@ app = server.handler
 app.add_middleware(bot_middleware.BotMiddleware, bot=MagicMock())
 client = TestClient(app)
 
+
 @patch("server.server.maxmind.geolocate")
 def test_geolocate_success(mock_geolocate):
     mock_geolocate.return_value = "country", "city", "latitude", "longitude"
@@ -624,21 +625,6 @@ async def test_rate_limit_handler():
     # Assert the content of the response
     assert response.body.decode("utf-8") == '{"message":"Rate limit exceeded"}'
 
-
-# @pytest.mark.asyncio
-# async def test_logout_rate_limiting():
-#     transport = httpx.MockTransport(app)
-#     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-#         # Make 5 requests to the logout endpoint
-#         for _ in range(5):
-#             response = await client.get("/logout")
-#             assert response.status_code == 307
-#             assert response.url.path == "/logout"
-
-#         # The 6th request should be rate limited
-#         response = await client.get("/logout")
-#         assert response.status_code == 429
-#         assert response.json() == {"message": "Rate limit exceeded"}
 
 @pytest.mark.asyncio
 async def test_logout_rate_limiting():


### PR DESCRIPTION

# Summary | Résumé

With httpx version 0.27.0 version, the app parameter was deprecated in AsyncClient. This code fixes the issue and we upgraded tot he latest version of httpx. Also, moved httpx to the requirements-dev file since it is used only for unit testing. 

Detail of issue can be found [here](https://github.com/encode/starlette/issues/2524) 
