### PR TITLE
Attach canvas to incident channel 

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -292,7 +292,7 @@ def submit(ack, view, say, body, client: WebClient, logger):
         channel_id=channel_id,
         document_content={
             "type": "markdown",
-            "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want. All you need to do is to start typing below! ⌨️",
+            "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want. All you need to do is to start typing below!️",
         },
     )
 

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -287,6 +287,15 @@ def submit(ack, view, say, body, client: WebClient, logger):
         link=meet_link["meetingUri"],
     )
 
+    # Create a canvas for the channel
+    client.conversations_canvas_create(
+        channel_id=channel_id,
+        document_content={
+            "type": "markdown",
+            "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want! All you need to do is to start typing",
+        },
+    )
+
     text = f"A hangout has been created at: {meet_link['meetingUri']}"
     say(text=text, channel=channel_id)
 

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -292,7 +292,7 @@ def submit(ack, view, say, body, client: WebClient, logger):
         channel_id=channel_id,
         document_content={
             "type": "markdown",
-            "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want! All you need to do is to start typing",
+            "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want. All you need to do is to start typing below! ⌨️",
         },
     )
 

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -288,7 +288,7 @@ def submit(ack, view, say, body, client: WebClient, logger):
     )
 
     # Create a canvas for the channel
-    client.conversations_canvas_create(
+    client.conversations_canvases_create(
         channel_id=channel_id,
         document_content={
             "type": "markdown",

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -483,6 +483,125 @@ def test_incident_submit_adds_bookmarks_for_a_meet_and_announces_it(
 @patch("modules.incident.incident.incident_document.create_incident_document")
 @patch("modules.incident.incident.incident_folder.get_folder_metadata")
 @patch("modules.incident.incident.log_to_sentinel")
+def test_incident_canvas_create_successful_called_with_correct_params(
+    _log_to_sentinel_mock,
+    mock_list_metadata,
+    mock_create_new_incident,
+    mock_merge_data,
+    mock_add_new_incident_to_list,
+    mock_google_meet,
+):
+    client = MagicMock()
+    ack = MagicMock()
+    logger = MagicMock()
+    view = helper_generate_view()
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    canvas_data = {
+        "type": "markdown",
+        "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want! All you need to do is to start typing",
+    }
+
+    client.conversations_create.return_value = {
+        "channel": {"id": "channel_id", "name": "channel_name"}
+    }
+    mock_google_meet_instance = mock_google_meet.return_value
+    mock_google_meet_instance.create_space.return_value = {
+        "name": "spaces/asdfasdf",
+        "meetingUri": "https://meet.google.com/aaa-bbbb-ccc",
+        "meetingCode": "aaa-bbbb-ccc",
+        "config": {"accessType": "TRUSTED", "entryPointAccess": "ALL"},
+    }
+    incident.submit(ack, view, say, body, client, logger)
+
+    client.conversations_canvas_create.assert_called_once_with(
+        channel_id="channel_id", document_content=canvas_data
+    )
+
+
+@patch("modules.incident.incident.GoogleMeet")
+@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
+@patch("modules.incident.incident.incident_document.update_boilerplate_text")
+@patch("modules.incident.incident.incident_document.create_incident_document")
+@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.log_to_sentinel")
+def test_incident_canvas_create_returns_successful_response(
+    _log_to_sentinel_mock,
+    mock_list_metadata,
+    mock_create_new_incident,
+    mock_merge_data,
+    mock_add_new_incident_to_list,
+    mock_google_meet,
+):
+    client = MagicMock()
+    ack = MagicMock()
+    logger = MagicMock()
+    view = helper_generate_view()
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    expected_response = {"ok": True, "canvas_id": "canvas_id"}
+    client.conversations_canvas_create.return_value = expected_response
+
+    client.conversations_create.return_value = {
+        "channel": {"id": "channel_id", "name": "channel_name"}
+    }
+    mock_google_meet_instance = mock_google_meet.return_value
+    mock_google_meet_instance.create_space.return_value = {
+        "name": "spaces/asdfasdf",
+        "meetingUri": "https://meet.google.com/aaa-bbbb-ccc",
+        "meetingCode": "aaa-bbbb-ccc",
+        "config": {"accessType": "TRUSTED", "entryPointAccess": "ALL"},
+    }
+    incident.submit(ack, view, say, body, client, logger)
+
+    assert client.conversations_canvas_create.return_value == expected_response
+    ack.assert_called_once()
+
+
+@patch("modules.incident.incident.GoogleMeet")
+@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
+@patch("modules.incident.incident.incident_document.update_boilerplate_text")
+@patch("modules.incident.incident.incident_document.create_incident_document")
+@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.log_to_sentinel")
+def test_incident_canvas_create_unsuccessful_called(
+    _log_to_sentinel_mock,
+    mock_list_metadata,
+    mock_create_new_incident,
+    mock_merge_data,
+    mock_add_new_incident_to_list,
+    mock_google_meet,
+):
+    client = MagicMock()
+    ack = MagicMock()
+    logger = MagicMock()
+    view = helper_generate_view()
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    expected_response = {"ok": False, "error": "invalid_type"}
+    client.conversations_canvas_create.return_value = expected_response
+
+    client.conversations_create.return_value = {
+        "channel": {"id": "channel_id", "name": "channel_name"}
+    }
+    mock_google_meet_instance = mock_google_meet.return_value
+    mock_google_meet_instance.create_space.return_value = {
+        "name": "spaces/asdfasdf",
+        "meetingUri": "https://meet.google.com/aaa-bbbb-ccc",
+        "meetingCode": "aaa-bbbb-ccc",
+        "config": {"accessType": "TRUSTED", "entryPointAccess": "ALL"},
+    }
+    incident.submit(ack, view, say, body, client, logger)
+
+    assert client.conversations_canvas_create.return_value == expected_response
+
+
+@patch("modules.incident.incident.GoogleMeet")
+@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
+@patch("modules.incident.incident.incident_document.update_boilerplate_text")
+@patch("modules.incident.incident.incident_document.create_incident_document")
+@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.log_to_sentinel")
 def test_incident_submit_creates_a_document_and_announces_it(
     _log_to_sentinel_mock,
     mock_list_metadata,

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -499,7 +499,7 @@ def test_incident_canvas_create_successful_called_with_correct_params(
     body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
     canvas_data = {
         "type": "markdown",
-        "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want! All you need to do is to start typing",
+        "markdown": "# Incident Canvas 📋\n\nUse this area to write/store anything you want. All you need to do is to start typing below!️",
     }
 
     client.conversations_create.return_value = {

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -514,7 +514,7 @@ def test_incident_canvas_create_successful_called_with_correct_params(
     }
     incident.submit(ack, view, say, body, client, logger)
 
-    client.conversations_canvas_create.assert_called_once_with(
+    client.conversations_canvases_create.assert_called_once_with(
         channel_id="channel_id", document_content=canvas_data
     )
 
@@ -540,7 +540,7 @@ def test_incident_canvas_create_returns_successful_response(
     say = MagicMock()
     body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
     expected_response = {"ok": True, "canvas_id": "canvas_id"}
-    client.conversations_canvas_create.return_value = expected_response
+    client.conversations_canvases_create.return_value = expected_response
 
     client.conversations_create.return_value = {
         "channel": {"id": "channel_id", "name": "channel_name"}
@@ -554,7 +554,7 @@ def test_incident_canvas_create_returns_successful_response(
     }
     incident.submit(ack, view, say, body, client, logger)
 
-    assert client.conversations_canvas_create.return_value == expected_response
+    assert client.conversations_canvases_create.return_value == expected_response
     ack.assert_called_once()
 
 
@@ -579,7 +579,7 @@ def test_incident_canvas_create_unsuccessful_called(
     say = MagicMock()
     body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
     expected_response = {"ok": False, "error": "invalid_type"}
-    client.conversations_canvas_create.return_value = expected_response
+    client.conversations_canvases_create.return_value = expected_response
 
     client.conversations_create.return_value = {
         "channel": {"id": "channel_id", "name": "channel_name"}
@@ -593,7 +593,7 @@ def test_incident_canvas_create_unsuccessful_called(
     }
     incident.submit(ack, view, say, body, client, logger)
 
-    assert client.conversations_canvas_create.return_value == expected_response
+    assert client.conversations_canvases_create.return_value == expected_response
 
 
 @patch("modules.incident.incident.GoogleMeet")


### PR DESCRIPTION
# Summary | Résumé

Attach canvas to an incident channel by default when an incident channel is created. 

![Screenshot 2025-01-24 at 4 00 59 PM](https://github.com/user-attachments/assets/a5fc4b7c-bd89-4b30-b9ba-04c63e31ddb9)

With a canvas, you can store a lot of different information: 
![Screenshot 2025-01-24 at 4 01 48 PM](https://github.com/user-attachments/assets/3de5ae80-3946-45cb-8ea8-fdf4a8378b67)

When a change is made to the canvas, it is announced in the channel so that everyone knows:

![Screenshot 2025-01-24 at 4 02 45 PM](https://github.com/user-attachments/assets/21267d99-49ad-4380-8f0d-68188fb259a9)
