### PR TITLE
refactor: Directory module's functions into class

### DIFF
--- a/app/integrations/google_next/directory.py
+++ b/app/integrations/google_next/directory.py
@@ -5,6 +5,8 @@ from googleapiclient.discovery import Resource  # type: ignore
 from integrations.google_next.service import (
     execute_google_api_call,
     handle_google_api_errors,
+    get_google_service,
+    GOOGLE_DELEGATED_ADMIN_EMAIL,
     GOOGLE_WORKSPACE_CUSTOMER_ID,
 )
 from integrations.utils.api import retry_request
@@ -14,212 +16,242 @@ from utils import filters
 logger = getLogger(__name__)
 
 
-@handle_google_api_errors
-def get_user(service, user_key, **kwargs):
-    """Get a user by user key in the Google Workspace domain.
+class GoogleDirectory:
+    """
+    A class to simplify the use of various Google Directory API operations across modules.
 
-    Args:
-        service (Resource): An authenticated Google service resource.
-        user_key (str): The user's primary email address, alias email address, or unique user ID.
-        kwargs: Additional keyword arguments to pass to. See the reference for more information.
+    This class provides methods to interact with the Google Workspace Directory API, including
+    operations for users, groups, and group members. It handles authentication and API calls,
+    and includes error handling for Google API errors.
 
