### PR TITLE
feat: add AWS DynamoDB Next module with CRUD operations and unit tests

### DIFF
--- a/app/integrations/aws/dynamodb_next.py
+++ b/app/integrations/aws/dynamodb_next.py
@@ -1,0 +1,175 @@
+"""AWS DynamoDB Next Module
+
+Provides simplified, standardized functions for DynamoDB operations using client_next.py.
+Features:
+- Consistent error handling and retries via client_next.execute_aws_api_call
+- Standardized OperationResult responses
+- Automatic pagination for scan/query operations
+- Unified logging and throttling management
+
+Usage:
+    result = get_item(
+        table_name="sre_bot_idempotency",
+        Key={"idempotency_key": {"S": "unique-key"}},
+    )
+    if result.is_success:
+        item = result.data
+    else:
+        error = result.message
+"""
+
+from typing import Any, Dict
+
+from core.config import settings
+from core.logging import get_module_logger
+from integrations.aws.client_next import execute_aws_api_call
+from infrastructure.operations.result import OperationResult
+
+logger = get_module_logger()
+
+AWS_REGION = settings.aws.AWS_REGION
+
+
+def get_item(
+    table_name: str,
+    Key: Dict[str, Any],
+    **kwargs,
+) -> OperationResult:
+    """Get an item from DynamoDB table.
+
+    Args:
+        table_name: DynamoDB table name
+        Key: Primary key attributes (DynamoDB format)
+        **kwargs: Additional parameters for get_item call
+
+    Returns:
+        OperationResult: Item if found, or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="get_item",
+        TableName=table_name,
+        Key=Key,
+        **kwargs,
+    )
+
+
+def put_item(
+    table_name: str,
+    Item: Dict[str, Any],
+    **kwargs,
+) -> OperationResult:
+    """Put an item into DynamoDB table.
+
+    Args:
+        table_name: DynamoDB table name
+        Item: Item attributes (DynamoDB format)
+        **kwargs: Additional parameters for put_item call
+
+    Returns:
+        OperationResult: Success or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="put_item",
+        TableName=table_name,
+        Item=Item,
+        **kwargs,
+    )
+
+
+def update_item(
+    table_name: str,
+    Key: Dict[str, Any],
+    **kwargs,
+) -> OperationResult:
+    """Update an item in DynamoDB table.
+
+    Args:
+        table_name: DynamoDB table name
+        Key: Primary key attributes (DynamoDB format)
+        **kwargs: Additional parameters for update_item call
+
+    Returns:
+        OperationResult: Updated attributes or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="update_item",
+        TableName=table_name,
+        Key=Key,
+        **kwargs,
+    )
+
+
+def delete_item(
+    table_name: str,
+    Key: Dict[str, Any],
+    **kwargs,
+) -> OperationResult:
+    """Delete an item from DynamoDB table.
+
+    Args:
+        table_name: DynamoDB table name
+        Key: Primary key attributes (DynamoDB format)
+        **kwargs: Additional parameters for delete_item call
+
+    Returns:
+        OperationResult: Success or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="delete_item",
+        TableName=table_name,
+        Key=Key,
+        **kwargs,
+    )
+
+
+def query(
+    table_name: str,
+    KeyConditionExpression: str,
+    **kwargs,
+) -> OperationResult:
+    """Query a DynamoDB table with automatic pagination.
+
+    Args:
+        table_name: DynamoDB table name
+        KeyConditionExpression: Query condition
+        **kwargs: Additional parameters for query call
+
+    Returns:
+        OperationResult: List of items or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="query",
+        TableName=table_name,
+        KeyConditionExpression=KeyConditionExpression,
+        keys=["Items"],
+        force_paginate=True,
+        **kwargs,
+    )
+
+
+def scan(
+    table_name: str,
+    **kwargs,
+) -> OperationResult:
+    """Scan a DynamoDB table with automatic pagination.
+
+    Args:
+        table_name: DynamoDB table name
+        **kwargs: Additional parameters for scan call
+
+    Returns:
+        OperationResult: List of items or error details
+    """
+    return execute_aws_api_call(
+        service_name="dynamodb",
+        method="scan",
+        TableName=table_name,
+        keys=["Items"],
+        force_paginate=True,
+        **kwargs,
+    )

--- a/app/tests/unit/integrations/__init__.py
+++ b/app/tests/unit/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AWS integrations."""

