### PR TITLE
Feat/add webhooks type

### DIFF
--- a/app/modules/slack/webhooks.py
+++ b/app/modules/slack/webhooks.py
@@ -13,7 +13,7 @@ from integrations.aws import dynamodb
 table = "webhooks"
 
 
-def create_webhook(channel, user_id, name):
+def create_webhook(channel, user_id, name, hook_type="alert"):
     id = str(uuid.uuid4())
     response = dynamodb.put_item(
         TableName=table,
@@ -26,6 +26,7 @@ def create_webhook(channel, user_id, name):
             "user_id": {"S": user_id},
             "invocation_count": {"N": "0"},
             "acknowledged_count": {"N": "0"},
+            "hook_type": {"S": hook_type},
         },
     )
 

--- a/app/modules/sre/webhook_helper.py
+++ b/app/modules/sre/webhook_helper.py
@@ -1,6 +1,7 @@
 """Webhook helper functions for the SRE Bot."""
 
 import re
+import logging
 
 from modules.slack import webhooks
 
@@ -26,6 +27,12 @@ def register(bot):
     bot.action("toggle_webhook")(toggle_webhook)
     bot.action("reveal_webhook")(reveal_webhook)
     bot.action("next_page")(next_page)
+    bot.action("channel")(ack_action)
+    bot.action("hook_type")(ack_action)
+
+
+def ack_action(ack, body):
+    ack()
 
 
 def handle_webhook_command(args, client, body, respond):
@@ -53,10 +60,14 @@ def handle_webhook_command(args, client, body, respond):
 def create_webhook(ack, view, body, logger, client, say):
     ack()
 
+    logging.info(view)
     errors = {}
 
     name = view["state"]["values"]["name"]["name"]["value"]
     channel = view["state"]["values"]["channel"]["channel"]["selected_channel"]
+    hook_type = view["state"]["values"]["hook_type"]["hook_type"]["selected_option"][
+        "value"
+    ]
     user = body["user"]["id"]
 
     if not re.match(r"^[\w\-\s]+$", name):
@@ -67,7 +78,7 @@ def create_webhook(ack, view, body, logger, client, say):
         ack(response_action="errors", errors=errors)
         return
 
-    id = webhooks.create_webhook(channel, user, name)
+    id = webhooks.create_webhook(channel, user, name, hook_type)
     client.conversations_join(channel=channel)
     if id:
         message = f"Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/{id}"
@@ -134,6 +145,39 @@ def create_webhook_modal(client, body):
                             },
                             "initial_channel": body["channel_id"],
                             "action_id": "channel",
+                        }
+                    ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Select a type of webhook (defaults to alert)",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "type": "actions",
+                    "block_id": "hook_type",
+                    "elements": [
+                        {
+                            "type": "static_select",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Select a type",
+                                "emoji": True,
+                            },
+                            "options": [
+                                {
+                                    "text": {"type": "plain_text", "text": "Alert"},
+                                    "value": "alert",
+                                },
+                                {
+                                    "text": {"type": "plain_text", "text": "Info"},
+                                    "value": "info",
+                                },
+                            ],
+                            "action_id": "hook_type",
                         }
                     ],
                 },
@@ -330,7 +374,9 @@ def toggle_webhook(ack, body, logger, client):
     list_all_webhooks(client, body, 0, MAX_BLOCK_SIZE, "all", update=True)
 
 
-def webhook_list_item(hook):
+def webhook_list_item(hook: dict):
+    hook_type: str = hook.get("hook_type", {"S": "alert"})["S"]
+    hook_type = hook_type.capitalize()
     return [
         {
             "type": "section",
@@ -367,7 +413,7 @@ def webhook_list_item(hook):
                 {
                     "type": "plain_text",
                     "emoji": True,
-                    "text": f"{hook['created_at']['S']} \n {hook['invocation_count']['N']} invocations | {hook['acknowledged_count']['N']} acknowledged",
+                    "text": f"{hook['created_at']['S']} | Type: {hook_type}\n {hook['invocation_count']['N']} invocations | {hook['acknowledged_count']['N']} acknowledged",
                 }
             ],
         },

--- a/app/modules/sre/webhook_helper.py
+++ b/app/modules/sre/webhook_helper.py
@@ -68,6 +68,8 @@ def create_webhook(ack, view, body, logger, client, say):
     hook_type = view["state"]["values"]["hook_type"]["hook_type"]["selected_option"][
         "value"
     ]