-    Returns:
-        dict: A user object.
+    While this class aims to simplify the usage of the Google Directory API, it is always possible
+    to use the Google API Python client directly as per the official documentation:
+    (https://googleapis.github.io/google-api-python-client/docs/)
 
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/get
+    Attributes:
+        scopes (list): The list of scopes to request.
+        delegated_email (str): The email address of the user to impersonate.
+        service (Resource): Optional - An authenticated Google service resource. If provided, the service will be used instead of creating a new one.
     """
 
-    return execute_google_api_call(service, "users", "get", userKey=user_key, **kwargs)
+    def __init__(
+        self, scopes=None, delegated_email=None, service: Resource | None = None
+    ):
+        if not scopes and not service:
+            raise ValueError("Either scopes or a service must be provided.")
+        if not delegated_email and not service:
+            delegated_email = GOOGLE_DELEGATED_ADMIN_EMAIL
+        self.scopes = scopes
+        self.delegated_email = delegated_email
+        self.service = service if service else self._get_directory_service()
 
-
-@handle_google_api_errors
-def list_users(
-    service: Resource,
-    customer: str | None = None,
-    **kwargs,
-) -> list[dict]:
-    """List all users in the Google Workspace domain.
-
-    Args:
-        service (Resource): An authenticated Google service resource.
-        customer (str): The unique ID for the customer's Google Workspace account. (default: GOOGLE_WORKSPACE_CUSTOMER_ID)
-        orderBy (str): The attribute to use for ordering the results. (default: "email")
-        kwargs: Additional keyword arguments to pass to. See the reference for more information.
-
-    Returns:
-        list: A list of user objects.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list
-    """
-    if not customer:
-        customer = GOOGLE_WORKSPACE_CUSTOMER_ID
-
-    return execute_google_api_call(
-        service,
-        "users",
-        "list",
-        paginate=True,
-        customer=customer,
-        **kwargs,
-    )
-
-
-# Groups methods
-@handle_google_api_errors
-def get_group(service: Resource, group_key: str, **kwargs):
-    """Get a group by group key in the Google Workspace domain.
-
-    Args:
-        service (Resource): An authenticated Google service resource.
-        group_key (str): The group's email address or unique group ID.
-        kwargs: Additional keyword arguments to pass to. See the reference for more information.
-
-    Returns:
-        dict: A group object.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/get
-    """
-
-    return execute_google_api_call(
-        service, "groups", "get", groupKey=group_key, **kwargs
-    )
-
-
-@handle_google_api_errors
-def list_groups(
-    service: Resource,
-    customer: str | None = None,
-    **kwargs,
-) -> list[dict]:
-    """List all groups in the Google Workspace domain. A query can be provided to filter the results (e.g. query="email:prefix-*" will filter for all groups where the email starts with 'prefix-').
-
-    Args:
-        service (Resource): An authenticated Google service resource.
-        customer (str): The unique ID for the customer's Google Workspace account. (default: GOOGLE_WORKSPACE_CUSTOMER_ID)
-        kwargs: Additional keyword arguments to pass to. See the reference for more information.
-    Returns:
-        list: A list of group objects.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/list
-    """
-    if not customer:
-        customer = GOOGLE_WORKSPACE_CUSTOMER_ID
-    return execute_google_api_call(
-        service,
-        "groups",
-        "list",
-        paginate=True,
-        customer=customer,
-        **kwargs,
-    )
-
-
-# Group members methods
-@handle_google_api_errors
-def list_group_members(service: Resource, group_key: str, **kwargs):
-    """List all group members in the Google Workspace domain.
-
-    Args:
-        service (Resource): An authenticated Google service resource
-        group_key (str): The group's email address or unique group ID.
-        delegated_user_email (str): The email address of the user to impersonate. (default: must be defined in .env)
-
-    Returns:
-        list: A list of group member objects.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/list
-    """
-
-    return execute_google_api_call(
-        service,
-        "members",
-        "list",
-        paginate=True,
-        groupKey=group_key,
-        **kwargs,
-    )
-
-
-def list_groups_with_members(
-    service: Resource,
-    query: str | None = None,
-    groups_filters: list = [],
-):
-    """List all groups in the Google Workspace domain with their members and their details.
-
-    Args:
-        service (Resource): An authenticated Google service resource.
-        query (str): A query to filter the groups. (default: None)
-        groups_filters (list): A list of filters to apply to the groups. (default: [])
-
-    Returns:
-        list: A list of group objects with members and their details.
-    """
-
-    groups: list[dict] = list_groups(
-        service,
-        query=query,
-        fields="groups(email, name, directMembersCount, description)",
-    )
-    logger.info(f"Found {len(groups)} groups.")
-    if len(groups) == 0:
-        return []
-
-    users: list[dict] = list_users(service)
-
-    if groups_filters is not None:
-        for groups_filter in groups_filters:
-            groups = filters.filter_by_condition(groups, groups_filter)
-        logger.info(f"Found {len(groups)} groups after filtering.")
-
-    groups_with_members = []
-
-    for group in groups:
-        logger.info(f"Getting members for group: {group['email']}")
-        try:
-            members = retry_request(
-                list_group_members,
-                service,
-                group["email"],
-                max_attempts=3,
-                delay=1,
-                fields="members(email, role, type, status)",
-            )
-        except Exception as e:
-            group["error"] = f"Error getting members: {e}"
-            logger.warning(f"Error getting members for group {group['email']}: {e}")
-            continue
-        members = get_members_details(members, users)
-        if members:
-            group.update({"members": members})
-            if any(member.get("error") for member in members) and not group.get(
-                "error"
-            ):
-                group["error"] = "Error getting members details."
-            groups_with_members.append(group)
-    return groups_with_members
-
-
-def get_members_details(members: list[dict], users: list[dict]):
-    """Get user details for a list of members.
-
-    Args:
-        members (list): A list of member objects.
-        tolerate_errors (bool): Whether to tolerate errors when getting user details.
-
-    Returns:
-        list: A list of member objects with user details.
-    """
-
-    for member in members:
-        logger.info(f"Getting user details for member: {member['email']}")
-        user_details = next(
-            (user for user in users if user["primaryEmail"] == member["email"]), None
+    def _get_directory_service(self) -> Resource:
+        """Get authenticated directory service for Google Workspace."""
+        return get_google_service(
+            "admin", "directory_v1", self.scopes, self.delegated_email
         )
-        if user_details:
-            member.update(user_details)
-        else:
-            member["error"] = "User details not found"
-            logger.warning(f"User details not found for member: {member['email']}")
 
-    return members
+    @handle_google_api_errors
+    def get_user(self, user_key, **kwargs):
+        """Get a user by user key in the Google Workspace domain.
+
+        Args:
+            service (Resource): An authenticated Google service resource.
+            user_key (str): The user's primary email address, alias email address, or unique user ID.
+            kwargs: Additional keyword arguments to pass to. See the reference for more information.
+
+        Returns:
+            dict: A user object.
+
+        Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/get
+        """
+
+        return execute_google_api_call(
+            self.service, "users", "get", userKey=user_key, **kwargs
+        )
+
+    @handle_google_api_errors
+    def list_users(
+        self,
+        customer: str | None = None,
+        **kwargs,
+    ) -> list[dict]:
+        """List all users in the Google Workspace domain.
+
+        Args:
+            service (Resource): An authenticated Google service resource.
+            customer (str): The unique ID for the customer's Google Workspace account. (default: GOOGLE_WORKSPACE_CUSTOMER_ID)
+            orderBy (str): The attribute to use for ordering the results. (default: "email")
+            kwargs: Additional keyword arguments to pass to. See the reference for more information.
+
+        Returns:
+            list: A list of user objects.
+
+        Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list
+        """
+        if not customer:
+            customer = GOOGLE_WORKSPACE_CUSTOMER_ID
+
+        return execute_google_api_call(
+            self.service,
+            "users",
+            "list",
+            paginate=True,
+            customer=customer,
+            **kwargs,
+        )
+
+    # Groups methods
+    @handle_google_api_errors
+    def get_group(self, group_key: str, **kwargs):
+        """Get a group by group key in the Google Workspace domain.
+
+        Args:
+            service (Resource): An authenticated Google service resource.
+            group_key (str): The group's email address or unique group ID.
+            kwargs: Additional keyword arguments to pass to. See the reference for more information.
+
+        Returns:
+            dict: A group object.
+
+        Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/get
+        """
+
+        return execute_google_api_call(
+            self.service, "groups", "get", groupKey=group_key, **kwargs
+        )
+
+    @handle_google_api_errors
+    def list_groups(
+        self,
+        customer: str | None = None,
+        **kwargs,
+    ) -> list[dict]:
+        """List all groups in the Google Workspace domain. A query can be provided to filter the results (e.g. query="email:prefix-*" will filter for all groups where the email starts with 'prefix-').
+
+        Args:
+            service (Resource): An authenticated Google service resource.
+            customer (str): The unique ID for the customer's Google Workspace account. (default: GOOGLE_WORKSPACE_CUSTOMER_ID)
+            kwargs: Additional keyword arguments to pass to. See the reference for more information.
+        Returns:
+            list: A list of group objects.
+
+        Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/list
+        """
+        if not customer:
+            customer = GOOGLE_WORKSPACE_CUSTOMER_ID
+        return execute_google_api_call(
+            self.service,
+            "groups",
+            "list",
+            paginate=True,
+            customer=customer,
+            **kwargs,
+        )
+
+    # Group members methods
+    @handle_google_api_errors
+    def list_group_members(self, group_key: str, **kwargs):
+        """List all group members in the Google Workspace domain.
+
+        Args:
+            service (Resource): An authenticated Google service resource
+            group_key (str): The group's email address or unique group ID.
+            delegated_user_email (str): The email address of the user to impersonate. (default: must be defined in .env)
+
+        Returns:
+            list: A list of group member objects.
+
+        Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/list
+        """
+
+        return execute_google_api_call(
+            self.service,
+            "members",
+            "list",
+            paginate=True,
+            groupKey=group_key,
+            **kwargs,
+        )
+
+    def list_groups_with_members(
+        self,
+        query: str | None = None,
+        groups_filters: list = [],
+    ):
+        """List all groups in the Google Workspace domain with their members and their details.
+
+        Args:
+            service (Resource): An authenticated Google service resource.
+            query (str): A query to filter the groups. (default: None)
+            groups_filters (list): A list of filters to apply to the groups. (default: [])
+
+        Returns:
+            list: A list of group objects with members and their details.
+        """
+
+        groups: list[dict] = self.list_groups(
+            query=query,
+            fields="groups(email, name, directMembersCount, description)",
+        )
+        logger.info(f"Found {len(groups)} groups.")
+        if len(groups) == 0:
+            return []
+
+        users: list[dict] = self.list_users()
+
+        if groups_filters is not None:
+            for groups_filter in groups_filters:
+                groups = filters.filter_by_condition(groups, groups_filter)
+            logger.info(f"Found {len(groups)} groups after filtering.")
+
+        groups_with_members = []
+
+        for group in groups:
+            logger.info(f"Getting members for group: {group['email']}")
+            try:
+                members = retry_request(
+                    self.list_group_members,
+                    group["email"],
+                    max_attempts=3,
+                    delay=1,
+                    fields="members(email, role, type, status)",
+                )
+            except Exception as e:
+                group["error"] = f"Error getting members: {e}"
+                logger.warning(f"Error getting members for group {group['email']}: {e}")
+                continue
+            members = self.get_members_details(members, users)
+            if members:
+                group.update({"members": members})
+                if any(member.get("error") for member in members) and not group.get(
+                    "error"
+                ):
+                    group["error"] = "Error getting members details."
+                groups_with_members.append(group)
+        return groups_with_members
+
+    def get_members_details(self, members: list[dict], users: list[dict]):
+        """Get user details for a list of members.
+
+        Args:
+            members (list): A list of member objects.
+            tolerate_errors (bool): Whether to tolerate errors when getting user details.
+
+        Returns:
+            list: A list of member objects with user details.
+        """
+
+        for member in members:
+            logger.info(f"Getting user details for member: {member['email']}")
+            user_details = next(
+                (user for user in users if user["primaryEmail"] == member["email"]),
+                None,
+            )
+            if user_details:
+                member.update(user_details)
+            else:
+                member["error"] = "User details not found"
+                logger.warning(f"User details not found for member: {member['email']}")
+
+        return members

--- a/app/tests/integrations/google_next/test_directory.py
+++ b/app/tests/integrations/google_next/test_directory.py
@@ -1,6 +1,5 @@
 """"Unit tests for the Google Directory API."""
 
-# import unittest
 from unittest.mock import MagicMock, call, patch
 
 import pytest

--- a/app/tests/integrations/google_next/test_directory.py
+++ b/app/tests/integrations/google_next/test_directory.py
@@ -1,300 +1,337 @@
 """"Unit tests for the Google Directory API."""
 
+# import unittest
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from integrations.google_next import directory
-
-GOOGLE_WORKSPACE_CUSTOMER_ID = "test_customer_id"
+from integrations.google_next.directory import GoogleDirectory
 
 
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_get_user_returns_user(mock_execute_google_api_call: MagicMock):
-    """Test get_user returns a user."""
-
-    mock_service = MagicMock()
-    mock_execute_google_api_call.return_value = {
-        "id": "test_user_id",
-        "name": "test_user",
-        "email": "user.name@domain.com",
-    }
-
-    result = directory.get_user(mock_service, "test_user_id")
-
-    expected_result = {
-        "id": "test_user_id",
-        "name": "test_user",
-        "email": "user.name@domain.com",
-    }
-    assert result == expected_result
-    mock_execute_google_api_call.assert_called_once_with(
-        mock_service, "users", "get", userKey="test_user_id"
-    )
+@pytest.fixture(scope="class")
+@patch("integrations.google_next.directory.get_google_service")
+def google_directory(mock_get_google_service) -> GoogleDirectory:
+    scopes = ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
+    delegated_email = "email@test.com"
+    mock_get_google_service.return_value = MagicMock()
+    return GoogleDirectory(scopes, delegated_email)
 
 
-@patch(
-    "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
-    new="test_customer_id",
+@pytest.mark.usefixtures(
+    "google_groups", "google_group_members", "google_users", "google_groups_w_users"
 )
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_list_users_returns_users(execute_google_api_call_mock: MagicMock):
-    mock_service = MagicMock()
+class TestGoogleDirectory:
+    @pytest.fixture(autouse=True)
+    def setup(self, google_directory: GoogleDirectory):
+        self.google_directory = google_directory
 
-    results = [
-        {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
-        {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
-    ]
+    def test_init_without_scopes_and_service(self):
+        """Test initialization without scopes and service raises ValueError."""
+        with pytest.raises(
+            ValueError, match="Either scopes or a service must be provided."
+        ):
+            GoogleDirectory(delegated_email="email@test.com")
 
-    execute_google_api_call_mock.return_value = results
-
-    assert directory.list_users(mock_service) == results
-
-    execute_google_api_call_mock.assert_called_once_with(
-        mock_service,
-        "users",
-        "list",
-        paginate=True,
-        customer="test_customer_id",
+    @patch(
+        "integrations.google_next.directory.GOOGLE_DELEGATED_ADMIN_EMAIL",
+        new="default@test.com",
     )
+    @patch("integrations.google_next.directory.get_google_service")
+    def test_init_without_delegated_email_and_service(self, mock_get_google_service):
+        """Test initialization without delegated email and service uses default email."""
+        mock_get_google_service.return_value = MagicMock()
+        google_directory = GoogleDirectory(
+            scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"]
+        )
+        assert google_directory.delegated_email == "default@test.com"
 
+    @patch("integrations.google_next.directory.get_google_service")
+    def test_get_directory_service(self, mock_get_google_service):
+        """Test get_directory_service returns a service."""
+        mock_get_google_service.return_value = MagicMock()
+        service = self.google_directory._get_directory_service()
+        assert service is not None
+        mock_get_google_service.assert_called_once_with(
+            "admin",
+            "directory_v1",
+            self.google_directory.scopes,
+            self.google_directory.delegated_email,
+        )
 
-@patch(
-    "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
-    new="test_customer_id",
-)
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_list_users_handles_customer_param(execute_google_api_call_mock: MagicMock):
-    mock_service = MagicMock()
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_get_user(self, mock_execute_google_api_call: MagicMock):
+        """Test get_user returns a user."""
+        mock_execute_google_api_call.return_value = {
+            "id": "test_user_id",
+            "name": "test_user",
+            "email": "user.name@domain.com",
+        }
+        result = self.google_directory.get_user("test_user_id")
+        expected_result = {
+            "id": "test_user_id",
+            "name": "test_user",
+            "email": "user.name@domain.com",
+        }
+        assert result == expected_result
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service, "users", "get", userKey="test_user_id"
+        )
 
-    results = [
-        {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
-        {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
-    ]
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_list_users_handles_customer_param(self, mock_execute_google_api_call):
+        """Test list_users returns users with customer param."""
+        mock_execute_google_api_call.return_value = [
+            {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
+        ]
+        result = self.google_directory.list_users(customer="test_customer_id")
+        expected_result = [
+            {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
+        ]
+        assert result == expected_result
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service,
+            "users",
+            "list",
+            paginate=True,
+            customer="test_customer_id",
+        )
 
-    execute_google_api_call_mock.return_value = results
-
-    assert directory.list_users(mock_service, customer="custom_id") == results
-
-    execute_google_api_call_mock.assert_called_once_with(
-        mock_service,
-        "users",
-        "list",
-        paginate=True,
-        customer="custom_id",
+    @patch(
+        "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
+        new="default_id",
     )
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_list_users(self, mock_execute_google_api_call):
+        """Test list_users returns users."""
+        mock_execute_google_api_call.return_value = [
+            {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
+        ]
+        result = self.google_directory.list_users()
+        expected_result = [
+            {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
+        ]
+        assert result == expected_result
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service,
+            "users",
+            "list",
+            paginate=True,
+            customer="default_id",
+        )
 
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_get_group(self, mock_execute_google_api_call):
+        """Test get_group returns a group."""
+        mock_execute_google_api_call.return_value = {
+            "id": "test_group_id",
+            "name": "test_group",
+            "email": "test_email@domain.com",
+        }
+        expected_result = {
+            "id": "test_group_id",
+            "name": "test_group",
+            "email": "test_email@domain.com",
+        }
+        result = self.google_directory.get_group("test_group_id")
+        assert result == expected_result
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service, "groups", "get", groupKey="test_group_id"
+        )
 
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_get_group_returns_group(mock_execute_google_api_call: MagicMock):
-    """Test get_group returns a group."""
-    mock_service = MagicMock()
-    mock_execute_google_api_call.return_value = {
-        "id": "test_group_id",
-        "name": "test_group",
-        "email": "test_email@domain.com",
-    }
-    expected_result = {
-        "id": "test_group_id",
-        "name": "test_group",
-        "email": "test_email@domain.com",
-    }
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_list_groups_handles_customer_param(self, mock_execute_google_api_call):
+        """Test list_groups returns groups with customer param."""
+        results = [
+            {"id": "test_group_id", "name": "test_group", "email": "email@domain.com"},
+            {
+                "id": "test_group_id2",
+                "name": "test_group2",
+                "email": "email2@domain.com",
+            },
+        ]
+        mock_execute_google_api_call.return_value = results
+        result = self.google_directory.list_groups(customer="test_customer_id")
+        assert result == results
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service,
+            "groups",
+            "list",
+            paginate=True,
+            customer="test_customer_id",
+        )
 
-    assert expected_result == directory.get_group(mock_service, "test_group_id")
-    mock_execute_google_api_call.assert_called_once_with(
-        mock_service, "groups", "get", groupKey="test_group_id"
+    @patch(
+        "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
+        new="default_id",
     )
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_list_groups(self, mock_execute_google_api_call):
+        """Test list_groups returns groups."""
+        results = [
+            {"id": "test_group_id", "name": "test_group", "email": "email@domain.com"},
+            {
+                "id": "test_group_id2",
+                "name": "test_group2",
+                "email": "email2@domain.com",
+            },
+        ]
+        mock_execute_google_api_call.return_value = results
+        result = self.google_directory.list_groups()
+        assert result == results
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service,
+            "groups",
+            "list",
+            paginate=True,
+            customer="default_id",
+        )
 
+    @patch("integrations.google_next.directory.execute_google_api_call")
+    def test_list_group_members(self, mock_execute_google_api_call):
+        """Test list_group_members returns group members."""
+        results = [
+            {"id": "test_member_id", "email": "member@domain.com"},
+            {"id": "test_member_id2", "email": "member2@domain.com"},
+        ]
+        mock_execute_google_api_call.return_value = results
+        result = self.google_directory.list_group_members("test_group_id")
+        assert result == results
+        mock_execute_google_api_call.assert_called_once_with(
+            self.google_directory.service,
+            "members",
+            "list",
+            paginate=True,
+            groupKey="test_group_id",
+        )
 
-@patch(
-    "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
-    new="test_customer_id",
-)
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_list_groups_returns_groups(mock_execute_google_api_call: MagicMock):
-    """Test list_groups returns groups."""
-    mock_service = MagicMock()
-    results = [
-        {"id": "test_group_id", "name": "test_group", "email": "email@domain.com"},
-        {"id": "test_group_id2", "name": "test_group2", "email": "email2@domain.com"},
-    ]
-    mock_execute_google_api_call.return_value = results
+    def test_list_groups_with_members(
+        self,
+        google_groups,
+        google_group_members,
+        google_users,
+        google_groups_w_users,
+    ):
+        groups = google_groups(2)
+        group_members = [[], google_group_members(2)]
+        users = google_users(2)
+        groups_with_users = google_groups_w_users(2, 2)
 
-    assert directory.list_groups(mock_service) == results
+        groups_with_users.remove(groups_with_users[0])
 
-    mock_execute_google_api_call.assert_called_once_with(
-        mock_service, "groups", "list", paginate=True, customer="test_customer_id"
-    )
+        self.google_directory.list_groups = MagicMock()
+        self.google_directory.list_groups.return_value = groups
+        self.google_directory.list_group_members = MagicMock()
+        self.google_directory.list_group_members.side_effect = group_members
+        self.google_directory.list_users = MagicMock()
+        self.google_directory.list_users.return_value = users
 
+        result = self.google_directory.list_groups_with_members()
+        assert result == groups_with_users
 
-@patch(
-    "integrations.google_next.directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
-    new="test_customer_id",
-)
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_list_groups_handles_customer_param(mock_execute_google_api_call: MagicMock):
-    """Test list_groups returns groups."""
-    mock_service = MagicMock()
-    results = [
-        {"id": "test_group_id", "name": "test_group", "email": "email@domain.com"},
-        {"id": "test_group_id2", "name": "test_group2", "email": "email2@domain.com"},
-    ]
-    mock_execute_google_api_call.return_value = results
+    def test_list_groups_with_members_without_groups(
+        self,
+    ):
+        self.google_directory.list_groups = MagicMock()
+        self.google_directory.list_groups.return_value = []
 
-    assert directory.list_groups(mock_service, customer="custom_id") == results
+        result = self.google_directory.list_groups_with_members()
+        assert result == []
 
-    mock_execute_google_api_call.assert_called_once_with(
-        mock_service, "groups", "list", paginate=True, customer="custom_id"
-    )
+    def test_list_groups_with_members_filtered_by_condition(
+        self,
+        google_groups,
+        google_group_members,
+        google_users,
+        google_groups_w_users,
+    ):
+        groups = google_groups(2, prefix="test-")
+        groups_to_filter_out = google_groups(4)[2:]
+        groups.extend(groups_to_filter_out)
+        group_members = [[], google_group_members(2)]
+        users = google_users(2)
+        groups_with_users = google_groups_w_users(4, 2, group_prefix="test-")[:2]
+        groups_with_users.remove(groups_with_users[0])
 
+        with patch(
+            "integrations.google_next.directory.filters.filter_by_condition"
+        ) as mock_filter_by_condition:
+            mock_filter_by_condition.return_value = groups[:2]
 
-@patch("integrations.google_next.directory.execute_google_api_call")
-def test_list_group_members_returns_group_members(
-    mock_execute_google_api_call: MagicMock,
-):
-    """Test list_group_members returns group members."""
-    mock_service = MagicMock()
-    results = [
-        {"id": "test_member_id", "email": "member@domain.com"},
-        {"id": "test_member_id2", "email": "member2@domain.com"},
-    ]
+        self.google_directory.list_groups = MagicMock()
+        self.google_directory.list_groups.return_value = groups
+        self.google_directory.list_group_members = MagicMock()
+        self.google_directory.list_group_members.side_effect = group_members
+        self.google_directory.list_users = MagicMock()
+        self.google_directory.list_users.return_value = users
 
-    mock_execute_google_api_call.return_value = results
+        groups_filters = [lambda group: "test-" in group["name"]]
 
-    assert directory.list_group_members(mock_service, "test_group_id") == results
+        response = self.google_directory.list_groups_with_members(
+            groups_filters=groups_filters
+        )
+        assert response == groups_with_users
+        assert mock_filter_by_condition.called_once_with(groups, groups_filters)
+        assert self.google_directory.list_group_members.call_count == 2
+        assert self.google_directory.list_users.call_count == 1
 
-    mock_execute_google_api_call.assert_called_once_with(
-        mock_service, "members", "list", paginate=True, groupKey="test_group_id"
-    )
+    @patch("integrations.google_next.directory.GoogleDirectory.get_members_details")
+    @patch("integrations.google_next.directory.retry_request")
+    @patch("integrations.google_next.directory.logger")
+    def test_list_groups_with_members_updates_group_with_group_error(
+        self, mock_logger, mock_retry_request, mock_get_members_details
+    ):
+        groups = [
+            {"id": "test_group_id1", "name": "test_group1", "email": "group_email1"},
+            {"id": "test_group_id2", "name": "test_group2", "email": "group_email2"},
+        ]
 
+        group_members = [
+            [{"id": "test_member_id1", "email": "email1"}],
+            [{"id": "test_member_id2", "email": "email2"}],
+        ]
 
-@patch("integrations.google_next.directory.list_groups")
-@patch("integrations.google_next.directory.list_group_members")
-@patch("integrations.google_next.directory.list_users")
-def test_list_groups_with_members_returns_groups_with_members(
-    mock_list_users: MagicMock,
-    mock_list_group_members: MagicMock,
-    mock_list_groups: MagicMock,
-    google_groups,
-    google_group_members,
-    google_users,
-    google_groups_w_users,
-):
-    """Test list_groups_with_members returns groups with members."""
-    mock_service = MagicMock()
-    groups = google_groups(2)
-    group_members = [[], google_group_members(2)]
-    users = google_users(2)
-    groups_with_users = google_groups_w_users(2, 2)
+        users = [
+            {"id": "test_user_id1", "name": "test_user1", "email": "email1"},
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2"},
+        ]
 
-    groups_with_users.remove(groups_with_users[0])
+        expected_output = [
+            {
+                "id": "test_group_id1",
+                "name": "test_group1",
+                "email": "group_email1",
+                "error": "Error getting members: Retry Exception",
+            },
+            {
+                "id": "test_group_id2",
+                "name": "test_group2",
+                "email": "group_email2",
+                "members": [
+                    {
+                        "id": "test_member_id2",
+                        "email": "email2",
+                        "name": "test_user2",
+                        "primaryEmail": "email2",
+                    }
+                ],
+            },
+        ]
 
-    mock_list_groups.return_value = groups
-    mock_list_group_members.side_effect = group_members
-    mock_list_users.return_value = users
-
-    assert directory.list_groups_with_members(mock_service) == groups_with_users
-
-
-@patch("integrations.google_next.directory.list_groups")
-@patch("integrations.google_next.directory.list_group_members")
-@patch("integrations.google_next.directory.list_users")
-def test_list_groups_with_members_returns_groups_with_no_members(
-    mock_list_user: MagicMock,
-    mock_list_group_members: MagicMock,
-    mock_list_groups: MagicMock,
-):
-    """Test list_groups_with_members returns groups with members."""
-
-    mock_service = MagicMock()
-    mock_list_groups.return_value = []
-
-    assert directory.list_groups_with_members(mock_service) == []
-
-
-@patch("integrations.google_next.directory.filters.filter_by_condition")
-@patch("integrations.google_next.directory.list_groups")
-@patch("integrations.google_next.directory.list_group_members")
-@patch("integrations.google_next.directory.list_users")
-def test_list_groups_with_members_filtered_by_condition(
-    mock_list_users,
-    mock_list_group_members,
-    mock_list_groups,
-    mock_filter_by_condition,
-    google_groups,
-    google_group_members,
-    google_users,
-    google_groups_w_users,
-):
-    mock_service = MagicMock()
-    groups = google_groups(2, prefix="test-")
-    groups_to_filter_out = google_groups(4)[2:]
-    groups.extend(groups_to_filter_out)
-    group_members = [[], google_group_members(2)]
-    users = google_users(2)
-    groups_with_users = google_groups_w_users(4, 2, group_prefix="test-")[:2]
-    groups_with_users.remove(groups_with_users[0])
-
-    mock_list_groups.return_value = groups
-    mock_list_group_members.side_effect = group_members
-    mock_list_users.return_value = users
-    mock_filter_by_condition.return_value = groups[:2]
-
-    groups_filters = [lambda group: "test-" in group["name"]]
-
-    assert (
-        directory.list_groups_with_members(mock_service, groups_filters=groups_filters)
-        == groups_with_users
-    )
-    assert mock_filter_by_condition.called_once_with(groups, groups_filters)
-    assert mock_list_group_members.call_count == 2
-    assert mock_list_users.call_count == 1
-
-
-@patch("integrations.google_next.directory.logger")
-@patch("integrations.google_next.directory.get_members_details")
-@patch("integrations.google_next.directory.retry_request")
-@patch("integrations.google_next.directory.list_groups")
-@patch("integrations.google_next.directory.list_group_members")
-@patch("integrations.google_next.directory.list_users")
-def test_list_groups_with_members_updates_group_with_group_error(
-    mock_list_users: MagicMock,
-    mock_list_group_members: MagicMock,
-    mock_list_groups: MagicMock,
-    mock_retry_request: MagicMock,
-    mock_get_members_details: MagicMock,
-    mock_logger: MagicMock,
-):
-    """Test list_groups_with_members returns groups with members."""
-
-    mock_service = MagicMock()
-
-    groups = [
-        {"id": "test_group_id1", "name": "test_group1", "email": "group_email1"},
-        {"id": "test_group_id2", "name": "test_group2", "email": "group_email2"},
-    ]
-
-    group_members = [
-        [{"id": "test_member_id1", "email": "email1"}],
-        [{"id": "test_member_id2", "email": "email2"}],
-    ]
-
-    users = [
-        {"id": "test_user_id1", "name": "test_user1", "email": "email1"},
-        {"id": "test_user_id2", "name": "test_user2", "email": "email2"},
-    ]
-
-    expected_output = [
-        {
-            "id": "test_group_id1",
-            "name": "test_group1",
-            "email": "group_email1",
-            "error": "Error getting members: Exception",
-        },
-        {
-            "id": "test_group_id2",
-            "name": "test_group2",
-            "email": "group_email2",
-            "members": [
+        self.google_directory.list_groups = MagicMock()
+        self.google_directory.list_groups.return_value = groups
+        self.google_directory.list_group_members = MagicMock()
+        self.google_directory.list_group_members.side_effect = group_members
+        self.google_directory.list_users = MagicMock()
+        self.google_directory.list_users.return_value = users
+        mock_retry_request.side_effect = [
+            Exception("Retry Exception"),
+            group_members[1],
+        ]
+        mock_get_members_details.side_effect = [
+            [
                 {
                     "id": "test_member_id2",
                     "email": "email2",
@@ -302,84 +339,97 @@ def test_list_groups_with_members_updates_group_with_group_error(
                     "primaryEmail": "email2",
                 }
             ],
-        },
-    ]
-
-    mock_list_groups.return_value = groups
-    mock_list_group_members.side_effect = group_members
-    mock_list_users.side_effect = users
-    mock_retry_request.side_effect = [Exception("Exception"), group_members[1]]
-    mock_get_members_details.side_effect = [
-        [
-            {
-                "id": "test_member_id2",
-                "email": "email2",
-                "name": "test_user2",
-                "primaryEmail": "email2",
-            }
-        ],
-    ]
-
-    with pytest.raises(Exception):
-        assert directory.list_groups_with_members(mock_service) == expected_output
-
-    mock_logger.info.assert_has_calls(
-        [
-            call("Found 2 groups."),
-            call("Found 2 groups after filtering."),
-            call("Getting members for group: group_email1"),
-            call("Getting members for group: group_email2"),
         ]
-    )
-    mock_logger.warning.assert_called_once_with(
-        "Error getting members for group group_email1: Exception"
-    )
-    mock_logger.error.assert_not_called()
+        with pytest.raises(Exception):
+            assert self.google_directory.list_groups_with_members() == expected_output
 
+        mock_logger.info.assert_has_calls(
+            [
+                call("Found 2 groups."),
+                call("Found 2 groups after filtering."),
+                call("Getting members for group: group_email1"),
+                call("Getting members for group: group_email2"),
+            ]
+        )
+        mock_logger.warning.assert_called_once_with(
+            "Error getting members for group group_email1: Retry Exception"
+        )
+        mock_logger.error.assert_not_called()
 
-@patch("integrations.google_next.directory.logger")
-@patch("integrations.google_next.directory.get_members_details")
-@patch("integrations.google_next.directory.retry_request")
-@patch("integrations.google_next.directory.list_groups")
-@patch("integrations.google_next.directory.list_group_members")
-@patch("integrations.google_next.directory.list_users")
-def test_list_groups_with_members_updates_group_with_user_details_error(
-    mock_list_users: MagicMock,
-    mock_list_group_members: MagicMock,
-    mock_list_groups: MagicMock,
-    mock_retry_request: MagicMock,
-    mock_get_members_details: MagicMock,
-    mock_logger: MagicMock,
-):
-    """Test list_groups_with_members returns groups with members."""
+    @patch("integrations.google_next.directory.GoogleDirectory.get_members_details")
+    @patch("integrations.google_next.directory.retry_request")
+    @patch("integrations.google_next.directory.logger")
+    def test_list_groups_with_members_updates_group_with_user_error(
+        self, mock_logger, mock_retry_request, mock_get_members_details
+    ):
 
-    mock_service = MagicMock()
+        groups = [
+            {"id": "test_group_id1", "name": "test_group1", "email": "group_email1"},
+            {"id": "test_group_id2", "name": "test_group2", "email": "group_email2"},
+        ]
 
-    groups = [
-        {"id": "test_group_id1", "name": "test_group1", "email": "group_email1"},
-        {"id": "test_group_id2", "name": "test_group2", "email": "group_email2"},
-    ]
+        group_members1 = [
+            [{"id": "test_member_id1", "email": "email1"}],
+            [{"id": "test_member_id2", "email": "email2"}],
+        ]
+        group_members2 = [
+            [{"id": "test_member_id2", "email": "email2"}],
+            [{"id": "test_member_id3", "email": "email3"}],
+        ]
 
-    group_members1 = [
-        [{"id": "test_member_id1", "email": "email1"}],
-        [{"id": "test_member_id2", "email": "email2"}],
-    ]
-    group_members2 = [
-        [{"id": "test_member_id2", "email": "email2"}],
-        [{"id": "test_member_id3", "email": "email3"}],
-    ]
+        users = [
+            {"id": "test_user_id2", "name": "test_user2", "email": "email2"},
+            {"id": "test_user_id3", "name": "test_user3", "email": "email3"},
+        ]
 
-    users = [
-        {"id": "test_user_id2", "name": "test_user2", "email": "email2"},
-        {"id": "test_user_id3", "name": "test_user3", "email": "email3"},
-    ]
-
-    expected_output = [
-        {
-            "id": "test_group_id1",
-            "name": "test_group1",
-            "email": "group_email1",
-            "members": [
+        expected_output = [
+            {
+                "id": "test_group_id1",
+                "name": "test_group1",
+                "email": "group_email1",
+                "members": [
+                    {
+                        "id": "test_member_id1",
+                        "email": "email1",
+                        "error": "User details not found",
+                    },
+                    {
+                        "id": "test_member_id2",
+                        "email": "email2",
+                        "name": "test_user2",
+                        "primaryEmail": "email2",
+                    },
+                ],
+                "error": "Error getting members details.",
+            },
+            {
+                "id": "test_group_id2",
+                "name": "test_group2",
+                "email": "group_email2",
+                "members": [
+                    {
+                        "id": "test_member_id2",
+                        "email": "email2",
+                        "name": "test_user2",
+                        "primaryEmail": "email2",
+                    },
+                    {
+                        "id": "test_member_id3",
+                        "email": "email3",
+                        "name": "test_user3",
+                        "primaryEmail": "email3",
+                    },
+                ],
+            },
+        ]
+        self.google_directory.list_groups = MagicMock()
+        self.google_directory.list_groups.return_value = groups
+        self.google_directory.list_group_members = MagicMock()
+        self.google_directory.list_users = MagicMock()
+        self.google_directory.list_users.return_value = users
+        mock_retry_request.side_effect = [group_members1, group_members2]
+        mock_get_members_details.side_effect = [
+            [
                 {
                     "id": "test_member_id1",
                     "email": "email1",
@@ -392,13 +442,7 @@ def test_list_groups_with_members_updates_group_with_user_details_error(
                     "primaryEmail": "email2",
                 },
             ],
-            "error": "Error getting members details.",
-        },
-        {
-            "id": "test_group_id2",
-            "name": "test_group2",
-            "email": "group_email2",
-            "members": [
+            [
                 {
                     "id": "test_member_id2",
                     "email": "email2",
@@ -412,130 +456,93 @@ def test_list_groups_with_members_updates_group_with_user_details_error(
                     "primaryEmail": "email3",
                 },
             ],
-        },
-    ]
+        ]
 
-    mock_list_groups.return_value = groups
-    mock_list_users.side_effect = users
-    mock_retry_request.side_effect = [group_members1, group_members2]
-    mock_get_members_details.side_effect = [
-        [
+        assert self.google_directory.list_groups_with_members() == expected_output
+
+        mock_logger.info.assert_has_calls(
+            [
+                call("Found 2 groups."),
+                call("Found 2 groups after filtering."),
+                call("Getting members for group: group_email1"),
+                call("Getting members for group: group_email2"),
+            ]
+        )
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
+
+    def test_get_members_details(self):
+        members = [
+            {"email": "email1", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
+            {"email": "email2", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
+        ]
+
+        users = [
+            {"name": "user1", "primaryEmail": "email1"},
+            {"name": "user2", "primaryEmail": "email2"},
+        ]
+
+        expected_result = [
             {
-                "id": "test_member_id1",
                 "email": "email1",
+                "role": "MEMBER",
+                "type": "USER",
+                "status": "ACTIVE",
+                "name": "user1",
+                "primaryEmail": "email1",
+            },
+            {
+                "email": "email2",
+                "role": "MEMBER",
+                "type": "USER",
+                "status": "ACTIVE",
+                "name": "user2",
+                "primaryEmail": "email2",
+            },
+        ]
+
+        assert (
+            self.google_directory.get_members_details(members, users) == expected_result
+        )
+
+    @patch("integrations.google_next.directory.logger")
+    def test_get_members_details_handles_user_not_found(self, mock_logger):
+        members = [
+            {"email": "email1", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
+            {"email": "email2", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
+        ]
+
+        users = [
+            {"name": "user2", "primaryEmail": "email2"},
+        ]
+
+        expected_result = [
+            {
+                "email": "email1",
+                "role": "MEMBER",
+                "type": "USER",
+                "status": "ACTIVE",
                 "error": "User details not found",
             },
             {
-                "id": "test_member_id2",
                 "email": "email2",
-                "name": "test_user2",
+                "role": "MEMBER",
+                "type": "USER",
+                "status": "ACTIVE",
+                "name": "user2",
                 "primaryEmail": "email2",
             },
-        ],
-        [
-            {
-                "id": "test_member_id2",
-                "email": "email2",
-                "name": "test_user2",
-                "primaryEmail": "email2",
-            },
-            {
-                "id": "test_member_id3",
-                "email": "email3",
-                "name": "test_user3",
-                "primaryEmail": "email3",
-            },
-        ],
-    ]
-
-    assert directory.list_groups_with_members(mock_service) == expected_output
-
-    mock_logger.info.assert_has_calls(
-        [
-            call("Found 2 groups."),
-            call("Found 2 groups after filtering."),
-            call("Getting members for group: group_email1"),
-            call("Getting members for group: group_email2"),
         ]
-    )
-    mock_logger.warning.assert_not_called()
-    mock_logger.error.assert_not_called()
 
-
-def test_get_members_details_returns_members():
-    """Test get_members_details returns members."""
-    members = [
-        {"email": "email1", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
-        {"email": "email2", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
-    ]
-
-    users = [
-        {"name": "user1", "primaryEmail": "email1"},
-        {"name": "user2", "primaryEmail": "email2"},
-    ]
-
-    expected_result = [
-        {
-            "email": "email1",
-            "role": "MEMBER",
-            "type": "USER",
-            "status": "ACTIVE",
-            "name": "user1",
-            "primaryEmail": "email1",
-        },
-        {
-            "email": "email2",
-            "role": "MEMBER",
-            "type": "USER",
-            "status": "ACTIVE",
-            "name": "user2",
-            "primaryEmail": "email2",
-        },
-    ]
-
-    assert directory.get_members_details(members, users) == expected_result
-
-
-@patch("integrations.google_next.directory.logger")
-def test_get_members_details_returns_members_with_error(
-    mock_logger: MagicMock,
-):
-    """Test get_members_details returns members."""
-    members = [
-        {"email": "email1", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
-        {"email": "email2", "role": "MEMBER", "type": "USER", "status": "ACTIVE"},
-    ]
-
-    users = [
-        {"name": "user2", "primaryEmail": "email2"},
-    ]
-
-    expected_result = [
-        {
-            "email": "email1",
-            "role": "MEMBER",
-            "type": "USER",
-            "status": "ACTIVE",
-            "error": "User details not found",
-        },
-        {
-            "email": "email2",
-            "role": "MEMBER",
-            "type": "USER",
-            "status": "ACTIVE",
-            "name": "user2",
-            "primaryEmail": "email2",
-        },
-    ]
-
-    assert directory.get_members_details(members, users) == expected_result
-
-    mock_logger.info.assert_has_calls(
-        [
-            call("Getting user details for member: email1"),
-            call("Getting user details for member: email2"),
-        ]
-    )
-    mock_logger.warning.assert_called_once_with(
-        "User details not found for member: email1"
-    )
+        assert (
+            self.google_directory.get_members_details(members, users) == expected_result
+        )
+        mock_logger.info.assert_has_calls(
+            [
+                call("Getting user details for member: email1"),
+                call("Getting user details for member: email2"),
+            ]
+        )
+        mock_logger.warning.assert_called_once_with(
+            "User details not found for member: email1"
+        )


### PR DESCRIPTION
# Summary | Résumé

# Summary | Résumé

Refactored the Google Next Directory module as a helper class.

- Google Directory is now a class
- State is preserved so the authenticated service can be created once and used multiple times before being closed
- Clarified use of these helper classes: the hoisted methods make it easy to use through the code base but it is possible to simply use the Service's `get_google_service` and use the [regular approach described in the documentation](https://googleapis.github.io/google-api-python-client/docs/pagination.html)