### PR TITLE
Feat/dynamo db incidents

### DIFF
--- a/.devcontainer/dynamodb-create.sh
+++ b/.devcontainer/dynamodb-create.sh
@@ -21,3 +21,4 @@ create_table() {
 create_table "webhooks"
 create_table "aws_access_requests"
 create_table "sre_bot_data"
+create_table "incidents"

--- a/app/integrations/aws/dynamodb.py
+++ b/app/integrations/aws/dynamodb.py
@@ -30,6 +30,7 @@ def query(
 
 @handle_aws_api_errors
 def scan(TableName, **kwargs):
+    """Scan a DynamoDB table. Will return only the list of items found in the table that match the query."""
     params = {
         "TableName": TableName,
     }
@@ -61,6 +62,10 @@ def put_item(TableName, **kwargs):
 
 @handle_aws_api_errors
 def get_item(TableName, **kwargs):
+    """Get an item from a DynamoDB table
+
+    Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.get_item
+    """
     params = {
         "TableName": TableName,
     }
@@ -70,7 +75,9 @@ def get_item(TableName, **kwargs):
         "dynamodb", "get_item", client_config=client_config, **params
     )
     if response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 200:
-        return response
+        return response.get("Item")
+    else:
+        return None
 
 
 @handle_aws_api_errors

--- a/app/modules/incident/incident_folder.py
+++ b/app/modules/incident/incident_folder.py
@@ -5,10 +5,12 @@ Includes functions to manage the folders, the metadata, and the list of incident
 
 import datetime
 import os
+import logging
+import uuid
 from slack_sdk.web import WebClient
 from slack_bolt import Ack
 from integrations.google_workspace import google_drive, sheets
-import logging
+from integrations.aws import dynamodb
 
 SRE_INCIDENT_FOLDER = os.environ.get("SRE_INCIDENT_FOLDER")
 INCIDENT_LIST = os.environ.get("INCIDENT_LIST")
@@ -305,3 +307,96 @@ def return_channel_name(input_str: str):
     if input_str.startswith(prefix):
         return "#" + input_str[len(prefix) :]
     return input_str
+
+
+def create_incident(
+    channel_id,
+    channel_name,
+    user_id,
+    teams,
+    report_url,
+    meet_url,
+    start_impact_time=None,
+    end_impact_time=None,
+    detection_time=None,
+    retrospective_url=None,
+    environment="prod",
+):
+    id = str(uuid.uuid4())
+    incident_data = {
+        "id": {"S": id},
+        "created_at": {"S": str(datetime.datetime.now())},
+        "channel_id": {"S": channel_id},
+        "channel_name": {"S": channel_name},
+        "status": {"S": "Open"},
+        "user_id": {"S": user_id},
+        "teams": {"SS": teams},
+        "report_url": {"S": report_url},
+        "meet_url": {"S": meet_url},
+        "environment": {"S": environment},
+    }
+    for key, value in [
+        ("start_impact_time", start_impact_time),
+        ("end_impact_time", end_impact_time),
+        ("detection_time", detection_time),
+        ("retrospective_url", retrospective_url),
+    ]:
+        if value:
+            incident_data[key] = {"S": value}
+
+    response = dynamodb.put_item(
+        TableName="incidents",
+        Item=incident_data,
+    )
+
+    if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+        logging.info(f"Created incident {id}")
+        return id
+    else:
+        return None
+
+
+def list_incidents(select="ALL_ATTRIBUTES", **kwargs):
+    """List all incidents in the incidents table."""
+    return dynamodb.scan(TableName="incidents", Select=select, **kwargs)
+
+
+def delete_incident(id):
+    """Not to be implemented in production"""
+    return dynamodb.delete_item(TableName="incidents", Key={"id": {"S": id}})
+
+
+def update_incident_field(id, field, value, type="S"):
+    """Update an attribute in an incident item.
+
+    Default type is string, but it can be changed to other types like N for numbers, SS for string sets, etc.
+
+    Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.update_item
+    """
+    expression_attribute_names = {f"#{field}": field}
+    expression_attribute_values = {f":{field}": {type: value}}
+
+    response = dynamodb.update_item(
+        TableName="incidents",
+        Key={"id": {"S": id}},
+        UpdateExpression=f"SET #{field} = :{field}",
+        ExpressionAttributeNames=expression_attribute_names,
+        ExpressionAttributeValues=expression_attribute_values,
+    )
+    if response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 200:
+        return response
+    else:
+        return None
+
+
+def get_incident(id):
+    return dynamodb.get_item(TableName="incidents", Key={"id": {"S": id}})
+
+
+def lookup_incident(field, value, field_type="S"):
+    """Lookup incidents by a specific field value."""
+    return dynamodb.scan(
+        TableName="incidents",
+        FilterExpression=f"{field} = :{field}",
+        ExpressionAttributeValues={f":{field}": {f"{field_type}": value}},
+    )

--- a/app/modules/incident/incident_folder.py
+++ b/app/modules/incident/incident_folder.py
@@ -361,11 +361,6 @@ def list_incidents(select="ALL_ATTRIBUTES", **kwargs):
     return dynamodb.scan(TableName="incidents", Select=select, **kwargs)
 
 
-def delete_incident(id):
-    """Not to be implemented in production"""
-    return dynamodb.delete_item(TableName="incidents", Key={"id": {"S": id}})
-
-
 def update_incident_field(id, field, value, type="S"):
     """Update an attribute in an incident item.
 

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -50,8 +50,8 @@ resource "aws_dynamodb_table" "sre_bot_data" {
 resource "aws_dynamodb_table" "incidents_table" {
   name           = "incidents"
   hash_key       = "id"
-  read_capacity  = 1
-  write_capacity = 1
+  read_capacity  = 2
+  write_capacity = 2
 
   attribute {
     name = "id"

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -45,3 +45,16 @@ resource "aws_dynamodb_table" "sre_bot_data" {
     type = "S"
   }
 }
+
+
+resource "aws_dynamodb_table" "incidents_table" {
+  name           = "incidents"
+  hash_key       = "id"
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

- Add incidents DynamoDB table to record incidents (transition from Google Sheets)
- Add DynamoDB incident related functions
   - create_incident
   - list_incidents
   - update_incident_field
   - get_incident
   - lookup_incident