### PR TITLE
feat: add idempotency cache table with TTL expiration

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -59,6 +59,27 @@ resource "aws_dynamodb_table" "incidents_table" {
   }
 }
 
+# Dedicated table for idempotency cache
+# Stores cached API responses with automatic TTL-based expiration
+resource "aws_dynamodb_table" "sre_bot_idempotency" {
+  name           = "sre_bot_idempotency"
+  hash_key       = "idempotency_key"
+  read_capacity  = 5
+  write_capacity = 5
+
+  attribute {
+    name = "idempotency_key"
+    type = "S"
+  }
+
+  # Enable TTL for automatic expiration of cached responses (default 1 hour)
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+}
+
 # The following code adds a backup configuration to the DynamoDB table.
 
 # Define a KMS key to encrypt the backup.


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new DynamoDB table dedicated to idempotency caching for API responses. The table is configured with automatic TTL-based expiration to ensure cached items are cleaned up efficiently.

**Infrastructure additions:**

* Added a new DynamoDB table resource `aws_dynamodb_table.sre_bot_idempotency` in `terraform/dynamodb.tf` to store cached API responses for idempotency purposes. The table uses `idempotency_key` as the hash key and is configured with read/write capacities of 5.
* Enabled TTL on the new table using the `ttl` attribute, allowing cached responses to expire automatically (default set to 1 hour).