### PR TITLE
Moving the httpx library to requirements instead of requirements-dev

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,6 +12,7 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==0.8.0
 google-api-core==2.24.0
 google-auth==2.37.0
+httpx==0.28.1
 itsdangerous==2.2.0
 pandas==2.2.3
 PyJWT==2.10.1

--- a/app/requirements_dev.txt
+++ b/app/requirements_dev.txt
@@ -3,7 +3,6 @@ checkov==3.2.347
 coverage==6.5.0
 flake8==6.1.0
 freezegun==1.5.1
-httpx==0.28.1
 setuptools==70.3.0
 pytest==8.3.4
 pytest-asyncio==0.25.2


### PR DESCRIPTION
# Summary | Résumé

To fix incident where the httpx needed to be moved to the requirements.txt. 
