### PR TITLE
Feat/add incident resources creation command

### DIFF
--- a/app/integrations/slack/commands.py
+++ b/app/integrations/slack/commands.py
@@ -21,7 +21,8 @@ def parse_command(command):
             else:
                 in_quote = True
         elif char == " " and not in_quote:
-            args.append(arg)
+            if arg:
+                args.append(arg)
             arg = ""
         else:
             arg += char

--- a/app/integrations/slack/commands.py
+++ b/app/integrations/slack/commands.py
@@ -28,3 +28,38 @@ def parse_command(command):
     if arg:
         args.append(arg)
     return args
+
+
+def parse_flags(args: list[str]) -> tuple[list[str], dict[str, str | bool]]:
+    """
+    Parses a list of arguments into positional args and flags.
+    This can be used in conjunction with parse_command to support flags in commands.
+
+    Flags can be --flag, --key value, or -f.
+
+    Args:
+        args (List[str]): The list of arguments.
+    Returns:
+        Tuple[List[str], Dict[str, Union[str, bool]]]: A tuple containing the list of positional arguments and a dictionary of flags.
+    """
+    positional: list[str] = []
+    flags: dict[str, str | bool] = {}
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("--"):
+            key = arg.lstrip("-")
+            if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                flags[key] = args[i + 1]
+                i += 2
+            else:
+                flags[key] = True
+                i += 1
+        elif arg.startswith("-") and len(arg) == 2:
+            key = arg.lstrip("-")
+            flags[key] = True
+            i += 1
+        else:
+            positional.append(arg)
+            i += 1
+    return positional, flags

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -1,7 +1,6 @@
 """Core module to handle Incident creation"""
 
 from slack_sdk import WebClient
