### PR TITLE
fix: add missing /auth prefix in sidemenu fetch

### DIFF
--- a/frontend/src/scenes/global/Sidemenu.jsx
+++ b/frontend/src/scenes/global/Sidemenu.jsx
@@ -47,7 +47,7 @@ const Sidemenu = () => {
 
     useEffect(() => {
       // Make a GET request to the "/user" endpoint
-      fetch('/me')
+      fetch('/auth/me')
         .then(response => {
           // Check if the response status code is OK (200)
           if (!response.ok) {


### PR DESCRIPTION
# Summary | Résumé

Small fix to add the missing /auth prefix to the sidemenu fetch