### PR TITLE
Fix: handle none argument for metadata

### DIFF
--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -351,6 +351,8 @@ def generate_incident_modal_view(
     """Generate the incident creation modal view."""
     if options is None:
         options = []
+    if not private_metadata:
+        private_metadata = ""
     handbook_string = f"For more details on what constitutes a security incident, visit our <{INCIDENT_HANDBOOK_URL}|Incident Management Handbook>"
     return {
         "type": "modal",


### PR DESCRIPTION
# Summary | Résumé

Fix the incident command payload to handle none argument in private_metadata