### PR TITLE
Feat/load incidents db

### DIFF
--- a/app/bin/clear_dev_db.sh
+++ b/app/bin/clear_dev_db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+TABLE_NAME="incidents"
+ENDPOINT_URL="http://dynamodb-local:8000"
+
+# List all items and extract their keys
+ITEM_KEYS=$(aws dynamodb scan --table-name $TABLE_NAME --endpoint-url $ENDPOINT_URL --query "Items[].id.S" --output text)
+
+# Print the number of items
+ITEM_COUNT=$(echo $ITEM_KEYS | wc -w)
+echo "Number of items to delete: $ITEM_COUNT"
+
+# Loop through each key and delete the item
+for KEY in $ITEM_KEYS; do
+  echo "Deleting item with key $KEY"
+  aws dynamodb delete-item \
+    --table-name $TABLE_NAME \
+    --key "{\"id\": {\"S\": \"$KEY\"}}" \
+    --endpoint-url $ENDPOINT_URL \
+    --no-cli-pager
+done

--- a/app/bin/reset_dev_db.sh
+++ b/app/bin/reset_dev_db.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+delete_incident_table() {
+  local TABLE_NAME=$1
+
+  # Check if table exists
+  if aws dynamodb describe-table --table-name $TABLE_NAME --endpoint-url http://dynamodb-local:8000 >/dev/null 2>&1; then
+    # Delete table
+    aws dynamodb delete-table --table-name $TABLE_NAME --endpoint-url http://dynamodb-local:8000
+  else
+    echo "Table $TABLE_NAME does not exist, skipping deletion"
+  fi
+}
+
+create_incident_table() {
+  local TABLE_NAME=$1
+
+  # Check if table exists
+  if aws dynamodb describe-table --table-name $TABLE_NAME --endpoint-url http://dynamodb-local:8000 >/dev/null 2>&1; then
+    echo "Table $TABLE_NAME already exists, skipping creation"
+  else
+    # Create table
+    aws dynamodb create-table \
+      --table-name $TABLE_NAME \
+      --attribute-definitions AttributeName=id,AttributeType=S \
+      --key-schema AttributeName=id,KeyType=HASH \
+      --provisioned-throughput ReadCapacityUnits=2,WriteCapacityUnits=2 \
+      --endpoint-url http://dynamodb-local:8000 \
+      --no-cli-pager
+  fi
+}
+
+
+delete_incident_table "incidents"
+create_incident_table "incidents"

