### PR TITLE
fix: remove google api scope for Role cmd

### DIFF
--- a/app/modules/role/role.py
+++ b/app/modules/role/role.py
@@ -219,7 +219,6 @@ def role_view_handler(ack, body, say, client):
         role_name,
         INTERNAL_TALENT_FOLDER,
         "id",
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     folder_id = None
@@ -246,7 +245,6 @@ def role_view_handler(ack, body, say, client):
         f"Template 2022/06 - {role_name} Interview Panel Scoring Document - <year/month> ",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Scoring Guide", scoring_guide_id)
@@ -256,7 +254,6 @@ def role_view_handler(ack, body, say, client):
         f"Template EN+FR 2022/09- {role_name} - Core Values Panel - Interview Guide - <year/month> - <candidate initials> ",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Core Values Interview Notes", core_values_interview_notes_id)
@@ -266,7 +263,6 @@ def role_view_handler(ack, body, say, client):
         f"Template EN+FR 2022/09 - {role_name} - Technical Panel - Interview Guide - <year/month> - <candidate initials> ",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Technical Interview Notes", technical_interview_notes_id)
@@ -276,7 +272,6 @@ def role_view_handler(ack, body, say, client):
         f"TEMPLATE Month YYYY - {role_name} - Kick-off form",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Intake Form", intake_form_id)
@@ -286,7 +281,6 @@ def role_view_handler(ack, body, say, client):
         "Phone Screen - Template",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Phone Screen Template", phone_screen_template_id)
@@ -296,7 +290,6 @@ def role_view_handler(ack, body, say, client):
         f"Recruitment Feedback - {role_name}",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created(
@@ -308,7 +301,6 @@ def role_view_handler(ack, body, say, client):
         f"Panelist Guidebook - Interview Best Practices - {role_name}",
         TEMPLATES_FOLDER,
         folder_id,
-        scopes=ROLE_SCOPES,
         delegated_user_email=BOT_EMAIL,
     )
     log_document_created("Panelist Guidebook Template", panelist_guidebook_template_id)

--- a/app/tests/modules/role/test_role.py
+++ b/app/tests/modules/role/test_role.py
@@ -310,7 +310,6 @@ def test_update_modal_locale_to_FR():
 
 @patch.object(role, "INTERNAL_TALENT_FOLDER", "internal_talent_folder")
 @patch("modules.role.role.BOT_EMAIL", "bot_email")
-@patch("modules.role.role.ROLE_SCOPES", ["https://www.googleapis.com/auth/drive"])
 @patch("modules.role.role.google_drive.copy_file_to_folder")
 @patch("modules.role.role.google_drive.create_folder")
 def test_create_new_folder(mock_create_new_folder, mock_copy_file_to_folder):
@@ -325,14 +324,12 @@ def test_create_new_folder(mock_create_new_folder, mock_copy_file_to_folder):
         "foo",
         "internal_talent_folder",
         "id",
-        scopes=["https://www.googleapis.com/auth/drive"],
         delegated_user_email="bot_email",
     )
 
 
 @patch.object(role, "INTERNAL_TALENT_FOLDER", "internal_talent_folder")
 @patch("modules.role.role.BOT_EMAIL", "bot_email")
-@patch("modules.role.role.ROLE_SCOPES", ["https://www.googleapis.com/auth/drive"])
 @patch("modules.role.role.logger")
 @patch("modules.role.role.google_drive.copy_file_to_folder")
 @patch("modules.role.role.google_drive.create_folder")
@@ -349,7 +346,6 @@ def test_create_new_folder_failed(
         "foo",
         "internal_talent_folder",
         "id",
-        scopes=["https://www.googleapis.com/auth/drive"],
         delegated_user_email="bot_email",
     )
     mock_logger.error.assert_called_once_with(
@@ -360,7 +356,6 @@ def test_create_new_folder_failed(
 
 @patch.multiple(role, **ROLE_CONSTANTS)  # type: ignore
 @patch("modules.role.role.BOT_EMAIL", "bot_email")
-@patch("modules.role.role.ROLE_SCOPES", ["https://www.googleapis.com/auth/drive"])
 @patch("modules.role.role.logger")
 @patch("modules.role.role.google_drive.create_folder")
 @patch("modules.role.role.google_drive.copy_file_to_folder")
@@ -382,7 +377,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Template 2022/06 - foo Interview Panel Scoring Document - <year/month> ",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -390,7 +384,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Template EN+FR 2022/09- foo - Core Values Panel - Interview Guide - <year/month> - <candidate initials> ",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -398,7 +391,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Template EN+FR 2022/09 - foo - Technical Panel - Interview Guide - <year/month> - <candidate initials> ",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -406,7 +398,6 @@ def test_copy_files_to_internal_talent_folder(
                 "TEMPLATE Month YYYY - foo - Kick-off form",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -414,7 +405,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Phone Screen - Template",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -422,7 +412,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Recruitment Feedback - foo",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
             call(
@@ -430,7 +419,6 @@ def test_copy_files_to_internal_talent_folder(
                 "Panelist Guidebook - Interview Best Practices - foo",
                 "mock_templates_folder",
                 "folder_id",
-                scopes=["https://www.googleapis.com/auth/drive"],
                 delegated_user_email="bot_email",
             ),
         ]


### PR DESCRIPTION
# Summary | Résumé

Fixing the Role cmd by removing the scope from within Google Workspace API calls.