### PR TITLE
fix: update report URL formatting in incident information view

### DIFF
--- a/app/modules/incident/information_display.py
+++ b/app/modules/incident/information_display.py
@@ -37,7 +37,7 @@ def incident_information_view(incident: Incident):
     if incident.end_impact_time != "Unknown":
         impact_end_timestamp = f"<!date^{int(float(incident.end_impact_time))}^{{date}} at {{time}}|Unknown>"
 
-    report_string = f"<https://docs.google.com/document/d/{incident.report_url}|:memo: Incident Report>"
+    report_string = f"<{incident.report_url}|:memo: Incident Report>"
     meet_string = f"<{incident.meet_url}|:headphones: Google Meet>"
     incident_data = incident.model_dump()
     incident_data.pop("logs")

--- a/app/tests/modules/incident/test_information_display.py
+++ b/app/tests/modules/incident/test_information_display.py
@@ -139,7 +139,7 @@ def test_incident_information_view(mock_convert_timestamp):
                 "type": "section",
                 "fields": [
                     {
-                        "text": "<https://docs.google.com/document/d/report_url|:memo: Incident Report>",
+                        "text": "<report_url|:memo: Incident Report>",
                         "type": "mrkdwn",
                     },
                     {


### PR DESCRIPTION
# Summary | Résumé

Small fix for the issue found in the Incident modal where the report URL is already the full link to the report. The issue was that it was assuming getting the document ID instead so the page wouldn't work