### PR TITLE
fix: add missing idempotency table for read/write

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -49,7 +49,8 @@ data "aws_iam_policy_document" "sre-bot_secrets_manager" {
       aws_dynamodb_table.aws_access_requests_table.arn,
       aws_dynamodb_table.webhooks_table.arn,
       aws_dynamodb_table.sre_bot_data.arn,
-      aws_dynamodb_table.incidents_table.arn
+      aws_dynamodb_table.incidents_table.arn,
+      aws_dynamodb_table.sre_bot_idempotency.arn,
     ]
 
   }


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a targeted update to the IAM policy document for the SRE bot in `terraform/iam.tf`. The change adds a new DynamoDB table to the list of resources the SRE bot can access.

Resource permissions update:

* Added `aws_dynamodb_table.sre_bot_idempotency.arn` to the resource list in the `aws_iam_policy_document` for SRE bot, granting it access to the idempotency table.