+    hook_type = hook_type if hook_type else "alert"
+    hook_type = hook_type.lower()
     user = body["user"]["id"]
 
     if not re.match(r"^[\w\-\s]+$", name):

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -315,6 +315,7 @@ def handle_webhook(
     webhook = webhooks.get_webhook(id)
     webhook_payload = WebhookPayload()
     if webhook:
+        hook_type: str = webhook.get("hook_type", {"S": "alert"})["S"]
         # if the webhook is active, then send forward the response to the webhook
         if webhooks.is_active(id):
             webhooks.increment_invocation_count(id)
@@ -328,7 +329,8 @@ def handle_webhook(
             else:
                 webhook_payload = payload
             webhook_payload.channel = webhook["channel"]["S"]
-            webhook_payload = append_incident_buttons(webhook_payload, id)
+            if hook_type == "alert":
+                webhook_payload = append_incident_buttons(webhook_payload, id)
             try:
                 webhook_payload_parsed = webhook_payload.model_dump(exclude_none=True)
                 request.state.bot.client.api_call(

--- a/app/tests/modules/slack/test_slack_webhooks.py
+++ b/app/tests/modules/slack/test_slack_webhooks.py
@@ -18,6 +18,32 @@ def test_create_webhook(dynamodb_mock):
             "user_id": {"S": "test_user_id"},
             "invocation_count": {"N": "0"},
             "acknowledged_count": {"N": "0"},
+            "hook_type": {"S": "alert"},
+        },
+    )
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_create_webhook_with_type(dynamodb_mock):
+    dynamodb_mock.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+    assert (
+        webhooks.create_webhook(
+            "test_channel", "test_user_id", "test_name", "test_type"
+        )
+        == ANY
+    )
+    dynamodb_mock.put_item.assert_called_once_with(
+        TableName="webhooks",
+        Item={
+            "id": {"S": ANY},
+            "channel": {"S": "test_channel"},
+            "name": {"S": "test_name"},
+            "created_at": {"S": ANY},
+            "active": {"BOOL": True},
+            "user_id": {"S": "test_user_id"},
+            "invocation_count": {"N": "0"},
+            "acknowledged_count": {"N": "0"},
+            "hook_type": {"S": "test_type"},
         },
     )
 
@@ -37,6 +63,7 @@ def test_create_webhook_return_none(dynamodb_mock):
             "user_id": {"S": "test_user_id"},
             "invocation_count": {"N": "0"},
             "acknowledged_count": {"N": "0"},
+            "hook_type": {"S": "alert"},
         },
     )
 
@@ -65,6 +92,7 @@ def test_get_webhook(dynamodb_mock):
         "user_id": {"S": "test_user_id"},
         "invocation_count": {"N": "0"},
         "acknowledged_count": {"N": "0"},
+        "type": {"S": "alert"},
     }
     assert webhooks.get_webhook("test_id") == {
         "id": {"S": "test_id"},
@@ -75,6 +103,7 @@ def test_get_webhook(dynamodb_mock):
         "user_id": {"S": "test_user_id"},
         "invocation_count": {"N": "0"},
         "acknowledged_count": {"N": "0"},
+        "type": {"S": "alert"},
     }
     dynamodb_mock.get_item.assert_called_once_with(
         TableName="webhooks", Key={"id": {"S": "test_id"}}

--- a/app/tests/modules/sre/test_webhook_helper.py
+++ b/app/tests/modules/sre/test_webhook_helper.py
@@ -235,6 +235,7 @@ def test_create_webhook_with_existing_webhook(create_webhook_mock):
         "channel",
         "user",
         "foo",
+        "alert",
     )
     logger.info.assert_called_with(
         "Webhook created with url: https://sre-bot.cdssandbox.xyz/hook/id"
@@ -273,6 +274,7 @@ def test_create_webhook_with_creation_error(create_webhook_mock):
         "channel",
         "user",
         "foo",
+        "alert",
     )
     logger.error.assert_called_with("Error creating webhook: channel, user, foo")
 
@@ -349,7 +351,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         {
                             "type": "plain_text",
                             "emoji": True,
-                            "text": "2020-01-01T00:00:00.000Z \n 0 invocations | 0 acknowledged",
+                            "text": "2020-01-01T00:00:00.000Z | Type: Alert\n 0 invocations | 0 acknowledged",
                         }
                     ],
                 },
@@ -386,7 +388,7 @@ def test_list_all_webhooks(list_all_webhooks_mock):
                         {
                             "type": "plain_text",
                             "emoji": True,
-                            "text": "2020-01-01T00:00:00.000Z \n 0 invocations | 0 acknowledged",
+                            "text": "2020-01-01T00:00:00.000Z | Type: Alert\n 0 invocations | 0 acknowledged",
                         }
                     ],
                 },
@@ -571,7 +573,7 @@ def test_webhook_list_item():
                 {
                     "type": "plain_text",
                     "emoji": True,
-                    "text": "2020-01-01T00:00:00.000Z \n 0 invocations | 0 acknowledged",
+                    "text": "2020-01-01T00:00:00.000Z | Type: Alert\n 0 invocations | 0 acknowledged",
                 }
             ],
         },
@@ -585,6 +587,7 @@ def helper_generate_view(name="name"):
             "values": {
                 "name": {"name": {"value": name}},
                 "channel": {"channel": {"selected_channel": "channel"}},
+                "hook_type": {"hook_type": {"selected_option": {"value": "alert"}}},
             }
         }
     }

--- a/app/tests/modules/sre/test_webhook_helper.py
+++ b/app/tests/modules/sre/test_webhook_helper.py
@@ -587,7 +587,7 @@ def helper_generate_view(name="name"):
             "values": {
                 "name": {"name": {"value": name}},
                 "channel": {"channel": {"selected_channel": "channel"}},
-                "hook_type": {"hook_type": {"selected_option": {"value": "alert"}}},
+                "hook_type": {"hook_type": {"selected_option": {"value": "Alert"}}},
             }
         }
     }


### PR DESCRIPTION
# Summary | Résumé

Add support for info based webhooks which will make it possible to append the Incident buttons only when the Alert hook type has been selected.
Added the type of hook on the list webhooks view.