### PR TITLE
Feat/isolate google calendar function

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,6 +64,9 @@ class GoogleWorkspaceSettings(BaseSettings):
     GOOGLE_WORKSPACE_CUSTOMER_ID: str = Field(
         default="", alias="GOOGLE_WORKSPACE_CUSTOMER_ID"
     )
+    GOOGLE_SRE_CALENDAR_ID: str = Field(
+        default="", alias="GOOGLE_SRE_CALENDAR_ID"
+    )
 
     GCP_SRE_SERVICE_ACCOUNT_KEY_FILE: str = Field(
         default="", alias="GCP_SRE_SERVICE_ACCOUNT_KEY_FILE"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,9 +64,7 @@ class GoogleWorkspaceSettings(BaseSettings):
     GOOGLE_WORKSPACE_CUSTOMER_ID: str = Field(
         default="", alias="GOOGLE_WORKSPACE_CUSTOMER_ID"
     )
-    GOOGLE_SRE_CALENDAR_ID: str = Field(
-        default="", alias="GOOGLE_SRE_CALENDAR_ID"
-    )
+    GOOGLE_SRE_CALENDAR_ID: str = Field(default="", alias="GOOGLE_SRE_CALENDAR_ID")
 
     GCP_SRE_SERVICE_ACCOUNT_KEY_FILE: str = Field(
         default="", alias="GCP_SRE_SERVICE_ACCOUNT_KEY_FILE"

--- a/app/integrations/google_workspace/google_calendar.py
+++ b/app/integrations/google_workspace/google_calendar.py
@@ -47,7 +47,9 @@ def get_freebusy(time_min, time_max, items, **kwargs):
 
 
 @handle_google_api_errors
-def insert_event(start, end, emails, title, incident_document, **kwargs) -> dict:
+def insert_event(
+    start, end, emails, title, calendar_id="primary", incident_document=None, **kwargs
+) -> dict:
     """Creates a new event in the specified calendars.
 
     Args:
@@ -106,7 +108,7 @@ def insert_event(start, end, emails, title, incident_document, **kwargs) -> dict
         scopes=["https://www.googleapis.com/auth/calendar.events"],
         delegated_user_email=delegated_user_email,
         body=body,
-        calendarId="primary",
+        calendarId=calendar_id,
         supportsAttachments=True,
         sendUpdates="all",
         conferenceDataVersion=1,

--- a/app/modules/dev/google.py
+++ b/app/modules/dev/google.py
@@ -10,6 +10,7 @@ from core.logging import get_module_logger
 
 GOOGLE_WORKSPACE_CUSTOMER_ID = google_service.GOOGLE_WORKSPACE_CUSTOMER_ID
 GOOGLE_SRE_CALENDAR_ID = settings.google_workspace.GOOGLE_SRE_CALENDAR_ID
+SRE_BOT_EMAIL = settings.google_workspace.SRE_BOT_EMAIL
 SRE_DRIVE_ID = settings.google_workspace.SRE_DRIVE_ID
 SRE_INCIDENT_FOLDER = settings.google_workspace.SRE_INCIDENT_FOLDER
 INCIDENT_TEMPLATE = settings.google_workspace.INCIDENT_TEMPLATE
@@ -93,11 +94,7 @@ def google_service_command(ack, client, body, respond, logger):
     event_start = "2025-05-15T15:30:00-04:00"
     event_end = "2025-05-15T16:00:00-04:00"
     event_title = "Test Calendar Event w/o SRE Bot Account"
-    delegated_user_email = "guillaume.charest@cds-snc.ca"
-    attendees = [
-        "sylvia.mclaughlin@cds-snc.ca",
-        "guillaume.charest@cds-snc.ca",
-    ]  # No attendees specified
+    attendees = [SRE_BOT_EMAIL]  # No attendees specified
 
     logger.info("calendar_event", event_start=event_start, event_end=event_end)
     calendar_event = google_calendar.insert_event(
@@ -107,7 +104,6 @@ def google_service_command(ack, client, body, respond, logger):
         title=event_title,
         calendar_id=GOOGLE_SRE_CALENDAR_ID,
         incident_document=None,
-        delegated_user_email=delegated_user_email,
     )
     logger.info("calendar_event_response", response=calendar_event)
 

--- a/app/modules/dev/google.py
+++ b/app/modules/dev/google.py
@@ -74,7 +74,6 @@ def google_service_command(ack, client, body, respond, logger):
     if not groups:
         respond("No groups found.")
         return
-    # log_object_info(groups)
     group = groups[1]
     logger.info("logging_group_details", details=group)
     logger.info("group_email", email=group["email"])
@@ -87,14 +86,11 @@ def google_service_command(ack, client, body, respond, logger):
     respond(f"Found {len(members)} members in group: {email}")
     for member in members:
         logger.info("member_details", details=member)
-        # Uncomment the next line to respond with each member's email
-        # respond(f"Member: {member['email']}")
-    # respond(f"Group: {group['email']}")
 
     event_start = "2025-05-15T15:30:00-04:00"
     event_end = "2025-05-15T16:00:00-04:00"
     event_title = "Test Calendar Event w/o SRE Bot Account"
-    attendees = [SRE_BOT_EMAIL]  # No attendees specified
+    attendees = [SRE_BOT_EMAIL]
 
     logger.info("calendar_event", event_start=event_start, event_end=event_end)
     calendar_event = google_calendar.insert_event(

--- a/app/modules/dev/google.py
+++ b/app/modules/dev/google.py
@@ -2,23 +2,114 @@
 
 from core.config import settings
 from integrations.google_workspace import (
-    google_directory,
+    google_service,
+    google_calendar,
 )
+from core.logging import get_module_logger
 
 
+GOOGLE_WORKSPACE_CUSTOMER_ID = google_service.GOOGLE_WORKSPACE_CUSTOMER_ID
+GOOGLE_SRE_CALENDAR_ID = settings.google_workspace.GOOGLE_SRE_CALENDAR_ID
 SRE_DRIVE_ID = settings.google_workspace.SRE_DRIVE_ID
 SRE_INCIDENT_FOLDER = settings.google_workspace.SRE_INCIDENT_FOLDER
 INCIDENT_TEMPLATE = settings.google_workspace.INCIDENT_TEMPLATE
+logger = get_module_logger()
+handle_google_api_errors = google_service.handle_google_api_errors
 
 
-def get_members(group):
-    members = google_directory.list_group_members(group)
+@handle_google_api_errors
+def get_groups():
+    scopes = ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
+    return google_service.execute_google_api_call(
+        "admin",
+        "directory_v1",
+        "groups",
+        "list",
+        scopes,
+        paginate=True,
+        customer=GOOGLE_WORKSPACE_CUSTOMER_ID,
+        maxResults=200,
+        orderBy="email",
+    )
+
+
+@handle_google_api_errors
+def get_members(group_key):
+    scopes = ["https://www.googleapis.com/auth/admin.directory.group.member.readonly"]
+    members = google_service.execute_google_api_call(
+        "admin",
+        "directory_v1",
+        "members",
+        "list",
+        scopes,
+        paginate=True,
+        groupKey=group_key,
+        maxResults=200,
+    )
     return members
+
+
+def log_object_info(obj):
+    """Logs only the keys of a dict or the type/length of a list."""
+    if isinstance(obj, dict):
+        logger.info(f"Dict keys: {list(obj.keys())}")
+    elif isinstance(obj, list):
+        logger.info(f"List of length {len(obj)}")
+        if obj:
+            log_object_info(obj[0])
+    elif isinstance(obj, tuple):
+        logger.info(f"Tuple of length {len(obj)}")
+        for idx, item in enumerate(obj):
+            logger.info(f"Tuple item {idx}:")
+            log_object_info(item)
+    else:
+        logger.info(f"Object type: {type(obj).__name__}")
+    return True
 
 
 def google_service_command(ack, client, body, respond, logger):
     ack()
-    respond("Nothing to see here.")
+    groups = get_groups()
+    if not groups:
+        respond("No groups found.")
+        return
+    # log_object_info(groups)
+    group = groups[1]
+    logger.info("logging_group_details", details=group)
+    logger.info("group_email", email=group["email"])
+    email = group["email"]
+    members = get_members(email)
+    if not members:
+        respond(f"No members found in group: {email}")
+        return
+    log_object_info(members)
+    respond(f"Found {len(members)} members in group: {email}")
+    for member in members:
+        logger.info("member_details", details=member)
+        # Uncomment the next line to respond with each member's email
+        # respond(f"Member: {member['email']}")
+    # respond(f"Group: {group['email']}")
+
+    event_start = "2025-05-15T15:30:00-04:00"
+    event_end = "2025-05-15T16:00:00-04:00"
+    event_title = "Test Calendar Event w/o SRE Bot Account"
+    delegated_user_email = "guillaume.charest@cds-snc.ca"
+    attendees = [
+        "sylvia.mclaughlin@cds-snc.ca",
+        "guillaume.charest@cds-snc.ca",
+    ]  # No attendees specified
+
+    logger.info("calendar_event", event_start=event_start, event_end=event_end)
+    calendar_event = google_calendar.insert_event(
+        start=event_start,
+        end=event_end,
+        emails=attendees,
+        title=event_title,
+        calendar_id=GOOGLE_SRE_CALENDAR_ID,
+        incident_document=None,
+        delegated_user_email=delegated_user_email,
+    )
+    logger.info("calendar_event_response", response=calendar_event)
 
 
 def test_content():

--- a/app/tests/integrations/google_workspace/test_google_calendar.py
+++ b/app/tests/integrations/google_workspace/test_google_calendar.py
@@ -192,7 +192,9 @@ def test_insert_event_no_kwargs_no_delegated_email(
     emails = ["test1@test.com", "test2@test.com"]
     title = "Test Event"
     document_id = "test_document_id"
-    result = google_calendar.insert_event(start, end, emails, title, document_id)
+    result = google_calendar.insert_event(
+        start, end, emails, title, incident_document=document_id
+    )
     assert result == {
         "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
         "event_link": "test_link",
@@ -284,7 +286,7 @@ def test_insert_event_with_kwargs(
         },
     }
     result = google_calendar.insert_event(
-        start, end, emails, title, document_id, **kwargs
+        start, end, emails, title, incident_document=document_id, **kwargs
     )
     assert result == {
         "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
@@ -359,7 +361,7 @@ def test_insert_event_with_no_document(
         },
     }
     result = google_calendar.insert_event(
-        start, end, emails, title, document_id, **kwargs
+        start, end, emails, title, incident_document=document_id, **kwargs
     )
     assert result == {
         "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
@@ -418,7 +420,10 @@ def test_insert_event_google_hangout_link_created(
     emails = ["test1@test.com", "test2@test.com"]
     title = "Test Event"
     document_id = "test_document_id"
-    result = google_calendar.insert_event(start, end, emails, title, document_id)
+
+    result = google_calendar.insert_event(
+        start, end, emails, title, incident_document=document_id
+    )
     assert result == {
         "event_info": "Retro has been scheduled for Thursday, July 25, 2024 at 01:30 PM EDT. Check your calendar for more details.",
         "event_link": "test_link",


### PR DESCRIPTION
# Summary | Résumé

This PR introduces enhancements to the Google Workspace integration around the calendar event management.  We are adding support for specifying a custom calendar ID when inserting events so that they can be added to other calendars, for example to a group calendar. 

Tests have been performed with the `google.py` module and the dedicated Service Account user can post a new event to group calendars if it is a member of the calendar and has `Make changes to events` role in that calendar's sharing settings.

### Enhancements to Google Calendar Event Management:
* Added `GOOGLE_SRE_CALENDAR_ID` to `GoogleWorkspaceSettings` for specifying a custom calendar ID. This will be required for the next iteration where incidents retro events are posted to a group calendar (`app/core/config.py`)
* Updated the `insert_event` function to accept a `calendar_id` parameter, replacing the hardcoded default value of `"primary"`. (`app/integrations/google_workspace/google_calendar.py`) [[1]](diffhunk://#diff-265efe0d402db5b7721761c65d7273594405a1c6580c894f47c2c49a6961c5b3L50-R52) [[2]](diffhunk://#diff-265efe0d402db5b7721761c65d7273594405a1c6580c894f47c2c49a6961c5b3L109-R111)

### Test Updates for `insert_event`:
* Modified test cases to align with the updated `insert_event` method signature, explicitly passing `incident_document` as a named argument. (`app/tests/integrations/google_workspace/test_google_calendar.py`) [[1]](diffhunk://#diff-77ca585cf7aec7a65891aec520a0eadfc9201f198c975f2ee2113a6e2ee34f5fL195-R197) [[2]](diffhunk://#diff-77ca585cf7aec7a65891aec520a0eadfc9201f198c975f2ee2113a6e2ee34f5fL287-R289) [[3]](diffhunk://#diff-77ca585cf7aec7a65891aec520a0eadfc9201f198c975f2ee2113a6e2ee34f5fL362-R364) [[4]](diffhunk://#diff-77ca585cf7aec7a65891aec520a0eadfc9201f198c975f2ee2113a6e2ee34f5fL421-R426)