-from slack_bolt import Say
 
 from core.config import settings
 from core.logging import get_module_logger

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -155,16 +155,22 @@ def initiate_resources_creation(
         client.conversations_invite(
             channel=incident_payload.channel_id, users=users_to_invite
         )
+    text = """🚨 *Incident Resources Created Successfully!*
+*Next Steps - Available Commands:*
+• `/sre incident roles manage` - Assign roles to the incident
+• `/sre incident schedule retro` - Schedule a retrospective meeting  
+• `/sre incident close` - Close and archive this incident
+• `/sre incident status update <status>` - Update incident status
+• `/sre incident updates add` - Add incident updates
+• `/sre incident show` - View incident details
 
-    text = "Run `/sre incident roles` to assign roles to the incident"
+*Quick Actions:*
+📋 Use the bookmarked incident report above to document findings
+👥 Assign roles to team members for clear responsibilities  
+📅 Schedule a retro meeting when ready
+
+_Type_ `/sre incident help` _for complete command list_"""
     client.chat_postMessage(text=text, channel=incident_payload.channel_id)
-
-    text = "Run `/sre incident close` to update the status of the incident document and incident spreadsheet to closed and to archive the channel"
-    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
-
-    text = "Run `/sre incident schedule` to let the SRE bot schedule a Retro Google calendar meeting for all participants."
-    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
-
     incident_document.update_boilerplate_text(
         document_id,
         incident_payload.name,

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -24,7 +24,6 @@ logger = get_module_logger()
 
 def initiate_resources_creation(
     client: WebClient,
-    say: Say,
     incident_payload: IncidentPayload,
 ):
     """Create an incident and its related resources. If incident Slack channel provided, skips that resource creation"""
@@ -54,7 +53,8 @@ def initiate_resources_creation(
         f"<@{incident_payload.user_id}> a initié un nouvel incident: {incident_payload.name} pour {incident_payload.product}"
         f" dans <#{incident_payload.channel_id}>"
     )
-    say(text=text, channel=INCIDENT_CHANNEL)
+    if INCIDENT_CHANNEL:
+        client.chat_postMessage(text=text, channel=INCIDENT_CHANNEL)
 
     # Add incident creator to channel
     client.conversations_invite(
@@ -80,7 +80,7 @@ def initiate_resources_creation(
     )
 
     text = f"A hangout has been created at: {meet_link['meetingUri']}"
-    say(text=text, channel=incident_payload.channel_id)
+    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
     # Create incident document
     document_id = incident_document.create_incident_document(
@@ -128,7 +128,7 @@ def initiate_resources_creation(
     )
 
     text = f":lapage: An incident report has been created at: {document_link}"
-    say(text=text, channel=incident_payload.channel_id)
+    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
     # Gather all user IDs in a list to ensure uniqueness
     users_to_invite = []
@@ -157,13 +157,13 @@ def initiate_resources_creation(
         )
 
     text = "Run `/sre incident roles` to assign roles to the incident"
-    say(text=text, channel=incident_payload.channel_id)
+    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
     text = "Run `/sre incident close` to update the status of the incident document and incident spreadsheet to closed and to archive the channel"
-    say(text=text, channel=incident_payload.channel_id)
+    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
     text = "Run `/sre incident schedule` to let the SRE bot schedule a Retro Google calendar meeting for all participants."
-    say(text=text, channel=incident_payload.channel_id)
+    client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
     incident_document.update_boilerplate_text(
         document_id,

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -157,7 +157,7 @@ def initiate_resources_creation(
     text = """🚨 *Incident Resources Created Successfully!*
 *Next Steps - Available Commands:*
 • `/sre incident roles manage` - Assign roles to the incident
-• `/sre incident schedule retro` - Schedule a retrospective meeting  
+• `/sre incident schedule retro` - Schedule a retrospective meeting
 • `/sre incident close` - Close and archive this incident
 • `/sre incident status update <status>` - Update incident status
 • `/sre incident updates add` - Add incident updates
@@ -165,7 +165,7 @@ def initiate_resources_creation(
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings
-👥 Assign roles to team members for clear responsibilities  
+👥 Assign roles to team members for clear responsibilities
 📅 Schedule a retro meeting when ready
 
 _Type_ `/sre incident help` _for complete command list_"""

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -202,7 +202,6 @@ def submit(ack: Ack, view, say, body, client: WebClient):  # noqa: C901
     try:
         core.initiate_resources_creation(
             client=client,
-            say=say,
             incident_payload=incident_payload,
         )
     except Exception as e:

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -21,7 +21,6 @@ from modules.incident import (
     db_operations,
     information_display,
     information_update,
-    core as incident_core,
 )
 from core.config import settings
 from core.logging import get_module_logger
@@ -62,7 +61,7 @@ Usage:
 
 *Examples:*
 - `/sre incident create`
-- `/sre incident channel list --stale`
+- `/sre incident list --stale`
 - `/sre incident close`
 - `/sre incident show`
 - `/sre incident products create "foo bar"`
@@ -104,7 +103,7 @@ Utilisation:
 
 *Exemples:*
 - `/sre incident create`
-- `/sre incident channel list --stale`
+- `/sre incident list --stale`
 - `/sre incident close`
 - `/sre incident show`
 - `/sre incident products create "foo bar"`
@@ -247,12 +246,10 @@ def handle_close(client, body, respond, ack, _args, _flags):
 
 def handle_create(_client, _body, respond, _ack, args: list[str], _flags: dict):
     """Handle create command."""
-    create_help_text = (
-        "\n `/sre incident create [resource] [options]`"
-        "\n"
-        "\n*Resources*"
-        "\n new [<incident_name>]        - create a new incident (upcoming feature)"
-    )
+    create_help_text = """`/sre incident create [resource] [options]`
+
+*Resources:*
+• `new [<incident_name>]` — create a new incident (upcoming feature)"""
     try:
         resource = args.pop(0)
     except IndexError:
@@ -277,18 +274,13 @@ def handle_show(client, body, respond, _ack, _args, _flags):
 
 def handle_list(client, body, respond, ack, args, _flags):
     """Handle list command."""
-    list_help_text = (
-        "\n `/sre incident list [options]`"
-        "\n      "
-        "\n*Options*"
-        "\n active"
-        "\n      - lists all active incidents (default; not stale or archived)"
-        "\n      - liste tous les incidents actifs (par défaut; ni obsolètes ni archivés)"
-        "\n stale"
-        "\n      - lists all incidents older than 14 days with no activity"
-        "\n      - liste tous les incidents plus vieux que 14 jours sans activité"
-        "\n Use `/sre incident help` to see a list of commands."
-    )
+    list_help_text = """`/sre incident list [options]`
+
+*Options:*
+• `active` — lists all active incidents (default; not stale or archived)
+• `stale` — lists all incidents older than 14 days with no activity
+
+Use `/sre incident help` to see a list of commands."""
     try:
         option = args.pop(0)
     except IndexError:
@@ -304,14 +296,12 @@ def handle_list(client, body, respond, ack, args, _flags):
 
 def handle_schedule(client, body, respond, ack, args, _flags):
     """Handle the schedule command"""
-    schedule_help_text = (
-        "\n `/sre incident schedule [options]`"
-        "\n"
-        "\n*Options*"
-        "\n retro             - schedule a retrospective for the incident"
-        "\n"
-        "\nUse `/sre incident help` to see a list of commands."
-    )
+    schedule_help_text = """`/sre incident schedule [options]`
+
+*Options:*
+• `retro` — schedule a retrospective for the incident
+
+Use `/sre incident help` to see a list of commands."""
     try:
         option = args.pop(0)
     except IndexError:
@@ -328,12 +318,10 @@ def handle_schedule(client, body, respond, ack, args, _flags):
 
 def handle_channels(_client, _body, respond, _ack, action, _args, _flags):
     """Handle the channels command."""
-    channels_help_text = (
-        "\n `/sre incident channels <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n <Upcoming feature>  - manage incident channels"
-    )
+    channels_help_text = """`/sre incident channels <action> [options] [arguments]`
+
+*Actions:*
+• `<Upcoming feature>` — manage incident channels"""
     match action:
         case _:
             respond(channels_help_text)
@@ -341,16 +329,14 @@ def handle_channels(_client, _body, respond, _ack, action, _args, _flags):
 
 def handle_products(client, body, respond, ack, action, args, flags):
     """Handle the products command."""
-    product_help_text = (
-        "\n `/sre incident products <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n create <product_name>      - create a new product name to be referenced in the incident resources"
-        '\n          _Tip: Use quotes for multi-word product names: `create "product name"`_'
-        "\n list                      - list all products currently available in the incident resources"
-        "\n"
-        "\nUse `/sre incident help` to see a list of commands."
-    )
+    product_help_text = """`/sre incident products <action> [options] [arguments]`
+
+*Actions:*
+• `create <product_name>` — create a new product name to be referenced in the incident resources
+  _Tip: Use quotes for multi-word product names: `create "product name"`_
+• `list` — list all products currently available in the incident resources
+
+Use `/sre incident help` to see a list of commands."""
     match action:
         case "create":
             name = " ".join(args)
@@ -373,15 +359,15 @@ def handle_products(client, body, respond, ack, action, args, flags):
 
 def handle_status(client, body, respond, ack, action, args, _flags):
     """Handle the status command."""
-    status_help_text = (
-        "\n `/sre incident status [options] [arguments]`"
-        "\n"
-        "\n*Options*"
-        "\n show              - show the current incident status"
-        "\n update <status>   - update the incident status to one of the valid statuses"
-        "\n"
-        "\n*Valid Statuses*"
-        "\n" + ", ".join(VALID_STATUS)
+    status_help_text = """`/sre incident status [options] [arguments]`
+
+*Options:*
+• `show` — show the current incident status
+• `update <status>` — update the incident status to one of the valid statuses
+
+*Valid Statuses:*
+""" + ", ".join(
+        VALID_STATUS
     )
     match action:
         case "update":
@@ -397,13 +383,11 @@ def handle_status(client, body, respond, ack, action, args, _flags):
 
 def handle_roles(client, body, respond, ack, action, _args, _flags):
     """Handle the roles command."""
-    roles_help_text = (
-        "\n `/sre incident roles <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n manage          - manage incident roles"
-        "\n show            - show current incident roles"
-    )
+    roles_help_text = """`/sre incident roles <action> [options] [arguments]`
+
+*Actions:*
+• `manage` — manage incident roles
+• `show` — show current incident roles"""
     match action:
         case "manage":
             incident_roles.manage_roles(client, body, ack, respond)
@@ -415,13 +399,11 @@ def handle_roles(client, body, respond, ack, action, _args, _flags):
 
 def handle_updates(client, body, respond, ack, action, _args, _flags):
     """Handle the updates command."""
-    updates_help_text = (
-        "\n `/sre incident updates <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n add             - add updates to the incident"
-        "\n show            - show current incident updates"
-    )
+    updates_help_text = """`/sre incident updates <action> [options] [arguments]`
+
+*Actions:*
+• `add` — add updates to the incident
+• `show` — show current incident updates"""
 
     match action:
         case "add":

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -180,7 +180,7 @@ def get_incident_actions() -> dict[str, Callable]:
 def get_resource_handlers():
     """Returns a dictionary mapping resources to their handler functions."""
     return {
-        "channel": handle_channels,
+        "channels": handle_channels,
         "product": handle_products,
         "roles": handle_roles,
         "updates": handle_updates,

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -377,7 +377,7 @@ def handle_status(client, body, respond, ack, action, args, _flags):
         "\n `/sre incident status [options] [arguments]`"
         "\n"
         "\n*Options*"
-        "\n show             - show the current incident status"
+        "\n show              - show the current incident status"
         "\n update <status>   - update the incident status to one of the valid statuses"
         "\n"
         "\n*Valid Statuses*"

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -46,7 +46,7 @@ Usage:
 `/sre incident [<resource>] <action> [options] [arguments]`
 
 *Resources:*
-• channel      - Manage incident channels
+• channels     - Manage incident channels
 • products     - Manage incident products (aka folders)
 • roles        - Manage incident roles
 • updates      - Add or show incident updates
@@ -88,7 +88,7 @@ Utilisation:
 `/sre incident [<ressource>] <action> [options] [arguments]`
 
 *Ressources:*
-• channel      - Gérer les canaux d'incidents
+• channels     - Gérer les canaux d'incidents
 • products     - Gérer les produits d'incidents (dossiers)
 • roles        - Gérer les rôles d'incidents
 • updates      - Ajouter ou afficher des mises à jour d'incidents
@@ -101,6 +101,16 @@ Utilisation:
 • help         - Afficher ce message d'aide
 • schedule     - Planifier un événement pour l'incident
 • show         - Afficher les détails de l'incident en cours
+
+*Exemples:*
+- `/sre incident create`
+- `/sre incident channel list --stale`
+- `/sre incident close`
+- `/sre incident show`
+- `/sre incident products create "foo bar"`
+- `/sre incident schedule retro`
+- `/sre incident status update Ready to be Reviewed`
+- `/sre incident updates add "new update"`
 
 *Commandes obsolètes (seront supprimées après le 2025-11-01):*
 • add_summary

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -300,7 +300,7 @@ def handle_schedule(client, body, respond, ack, args, flags):
     try:
         option = args.pop(0)
     except IndexError:
-        option = None
+        option = "retro"  # default to retro if no option is provided
     match option:
         case "retro":
             schedule_retro.open_incident_retro_modal(client, body, ack)

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -231,11 +231,6 @@ def handle_help(_client, _body, respond, _ack, _args, _flags) -> None:
     respond(help_text)
 
 
-def handle_details(client, body, respond, _ack, _args, _flags):
-    """Handle details command."""
-    information_display.open_incident_info_view(client, body, respond)
-
-
 def handle_close(client, body, respond, ack, _args, _flags):
     close_incident(client, body, ack, respond)
 
@@ -260,7 +255,13 @@ def handle_create(_client, _body, respond, _ack, args: list[str], _flags: dict):
             respond(create_help_text)
 
 
-def handle_list(client, body, respond, ack, args, flags):
+def handle_details(client, body, respond, _ack, _args, _flags):
+    """Handle details command."""
+    information_display.open_incident_info_view(client, body, respond)
+
+
+def handle_list(client, body, respond, ack, args, _flags):
+    """Handle list command."""
     list_help_text = (
         "\n `/sre incident list [options]`"
         "\n      "
@@ -286,7 +287,31 @@ def handle_list(client, body, respond, ack, args, flags):
             respond(list_help_text)
 
 
-def handle_updates(client, body, respond, ack, args, flags):
+def handle_schedule(client, body, respond, ack, args, flags):
+    """Handle the schedule command"""
+    schedule_help_text = (
+        "\n `/sre incident schedule [options]`"
+        "\n"
+        "\n*Options*"
+        "\n retro             - schedule a retrospective for the incident"
+        "\n"
+        "\nUse `/sre incident help` to see a list of commands."
+    )
+    try:
+        option = args.pop(0)
+    except IndexError:
+        option = None
+    match option:
+        case "retro":
+            schedule_retro.open_incident_retro_modal(client, body, ack)
+        case _:
+            respond(schedule_help_text)
+
+
+# resource level actions
+
+
+def handle_updates(client, body, respond, ack, _args, flags):
     """Handle the updates command."""
     if "--add" in flags:
         open_updates_dialog(client, body, ack)
@@ -328,19 +353,6 @@ def handle_product(client, body, respond, ack, action, args, flags):
             incident_folder.list_folders_view(client, body, ack)
         case _:
             respond(product_help_text)
-
-
-def handle_schedule(client, body, respond, ack, args, flags):
-    if not args:
-        args = ["retro"]
-    action = args[0]
-    match action:
-        case "retro":
-            schedule_retro.open_incident_retro_modal(client, body, ack)
-        case _:
-            respond(
-                f"Unknown schedule action: {action}. Currently, only 'retro' is supported."
-            )
 
 
 def handle_status(client, body, respond, ack, action, args, _flags):
@@ -394,7 +406,6 @@ def handle_legacy_stale(client, body, respond, ack, _args, _flags):
     respond(
         "The `/sre incident stale` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident list --stale` instead."
     )
-    # Optionally, call the new handler logic:
     stale_incidents(client, body, ack)
 
 

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -76,7 +76,7 @@ Usage:
 • list-folders
 • stale
 
-_For details on each subcommand, use:_  
+_For details on each subcommand, use:_
 `/sre incident <subcommand> help`
 
 ---
@@ -249,7 +249,8 @@ def handle_create(_client, _body, respond, _ack, args: list[str], _flags: dict):
     create_help_text = """`/sre incident create [resource] [options]`
 
 *Resources:*
-• `new [<incident_name>]` — create a new incident (upcoming feature)"""
+• `new [<incident_name>]` — create a new incident (upcoming feature)
+• `resources` — create resources for an existing incident (document, meet links, etc.) (upcoming feature)"""
     try:
         resource = args.pop(0)
     except IndexError:

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -216,7 +216,7 @@ def handle_incident_command(
     if first_arg in resource_handlers:
         # this is to handle if the argument is a resource
         resource = first_arg
-        action = args_list.pop(0) if len(args_list) > 1 else "help"
+        action = args_list.pop(0) if args_list else "help"
         resource_handler: Callable = resource_handlers[resource]
         resource_handler(client, body, respond, ack, action, args_list, flags)
     elif first_arg in incident_actions:

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -236,6 +236,10 @@ def handle_details(client, body, respond, _ack, _args, _flags):
     information_display.open_incident_info_view(client, body, respond)
 
 
+def handle_close(client, body, respond, ack, _args, _flags):
+    close_incident(client, body, ack, respond)
+
+
 def handle_create(_client, _body, respond, _ack, args: list[str], _flags: dict):
     """Handle create command."""
     create_help_text = (
@@ -266,10 +270,6 @@ def handle_create(_client, _body, respond, _ack, args: list[str], _flags: dict):
                 respond(f"Failed to create folder `{name}`.")
         case _:
             respond(create_help_text)
-
-
-def handle_close(client, body, respond, ack, args, flags):
-    close_incident(client, body, ack, respond)
 
 
 def handle_list(client, body, respond, ack, _args, flags):

--- a/app/tests/integrations/slack/test_commands.py
+++ b/app/tests/integrations/slack/test_commands.py
@@ -19,3 +19,17 @@ def test_parse_command_two_args():
 
 def test_parse_command_with_quotes():
     assert slack_commands.parse_command('sre "foo bar baz"') == ["sre", "foo bar baz"]
+
+
+def test_parse_flags_no_flags():
+    args, flags = slack_commands.parse_flags(["sre", "foo", "bar"])
+    assert args == ["sre", "foo", "bar"]
+    assert flags == {}
+
+
+def test_parse_flags_with_flags():
+    args, flags = slack_commands.parse_flags(
+        ["sre", "foo", "--flag", "--key", "value", "-f"]
+    )
+    assert args == ["sre", "foo"]
+    assert flags == {"flag": True, "key": "value", "f": True}

--- a/app/tests/integrations/slack/test_commands.py
+++ b/app/tests/integrations/slack/test_commands.py
@@ -33,3 +33,19 @@ def test_parse_flags_with_flags():
     )
     assert args == ["sre", "foo"]
     assert flags == {"flag": True, "key": "value", "f": True}
+
+    args, flags = slack_commands.parse_flags(
+        ["-f", "--key", "value", "sre", "foo", "--flag"]
+    )
+    assert args == ["sre", "foo"]
+    assert flags == {"flag": True, "key": "value", "f": True}
+
+
+def test_parse_command_with_flags():
+    command = 'sre foo --flag --key "value with spaces" -f'
+    args = slack_commands.parse_command(command)
+    assert args == ["sre", "foo", "--flag", "--key", "value with spaces", "-f"]
+
+    positional, flags = slack_commands.parse_flags(args)
+    assert positional == ["sre", "foo"]
+    assert flags == {"flag": True, "key": "value with spaces", "f": True}

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -246,7 +246,6 @@ def test_incident_submit_calls_succeeds(
 
     mock_core.initiate_resources_creation.assert_called_once_with(
         client=client,
-        say=say,
         incident_payload=incident_payload,
     )
 

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -17,6 +17,7 @@ def helper_generate_default_incident_params():
     )
 
 
+@patch("modules.incident.core.INCIDENT_CHANNEL", "incident-channel")
 @patch("modules.incident.core.logger")
 @patch("modules.incident.core.on_call.get_on_call_users_from_folder")
 @patch("modules.incident.core.db_operations")
@@ -110,7 +111,7 @@ _Type_ `/sre incident help` _for complete command list_"""
     )
     client.chat_postMessage.assert_any_call(
         text="<@user_id> has kicked off a new incident: name for product in <#channel_id>\n<@user_id> a initié un nouvel incident: name pour product dans <#channel_id>",
-        channel=core.INCIDENT_CHANNEL,
+        channel="incident-channel",
     )
     mock_google_meet.create_space.assert_called_once()
     client.bookmarks_add.assert_has_calls(

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -82,7 +82,7 @@ def test_initiate_resources_creation_succeeds(
             },
         ],
     }
-    core.initiate_resources_creation(client, say, incident_payload)
+    core.initiate_resources_creation(client, incident_payload)
 
     # this must be performed before the resources creation is called.
     client.conversations_create.assert_not_called()
@@ -94,7 +94,7 @@ def test_initiate_resources_creation_succeeds(
     client.conversations_setPurpose.assert_called_once_with(
         channel="channel_id", purpose="name"
     )
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text="<@user_id> has kicked off a new incident: name for product in <#channel_id>\n<@user_id> a initié un nouvel incident: name pour product dans <#channel_id>",
         channel=core.INCIDENT_CHANNEL,
     )
@@ -123,7 +123,7 @@ def test_initiate_resources_creation_succeeds(
         },
     )
 
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text="A hangout has been created at: https://meet.google.com/aaa-bbbb-ccc",
         channel="channel_id",
     )
@@ -165,20 +165,20 @@ def test_initiate_resources_creation_succeeds(
         any_order=True,
     )
 
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text=":lapage: An incident report has been created at: https://docs.google.com/document/d/document_id/edit",
         channel="channel_id",
     )
 
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text="Run `/sre incident roles` to assign roles to the incident",
         channel="channel_id",
     )
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text="Run `/sre incident close` to update the status of the incident document and incident spreadsheet to closed and to archive the channel",
         channel="channel_id",
     )
-    say.assert_any_call(
+    client.chat_postMessage.assert_any_call(
         text="Run `/sre incident schedule` to let the SRE bot schedule a Retro Google calendar meeting for all participants.",
         channel="channel_id",
     )
@@ -216,7 +216,7 @@ def test_initiate_resources_creation_oncall_fails(
     client = MagicMock()
     say = MagicMock()
     with pytest.raises(Exception) as excinfo:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     assert str(excinfo.value) == "oncall error"
     mock_create_incident_conversation.assert_not_called()
     mock_google_meet.create_space.assert_not_called()
@@ -248,7 +248,7 @@ def test_initiate_resources_creation_meet_fails(
     client = MagicMock()
     say = MagicMock()
     with pytest.raises(Exception) as excinfo:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     assert str(excinfo.value) == "meet error"
     mock_create_incident_conversation.assert_not_called()
     mock_google_meet.create_space.assert_called_once()
@@ -281,7 +281,7 @@ def test_initiate_resources_creation_document_fails(
     client = MagicMock()
     say = MagicMock()
     with pytest.raises(Exception) as excinfo:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     assert str(excinfo.value) == "doc error"
     mock_create_incident_conversation.assert_not_called()
     mock_google_meet.create_space.assert_called_once()
@@ -317,7 +317,7 @@ def test_initiate_resources_creation_db_fails(
     client = MagicMock()
     say = MagicMock()
     with pytest.raises(Exception) as excinfo:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     assert str(excinfo.value) == "db error"
     mock_create_incident_conversation.assert_not_called()
     mock_google_meet.create_space.assert_called_once()
@@ -354,7 +354,7 @@ def test_initiate_resources_creation_security_group_fails(
     say = MagicMock()
     client.usergroups_users_list.side_effect = Exception("security error")
     try:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     except Exception as e:
         assert str(e) == "security error"
     mock_create_incident_conversation.assert_not_called()
@@ -406,7 +406,7 @@ def test_initiate_resources_creation_no_users_to_invite(
     client = MagicMock()
     say = MagicMock()
     client.usergroups_users_list.return_value = {"ok": True, "users": ["user_id"]}
-    core.initiate_resources_creation(client, say, incident_payload)
+    core.initiate_resources_creation(client, incident_payload)
     client.conversations_invite.assert_called_once_with(
         channel="channel_id", users="user_id"
     )
@@ -439,6 +439,6 @@ def test_initiate_resources_creation_boilerplate_update_fails(
     client = MagicMock()
     say = MagicMock()
     try:
-        core.initiate_resources_creation(client, say, incident_payload)
+        core.initiate_resources_creation(client, incident_payload)
     except Exception as e:
         assert str(e) == "boilerplate error"

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -84,7 +84,7 @@ def test_initiate_resources_creation_succeeds(
     expected_text = """🚨 *Incident Resources Created Successfully!*
 *Next Steps - Available Commands:*
 • `/sre incident roles manage` - Assign roles to the incident
-• `/sre incident schedule retro` - Schedule a retrospective meeting  
+• `/sre incident schedule retro` - Schedule a retrospective meeting
 • `/sre incident close` - Close and archive this incident
 • `/sre incident status update <status>` - Update incident status
 • `/sre incident updates add` - Add incident updates
@@ -92,7 +92,7 @@ def test_initiate_resources_creation_succeeds(
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings
-👥 Assign roles to team members for clear responsibilities  
+👥 Assign roles to team members for clear responsibilities
 📅 Schedule a retro meeting when ready
 
 _Type_ `/sre incident help` _for complete command list_"""

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -328,7 +328,7 @@ def test_handle_list_with_stale(mock_stale_incidents):
     mock_stale_incidents.assert_called_once_with(client, body, ack)
 
 
-def test_handle_schedule_without_action():
+def test_handle_schedule_with_invalid_option():
     respond = MagicMock()
     ack = MagicMock()
     client = MagicMock()
@@ -341,7 +341,7 @@ def test_handle_schedule_without_action():
         "\n"
         "\nUse `/sre incident help` to see a list of commands."
     )
-    incident_helper.handle_schedule(client, body, respond, ack, [], {})
+    incident_helper.handle_schedule(client, body, respond, ack, ["asdf"], {})
     respond.assert_called_once_with(schedule_help_text)
 
 

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -22,7 +22,7 @@ def test_legacy_handle_incident_command_with_create_command(mock_create_folder):
     respond.assert_has_calls(
         [
             call(
-                "The `/sre incident create-folder` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident create --folder <folder_name>` instead."
+                "The `/sre incident create-folder` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident create folder <folder_name>` instead."
             ),
             call("Folder `foo bar` created."),
         ]
@@ -30,8 +30,8 @@ def test_legacy_handle_incident_command_with_create_command(mock_create_folder):
 
 
 @patch("modules.incident.incident_helper.google_drive.create_folder")
-def test_legacy_handle_incident_command_with_create_command_error(create_folder_mock):
-    create_folder_mock.return_value = None
+def test_legacy_handle_incident_command_with_create_command_error(mock_create_folder):
+    mock_create_folder.return_value = None
     respond = MagicMock()
     ack = MagicMock()
 
@@ -41,7 +41,7 @@ def test_legacy_handle_incident_command_with_create_command_error(create_folder_
     respond.assert_has_calls(
         [
             call(
-                "The `/sre incident create-folder` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident create --folder <folder_name>` instead."
+                "The `/sre incident create-folder` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident create folder <folder_name>` instead."
             ),
             call("Failed to create folder `foo bar`."),
         ]
@@ -49,7 +49,7 @@ def test_legacy_handle_incident_command_with_create_command_error(create_folder_
 
 
 @patch("modules.incident.incident_helper.close_incident")
-def test_legacy_handle_incident_command_with_close(close_incident_mock):
+def test_legacy_handle_incident_command_with_close(mock_close_incident):
     client = MagicMock()
     body = {
         "channel_id": "channel_id",
@@ -60,11 +60,11 @@ def test_legacy_handle_incident_command_with_close(close_incident_mock):
     ack = MagicMock()
 
     incident_helper.handle_incident_command(["close"], client, body, respond, ack)
-    close_incident_mock.assert_called_once_with(client, body, ack, respond)
+    mock_close_incident.assert_called_once_with(client, body, ack, respond)
 
 
 @patch("modules.incident.incident_helper.incident_folder.list_folders_view")
-def test_legacy_handle_incident_command_with_list_folders(list_folders_mock):
+def test_legacy_handle_incident_command_with_list_folders(mock_list_folders):
     client = MagicMock()
     body = MagicMock()
     respond = MagicMock()
@@ -73,7 +73,7 @@ def test_legacy_handle_incident_command_with_list_folders(list_folders_mock):
     incident_helper.handle_incident_command(
         ["list-folders"], client, body, respond, ack
     )
-    list_folders_mock.assert_called_once_with(client, body, ack)
+    mock_list_folders.assert_called_once_with(client, body, ack)
 
 
 # @patch("modules.incident.incident_helper.handle_status")
@@ -99,7 +99,7 @@ def test_legacy_handle_incident_command_with_update_status_command(
 
 
 @patch("modules.incident.incident_helper.open_updates_dialog")
-def test_legacy_handle_incident_command_with_add_summary(open_updates_dialog_mock):
+def test_legacy_handle_incident_command_with_add_summary(mock_open_updates_dialog):
 
     client = MagicMock()
     body = {
@@ -114,11 +114,11 @@ def test_legacy_handle_incident_command_with_add_summary(open_updates_dialog_moc
     respond.assert_called_once_with(
         "The `/sre incident add_summary` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident updates` instead."
     )
-    open_updates_dialog_mock.assert_called_once_with(client, body, ack)
+    mock_open_updates_dialog.assert_called_once_with(client, body, ack)
 
 
 @patch("modules.incident.incident_helper.display_current_updates")
-def test_legacy_handle_incident_command_with_summary(display_current_updates_mock):
+def test_handle_incident_legacy_summary_command(mock_display_current_updates):
     client = MagicMock()
     body = {
         "channel_id": "channel_id",
@@ -132,7 +132,48 @@ def test_legacy_handle_incident_command_with_summary(display_current_updates_moc
     respond.assert_called_once_with(
         "The `/sre incident summary` command is deprecated and will be discontinued after 2025-11-01. Please use `/sre incident updates` instead."
     )
-    display_current_updates_mock.assert_called_once_with(client, body, respond, ack)
+    mock_display_current_updates.assert_called_once_with(client, body, respond, ack)
+
+
+@patch("modules.incident.incident_helper.display_current_updates")
+def test_handle_incident_legacy_summary_command_calls_new_handler(
+    mock_display_current_updates,
+):
+    client = MagicMock()
+    body = {
+        "channel_id": "channel_id",
+        "channel_name": "incident-2024-01-12-test",
+        "user_id": "user_id",
+    }
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_incident_command(["summary"], client, body, respond, ack)
+    mock_display_current_updates.assert_called_once_with(client, body, respond, ack)
+
+
+@patch("modules.incident.incident_helper.stale_incidents")
+def test_handle_incident_legacy_stale_command(mock_stale_incidents):
+    client = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_incident_command(["stale"], client, body, respond, ack)
+    mock_stale_incidents.assert_called_once_with(client, body, ack)
+
+
+@patch("modules.incident.incident_helper.handle_legacy_stale")
+def test_handle_incident_legacy_stale_command_calls_new_handler(
+    mock_handle_legacy_stale,
+):
+    client = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_incident_command(["stale"], client, body, respond, ack)
+    mock_handle_legacy_stale.assert_called_once_with(client, body, respond, ack, [], {})
 
 
 # New command tests
@@ -172,6 +213,7 @@ def test_handle_incident_command_with_help():
 
 # Test incident actions
 
+
 def test_handle_incident_command_dispatches_to_correct_handler():
     client = MagicMock()
     body = MagicMock()
@@ -192,20 +234,6 @@ def test_handle_incident_command_dispatches_to_correct_handler():
             ), f"{handler_name} should be called for first_arg '{first_arg}'"
 
 
-# Test for resource handlers
-
-
-@patch("modules.incident.incident_helper.incident_roles.manage_roles")
-def test_handle_incident_command_with_roles(manage_roles_mock):
-    client = MagicMock()
-    body = MagicMock()
-    respond = MagicMock()
-    ack = MagicMock()
-
-    incident_helper.handle_incident_command(["roles"], client, body, respond, ack)
-    manage_roles_mock.assert_called_once_with(client, body, ack, respond)
-
-
 @patch("modules.incident.incident_helper.close_incident")
 def test_handle_incident_command_with_close(close_incident_mock):
     client = MagicMock()
@@ -221,19 +249,22 @@ def test_handle_incident_command_with_close(close_incident_mock):
     close_incident_mock.assert_called_once_with(client, body, ack, respond)
 
 
-@patch("modules.incident.incident_helper.stale_incidents")
-def test_handle_incident_command_with_stale(stale_incidents_mock):
+# Test for resource handlers
+
+
+@patch("modules.incident.incident_helper.incident_roles.manage_roles")
+def test_handle_incident_command_with_roles(manage_roles_mock):
     client = MagicMock()
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
 
-    incident_helper.handle_incident_command(["stale"], client, body, respond, ack)
-    stale_incidents_mock.assert_called_once_with(client, body, ack)
+    incident_helper.handle_incident_command(["roles"], client, body, respond, ack)
+    manage_roles_mock.assert_called_once_with(client, body, ack, respond)
 
 
 @patch("modules.incident.incident_helper.schedule_retro")
-def test_handle_incident_command_with_retro(schedule_retro_mock):
+def test_handle_incident_command_with_schedule(mock_schedule_retro):
     client = MagicMock()
     body = {
         "channel_id": "channel_id",
@@ -244,7 +275,7 @@ def test_handle_incident_command_with_retro(schedule_retro_mock):
     ack = MagicMock()
 
     incident_helper.handle_incident_command(["schedule"], client, body, respond, ack)
-    schedule_retro_mock.open_incident_retro_modal.assert_called_once_with(
+    mock_schedule_retro.open_incident_retro_modal.assert_called_once_with(
         client, body, ack
     )
 

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -396,6 +396,23 @@ def test_handle_schedule_with_retro(mock_schedule_retro):
 # resource level actions
 
 
+def test_handle_channels_with_no_action():
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+    channels_help_text = (
+        "\n `/sre incident channels <action> [options] [arguments]`"
+        "\n"
+        "\n*Actions*"
+        "\n <Upcoming feature>  - manage incident channels"
+    )
+    incident_helper.handle_channels(
+        client, body, respond, ack, None, [], {}
+    )
+    respond.assert_called_once_with(channels_help_text)
+
+
 def test_handle_products_with_no_action():
     respond = MagicMock()
     ack = MagicMock()

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -118,7 +118,7 @@ def test_legacy_handle_incident_command_with_add_summary(mock_open_updates_dialo
 
 
 @patch("modules.incident.incident_helper.display_current_updates")
-def test_handle_incident_legacy_summary_command(mock_display_current_updates):
+def test_legacy_handle_incident_summary_command(mock_display_current_updates):
     client = MagicMock()
     body = {
         "channel_id": "channel_id",
@@ -136,7 +136,7 @@ def test_handle_incident_legacy_summary_command(mock_display_current_updates):
 
 
 @patch("modules.incident.incident_helper.display_current_updates")
-def test_handle_incident_legacy_summary_command_calls_new_handler(
+def test_legacy_handle_incident_summary_command_calls_new_handler(
     mock_display_current_updates,
 ):
     client = MagicMock()
@@ -153,7 +153,7 @@ def test_handle_incident_legacy_summary_command_calls_new_handler(
 
 
 @patch("modules.incident.incident_helper.stale_incidents")
-def test_handle_incident_legacy_stale_command(mock_stale_incidents):
+def test_legacy_handle_incident_stale_command(mock_stale_incidents):
     client = MagicMock()
     body = MagicMock()
     respond = MagicMock()
@@ -164,7 +164,7 @@ def test_handle_incident_legacy_stale_command(mock_stale_incidents):
 
 
 @patch("modules.incident.incident_helper.handle_legacy_stale")
-def test_handle_incident_legacy_stale_command_calls_new_handler(
+def test_legacy_handle_incident_stale_command_calls_new_handler(
     mock_handle_legacy_stale,
 ):
     client = MagicMock()
@@ -235,7 +235,7 @@ def test_handle_incident_command_dispatches_to_correct_handler():
 
 
 @patch("modules.incident.incident_helper.close_incident")
-def test_handle_incident_command_with_close(close_incident_mock):
+def test_handle_close(mock_close_incident):
     client = MagicMock()
     body = {
         "channel_id": "channel_id",
@@ -245,8 +245,8 @@ def test_handle_incident_command_with_close(close_incident_mock):
     respond = MagicMock()
     ack = MagicMock()
 
-    incident_helper.handle_incident_command(["close"], client, body, respond, ack)
-    close_incident_mock.assert_called_once_with(client, body, ack, respond)
+    incident_helper.handle_close(client, body, respond, ack, [], {})
+    mock_close_incident.assert_called_once_with(client, body, ack, respond)
 
 
 # Test for resource handlers

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -278,12 +278,10 @@ def test_handle_create_without_resource():
     ack = MagicMock()
     client = MagicMock()
     body = MagicMock()
-    create_help_text = (
-        "\n `/sre incident create [resource] [options]`"
-        "\n"
-        "\n*Resources*"
-        "\n new [<incident_name>]        - create a new incident (upcoming feature)"
-    )
+    create_help_text = """`/sre incident create [resource] [options]`
+
+*Resources:*
+• `new [<incident_name>]` — create a new incident (upcoming feature)"""
     incident_helper.handle_create(client, body, respond, ack, [], {})
     respond.assert_called_once_with(create_help_text)
 
@@ -304,18 +302,13 @@ def test_handle_list_without_resource():
     ack = MagicMock()
     client = MagicMock()
     body = MagicMock()
-    list_help_text = (
-        "\n `/sre incident list [options]`"
-        "\n      "
-        "\n*Options*"
-        "\n active"
-        "\n      - lists all active incidents (default; not stale or archived)"
-        "\n      - liste tous les incidents actifs (par défaut; ni obsolètes ni archivés)"
-        "\n stale"
-        "\n      - lists all incidents older than 14 days with no activity"
-        "\n      - liste tous les incidents plus vieux que 14 jours sans activité"
-        "\n Use `/sre incident help` to see a list of commands."
-    )
+    list_help_text = """`/sre incident list [options]`
+
+*Options:*
+• `active` — lists all active incidents (default; not stale or archived)
+• `stale` — lists all incidents older than 14 days with no activity
+
+Use `/sre incident help` to see a list of commands."""
 
     incident_helper.handle_list(client, body, respond, ack, [], {})
     respond.assert_called_once_with(list_help_text)
@@ -364,14 +357,12 @@ def test_handle_schedule_with_invalid_option():
     ack = MagicMock()
     client = MagicMock()
     body = MagicMock()
-    schedule_help_text = (
-        "\n `/sre incident schedule [options]`"
-        "\n"
-        "\n*Options*"
-        "\n retro             - schedule a retrospective for the incident"
-        "\n"
-        "\nUse `/sre incident help` to see a list of commands."
-    )
+    schedule_help_text = """`/sre incident schedule [options]`
+
+*Options:*
+• `retro` — schedule a retrospective for the incident
+
+Use `/sre incident help` to see a list of commands."""
     incident_helper.handle_schedule(client, body, respond, ack, ["asdf"], {})
     respond.assert_called_once_with(schedule_help_text)
 
@@ -393,6 +384,25 @@ def test_handle_schedule_with_retro(mock_schedule_retro):
     )
 
 
+@patch("modules.incident.incident_helper.schedule_retro")
+def test_handle_incident_command_with_schedule(mock_schedule_retro):
+    client = MagicMock()
+    body = {
+        "channel_id": "channel_id",
+        "channel_name": "incident-2024-01-12-test",
+        "user_id": "user_id",
+    }
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["schedule", "retro"], client, body, respond, ack
+    )
+    mock_schedule_retro.open_incident_retro_modal.assert_called_once_with(
+        client, body, ack
+    )
+
+
 # resource level actions
 
 
@@ -401,12 +411,10 @@ def test_handle_channels_with_no_action():
     ack = MagicMock()
     client = MagicMock()
     body = MagicMock()
-    channels_help_text = (
-        "\n `/sre incident channels <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n <Upcoming feature>  - manage incident channels"
-    )
+    channels_help_text = """`/sre incident channels <action> [options] [arguments]`
+
+*Actions:*
+• `<Upcoming feature>` — manage incident channels"""
     incident_helper.handle_channels(client, body, respond, ack, None, [], {})
     respond.assert_called_once_with(channels_help_text)
 
@@ -414,16 +422,14 @@ def test_handle_channels_with_no_action():
 def test_handle_products_with_no_action():
     respond = MagicMock()
     ack = MagicMock()
-    product_help_text = (
-        "\n `/sre incident products <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n create <product_name>      - create a new product name to be referenced in the incident resources"
-        '\n          _Tip: Use quotes for multi-word product names: `create "product name"`_'
-        "\n list                      - list all products currently available in the incident resources"
-        "\n"
-        "\nUse `/sre incident help` to see a list of commands."
-    )
+    product_help_text = """`/sre incident products <action> [options] [arguments]`
+
+*Actions:*
+• `create <product_name>` — create a new product name to be referenced in the incident resources
+  _Tip: Use quotes for multi-word product names: `create "product name"`_
+• `list` — list all products currently available in the incident resources
+
+Use `/sre incident help` to see a list of commands."""
     incident_helper.handle_products(
         MagicMock(), MagicMock(), respond, ack, None, [], {}
     )
@@ -475,15 +481,15 @@ def test_handle_products_with_create_error(mock_create_folder):
 def test_handle_status_with_no_action():
     respond = MagicMock()
     ack = MagicMock()
-    status_help_text = (
-        "\n `/sre incident status [options] [arguments]`"
-        "\n"
-        "\n*Options*"
-        "\n show              - show the current incident status"
-        "\n update <status>   - update the incident status to one of the valid statuses"
-        "\n"
-        "\n*Valid Statuses*"
-        "\n" + ", ".join(VALID_STATUS)
+    status_help_text = """`/sre incident status [options] [arguments]`
+
+*Options:*
+• `show` — show the current incident status
+• `update <status>` — update the incident status to one of the valid statuses
+
+*Valid Statuses:*
+""" + ", ".join(
+        VALID_STATUS
     )
     incident_helper.handle_status(MagicMock(), MagicMock(), respond, ack, None, [], {})
     respond.assert_called_once_with(status_help_text)
@@ -536,9 +542,14 @@ def test_handle_roles_with_no_action(mock_incident_roles):
     body = MagicMock()
     respond = MagicMock()
     ack = MagicMock()
+    roles_help_text = """`/sre incident roles <action> [options] [arguments]`
 
+*Actions:*
+• `manage` — manage incident roles
+• `show` — show current incident roles"""
     incident_helper.handle_roles(client, body, respond, ack, None, [], {})
     mock_incident_roles.assert_not_called()
+    respond.assert_called_once_with(roles_help_text)
 
 
 @patch("modules.incident.incident_helper.incident_roles")
@@ -562,35 +573,14 @@ def test_handle_roles_with_show():
     respond.assert_called_once_with("Upcoming feature: show current incident roles.")
 
 
-@patch("modules.incident.incident_helper.schedule_retro")
-def test_handle_incident_command_with_schedule(mock_schedule_retro):
-    client = MagicMock()
-    body = {
-        "channel_id": "channel_id",
-        "channel_name": "incident-2024-01-12-test",
-        "user_id": "user_id",
-    }
-    respond = MagicMock()
-    ack = MagicMock()
-
-    incident_helper.handle_incident_command(
-        ["schedule", "retro"], client, body, respond, ack
-    )
-    mock_schedule_retro.open_incident_retro_modal.assert_called_once_with(
-        client, body, ack
-    )
-
-
 def test_handle_updates_with_no_action():
     respond = MagicMock()
     ack = MagicMock()
-    updates_help_text = (
-        "\n `/sre incident updates <action> [options] [arguments]`"
-        "\n"
-        "\n*Actions*"
-        "\n add             - add updates to the incident"
-        "\n show            - show current incident updates"
-    )
+    updates_help_text = """`/sre incident updates <action> [options] [arguments]`
+
+*Actions:*
+• `add` — add updates to the incident
+• `show` — show current incident updates"""
     incident_helper.handle_updates(MagicMock(), MagicMock(), respond, ack, None, [], {})
     respond.assert_called_once_with(updates_help_text)
 

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -249,6 +249,48 @@ def test_handle_close(mock_close_incident):
     mock_close_incident.assert_called_once_with(client, body, ack, respond)
 
 
+def test_handle_create_new():
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+
+    incident_helper.handle_create(client, body, respond, ack, ["new"], {})
+    respond.assert_called_once_with("Upcoming feature: create a new incident.")
+
+
+def test_handle_create_no_resource():
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+    create_help_text = (
+        "\n `/sre incident create [resource] [options]`"
+        "\n"
+        "\n*Resources*"
+        "\n new [<incident_name>]        - create a new incident (upcoming feature)"
+    )
+    incident_helper.handle_create(client, body, respond, ack, [], {})
+    respond.assert_called_once_with(create_help_text)
+
+
+@patch("modules.incident.incident_helper.information_display.open_incident_info_view")
+def test_handle_details(mock_open_incident_info_view):
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+
+    incident_helper.handle_details(client, body, respond, ack, [], {})
+    mock_open_incident_info_view.assert_called_once_with(client, body, respond)
+
+    # "create": handle_create,
+    # "details": handle_details,
+    # "help": handle_help,
+    # "list": handle_list,
+    # "schedule": handle_schedule,
+
+
 # Test for resource handlers
 
 

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -407,9 +407,7 @@ def test_handle_channels_with_no_action():
         "\n*Actions*"
         "\n <Upcoming feature>  - manage incident channels"
     )
-    incident_helper.handle_channels(
-        client, body, respond, ack, None, [], {}
-    )
+    incident_helper.handle_channels(client, body, respond, ack, None, [], {})
     respond.assert_called_once_with(channels_help_text)
 
 
@@ -481,7 +479,7 @@ def test_handle_status_with_no_action():
         "\n `/sre incident status [options] [arguments]`"
         "\n"
         "\n*Options*"
-        "\n show             - show the current incident status"
+        "\n show              - show the current incident status"
         "\n update <status>   - update the incident status to one of the valid statuses"
         "\n"
         "\n*Valid Statuses*"

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -462,6 +462,47 @@ def test_handle_status_with_no_action():
     respond.assert_called_once_with(status_help_text)
 
 
+@patch("modules.incident.incident_helper.handle_update_status_command")
+def test_handle_status_with_update(mock_update_status_command):
+    client = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_status(
+        client, body, respond, ack, "update", ["Ready", "to", "be", "Reviewed"], {}
+    )
+    mock_update_status_command.assert_called_once_with(
+        client, body, respond, ack, ["Ready", "to", "be", "Reviewed"]
+    )
+
+
+@patch("modules.incident.incident_helper.handle_update_status_command")
+def test_handle_status_with_update_no_args(mock_update_status_command):
+    client = MagicMock()
+    body = MagicMock()
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_status(client, body, respond, ack, "update", [], {})
+    mock_update_status_command.assert_not_called()
+    respond.assert_called_once_with("Please provide a status to update.")
+
+
+def test_handle_status_with_show():
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = {
+        "channel_id": "channel_id",
+        "channel_name": "incident-2024-01-12-test",
+        "user_id": "user_id",
+    }
+
+    incident_helper.handle_status(client, body, respond, ack, "show", [], {})
+    respond.assert_called_once_with("Upcoming feature: show current incident status.")
+
+
 @patch("modules.incident.incident_helper.incident_roles.manage_roles")
 def test_handle_incident_command_with_roles(manage_roles_mock):
     client = MagicMock()

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -281,7 +281,8 @@ def test_handle_create_without_resource():
     create_help_text = """`/sre incident create [resource] [options]`
 
 *Resources:*
-• `new [<incident_name>]` — create a new incident (upcoming feature)"""
+• `new [<incident_name>]` — create a new incident (upcoming feature)
+• `resources` — create resources for an existing incident (document, meet links, etc.) (upcoming feature)"""
     incident_helper.handle_create(client, body, respond, ack, [], {})
     respond.assert_called_once_with(create_help_text)
 


### PR DESCRIPTION
# Summary | Résumé

This pull request standardizes the pattern for Slack slash commands in incident management, refactoring command parsing and message delivery for consistency and maintainability.

**Slash command pattern standardization:**

* All incident-related commands now follow the pattern:  
  `/sre incident [<resource>] <action> [options] [arguments]`  
  This makes command usage more predictable and easier to document.  
    
* Refactored command parsing logic to support resource/action separation, enabling extensible handler dispatch and clearer help text for each resource and action.  
    
* Updated help messages and examples to reflect the new standardized pattern, improving user guidance and discoverability of available commands.  
    
* Improved flag and argument parsing with a new utility function (`parse_flags`), supporting flexible command-line style options in Slack commands.

**Additional improvements:**

* Replaced all uses of the `say` function with direct calls to `client.chat_postMessage`, ensuring consistent message delivery and simplifying the codebase.  
    
* Enhanced tests to cover the new command parsing logic and flag handling, ensuring robust behavior and future extensibility.

These changes make incident command handling more modular, easier to extend, and more user-friendly, laying the groundwork for future features and improved Slack UX, including a better support for API calls.