### PR TITLE
fix: remove endpoint debugging logger

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -259,7 +259,6 @@ class ServerSettings(BaseSettings):
         Returns:
             The validated value of the ISSUER_CONFIG field.
         """
-        logger.info("validate_issuer_config", v=v)
         if v is None or not isinstance(v, dict):
             return {}
         return v

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -12,8 +12,6 @@ ISSUER_CONFIG = settings.server.ISSUER_CONFIG
 logger = get_module_logger()
 security = HTTPBearer()
 
-logger.info("issuer_config_loaded", issuer_config=ISSUER_CONFIG)
-
 
 class JWKSManager:
     """
@@ -36,15 +34,11 @@ class JWKSManager:
         Returns:
             Optional[PyJWKClient]: The JWKS client for the specified issuer, or None if not found.
         """
-        logger.info(
-            "get_jwks_client_called", issuer=issuer, issuer_config=self.issuer_config
-        )
         if not self.issuer_config or issuer not in self.issuer_config:
             return None
         if issuer not in self.jwks_clients:
             try:
                 cfg = self.issuer_config[issuer]
-                logger.info("creating_jwks_client", jwks_uri=cfg.get("jwks_uri"))
                 self.jwks_clients[issuer] = PyJWKClient(
                     cfg["jwks_uri"], cache_jwk_set=True, lifespan=3600, timeout=10
                 )
@@ -67,14 +61,8 @@ def get_issuer_from_token(token: str) -> Optional[str]:
     Returns:
         str | None: The issuer (iss) claim from the token if present, otherwise None.
     """
-
-    logger.info("get_issuer_from_token", token=token)
     try:
         unverified_payload = decode(token, options={"verify_signature": False})
-        logger.info(
-            "unverified_payload",
-            unverified_payload=unverified_payload,
-        )
         return unverified_payload.get("iss")
     except Exception:
         return None
@@ -101,7 +89,6 @@ def extract_user_info_from_token(token: str) -> Tuple[Optional[str], Optional[st
         # sub is always present
         if "sub" in payload:
             user_id = payload["sub"].split("/")[-1]
-        logger.info("user_info_extracted", user_id=user_id, user_email=user_email)
 
         return user_id, user_email
     except Exception as e:
@@ -125,10 +112,6 @@ async def validate_jwt_token(
     Raises:
         HTTPException: If the token is invalid, untrusted, or if any other error occurs during validation.
     """
-    logger.info(
-        "validate_jwt_token",
-        credentials=credentials,
-    )
     if (
         credentials is None
         or not credentials.scheme == "Bearer"
@@ -136,20 +119,15 @@ async def validate_jwt_token(
     ):
         raise HTTPException(status_code=401, detail="Missing or invalid token")
     token = credentials.credentials
-    logger.info("token_received", token=token)
     issuer = get_issuer_from_token(token)
-    logger.info("issuer_extracted", issuer=issuer)
     if not issuer:
         raise HTTPException(status_code=401, detail="Issuer not found in token")
     jwks_client = jwks_manager.get_jwks_client(issuer)
-    logger.info("jwks_client_result", jwks_client=bool(jwks_client))
     if not jwks_client or not jwks_manager.issuer_config:
         raise HTTPException(status_code=401, detail="Untrusted or missing token issuer")
     cfg = jwks_manager.issuer_config[issuer]
-    logger.info("jwks_config_used", cfg=cfg)
     try:
         signing_key = jwks_client.get_signing_key_from_jwt(token)
-        logger.info("signing_key_obtained", signing_key=str(signing_key))
         payload = decode(
             token,
             signing_key.key,
@@ -157,7 +135,6 @@ async def validate_jwt_token(
             audience=cfg["audience"],
             options={"verify_exp": True},
         )
-        logger.info("jwt_token_validated", payload=payload)
         return payload
     except (PyJWKClientError, PyJWTError) as e:
         logger.warning("jwt_validation_failed", error=str(e), issuer=issuer)


### PR DESCRIPTION
# Summary | Résumé

Cleanup the logging used to debug the production issuer_config (there was a trailing `/` at the issuer key)