### PR TITLE
Add summary command

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -221,6 +221,8 @@ def submit(ack, view, say, body, client: WebClient, logger):
         meet_url=meet_link["meetingUri"],
         environment=environment,
     )
+    logger.info(f"Created incident in dynamodb: {slug}")
+
     # Bookmark incident document
     client.bookmarks_add(
         channel_id=channel_id,


### PR DESCRIPTION
# Summary | Résumé

Added two new commands to the sre incident bot:
1. /sre incident add_summary
This opens a text box and an Incident Commander can put text into it around the current summary of the incident
2. /sre incidentsummary
This will post the current summary into the incident channel

# Test instructions | Instructions pour tester la modification
1. Run the dev sre bot
2. call /dev-sre incident add_summary
3. call /dev-sre incident summary
4. You should be able to add a summary for the incident as well as see a summary for the incident

