### PR TITLE
Feat: enhance AWS Identity Store integration 

### DIFF
--- a/app/integrations/aws/identity_store_next.py
+++ b/app/integrations/aws/identity_store_next.py
@@ -240,6 +240,23 @@ def list_groups(
 
     Returns:
         IntegrationResponse: Standardized response model for external API integrations.
+
+    Example:
+        ```
+        result = list_groups()
+        if result.success:
+            groups = result.data  # List of groups
+        else:
+            logger.error("Failed to list groups", error=result.error)
+        # Filters can be applied, e.g.:
+        filters = [
+            {
+                "AttributePath": "DisplayName",
+                "AttributeValue": "Group-Name", # Supports exact match only
+            }
+        ]
+        result = list_groups(Filters=filters)
+        ```
     """
 
     return execute_aws_api_call(
@@ -314,8 +331,8 @@ def get_group_membership_id(
     Get the membership ID for a user in a group.
 
     Args:
-        group_id (str): The group ID
-        user_id (str): The user ID
+        group_id (str): The group ID; either a UUID or display name
+        user_id (str): The user ID; either a UUID or username, typically email
         **kwargs: Additional parameters for the API call
 
     Returns:
@@ -499,7 +516,7 @@ def get_batch_groups(group_ids: List[str], **kwargs) -> IntegrationResponse:
 
 
 def _fetch_group_memberships_parallel(
-    group_ids: List[str], max_workers: int = 10
+    group_ids: List[str], max_workers: int = 10, **kwargs
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Parallel helper function to fetch memberships for multiple groups."""
     memberships_by_group = {}
@@ -507,7 +524,8 @@ def _fetch_group_memberships_parallel(
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Submit all tasks
         future_to_gid = {
-            executor.submit(list_group_memberships, gid): gid for gid in group_ids
+            executor.submit(list_group_memberships, gid, **kwargs): gid
+            for gid in group_ids
         }
         # Collect results as they complete
         for future in as_completed(future_to_gid):
@@ -597,6 +615,9 @@ def _assemble_groups_with_memberships(
 
 def list_groups_with_memberships(
     groups_filters: Optional[List] = None,
+    groups_kwargs: Optional[Dict[str, Any]] = None,
+    memberships_kwargs: Optional[Dict[str, Any]] = None,
+    users_kwargs: Optional[Dict[str, Any]] = None,
     tolerate_errors: bool = False,
 ) -> IntegrationResponse:
     """
@@ -614,12 +635,15 @@ def list_groups_with_memberships(
     """
     logger.info(
         "listing_groups_with_memberships",
+        groups_kwargs=groups_kwargs,
+        memberships_kwargs=memberships_kwargs,
+        users_kwargs=users_kwargs,
         groups_filters=groups_filters,
         tolerate_errors=tolerate_errors,
     )
 
     # 1. Fetch all groups
-    response: IntegrationResponse = list_groups()
+    response: IntegrationResponse = list_groups(**(groups_kwargs or {}))
     if response.success and isinstance(response.data, list):
         groups: List[Dict[str, Any]] = response.data
     else:
@@ -639,11 +663,12 @@ def list_groups_with_memberships(
 
     # 3. Batch fetch group memberships using our utility functions
     group_ids = [g["GroupId"] for g in groups if "GroupId" in g]
-    memberships_by_group = _fetch_group_memberships_parallel(group_ids)
-    logger.info("memberships_batch_fetched", count=len(memberships_by_group))
+    memberships_by_group = _fetch_group_memberships_parallel(
+        group_ids, **memberships_kwargs or {}
+    )
 
     # 5. Batch fetch all user details using our utility function
-    response = list_users()
+    response = list_users(**(users_kwargs or {}))
     if not response.success:
         return build_error_response(
             error=Exception("Failed to list users"),

--- a/app/tests/integrations/aws/fixtures_identity_store.py
+++ b/app/tests/integrations/aws/fixtures_identity_store.py
@@ -24,7 +24,6 @@ def fake_user_client(user: Dict[str, Any]) -> FakeClient:
 
 
 def fake_group_client(groups: List[Dict[str, Any]]) -> FakeClient:
-    """Return a FakeClient that pages groups via paginator or returns describe_group."""
     """
     Return a FakeClient that pages groups via paginator or returns describe_group.
 


### PR DESCRIPTION
# Summary | Résumé

This pull request enhances the flexibility and usability of AWS Identity Store integration functions by allowing more granular control through additional keyword arguments and improving documentation. The most significant changes include expanded support for filtering and parameter passing in core listing and batching functions, as well as updates to docstrings for clarity.

### API flexibility and parameterization

* Added support for passing `groups_kwargs`, `memberships_kwargs`, and `users_kwargs` to the `list_groups_with_memberships` function, enabling more granular control over group, membership, and user queries. These kwargs are now logged for traceability. [[1]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879R618-R620) [[2]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879R638-R646)
* Modified the `_fetch_group_memberships_parallel` helper to accept and forward additional keyword arguments, allowing for customized membership queries in batch operations.
* Updated `list_groups_with_memberships` to use the provided kwargs when calling `list_groups`, `_fetch_group_memberships_parallel`, and `list_users`, improving the ability to filter and customize data retrieval. [[1]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879R638-R646) [[2]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879L642-R671)

### Documentation improvements

* Added a usage example to the `list_groups` docstring, demonstrating how to apply filters and handle results, making it easier for users to understand how to use the function.
* Clarified argument descriptions in the `get_group_membership_id` docstring to indicate that both UUIDs and display names/usernames are accepted.
* Improved the docstring for the `fake_group_client` test fixture for better readability and consistency.