### PR TITLE
Feat/webhook resolve slack user

### DIFF
--- a/app/modules/webhooks/slack.py
+++ b/app/modules/webhooks/slack.py
@@ -1,0 +1,15 @@
+from integrations.slack.users import (
+    replace_users_emails_in_dict,
+    replace_users_emails_with_mention,
+)
+from models.webhooks import WebhookPayload
+
+
+def map_emails_to_slack_users(webhook_payload: WebhookPayload) -> WebhookPayload:
+    """Replace email addresses in a Slack webhook payload's 'blocks' or top-level 'text'
+    with Slack user mentions when resolvable; return the modified payload."""
+    if webhook_payload.text:
+        webhook_payload.text = replace_users_emails_with_mention(webhook_payload.text)
+    if webhook_payload.blocks:
+        webhook_payload.blocks = replace_users_emails_in_dict(webhook_payload.blocks)
+    return webhook_payload

--- a/app/tests/api/v1/test_webhooks.py
+++ b/app/tests/api/v1/test_webhooks.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, MagicMock, PropertyMock, call, ANY
 
-# from urllib import response
 import pytest
 import httpx
 from fastapi.testclient import TestClient
@@ -25,6 +24,7 @@ def test_client(bot_mock):
     return TestClient(test_app)
 
 
+@patch("api.v1.routes.webhooks.map_emails_to_slack_users")
 @patch("api.v1.routes.webhooks.log_to_sentinel")
 @patch("api.v1.routes.webhooks.append_incident_buttons")
 @patch("api.v1.routes.webhooks.handle_webhook_payload")
@@ -36,6 +36,7 @@ def test_handle_webhook(
     mock_handle_webhook_payload,
     mock_append_incident_buttons,
     mock_log_to_sentinel,
+    mock_map_emails_to_slack_users,
     test_client,
 ):
     payload = {"text": "some text"}
@@ -66,6 +67,7 @@ def test_handle_webhook(
     mock_handle_webhook_payload.assert_called_once_with(payload, ANY)
     mock_append_incident_buttons.assert_called_once()
     mock_log_to_sentinel.assert_called_once()
+    mock_map_emails_to_slack_users.assert_called_once()
 
 
 def test_handle_webhook_malformed_json_string(test_client):

--- a/app/tests/modules/webhooks/test_webhooks_slack.py
+++ b/app/tests/modules/webhooks/test_webhooks_slack.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from models.webhooks import WebhookPayload
+from modules.webhooks.slack import map_emails_to_slack_users
+
+
+@patch("modules.webhooks.slack.replace_users_emails_with_mention")
+def test_map_emails_to_slack_users_text_only(mock_replace_users_emails_with_mention):
+    payload = WebhookPayload(text="hello user@example.com", blocks=None)
+    mock_replace_users_emails_with_mention.return_value = "hello <@U12345>"
+    result = map_emails_to_slack_users(payload)
+    assert result.text == "hello <@U12345>"
+    mock_replace_users_emails_with_mention.assert_called_once_with(
+        "hello user@example.com"
+    )
+
+
+@patch("modules.webhooks.slack.replace_users_emails_in_dict")
+def test_map_emails_to_slack_users_blocks_only(mock_replace_users_emails_in_dict):
+    blocks = [{"type": "section", "text": "user@example.com"}]
+    payload = WebhookPayload(text=None, blocks=blocks)
+    mock_replace_users_emails_in_dict.return_value = [
+        {"type": "section", "text": "<@U12345>"}
+    ]
+    result = map_emails_to_slack_users(payload)
+    assert result.blocks == [{"type": "section", "text": "<@U12345>"}]
+    mock_replace_users_emails_in_dict.assert_called_once_with(blocks)
+
+
+@patch("modules.webhooks.slack.replace_users_emails_in_dict")
+@patch("modules.webhooks.slack.replace_users_emails_with_mention")
+def test_map_emails_to_slack_users_text_and_blocks(
+    mock_replace_users_emails_with_mention, mock_replace_users_emails_in_dict
+):
+    blocks = [{"type": "section", "text": "user@example.com"}]
+    payload = WebhookPayload(text="hello user@example.com", blocks=blocks)
+    mock_replace_users_emails_with_mention.return_value = "hello <@U12345>"
+    mock_replace_users_emails_in_dict.return_value = [
+        {"type": "section", "text": "<@U12345>"}
+    ]
+    result = map_emails_to_slack_users(payload)
+    assert result.text == "hello <@U12345>"
+    assert result.blocks == [{"type": "section", "text": "<@U12345>"}]
+    mock_replace_users_emails_with_mention.assert_called_once_with(
+        "hello user@example.com"
+    )
+    mock_replace_users_emails_in_dict.assert_called_once_with(blocks)
+
+
+def test_map_emails_to_slack_users_no_text_no_blocks():
+    payload = WebhookPayload(text=None, blocks=None)
+    result = map_emails_to_slack_users(payload)
+    assert result.text is None
+    assert result.blocks is None
+
+
+@patch("modules.webhooks.slack.replace_users_emails_in_dict")
+@patch("modules.webhooks.slack.replace_users_emails_with_mention")
+def test_map_emails_to_slack_users_empty_text_and_blocks(
+    mock_replace_users_emails_with_mention, mock_replace_users_emails_in_dict
+):
+    payload = WebhookPayload(text="", blocks=[])
+    mock_replace_users_emails_with_mention.return_value = ""
+    mock_replace_users_emails_in_dict.return_value = []
+    result = map_emails_to_slack_users(payload)
+    assert result.text == ""
+    assert not result.blocks
+    mock_replace_users_emails_with_mention.assert_not_called()
+    mock_replace_users_emails_in_dict.assert_not_called()


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new feature to automatically replace email addresses in Slack webhook payloads with Slack user mentions, improving message clarity and user identification in Slack alerts. The change is integrated into the webhook handling flow and is thoroughly tested to ensure robustness across various payload structures and edge cases.

**Slack email-to-mention mapping integration:**

* Added `map_emails_to_slack_users` to `modules/webhooks/slack.py`, which replaces email addresses in webhook payloads (`text` and `blocks`) with Slack user mentions when possible.
* Updated the webhook route handler in `api/v1/routes/webhooks.py` to call `map_emails_to_slack_users` on incoming Slack webhook payloads before further processing. The handler is now asynchronous. [[1]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46R13) [[2]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46L24-R25) [[3]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46R75)

**Slack user utilities:**

* Implemented `replace_users_emails_with_mention` and `replace_users_emails_in_dict` in `integrations/slack/users.py` to resolve emails to Slack user IDs and recursively update strings in nested data structures.

**Testing and validation:**

* Added comprehensive unit tests for the email-to-mention replacement logic in `tests/integrations/slack/test_users.py`, covering multiple scenarios including success, failures, nested data, and edge cases.
* Added tests for the new mapping function in `tests/modules/webhooks/test_webhooks_slack.py`, verifying correct behavior for various payload shapes.
* Updated webhook route tests in `tests/api/v1/test_webhooks.py` to verify that email-to-mention mapping is invoked during webhook handling. [[1]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757R27) [[2]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757R39) [[3]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757R70)