### PR TITLE
Feat: update help command to support French language

### DIFF
--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -76,11 +76,11 @@ Usage:
 • list-folders
 • stale
 
-_For details on each subcommand, use:_
-`/sre incident <subcommand> help`
+_For details on each resource, use:_
+`/sre incident <resource> help`
+"""
 
----
-
+help_text_fr = """
 *Gestion des Incidents IFS:*
 
 Utilisation:
@@ -118,8 +118,8 @@ Utilisation:
 • list-folders
 • stale
 
-_Pour les détails sur chaque sous-commande, utilisez:_
-`/sre incident <sous-commande> help`
+_Pour les détails sur chaque resource, utilisez:_
+`/sre incident <resource> help`
 """
 
 
@@ -165,6 +165,7 @@ def get_incident_actions() -> dict[str, Callable]:
         "close": handle_close,
         "show": handle_show,
         "help": handle_help,
+        "aide": handle_help,
         "list": handle_list,
         "schedule": handle_schedule,
         # legacy commands
@@ -222,6 +223,8 @@ def handle_incident_command(
     elif first_arg in incident_actions:
         # this is to handle if the argument is a valid action on the incident itself
         action = first_arg
+        if action == "aide":
+            args_list = ["fr"] + args_list
         action_handler: Callable = incident_actions[action]
         action_handler(client, body, respond, ack, args_list, flags)
     else:
@@ -235,9 +238,12 @@ def handle_incident_command(
             )
 
 
-def handle_help(_client, _body, respond, _ack, _args, _flags) -> None:
+def handle_help(_client, _body, respond, _ack, args, _flags) -> None:
     """Handle help command."""
-    respond(help_text)
+    if args and args[0].lower() in ["fr", "aide"]:
+        respond(help_text_fr)
+    else:
+        respond(help_text)
 
 
 def handle_close(client, body, respond, ack, _args, _flags):

--- a/app/tests/modules/incident/test_incident_helper.py
+++ b/app/tests/modules/incident/test_incident_helper.py
@@ -203,16 +203,6 @@ def test_handle_incident_command_with_unknown_command():
     )
 
 
-def test_handle_incident_command_with_help():
-    respond = MagicMock()
-    ack = MagicMock()
-
-    incident_helper.handle_incident_command(
-        ["help"], MagicMock(), MagicMock(), respond, ack
-    )
-    respond.assert_called_once_with(incident_helper.help_text)
-
-
 def test_handle_incident_command_dispatches_to_correct_handler():
     client = MagicMock()
     body = MagicMock()
@@ -285,6 +275,26 @@ def test_handle_create_without_resource():
 • `resources` — create resources for an existing incident (document, meet links, etc.) (upcoming feature)"""
     incident_helper.handle_create(client, body, respond, ack, [], {})
     respond.assert_called_once_with(create_help_text)
+
+
+def test_handle_help():
+    respond = MagicMock()
+    ack = MagicMock()
+
+    incident_helper.handle_incident_command(
+        ["help"], MagicMock(), MagicMock(), respond, ack
+    )
+    respond.assert_called_once_with(incident_helper.help_text)
+
+
+def test_handle_help_with_french():
+    respond = MagicMock()
+    ack = MagicMock()
+    client = MagicMock()
+    body = MagicMock()
+
+    incident_helper.handle_help(client, body, respond, ack, ["fr"], {})
+    respond.assert_called_once_with(incident_helper.help_text_fr)
 
 
 @patch("modules.incident.incident_helper.information_display.open_incident_info_view")


### PR DESCRIPTION
# Summary | Résumé

This pull request enhances the incident command helper by adding French language support for help text and commands. 

The key changes include splitting the French help text in a distinct output so that it better fits in Slack UI, updating help command logic to support French, and expanding tests to cover the new functionality.