### PR TITLE
Fix/incident report url

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -218,7 +218,7 @@ def submit(ack, view, say, body, client: WebClient, logger):
         "name": name,
         "user_id": user_id,
         "teams": [team_name],
-        "report_url": document_id,
+        "report_url": document_link,
         "meet_url": meet_link["meetingUri"],
         "environment": environment,
     }

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -218,7 +218,7 @@ def submit(ack, view, say, body, client: WebClient, logger):
         "name": name,
         "user_id": user_id,
         "teams": [team_name],
-        "report_url": document_link,
+        "report_url": document_id,
         "meet_url": meet_link["meetingUri"],
         "environment": environment,
     }

--- a/app/modules/incident/information_update.py
+++ b/app/modules/incident/information_update.py
@@ -11,6 +11,7 @@ from modules.incident import (
     incident_folder,
     utils,
 )
+from integrations.google_workspace import google_docs
 
 FIELD_SCHEMA = {
     "detection_time": {"type": "datetime"},
@@ -301,7 +302,8 @@ def handle_update_field_submission(client: WebClient, body, ack: Ack, view, logg
             return
     if value and value_type:
         if action == "status" and isinstance(value, str):
-            incident_document.update_incident_document_status(report_url, value)
+            document_id = google_docs.extract_google_doc_id(report_url)
+            incident_document.update_incident_document_status(document_id, value)
             incident_folder.update_spreadsheet_incident_status(channel_name, value)
 
         db_operations.update_incident_field(

--- a/app/tests/modules/incident/test_information_update.py
+++ b/app/tests/modules/incident/test_information_update.py
@@ -467,6 +467,7 @@ def test_handle_update_field_submission_text_type(
     mock_incident_folder.update_spreadsheet_incident_status.assert_not_called()
 
 
+@patch("modules.incident.information_update.google_docs")
 @patch("modules.incident.information_update.incident_document")
 @patch("modules.incident.information_update.incident_folder")
 @patch("modules.incident.information_update.information_display")
@@ -476,6 +477,7 @@ def test_handle_update_field_submission_dropdown_type(
     mock_information_display,
     mock_incident_folder,
     mock_incident_document,
+    mock_google_docs,
 ):
     mock_client = MagicMock()
     mock_ack = MagicMock()
@@ -500,6 +502,7 @@ def test_handle_update_field_submission_dropdown_type(
         "user": {"id": incident_data["user_id"]},
         "view": {"root_view_id": "root_view_id"},
     }
+    mock_google_docs.extract_google_doc_id.return_value = "document_id"
     mock_information_display.incident_information_view.return_value = {
         "view": [{"block": "block_id"}]
     }
@@ -519,9 +522,9 @@ def test_handle_update_field_submission_dropdown_type(
         channel=incident_data["channel_id"],
         text="<@user_id> has updated the field status to Closed",
     )
-    # update incident document and spreadsheet if the action is "status"
+    mock_google_docs.extract_google_doc_id.assert_called_once_with("report_url")
     mock_incident_document.update_incident_document_status.assert_called_once_with(
-        incident_data["report_url"], "Closed"
+        "document_id", "Closed"
     )
     mock_incident_folder.update_spreadsheet_incident_status.assert_called_once_with(
         incident_data["channel_name"], "Closed"


### PR DESCRIPTION
# Summary | Résumé

Fix the Incident update status function to parse the document id from the URL so that the document can be properly updated.