--- a/app/integrations/google_workspace/sheets.py
+++ b/app/integrations/google_workspace/sheets.py
@@ -7,7 +7,7 @@ from integrations.google_workspace.google_service import (
 
 
 @handle_google_api_errors
-def get_values(spreadsheetId: str, range: str | None = None, fields=None):
+def get_values(spreadsheetId: str, range: str | None = None, fields=None) -> dict:
     """Gets the values from a Google Sheet.
 
     Args:
@@ -31,7 +31,7 @@ def get_values(spreadsheetId: str, range: str | None = None, fields=None):
 
 
 @handle_google_api_errors
-def get_sheet(spreadsheetId: str, ranges: str):
+def get_sheet(spreadsheetId: str, ranges: str, includeGridData: bool = False) -> dict:
     """Gets a Google Sheet.
 
     Args:
@@ -40,6 +40,8 @@ def get_sheet(spreadsheetId: str, ranges: str):
 
     Returns:
         dict: The response from the Google Sheets API.
+    Reference:
+    https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
     """
     return execute_google_api_call(
         "sheets",
@@ -48,7 +50,7 @@ def get_sheet(spreadsheetId: str, ranges: str):
         "get",
         spreadsheetId=spreadsheetId,
         ranges=ranges,
-        includeGridData=False,
+        includeGridData=includeGridData,
     )
 
 

--- a/app/integrations/slack/channels.py
+++ b/app/integrations/slack/channels.py
@@ -6,8 +6,10 @@ import re
 import time
 from datetime import datetime, timedelta
 
+from slack_sdk import WebClient
 
-def get_channels(client, pattern=None):
+
+def get_channels(client: WebClient, pattern=None, exclude_archived=True):
     channels = []
     cursor = None
 
@@ -16,7 +18,10 @@ def get_channels(client, pattern=None):
     # and the way it hanles retrieval of channels.
     while True:
         response = client.conversations_list(
-            exclude_archived=True, limit=100, types="public_channel", cursor=cursor
+            exclude_archived=exclude_archived,
+            limit=100,
+            types="public_channel",
+            cursor=cursor,
         )
 
         # if we did not get a successful response, break out of the loop

--- a/app/modules/dev/core.py
+++ b/app/modules/dev/core.py
@@ -1,5 +1,5 @@
 import os
-from . import aws_dev, google, slack
+from . import aws_dev, google, slack, incident
 
 PREFIX = os.environ.get("PREFIX", "")
 
@@ -21,6 +21,10 @@ def dev_command(ack, logger, respond, client, body, args):
             slack.slack_command(ack, client, body, respond, logger, args)
         case "stale":
             test_stale_channel_notification(ack, logger, respond, client, body)
+        case "incident":
+            incident.list_incidents(ack, logger, respond, client, body)
+        case "load-incidents":
+            incident.load_incidents(ack, logger, respond, client, body)
 
 
 def test_stale_channel_notification(ack, logger, respond, client, body):

--- a/app/modules/dev/incident.py
+++ b/app/modules/dev/incident.py
@@ -11,6 +11,7 @@ def list_incidents(ack, logger, respond, client: WebClient, body):
     """List incidents"""
     logger.info("Listing incidents...")
     incidents = incident_folder.list_incidents()
+    respond(f"Found {len(incidents)} incidents")
     if len(incidents) > 10:
         incidents = incidents[:10]
     logger.info(json.dumps(incidents, indent=2))
@@ -20,14 +21,14 @@ def list_incidents(ack, logger, respond, client: WebClient, body):
             f"ID: {incident['id']['S']}\nName: {incident['name']['S']}\nStatus: {incident['status']['S']}\nEnvironment: {incident['environment']['S']}\nChannel: <#{incident['channel_id']['S']}>\n"
         )
     message = "\n\n".join(formatted_incidents)
-    respond(f"Found {len(incidents)} incidents:\n\n{message}")
+    respond(f"listing the 10 first incidents:\n\n{message}")
     logger.info("finished processing request")
 
 
 def load_incidents(ack, logger, respond, client: WebClient, body):
     """Load incidents from Google Sheet"""
     logger.info("Loading incidents...")
-    incidents = incident_folder.get_incidents_from_sheet()
+    incidents = incident_folder.get_incidents_from_sheet(15)
     incidents = incident_folder.complete_incidents_details(client, logger, incidents)
     count = incident_folder.create_missing_incidents(logger, incidents)
     respond(f"Loaded {count} incidents")

--- a/app/modules/dev/incident.py
+++ b/app/modules/dev/incident.py
@@ -1,0 +1,35 @@
+import json
+import os
+
+from slack_sdk import WebClient
+from modules.incident import incident_folder
+
+INCIDENT_LIST = os.getenv("INCIDENT_LIST")
+
+
+def list_incidents(ack, logger, respond, client: WebClient, body):
+    """List incidents"""
+    logger.info("Listing incidents...")
+    incidents = incident_folder.list_incidents()
+    if len(incidents) > 10:
+        incidents = incidents[:10]
+    logger.info(json.dumps(incidents, indent=2))
+    formatted_incidents = []
+    for incident in incidents:
+        formatted_incidents.append(
+            f"ID: {incident['id']['S']}\nName: {incident['name']['S']}\nStatus: {incident['status']['S']}\nEnvironment: {incident['environment']['S']}\nChannel: <#{incident['channel_id']['S']}>\n"
+        )
+    message = "\n\n".join(formatted_incidents)
+    respond(f"Found {len(incidents)} incidents:\n\n{message}")
+    logger.info("finished processing request")
+
+
+def load_incidents(ack, logger, respond, client: WebClient, body):
+    """Load incidents from Google Sheet"""
+    logger.info("Loading incidents...")
+    incidents = incident_folder.get_incidents_from_sheet()
+    incidents = incident_folder.complete_incidents_details(client, logger, incidents)
+    count = incident_folder.create_missing_incidents(logger, incidents)
+    respond(f"Loaded {count} incidents")
+    logger.info(f"{len(incidents)} incidents")
+    logger.info("finished loading incidents")

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -101,12 +101,6 @@ def submit(ack, view, say, body, client: WebClient, logger):
 
     name = view["state"]["values"]["name"]["name"]["value"]
     folder = view["state"]["values"]["product"]["product"]["selected_option"]["value"]
-    folders = incident_folder.list_incident_folders()
-    team_name = "Unknown"
-    for f in folders:
-        if f["id"] == folder:
-            team_name = f["name"]
-            break
     product = view["state"]["values"]["product"]["product"]["selected_option"]["text"][
         "text"
     ]
@@ -211,6 +205,12 @@ def submit(ack, view, say, body, client: WebClient, logger):
         document_link, name, slug, product, channel_url
     )
 
+    folders = incident_folder.list_incident_folders()
+    team_name = "Unknown"
+    for f in folders:
+        if f["id"] == folder:
+            team_name = f["name"]
+            break
     incident_folder.create_incident(
         channel_id,
         slug,

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -207,10 +207,11 @@ def submit(ack, view, say, body, client: WebClient, logger):
     incident_folder.create_incident(
         channel_id,
         slug,
+        name,
         user_id,
         teams,
         document_link,
-        meet_link["meetingUri"],
+        meet_url=meet_link["meetingUri"],
     )
     # Bookmark incident document
     client.bookmarks_add(

--- a/app/modules/incident/incident_folder.py
+++ b/app/modules/incident/incident_folder.py
@@ -312,10 +312,13 @@ def return_channel_name(input_str: str):
 def create_incident(
     channel_id,
     channel_name,
+    name,
     user_id,
     teams,
     report_url,
-    meet_url,
+    status="Open",
+    meet_url=None,
+    created_at=None,
     incident_commander=None,
     operations_lead=None,
     severity=None,
@@ -325,13 +328,16 @@ def create_incident(
     retrospective_url=None,
     environment="prod",
 ):
+    if not created_at:
+        created_at = str(datetime.datetime.now().timestamp())
     id = str(uuid.uuid4())
     incident_data = {
         "id": {"S": id},
-        "created_at": {"S": str(datetime.datetime.now())},
+        "created_at": {"S": created_at},
         "channel_id": {"S": channel_id},
         "channel_name": {"S": channel_name},
-        "status": {"S": "Open"},
+        "name": {"S": name},
+        "status": {"S": status},
         "user_id": {"S": user_id},
         "teams": {"SS": teams},
         "report_url": {"S": report_url},
@@ -356,10 +362,9 @@ def create_incident(
     )
 
     if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
-        logging.info(f"Created incident {id}")
+        logging.info("Created incident %s", id)
         return id
-    else:
-        return None
+    return None
 
 
 def list_incidents(select="ALL_ATTRIBUTES", **kwargs):

--- a/app/modules/incident/incident_folder.py
+++ b/app/modules/incident/incident_folder.py
@@ -7,8 +7,10 @@ import datetime
 import os
 import logging
 import re
+import time
 import uuid
 from slack_sdk.web import WebClient
+from slack_sdk.errors import SlackApiError
 from slack_bolt import Ack
 from integrations.google_workspace import google_drive, sheets
 from integrations.aws import dynamodb
@@ -351,46 +353,65 @@ def get_incidents_from_sheet(days=0) -> list:
             if days > 0:
                 if incident_details["created_at"] < date_lookback_str:
                     continue
-            else:
-                incidents_details.append(incident_details)
+            incidents_details.append(incident_details)
         return incidents_details
     return []
 
 
-def complete_incidents_details(client: WebClient, logger, incidents):
+def complete_incidents_details(client: WebClient, logger, incidents: list[dict]):
     """Complete incidents details with channel info"""
     for incident in incidents:
-        response = client.conversations_info(channel=incident["channel_id"])
-        if response.get("ok"):
-            channel_info = response.get("channel")
-            incident["channel_name"] = channel_info.get("name")
-
-            if (
-                "incident-dev-" in incident["channel_name"]
-                or "Development" in incident["teams"]
-            ):
-                incident["environment"] = "dev"
-            else:
-                incident["environment"] = "prod"
-            logger.info(f"incident environment: {incident['environment']}")
-            created_at = channel_info.get("created", incident["created_at"])
-            incident["created_at"] = str(created_at)
-
-            is_archived = channel_info.get("is_archived")
-            is_member = channel_info.get("is_member")
-
-            meet_url = ""
-            if not is_archived:
-                if not is_member:
-                    client.conversations_join(channel=incident["channel_id"])
-                response = client.bookmarks_list(channel_id=incident["channel_id"])
-                if response["ok"]:
-                    for item in range(len(response["bookmarks"])):
-                        if response["bookmarks"][item]["title"] == "Meet link":
-                            meet_url = response["bookmarks"][item]["link"]
-            if meet_url:
-                incident["meet_url"] = meet_url
+        logger.info(
+            f"Getting info for incident {incident['channel_id']} - {incident['name']}"
+        )
+        incident.update(get_incident_details(client, logger, incident))
+        time.sleep(0.2)
     return incidents
+
+
+def get_incident_details(client: WebClient, logger, incident):
+    max_retries = 5
+    retry_attempts = 0
+    while retry_attempts < max_retries:
+        try:
+            response = client.conversations_info(channel=incident["channel_id"])
+            if response.get("ok"):
+                channel_info = response.get("channel")
+                incident["channel_name"] = channel_info.get("name")
+
+                if (
+                    "incident-dev-" in incident["channel_name"]
+                    or "Development" in incident["teams"]
+                ):
+                    incident["environment"] = "dev"
+                else:
+                    incident["environment"] = "prod"
+                created_at = channel_info.get("created", incident["created_at"])
+                incident["created_at"] = str(created_at)
+
+                is_archived = channel_info.get("is_archived")
+                is_member = channel_info.get("is_member")
+
+                meet_url = ""
+                if not is_archived:
+                    if not is_member:
+                        client.conversations_join(channel=incident["channel_id"])
+                    response = client.bookmarks_list(channel_id=incident["channel_id"])
+                    if response["ok"]:
+                        for item in range(len(response["bookmarks"])):
+                            if response["bookmarks"][item]["title"] == "Meet link":
+                                meet_url = response["bookmarks"][item]["link"]
+                if meet_url:
+                    incident["meet_url"] = meet_url
+        except SlackApiError as e:
+            if retry_attempts < max_retries:
+                logger.error(f"Error getting incident details: {e}")
+                logger.info("Retrying in 10 seconds...")
+                time.sleep(10)
+                retry_attempts += 1
+            else:
+                logger.error(f"Error getting incident details: {e}")
+    return incident
 
 
 def create_missing_incidents(logger, incidents):
@@ -439,6 +460,10 @@ def create_incident(
     retrospective_url=None,
     environment="prod",
 ):
+    incident_exists = lookup_incident("channel_id", channel_id)
+    if len(incident_exists) > 0:
+        return incident_exists[0]["id"]["S"]
+
     if not created_at:
         created_at = str(datetime.datetime.now().timestamp())
     id = str(uuid.uuid4())

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -332,22 +332,23 @@ def open_update_field_view(client: WebClient, body, ack: Ack, respond: Respond):
 
 
 def incident_information_view(incident):
-    logging.info(f"Loading Status View for:\n{incident}")
-    incident_name = incident.get("channel_name", "Unknown").get("S", "Unknown")
+    logging.info("Loading Status View for:\n%s", incident)
+    name = incident.get("name", "Unknown").get("S", "Unknown")
     incident_id = incident.get("id", "Unknown").get("S", "Unknown")
-    incident_status = incident.get("status", "Unknown").get("S", "Unknown")
-    incident_created_at = parse_incident_datetime_string(
-        incident.get("created_at", {}).get("S", "Unknown")
-    )
-    incident_start_impact_time = parse_incident_datetime_string(
-        incident.get("start_impact_time", {}).get("S", "Unknown")
-    )
-    incident_end_impact_time = parse_incident_datetime_string(
-        incident.get("end_impact_time", {}).get("S", "Unknown")
-    )
-    incident_detection_time = parse_incident_datetime_string(
-        incident.get("detection_time", {}).get("S", "Unknown")
-    )
+    status = incident.get("status", "Unknown").get("S", "Unknown")
+    created_at = incident.get("created_at", {}).get("S", "Unknown")
+    if created_at != "Unknown":
+        created_at = convert_timestamp(created_at)
+    impact_start_timestamp = incident.get("start_impact_time", {}).get("S", "Unknown")
+    if impact_start_timestamp != "Unknown":
+        impact_start_timestamp = convert_timestamp(impact_start_timestamp)
+
+    impact_end_timestamp = incident.get("end_impact_time", {}).get("S", "Unknown")
+    if impact_end_timestamp != "Unknown":
+        impact_end_timestamp = convert_timestamp(impact_end_timestamp)
+    detection_timestamp = incident.get("detection_time", {}).get("S", "Unknown")
+    if detection_timestamp != "Unknown":
+        detection_timestamp = convert_timestamp(detection_timestamp)
     return {
         "type": "modal",
         "callback_id": "incident_information_view",
@@ -358,7 +359,7 @@ def incident_information_view(incident):
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": incident_name,
+                    "text": name,
                     "emoji": True,
                 },
             },
@@ -374,7 +375,7 @@ def incident_information_view(incident):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Status*:\n" + incident_status,
+                    "text": "*Status*:\n" + status,
                 },
                 "accessory": {
                     "type": "button",
@@ -388,14 +389,14 @@ def incident_information_view(incident):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Time Created*:\n" + incident_created_at,
+                    "text": "*Time Created*:\n" + created_at,
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Detection Time*:\n" + incident_detection_time,
+                    "text": "*Detection Time*:\n" + detection_timestamp,
                 },
                 "accessory": {
                     "type": "button",
@@ -408,7 +409,7 @@ def incident_information_view(incident):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Start of Impact*:\n" + incident_start_impact_time,
+                    "text": "*Start of Impact*:\n" + impact_start_timestamp,
                 },
                 "accessory": {
                     "type": "button",
@@ -421,7 +422,7 @@ def incident_information_view(incident):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*End of Impact*:\n" + incident_end_impact_time,
+                    "text": "*End of Impact*:\n" + impact_end_timestamp,
                 },
                 "accessory": {
                     "type": "button",
@@ -461,3 +462,13 @@ def parse_incident_datetime_string(datetime_string: str) -> str:
         return parsed_datetime.strftime("%Y-%m-%d %H:%M")
     else:
         return "Unknown"
+
+
+def convert_timestamp(timestamp: str) -> str:
+    try:
+        datetime_str = datetime.fromtimestamp(float(timestamp)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except ValueError:
+        datetime_str = "Unknown"
+    return datetime_str

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -90,7 +90,9 @@ def register(bot: App):
     )
 
 
-def handle_incident_command(args, client: WebClient, body, respond: Respond, ack: Ack):
+def handle_incident_command(
+    args, client: WebClient, body, respond: Respond, ack: Ack, logger
+):
     """Handle the /sre incident command."""
 
     # If no arguments are provided, open the update status view

--- a/app/modules/sre/sre.py
+++ b/app/modules/sre/sre.py
@@ -60,7 +60,9 @@ def sre_command(
                 return
             geolocate_helper.geolocate(args, respond)
         case "incident":
-            incident_helper.handle_incident_command(args, client, body, respond, ack)
+            incident_helper.handle_incident_command(
+                args, client, body, respond, ack, logger
+            )
         case "webhooks":
             webhook_helper.handle_webhook_command(args, client, body, respond)
         case "test":

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -437,24 +437,16 @@ def test_incident_canvas_create_successful_called_with_correct_params(
 
 
 @patch("modules.incident.incident.GoogleMeet")
-@patch("modules.incident.incident.incident_folder.dynamodb")
-@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
-@patch("modules.incident.incident.incident_document.update_boilerplate_text")
-@patch("modules.incident.incident.incident_document.create_incident_document")
-@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.incident_document")
+@patch("modules.incident.incident.incident_folder")
 @patch("modules.incident.incident.log_to_sentinel")
 def test_incident_canvas_create_returns_successful_response(
     _log_to_sentinel_mock,
-    mock_list_metadata,
-    mock_create_new_incident,
-    mock_merge_data,
-    mock_add_new_incident_to_list,
-    mock_dynamodb,
+    mock_incident_folder,
+    mock_incident_document,
     mock_google_meet,
 ):
-    mock_dynamodb.put_item.return_value = {
-        "ResponseMetadata": {"HTTPStatusCode": 200},
-    }
+    mock_incident_folder.create_item.return_value = "incident_id"
     client = MagicMock()
     ack = MagicMock()
     logger = MagicMock()
@@ -481,24 +473,17 @@ def test_incident_canvas_create_returns_successful_response(
 
 
 @patch("modules.incident.incident.GoogleMeet")
-@patch("modules.incident.incident.incident_folder.dynamodb")
-@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
-@patch("modules.incident.incident.incident_document.update_boilerplate_text")
-@patch("modules.incident.incident.incident_document.create_incident_document")
-@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.incident_document")
+@patch("modules.incident.incident.incident_folder")
 @patch("modules.incident.incident.log_to_sentinel")
 def test_incident_canvas_create_unsuccessful_called(
     _log_to_sentinel_mock,
-    mock_list_metadata,
-    mock_create_new_incident,
-    mock_merge_data,
-    mock_add_new_incident_to_list,
-    mock_dynamodb,
+    mock_incident_folder,
+    mock_incident_document,
     mock_google_meet,
 ):
-    mock_dynamodb.put_item.return_value = {
-        "ResponseMetadata": {"HTTPStatusCode": 200},
-    }
+    mock_incident_folder.create_item.return_value = "incident_id"
+
     client = MagicMock()
     ack = MagicMock()
     logger = MagicMock()
@@ -523,21 +508,13 @@ def test_incident_canvas_create_unsuccessful_called(
     assert client.conversations_canvases_create.return_value == expected_response
 
 
-@patch("modules.incident.incident.incident_document.update_boilerplate_text")
-@patch("modules.incident.incident_folder.create_incident")
-@patch("modules.incident.incident.incident_folder.dynamodb")
-@patch("modules.incident.incident.incident_folder.add_new_incident_to_list")
-@patch("modules.incident.incident.incident_document.create_incident_document")
+@patch("modules.incident.incident.incident_document")
 @patch("modules.incident.incident.GoogleMeet")
-@patch("modules.incident.incident.incident_folder.get_folder_metadata")
+@patch("modules.incident.incident.incident_folder")
 def test_incident_submit_creates_a_document_and_announces_it(
     mock_incident_folder,
     mock_google_meet,
     mock_incident_document,
-    mock_add_new_incident_to_list,
-    mock_dynamodb,
-    mock_create_new_incident,
-    mock_boilerplate_text,
 ):
     ack = MagicMock()
     logger = MagicMock()
@@ -555,25 +532,25 @@ def test_incident_submit_creates_a_document_and_announces_it(
         "channel": {"id": "channel_id", "name": "channel_name"}
     }
 
-    # Set up the mock to return the structure your code expects for the dynamodb database
-    mock_dynamodb.put_item.return_value = {
-        "ResponseMetadata": {"HTTPStatusCode": 200},
-    }
-    mock_incident_document.return_value = "id"
+    mock_incident_folder.create_item.return_value = "incident_id"
+
+    mock_incident_document.create_incident_document.return_value = "id"
 
     mock_incident_folder.get_folder_metadata.return_value = {"appProperties": {}}
 
     incident.submit(ack, view, say, body, client, logger)
-    mock_incident_document.assert_called_once_with(f"{DATE}-name", "folder")
+    mock_incident_document.create_incident_document.assert_called_once_with(
+        f"{DATE}-name", "folder"
+    )
 
-    mock_add_new_incident_to_list.assert_called_once_with(
+    mock_incident_folder.add_new_incident_to_list.assert_called_once_with(
         "https://docs.google.com/document/d/id/edit",
         "name",
         f"{DATE}-name",
         "product",
         "https://gcdigital.slack.com/archives/channel_id",
     )
-    mock_incident_folder.assert_called_once_with("folder")
+    mock_incident_folder.get_folder_metadata.assert_called_once_with("folder")
 
 
 @patch("modules.incident.incident.GoogleMeet")

--- a/app/tests/modules/incident/test_incident_folder.py
+++ b/app/tests/modules/incident/test_incident_folder.py
@@ -354,12 +354,18 @@ def test_return_channel_name_dev_prefix_only():
 @patch("modules.incident.incident_folder.dynamodb")
 def test_create_incident(mock_dynamodb, mock_datetime, mock_uuid):
     mock_uuid.uuid4.return_value = "978f1d91-f2b4-4ad2-9f2f-86c0f1fce72d"
-    mock_created_at = mock_datetime.datetime.now.return_value = (
-        "2025-01-22 21:58:18.689313"
+    mock_created_at = mock_datetime.datetime.now.return_value.timestamp.return_value = (
+        1234567890
     )
     mock_dynamodb.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
     assert incident_folder.create_incident(
-        "channel_id", "channel_name", "user_id", ["teams"], "report_url", "meet_url"
+        "channel_id",
+        "channel_name",
+        "name",
+        "user_id",
+        ["teams"],
+        "report_url",
+        meet_url="meet_url",
     )
     mock_dynamodb.put_item.assert_called_once_with(
         TableName="incidents",
@@ -368,6 +374,7 @@ def test_create_incident(mock_dynamodb, mock_datetime, mock_uuid):
             "created_at": {"S": str(mock_created_at)},
             "channel_id": {"S": "channel_id"},
             "channel_name": {"S": "channel_name"},
+            "name": {"S": "name"},
             "status": {"S": "Open"},
             "user_id": {"S": "user_id"},
             "teams": {"SS": ["teams"]},
@@ -383,25 +390,26 @@ def test_create_incident(mock_dynamodb, mock_datetime, mock_uuid):
 @patch("modules.incident.incident_folder.dynamodb")
 def test_create_incident_with_optional_args(mock_dynamodb, mock_datetime, mock_uuid):
     mock_uuid.uuid4.return_value = "978f1d91-f2b4-4ad2-9f2f-86c0f1fce72d"
-    mock_created_at = mock_datetime.datetime.now.return_value = (
-        "2025-01-22 21:58:18.689313"
+    mock_created_at = mock_datetime.datetime.now.return_value.timestamp.return_value = (
+        1234567890
     )
     mock_dynamodb.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
     assert incident_folder.create_incident(
         "channel_id",
         "channel_name",
+        "name",
         "user_id",
         ["teams"],
         "report_url",
-        "meet_url",
-        "incident_commander",
-        "operations_lead",
-        "severity",
-        "start_time",
-        "end_time",
-        "detection_time",
-        "retro_url",
-        "dev",
+        meet_url="meet_url",
+        incident_commander="incident_commander",
+        operations_lead="operations_lead",
+        severity="severity",
+        start_impact_time="start_time",
+        end_impact_time="end_time",
+        detection_time="detection_time",
+        retrospective_url="retro_url",
+        environment="dev",
     )
     mock_dynamodb.put_item.assert_called_once_with(
         TableName="incidents",
@@ -410,6 +418,7 @@ def test_create_incident_with_optional_args(mock_dynamodb, mock_datetime, mock_u
             "created_at": {"S": str(mock_created_at)},
             "channel_id": {"S": "channel_id"},
             "channel_name": {"S": "channel_name"},
+            "name": {"S": "name"},
             "status": {"S": "Open"},
             "user_id": {"S": "user_id"},
             "teams": {"SS": ["teams"]},
@@ -432,12 +441,18 @@ def test_create_incident_with_optional_args(mock_dynamodb, mock_datetime, mock_u
 @patch("modules.incident.incident_folder.dynamodb")
 def test_create_incident_handle_error(mock_dynamodb, mock_datetime, mock_uuid):
     mock_uuid.uuid4.return_value = "978f1d91-f2b4-4ad2-9f2f-86c0f1fce72d"
-    mock_created_at = mock_datetime.datetime.now.return_value = (
-        "2025-01-22 21:58:18.689313"
+    mock_created_at = mock_datetime.datetime.now.return_value.timestamp.return_value = (
+        1234567890
     )
     mock_dynamodb.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 400}}
     response = incident_folder.create_incident(
-        "channel_id", "channel_name", "user_id", ["teams"], "report_url", "meet_url"
+        "channel_id",
+        "channel_name",
+        "name",
+        "user_id",
+        ["teams"],
+        "report_url",
+        meet_url="meet_url",
     )
     assert response is None
     mock_dynamodb.put_item.assert_called_once_with(
@@ -447,6 +462,7 @@ def test_create_incident_handle_error(mock_dynamodb, mock_datetime, mock_uuid):
             "created_at": {"S": str(mock_created_at)},
             "channel_id": {"S": "channel_id"},
             "channel_name": {"S": "channel_name"},
+            "name": {"S": "name"},
             "status": {"S": "Open"},
             "user_id": {"S": "user_id"},
             "teams": {"SS": ["teams"]},

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -697,24 +697,11 @@ def test_open_update_field_view(mock_update_field_view, mock_logging):
 def test_incident_information_view(mock_logging, mock_parse_incident_datetime_string):
     incident_data = generate_incident_data()
     id = incident_data["id"]["S"]
-    mock_parse_incident_datetime_string.side_effect = [
-        "2025-01-23 17:02",
-        "Unknown",
-        "Unknown",
-        "Unknown",
-    ]
     view = incident_helper.incident_information_view(incident_data)
     mock_logging.info.assert_called_once_with(
-        f"Loading Status View for:\n{incident_data}"
+        "Loading Status View for:\n%s", incident_data
     )
-    mock_parse_incident_datetime_string.assert_has_calls(
-        [
-            call("2025-01-23 17:02:16.915368"),
-            call("Unknown"),
-            call("Unknown"),
-            call("Unknown"),
-        ]
-    )
+    mock_parse_incident_datetime_string.assert_not_called()
     assert view == {
         "type": "modal",
         "callback_id": "incident_information_view",
@@ -729,7 +716,7 @@ def test_incident_information_view(mock_logging, mock_parse_incident_datetime_st
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": "channel_name",
+                    "text": "name",
                     "emoji": True,
                 },
             },
@@ -759,7 +746,7 @@ def test_incident_information_view(mock_logging, mock_parse_incident_datetime_st
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Time Created*:\n2025-01-23 17:02",
+                    "text": "*Time Created*:\n2009-02-13 23:31:30",
                 },
             },
             {
@@ -843,7 +830,7 @@ def test_parse_incident_datetime_string():
 
 
 def generate_incident_data(
-    created_at="2025-01-23 17:02:16.915368",
+    created_at="1234567890",
     incident_commander=None,
     operations_lead=None,
     severity=None,
@@ -859,6 +846,7 @@ def generate_incident_data(
         "created_at": {"S": created_at},
         "channel_id": {"S": "channel_id"},
         "channel_name": {"S": "channel_name"},
+        "name": {"S": "name"},
         "status": {"S": "status"},
         "user_id": {"S": "user_id"},
         "teams": {"SS": ["team1", "team2"]},

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -10,15 +10,20 @@ from unittest.mock import ANY, MagicMock, patch
 SLACK_SECURITY_USER_GROUP_ID = os.getenv("SLACK_SECURITY_USER_GROUP_ID")
 
 
+@patch("modules.incident.incident_helper.incident_conversation")
 @patch("modules.incident.incident_helper.open_incident_info_view")
-def test_handle_incident_command_with_empty_args(mock_open_incident_info_view):
+def test_handle_incident_command_with_empty_args(
+    mock_open_incident_info_view, mock_incident_conversation
+):
     client = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
     body = {
         "channel_id": "channel_id",
     }
-    incident_helper.handle_incident_command([], client, body, respond, ack)
+    mock_incident_conversation.is_incident_channel.return_value = (True, False)
+    incident_helper.handle_incident_command([], client, body, respond, ack, logger)
     mock_open_incident_info_view.assert_called_once_with(client, body, ack, respond)
 
 
@@ -27,8 +32,10 @@ def test_handle_incident_command_with_create_command(create_folder_mock):
     create_folder_mock.return_value = {"id": "test_id", "name": "foo bar"}
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     incident_helper.handle_incident_command(
-        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond, ack
+        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond, ack, logger
     )
     respond.assert_called_once_with("Folder `foo bar` created.")
 
@@ -38,8 +45,10 @@ def test_handle_incident_command_with_create_command_error(create_folder_mock):
     create_folder_mock.return_value = None
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     incident_helper.handle_incident_command(
-        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond, ack
+        ["create-folder", "foo", "bar"], MagicMock(), MagicMock(), respond, ack, logger
     )
     respond.assert_called_once_with("Failed to create folder `foo bar`.")
 
@@ -47,8 +56,10 @@ def test_handle_incident_command_with_create_command_error(create_folder_mock):
 def test_handle_incident_command_with_help():
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     incident_helper.handle_incident_command(
-        ["help"], MagicMock(), MagicMock(), respond, ack
+        ["help"], MagicMock(), MagicMock(), respond, ack, logger
     )
     respond.assert_called_once_with(incident_helper.help_text)
 
@@ -59,8 +70,10 @@ def test_handle_incident_command_with_list_folders(list_folders_mock):
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     incident_helper.handle_incident_command(
-        ["list-folders"], client, body, respond, ack
+        ["list-folders"], client, body, respond, ack, logger
     )
     list_folders_mock.assert_called_once_with(client, body, ack)
 
@@ -71,7 +84,11 @@ def test_handle_incident_command_with_roles(manage_roles_mock):
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
-    incident_helper.handle_incident_command(["roles"], client, body, respond, ack)
+    logger = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["roles"], client, body, respond, ack, logger
+    )
     manage_roles_mock.assert_called_once_with(client, body, ack, respond)
 
 
@@ -85,7 +102,11 @@ def test_handle_incident_command_with_close(close_incident_mock):
     }
     respond = MagicMock()
     ack = MagicMock()
-    incident_helper.handle_incident_command(["close"], client, body, respond, ack)
+    logger = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["close"], client, body, respond, ack, logger
+    )
     close_incident_mock.assert_called_once_with(client, body, ack, respond)
 
 
@@ -95,7 +116,11 @@ def test_handle_incident_command_with_stale(stale_incidents_mock):
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
-    incident_helper.handle_incident_command(["stale"], client, body, respond, ack)
+    logger = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["stale"], client, body, respond, ack, logger
+    )
     stale_incidents_mock.assert_called_once_with(client, body, ack)
 
 
@@ -109,7 +134,11 @@ def test_handle_incident_command_with_retro(schedule_retro_mock):
     }
     respond = MagicMock()
     ack = MagicMock()
-    incident_helper.handle_incident_command(["schedule"], client, body, respond, ack)
+    logger = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["schedule"], client, body, respond, ack, logger
+    )
     schedule_retro_mock.schedule_incident_retro.assert_called_once_with(
         client, body, ack
     )
@@ -123,8 +152,10 @@ def test_handle_incident_command_with_update_status_command(
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     args = ["status", "Ready", "to", "be", "Reviewed"]
-    incident_helper.handle_incident_command(args, client, body, respond, ack)
+    incident_helper.handle_incident_command(args, client, body, respond, ack, logger)
     args.pop(0)
     mock_handle_update_status_command.assert_called_once_with(
         client, body, respond, ack, args
@@ -134,8 +165,10 @@ def test_handle_incident_command_with_update_status_command(
 def test_handle_incident_command_with_unknown_command():
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     incident_helper.handle_incident_command(
-        ["foo"], MagicMock(), MagicMock(), respond, ack
+        ["foo"], MagicMock(), MagicMock(), respond, ack, logger
     )
     respond.assert_called_once_with(
         "Unknown command: foo. Type `/sre incident help` to see a list of commands."

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -5,7 +5,7 @@ import pytest
 from modules import incident_helper
 import logging
 
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, patch
 
 SLACK_SECURITY_USER_GROUP_ID = os.getenv("SLACK_SECURITY_USER_GROUP_ID")
 

--- a/app/tests/modules/sre/test_sre.py
+++ b/app/tests/modules/sre/test_sre.py
@@ -85,15 +85,17 @@ def test_sre_command_with_incident_argument(command_runner):
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
+    logger = MagicMock()
+
     sre.sre_command(
         ack,
         {"text": "incident"},
-        MagicMock(),
+        logger,
         respond,
         clientMock,
         body,
     )
-    command_runner.assert_called_once_with([], clientMock, body, respond, ack)
+    command_runner.assert_called_once_with([], clientMock, body, respond, ack, logger)
 
 
 @patch("modules.sre.webhook_helper.handle_webhook_command")


### PR DESCRIPTION
# Summary | Résumé

The proposed changes are to support the transition to the DynamoDB as well as support local development without polluting the production data. It may seem like a lot but only a small subset are actually affecting the behaviour of the bot at the moment.

- `app/bin/*.sh`: added scripts to delete items in a local incident db or delete the whole table and recreated it (useful if many items)
- `app/integrations/google_workspace/sheets.py`: small change to enable toggling `includeGridData`
- `app/integrations/slack/channels.py`: small change to support getting archived channels
- `app/modules/dev/core.py` and `app/modules/dev/incident.py:` add a few test commands for incident feature
- `app/modules/incident/incident.py`: modify the submit function to create the incidents with the proper parameters
- `app/modules/incident/incident_folder.py`: These are the core changes but most of these are not affecting the incident feature in production.
   - `get_incidents_from_sheet`: During the transition, this function will get all the metadata from the Google Sheet (the current source of truth) 
   - `complete_incidents_details` & `get_incident_details`: Iterate through each of the incidents parsed from the Google Sheet and update the missing parameters values when possible.
   - `create_missing_incidents`: creates all the incidents that are not currently found in the db (in dev that would be the local DB)
   - `create_incident`: _(the only change that modifies the **current** behaviour)_ a small tweak to the main create_incident function to first validate if an incident already is present with the channel_id being passed. If it actually does, the existing incident ID is passed instead of recreating it in the DB.
- `app/modules/incident/incident_helper.py`: simply adjust the view to match the changes in the incident item
- `app/modules/sre/sre.py`: just passing the logger to the incident helper