### PR TITLE
Adding deployment alarm to SRE bot

### DIFF
--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "sre_bot_warning" {
 
 resource "aws_cloudwatch_metric_alarm" "sre_bot_failed_deployment" {
   alarm_name          = "SRE Bot Failed Deployment"
-  alarm_description   = "Warnings logged by the SRE Bot"
+  alarm_description   = "Deployement error for the SRE Bot"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
   metric_name               = "CPUUtilization"

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -56,17 +56,34 @@ resource "aws_cloudwatch_metric_alarm" "sre_bot_warning" {
   ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "sre_bot_failed_deployment" {
-  alarm_name          = "SRE Bot Failed Deployment"
-  alarm_description   = "Deployement error for the SRE Bot"
+resource "aws_cloudwatch_metric_alarm" "sre_bot_high_cpu" {
+  alarm_name          = "SRE Bot ECS High CPU Utilization"
+  alarm_description   = "ECS High CPU Utilization for the SRE Bot"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/ECS"
+  period                    = "60" # for 60 seconds
+  evaluation_periods        = "120"
+  statistic                 = "Average"
+  threshold                 = "80" # trigger if cpu usage is above 80%
+  insufficient_data_actions = []
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "sre_bot_high_memory" {
+  alarm_name          = "SRE Bot ECS High Memory Utilization"
+  alarm_description   = "ECS High Memory Utilization for the SRE Bot"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name               = "MemoryUtilization"
+  namespace                 = "AWS/ECS"
   period                    = "60"
   evaluation_periods        = "120"
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = "80" # trigger if memory usage is > 80% for 60 seconds period. 
   insufficient_data_actions = []
 
   alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -55,3 +55,20 @@ resource "aws_cloudwatch_metric_alarm" "sre_bot_warning" {
   alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
   ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "sre_bot_failed_deployment" {
+  alarm_name          = "SRE Bot Failed Deployment"
+  alarm_description   = "Warnings logged by the SRE Bot"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/ECS"
+  period                    = "60"
+  evaluation_periods        = "120"
+  statistic                 = "Average"
+  threshold                 = "80"
+  insufficient_data_actions = []
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -64,7 +64,7 @@ resource "aws_ecs_service" "main" {
   alarms {
     enable      = true
     rollback    = true
-    alarm_names = [aws_cloudwatch_metric_alarm.sre_bot_failed_deployment.alarm_name]
+    alarm_names = [aws_cloudwatch_metric_alarm.sre_bot_high_cpu.alarm_name, aws_cloudwatch_metric_alarm.sre_bot_high_memory.alarm_name]
   }
 
   tags = {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -60,6 +60,13 @@ resource "aws_ecs_service" "main" {
     container_port   = 8000
   }
 
+  # Enable deployment alarms
+  alarms {
+    enable      = true
+    rollback    = true
+    alarm_names = [aws_cloudwatch_metric_alarm.sre_bot_failed_deployment.alarm_name]
+  }
+
   tags = {
     "CostCentre" = var.billing_code
   }


### PR DESCRIPTION
# Summary | Résumé

Adding deployment alarm to the SRE bot. Created the alarm using the recommendations outlined here - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-alarm-failure.html
