### PR TITLE
Adding 5 minute sleep cycle to ecs wait

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -66,6 +66,8 @@ jobs:
         id: ecs_wait
         continue-on-error: true
         run: |
+          echo "Wait for 15 minutes for ECS to stabilize.."
+          sleep 300 # Sleep for 5 minutes and ecs wait waits for 10 minutes
           aws ecs wait services-stable \
             --cluster sre-bot-cluster \
             --services sre-bot-service 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -67,7 +67,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Wait for 15 minutes for ECS to stabilize.."
-          sleep 300 # Sleep for 5 minutes and ecs wait waits for 10 minutes
+          sleep 300 # Sleep for 5 minutes. The ecs wait command waits for an additional 10 minutes
           aws ecs wait services-stable \
             --cluster sre-bot-cluster \
             --services sre-bot-service 


### PR DESCRIPTION

# Summary | Résumé

Adding a sleep cycle of 5 minutes to the ecs wait task since there is no native way to increase the timeout to more than the default 10 minutes. 

Issue is documented [here](https://github.com/aws/containers-roadmap/issues/2474) and it is on the roadmap (ie to increase timeout limit)