### PR TITLE
feat: bump AWS CLI version to 2.32.6 in devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {
-			"version": "2.2.29"
+			"version": "2.32.6"
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest",


### PR DESCRIPTION
# Summary | Résumé

Bump the AWS CLI version