--- a/app/tests/unit/integrations/aws/__init__.py
+++ b/app/tests/unit/integrations/aws/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AWS integration functions."""

--- a/app/tests/unit/integrations/aws/test_dynamodb_next.py
+++ b/app/tests/unit/integrations/aws/test_dynamodb_next.py
@@ -1,0 +1,238 @@
+"""Unit tests for dynamodb_next.py wrapper module."""
+
+import pytest
+from unittest.mock import patch
+
+from integrations.aws.dynamodb_next import (
+    get_item,
+    put_item,
+    update_item,
+    delete_item,
+    query,
+    scan,
+)
+from infrastructure.operations.result import OperationResult, OperationStatus
+
+pytestmark = pytest.mark.unit
+
+
+class TestDynamoDBNextGetItem:
+    """Tests for get_item function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_get_item_calls_execute_with_correct_params(self, mock_execute):
+        """get_item calls execute_aws_api_call with correct parameters."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Item retrieved",
+        )
+
+        result = get_item(
+            table_name="test_table",
+            Key={"id": {"S": "123"}},
+        )
+
+        mock_execute.assert_called_once_with(
+            service_name="dynamodb",
+            method="get_item",
+            TableName="test_table",
+            Key={"id": {"S": "123"}},
+        )
+        assert result.is_success
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_get_item_returns_operation_result(self, mock_execute):
+        """get_item returns OperationResult."""
+        expected_result = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Found",
+            data={"Item": {"id": {"S": "123"}}},
+        )
+        mock_execute.return_value = expected_result
+
+        result = get_item(
+            table_name="test_table",
+            Key={"id": {"S": "123"}},
+        )
+
+        assert result is expected_result
+        assert result.is_success
+
+
+class TestDynamoDBNextPutItem:
+    """Tests for put_item function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_put_item_calls_execute_with_correct_params(self, mock_execute):
+        """put_item calls execute_aws_api_call with correct parameters."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Item stored",
+        )
+
+        result = put_item(
+            table_name="test_table",
+            Item={"id": {"S": "123"}, "name": {"S": "test"}},
+        )
+
+        mock_execute.assert_called_once_with(
+            service_name="dynamodb",
+            method="put_item",
+            TableName="test_table",
+            Item={"id": {"S": "123"}, "name": {"S": "test"}},
+        )
+        assert result.is_success
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_put_item_supports_additional_kwargs(self, mock_execute):
+        """put_item supports additional parameters."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Item stored",
+        )
+
+        result = put_item(
+            table_name="test_table",
+            Item={"id": {"S": "123"}},
+            ConditionExpression="attribute_not_exists(id)",
+        )
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["ConditionExpression"] == "attribute_not_exists(id)"
+        assert result.is_success
+
+
+class TestDynamoDBNextUpdateItem:
+    """Tests for update_item function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_update_item_calls_execute_with_correct_params(self, mock_execute):
+        """update_item calls execute_aws_api_call with correct parameters."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Item updated",
+        )
+
+        result = update_item(
+            table_name="test_table",
+            Key={"id": {"S": "123"}},
+            UpdateExpression="SET #n = :val",
+        )
+
+        mock_execute.assert_called_once_with(
+            service_name="dynamodb",
+            method="update_item",
+            TableName="test_table",
+            Key={"id": {"S": "123"}},
+            UpdateExpression="SET #n = :val",
+        )
+        assert result.is_success
+
+
+class TestDynamoDBNextDeleteItem:
+    """Tests for delete_item function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_delete_item_calls_execute_with_correct_params(self, mock_execute):
+        """delete_item calls execute_aws_api_call with correct parameters."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Item deleted",
+        )
+
+        result = delete_item(
+            table_name="test_table",
+            Key={"id": {"S": "123"}},
+        )
+
+        mock_execute.assert_called_once_with(
+            service_name="dynamodb",
+            method="delete_item",
+            TableName="test_table",
+            Key={"id": {"S": "123"}},
+        )
+        assert result.is_success
+
+
+class TestDynamoDBNextQuery:
+    """Tests for query function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_query_calls_execute_with_pagination(self, mock_execute):
+        """query calls execute_aws_api_call with pagination enabled."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Query completed",
+            data={"Items": []},
+        )
+
+        result = query(
+            table_name="test_table",
+            KeyConditionExpression="id = :id",
+        )
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["service_name"] == "dynamodb"
+        assert call_kwargs["method"] == "query"
+        assert call_kwargs["force_paginate"] is True
+        assert call_kwargs["keys"] == ["Items"]
+        assert result.is_success
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_query_supports_expression_values(self, mock_execute):
+        """query supports expression attribute values."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Query completed",
+            data={"Items": []},
+        )
+
+        result = query(
+            table_name="test_table",
+            KeyConditionExpression="id = :id",
+            ExpressionAttributeValues={":id": {"S": "123"}},
+        )
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["ExpressionAttributeValues"] == {":id": {"S": "123"}}
+        assert result.is_success
+
+
+class TestDynamoDBNextScan:
+    """Tests for scan function."""
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_scan_calls_execute_with_pagination(self, mock_execute):
+        """scan calls execute_aws_api_call with pagination enabled."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Scan completed",
+            data={"Items": []},
+        )
+
+        result = scan(table_name="test_table")
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["service_name"] == "dynamodb"
+        assert call_kwargs["method"] == "scan"
+        assert call_kwargs["force_paginate"] is True
+        assert call_kwargs["keys"] == ["Items"]
+        assert result.is_success
+
+    @patch("integrations.aws.dynamodb_next.execute_aws_api_call")
+    def test_scan_supports_filter_expression(self, mock_execute):
+        """scan supports filter expression."""
+        mock_execute.return_value = OperationResult(
+            status=OperationStatus.SUCCESS,
+            message="Scan completed",
+            data={"Items": []},
+        )
+
+        result = scan(
+            table_name="test_table",
+            FilterExpression="attribute_exists(ttl)",
+        )
+
+        call_kwargs = mock_execute.call_args[1]
+        assert call_kwargs["FilterExpression"] == "attribute_exists(ttl)"
+        assert result.is_success


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new standardized wrapper module for AWS DynamoDB operations and comprehensive unit test coverage for its functionality. The main goal is to simplify DynamoDB usage by providing consistent error handling, automatic pagination, and unified operation results, while ensuring reliability through robust tests.

**DynamoDB Wrapper Module Implementation:**

* Added `dynamodb_next.py` module that provides standardized functions (`get_item`, `put_item`, `update_item`, `delete_item`, `query`, `scan`) for DynamoDB operations, featuring consistent error handling, automatic pagination, and unified `OperationResult` responses.

**Unit Test Coverage:**

* Added `test_dynamodb_next.py` with extensive unit tests for each function in the new wrapper, verifying correct parameter passing, support for additional arguments, pagination, and proper result handling.

**Documentation Improvements:**

* Added module-level docstrings to test package `__init__.py` files for AWS integrations, clarifying their purpose and improving codebase readability. [[1]](diffhunk://#diff-6e3d03df867c550042a00cc23169bee04c6f5708095981e1d5fb844cf9af3028R1) [[2]](diffhunk://#diff-7e251c86eba57c26aea0b4e905cd04ad2c5adaf0e31aa37b7b241a05ddb6a4e0R1)