### PR TITLE
Feat/update incident helper status

### DIFF
--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -498,17 +498,6 @@ def channel_item(channel):
     ]
 
 
-def return_channel_name(input_str: str):
-    # return the channel name without the incident- prefix and appending a # to the channel name
-    prefix = "incident-"
-    dev_prefix = prefix + "dev-"
-    if input_str.startswith(dev_prefix):
-        return "#" + input_str[len(dev_prefix) :]
-    if input_str.startswith(prefix):
-        return "#" + input_str[len(prefix) :]
-    return input_str
-
-
 def handle_update_status_command(
     client: WebClient, body, respond: Respond, ack: Ack, args
 ):

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -42,6 +42,9 @@ help_text = """
 \n `/sre incident stale`
 \n      - lists all incidents older than 14 days with no activity
 \n      - lister tous les incidents plus vieux que 14 jours sans activité
+\n `/sre incident status <status>`
+\n      - update the status of the incident with the provided status. Supported statuses are: Open, In Progress, Ready to be Reviewed, Reviewed, Closed
+\n      - mettre à jour le statut de l'incident avec le statut fourni. Les statuts pris en charge sont : Open, In Progress, Ready to be Reviewed, Reviewed, Closed
 """
 
 

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -557,36 +557,6 @@ def test_close_incident_handles_post_message_failure(mock_incident_status, caplo
     assert error_message in caplog.text
 
 
-def test_return_channel_name_with_prefix():
-    # Test the function with a string that includes the prefix.
-    assert incident_helper.return_channel_name("incident-abc123") == "#abc123"
-
-
-def test_return_channel_name_with_dev_prefix():
-    # Test the function with a string that includes the incident-dev prefix.
-    assert incident_helper.return_channel_name("incident-dev-abc123") == "#abc123"
-
-
-def test_return_channel_name_without_prefix():
-    # Test the function with a string that does not include the prefix.
-    assert incident_helper.return_channel_name("general") == "general"
-
-
-def test_return_channel_name_empty_string():
-    # Test the function with an empty string.
-    assert incident_helper.return_channel_name("") == ""
-
-
-def test_return_channel_name_prefix_only():
-    # Test the function with a string that is only the prefix.
-    assert incident_helper.return_channel_name("incident-") == "#"
-
-
-def test_return_channel_name_dev_prefix_only():
-    # Test the function with a string that is only the incident-dev prefix.
-    assert incident_helper.return_channel_name("incident-dev-") == "#"
-
-
 @patch("modules.incident.incident_helper.logging.error")
 def test_schedule_incident_retro_not_incident_channel_exception(mock_logging_error):
     mock_ack = MagicMock()


### PR DESCRIPTION
# Summary | Résumé

- Updated help text with incident status update command
- Removed duplicate `return_channel_name` function