### PR TITLE
Fix: add initial option for webhook type selection in modal

### DIFF
--- a/app/modules/sre/webhook_helper.py
+++ b/app/modules/sre/webhook_helper.py
@@ -179,6 +179,10 @@ def create_webhook_modal(client, body):
                                     "value": "info",
                                 },
                             ],
+                            "initial_option": {
+                                "text": {"type": "plain_text", "text": "Alert"},
+                                "value": "alert",
+                            },
                             "action_id": "hook_type",
                         }
                     ],


### PR DESCRIPTION
# Summary | Résumé

Small fix to ensure a default value is set for the type of webhook