### PR TITLE
fix: NoneType error on security_users if not security incident

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -255,11 +255,11 @@ def submit(ack, view, say, body, client: WebClient, logger):  # noqa: C901
         # and add them to the list of users to invite
         response = client.usergroups_users_list(usergroup=SLACK_SECURITY_USER_GROUP_ID)
 
-    # if we are testing, ie PREFIX is "dev" then don't add the security group users since we don't want to spam them
-    if response.get("ok") and PREFIX == "":
-        for security_user in response["users"]:
-            if security_user != user_id:
-                users_to_invite.append(security_user)
+        # if we are testing, ie PREFIX is "dev" then don't add the security group users since we don't want to spam them
+        if response.get("ok") and PREFIX == "":
+            for security_user in response["users"]:
+                if security_user != user_id:
+                    users_to_invite.append(security_user)
 
     # Invite all collected users to the channel in a single API call
     if users_to_invite:

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -845,7 +845,7 @@ def test_incident_submit_does_not_invite_security_group_members_if_not_selected(
     }
     client.usergroups_users_list.return_value = {
         "ok": True,
-        "users": ["creator_user_id"],
+        "users": ["creator_user_id", "security_user_id"],
     }
 
     mock_incident_document.create_incident_document.return_value = "id"
@@ -858,7 +858,7 @@ def test_incident_submit_does_not_invite_security_group_members_if_not_selected(
     incident.submit(ack, view, say, body, client, logger)
     mock_get_on_call_users.assert_called_once_with("oncall")
     client.users_lookupByEmail.assert_any_call(email="email")
-    client.usergroups_users_list(usergroup="SLACK_SECURITY_USER_GROUP_ID")
+    client.usergroups_users_list.assert_not_called()
     client.conversations_invite.assert_has_calls(
         [
             call(channel="channel_id", users="creator_user_id"),


### PR DESCRIPTION
# Summary | Résumé

Small fix to ensure security users addition logic is only processed if the response has been updated with actual users.