### PR TITLE
Refactor/remove submit button from incident creation modal

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -46,7 +46,6 @@ def open_create_incident_modal(client, ack, command, body):
         "type": "modal",
         "callback_id": "incident_view",
         "title": {"type": "plain_text", "text": i18n.t("incident.modal.title")},
-        "submit": {"type": "plain_text", "text": i18n.t("incident.submit")},
         "blocks": [
             {
                 "type": "section",

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -22,7 +22,6 @@ def test_incident_open_modal_calls_ack(
     loaded_view = mock_generate_incident_modal_view.return_value = ANY
     mock_i18n.t.side_effect = [
         "SRE - Start an incident",
-        "Submit",
         "Launching incident process...",
     ]
     mock_get_user_locale.return_value = "en-US"
@@ -40,7 +39,6 @@ def test_incident_open_modal_calls_ack(
     assert kwargs["view"]["type"] == "modal"
     assert kwargs["view"]["callback_id"] == "incident_view"
     assert kwargs["view"]["title"]["text"] == "SRE - Start an incident"
-    assert kwargs["view"]["submit"]["text"] == "Submit"
     assert (
         kwargs["view"]["blocks"][0]["text"]["text"]
         == ":beach-ball: Launching incident process..."


### PR DESCRIPTION
# Summary | Résumé

Remove the submission button from the loading view of the incident creation modal.

When the submit button is clicked while the data is loading and before the modal is refreshed with all the fields, it triggers the submit() function but doesn't validates the mandatory fields, which raises an error.