### PR TITLE
Feat/aws account creation ops group

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -205,6 +205,7 @@ class AWSFeatureSettings(BaseSettings):
     AWS_ADMIN_GROUPS: list[str] = Field(
         default=["sre-ifs@cds-snc.ca"], alias="AWS_ADMIN_GROUPS"
     )
+    AWS_OPS_GROUP_NAME: str = Field(default="", alias="AWS_OPS_GROUP_NAME")
     SPENDING_SHEET_ID: str = Field(default="", alias="SPENDING_SHEET_ID")
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/modules/aws/ops_group_assignment.py
+++ b/app/modules/aws/ops_group_assignment.py
@@ -45,7 +45,7 @@ def execute():
 
     if not unassigned_accounts:
         status = {
-            "status": "success",
+            "status": "ok",
             "message": (
                 f"Ops group '{AWS_OPS_GROUP_NAME}' is already assigned to all active accounts."
             ),

--- a/app/modules/aws/ops_group_assignment.py
+++ b/app/modules/aws/ops_group_assignment.py
@@ -1,0 +1,107 @@
+import json
+from core.config import settings
+from core.logging import get_module_logger
+
+from integrations.aws import identity_store, organizations, sso_admin
+
+
+AWS_OPS_GROUP_NAME = settings.aws_feature.AWS_OPS_GROUP_NAME
+
+
+logger = get_module_logger()
+
+
+def execute():
+    """Assign the AWS Ops group to member accounts."""
+    # if the feature is not enabled, exit
+    if not AWS_OPS_GROUP_NAME:
+        return
+    aws_ops_group_id = identity_store.get_group_id(AWS_OPS_GROUP_NAME)
+    if not aws_ops_group_id:
+        status = {
+            "status": "failed",
+            "message": (
+                f"Ops group '{AWS_OPS_GROUP_NAME}' not found in AWS Identity Center."
+            ),
+        }
+        logger.error("ops_group_not_found", group_name=AWS_OPS_GROUP_NAME)
+        return status
+
+    organizations_accounts = organizations.list_organization_accounts()
+    account_assignments = sso_admin.list_account_assignments_for_principal(
+        principal_id=aws_ops_group_id, principal_type="GROUP"
+    )
+    assigned_account_ids = {
+        assignment["AccountId"] for assignment in account_assignments
+    }
+
+    # get the accounts not yet assigned
+    unassigned_accounts = [
+        account
+        for account in organizations_accounts
+        if account.get("Id") not in assigned_account_ids
+        and account.get("Status") == "ACTIVE"
+    ]
+
+    if not unassigned_accounts:
+        status = {
+            "status": "success",
+            "message": (
+                f"Ops group '{AWS_OPS_GROUP_NAME}' is already assigned to all active accounts."
+            ),
+        }
+        logger.info(
+            "all_accounts_already_assigned",
+            group_name=AWS_OPS_GROUP_NAME,
+            total_accounts=len(organizations_accounts),
+        )
+        return status
+
+    # assign the ops group to unassigned accounts
+    for account in unassigned_accounts:
+        account_id = account.get("Id")
+        if not account_id:
+            logger.error(
+                "account_missing_id",
+                account=json.dumps(account, default=str),
+            )
+            continue
+        logger.info(
+            "assigning_ops_group_to_account",
+            aws_ops_group_id=aws_ops_group_id,
+            account_name=account.get("Name"),
+            account_id=account_id,
+        )
+        success = sso_admin.create_account_assignment(
+            user_id=aws_ops_group_id,
+            account_id=account_id,
+            permission_set="write",
+            principal_type="GROUP",
+        )
+        if success:
+            status = {
+                "status": "success",
+                "message": (
+                    f"Ops group '{AWS_OPS_GROUP_NAME}' assigned to account '{account.get('Name')}'."
+                ),
+            }
+            logger.info(
+                "ops_group_assigned_to_account",
+                group_name=AWS_OPS_GROUP_NAME,
+                account_name=account.get("Name"),
+                account_id=account_id,
+            )
+        else:
+            status = {
+                "status": "failed",
+                "message": (
+                    f"Failed to assign Ops group '{AWS_OPS_GROUP_NAME}' to account '{account.get('Name')}'."
+                ),
+            }
+            logger.error(
+                "failed_to_assign_ops_group_to_account",
+                group_name=AWS_OPS_GROUP_NAME,
+                account_name=account.get("Name"),
+                account_id=account_id,
+            )
+    return status

--- a/app/tests/modules/aws/test_ops_group_assignment.py
+++ b/app/tests/modules/aws/test_ops_group_assignment.py
@@ -94,7 +94,7 @@ def test_execute_all_accounts_already_assigned(
         }
     ]
     result = ops_group_assignment.execute()
-    assert result["status"] == "success"
+    assert result["status"] == "ok"
     assert "already assigned" in result["message"]
 
 

--- a/app/tests/modules/aws/test_ops_group_assignment.py
+++ b/app/tests/modules/aws/test_ops_group_assignment.py
@@ -1,0 +1,117 @@
+import json
+from unittest.mock import patch, MagicMock
+from modules.aws import ops_group_assignment
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", "OpsGroup")
+@patch("modules.aws.ops_group_assignment.logger")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.identity_store")
+def test_execute_assigns_to_unassigned_accounts(
+    mock_identity_store, mock_organizations, mock_sso_admin, mock_logger
+):
+    mock_identity_store.get_group_id.return_value = "group-id"
+    mock_organizations.list_organization_accounts.return_value = [
+        {"Id": "111111111111", "Status": "ACTIVE"},
+        {"Id": "222222222222", "Status": "SUSPENDED"},
+        {"Id": "333333333333", "Status": "ACTIVE"},
+    ]
+    mock_sso_admin.list_account_assignments_for_principal.return_value = [
+        {
+            "AccountId": "111111111111",
+            "PrincipalId": "group-id",
+            "PrincipalType": "GROUP",
+        }
+    ]
+    mock_sso_admin.create_account_assignment.return_value = True
+    result = ops_group_assignment.execute()
+    assert result["status"] == "success"
+    assert "assigned to account" in result["message"]
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", None)
+def test_execute_feature_disabled():
+    result = ops_group_assignment.execute()
+    assert result is None
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", "OpsGroup")
+@patch("modules.aws.ops_group_assignment.logger")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.identity_store")
+def test_execute_ops_group_not_found(
+    mock_identity_store, mock_organizations, mock_sso_admin, mock_logger
+):
+    mock_identity_store.get_group_id.return_value = None
+    result = ops_group_assignment.execute()
+    assert result["status"] == "failed"
+    assert "not found" in result["message"]
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", "OpsGroup")
+@patch("modules.aws.ops_group_assignment.logger")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.identity_store")
+def test_execute_account_missing_id(
+    mock_identity_store, mock_organizations, mock_sso_admin, mock_logger
+):
+    mock_identity_store.get_group_id.return_value = "group-id"
+    mock_organizations.list_organization_accounts.return_value = [
+        {"Name": "NoIdAccount", "Status": "ACTIVE"},
+        {"Id": "111111111111", "Status": "ACTIVE"},
+    ]
+    mock_sso_admin.list_account_assignments_for_principal.return_value = []
+    mock_sso_admin.create_account_assignment.return_value = True
+    result = ops_group_assignment.execute()
+    assert result["status"] == "success"
+    mock_logger.error.assert_any_call(
+        "account_missing_id",
+        account=json.dumps({"Name": "NoIdAccount", "Status": "ACTIVE"}, default=str),
+    )
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", "OpsGroup")
+@patch("modules.aws.ops_group_assignment.logger")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.identity_store")
+def test_execute_all_accounts_already_assigned(
+    mock_identity_store, mock_organizations, mock_sso_admin, mock_logger
+):
+    mock_identity_store.get_group_id.return_value = "group-id"
+    mock_organizations.list_organization_accounts.return_value = [
+        {"Id": "111111111111", "Status": "ACTIVE"},
+        {"Id": "222222222222", "Status": "SUSPENDED"},
+    ]
+    mock_sso_admin.list_account_assignments_for_principal.return_value = [
+        {
+            "AccountId": "111111111111",
+            "PrincipalId": "group-id",
+            "PrincipalType": "GROUP",
+        }
+    ]
+    result = ops_group_assignment.execute()
+    assert result["status"] == "success"
+    assert "already assigned" in result["message"]
+
+
+@patch("modules.aws.ops_group_assignment.AWS_OPS_GROUP_NAME", "OpsGroup")
+@patch("modules.aws.ops_group_assignment.logger")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.identity_store")
+def test_execute_assignment_fails(
+    mock_identity_store, mock_organizations, mock_sso_admin, mock_logger
+):
+    mock_identity_store.get_group_id.return_value = "group-id"
+    mock_organizations.list_organization_accounts.return_value = [
+        {"Id": "333333333333", "Status": "ACTIVE"},
+    ]
+    mock_sso_admin.list_account_assignments_for_principal.return_value = []
+    mock_sso_admin.create_account_assignment.return_value = False
+    result = ops_group_assignment.execute()
+    assert result["status"] == "failed"
+    assert "Failed to assign" in result["message"]


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new feature for assigning an AWS Ops group to all AWS accounts. The main changes include the addition of a new command handler, supporting logic for group assignment, configuration updates, and enhancements to AWS integration functions.

**New AWS Ops group assignment feature:**

* Added `request_groups_ops` handler to `command_handler` in `modules/aws/groups.py`, allowing admins to trigger Ops group assignment via Slack commands. [[1]](diffhunk://#diff-bedbd114a093406d7092643fa653b6f6ffdbc5bf76db0d317f0bb94b76cee004R36-R37) [[2]](diffhunk://#diff-bedbd114a093406d7092643fa653b6f6ffdbc5bf76db0d317f0bb94b76cee004R130-R165)
* Implemented `ops_group_assignment.py` module, which assigns the specified Ops group to all active AWS accounts, including error handling for missing group, disabled feature, and assignment failures.
* Updated configuration to include `AWS_OPS_GROUP_NAME` in `AWSFeatureSettings` for enabling/disabling the feature and specifying the group name.

**Enhancements to AWS integration functions:**

* Updated `create_account_assignment` and related functions in `sso_admin.py` to support both user and group principal types, and added a new function to list account assignments for a principal. [[1]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955L32-R34) [[2]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955L50-R52) [[3]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955R95-R121)

**Testing and validation:**

* Added unit tests for the new command handler and feature logic in `test_aws_groups.py`, covering permission checks, feature status, and response handling. [[1]](diffhunk://#diff-f579ea7b3c100be88a42d4cc3a07de786f55b0490786c627d1a1eced0e0457e8R66-R79) [[2]](diffhunk://#diff-f579ea7b3c100be88a42d4cc3a07de786f55b0490786c627d1a1eced0e0457e8R286-R421)
* Added dedicated tests for the Ops group assignment logic in `test_ops_group_assignment.py`, ensuring correct behavior for all edge cases including missing group, disabled feature, assignment failures, and already assigned accounts.