### PR TITLE
feat: centralize integration error classification

### DIFF
--- a/app/infrastructure/operations/__init__.py
+++ b/app/infrastructure/operations/__init__.py
@@ -8,6 +8,7 @@ classifiers for provider exceptions.
 from infrastructure.operations.classifiers import (
     classify_aws_error,
     classify_http_error,
+    classify_integration_error,
 )
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
@@ -17,4 +18,5 @@ __all__ = [
     "OperationStatus",
     "classify_http_error",
     "classify_aws_error",
+    "classify_integration_error",
 ]

--- a/app/modules/groups/providers/aws_identity_center.py
+++ b/app/modules/groups/providers/aws_identity_center.py
@@ -694,53 +694,43 @@ class AwsIdentityCenterProvider(GroupProvider):
         try:
             # Get identity store ID if available (from instance attribute)
             if not self.identity_store_id:
-                return HealthCheckResult(
+                return self._build_health_check_result(
                     healthy=False,
                     status="degraded",
-                    details={
-                        "message": "Identity store ID not configured",
-                    },
+                    message="Identity store ID not configured",
                 )
 
             # Perform minimal API call: list groups with maxResults=1
             resp = identity_store.list_groups(maxResults=1)
 
             if not hasattr(resp, "success"):
-                return HealthCheckResult(
+                return self._build_health_check_result(
                     healthy=False,
                     status="unhealthy",
-                    details={
-                        "message": "AWS Identity Center API returned unexpected type",
-                    },
+                    message="AWS Identity Center API returned unexpected type",
                 )
 
             if not resp.is_success:
-                return HealthCheckResult(
+                return self._build_health_check_result(
                     healthy=False,
                     status="unhealthy",
-                    details={
-                        "message": "AWS Identity Center API unreachable",
-                        "error": str(resp),
-                    },
+                    message="AWS Identity Center API unreachable",
+                    error=str(resp),
                 )
 
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=True,
                 status="healthy",
-                details={
-                    "identity_store_id": self.identity_store_id,
-                    "message": "Provider is operational",
-                },
+                message="Provider is operational",
+                provider_details={"identity_store_id": self.identity_store_id},
             )
 
         except IntegrationError as e:
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=False,
                 status="unhealthy",
-                details={
-                    "message": str(e),
-                    "error_code": "API_ERROR",
-                },
+                message=str(e),
+                provider_details={"error_code": "API_ERROR"},
             )
         except Exception as e:
             logger.error(
@@ -748,11 +738,9 @@ class AwsIdentityCenterProvider(GroupProvider):
                 error=str(e),
                 error_type=type(e).__name__,
             )
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=False,
                 status="unhealthy",
-                details={
-                    "message": "Unexpected error during health check",
-                    "error": str(e),
-                },
+                message="Unexpected error during health check",
+                error=str(e),
             )

--- a/app/modules/groups/providers/base.py
+++ b/app/modules/groups/providers/base.py
@@ -481,6 +481,48 @@ class GroupProvider(ABC):
         else:
             return self._health_check_impl()
 
+    def _build_health_check_result(
+        self,
+        healthy: bool,
+        status: str,
+        message: str,
+        provider_details: Optional[dict] = None,
+        error: Optional[str] = None,
+    ) -> HealthCheckResult:
+        """Build a standardized HealthCheckResult with provider-specific details.
+
+        This helper method centralizes health check result construction,
+        reducing duplication across providers. Providers can override to
+        customize the details dict.
+
+        Args:
+            healthy: Whether the provider is healthy
+            status: Status string (e.g., "healthy", "unhealthy", "degraded")
+            message: Human-readable status message
+            provider_details: Optional provider-specific details (merged into result)
+            error: Optional error string to include in details
+
+        Returns:
+            HealthCheckResult with standardized structure
+        """
+        details = {
+            "message": message,
+        }
+
+        # Add provider-specific details
+        if provider_details:
+            details.update(provider_details)
+
+        # Add error if provided
+        if error:
+            details["error"] = error
+
+        return HealthCheckResult(
+            healthy=healthy,
+            status=status,
+            details=details,
+        )
+
     @abstractmethod
     def _health_check_impl(self) -> HealthCheckResult:
         """Implementation of health_check (no circuit breaker wrapper).

--- a/app/modules/groups/providers/google_workspace.py
+++ b/app/modules/groups/providers/google_workspace.py
@@ -405,32 +405,26 @@ class GoogleWorkspaceProvider(PrimaryGroupProvider):
             resp = google_directory.list_groups(maxResults=1)
 
             if hasattr(resp, "is_success") and not resp.is_success:
-                return HealthCheckResult(
+                return self._build_health_check_result(
                     healthy=False,
                     status="unhealthy",
-                    details={
-                        "message": "Google Workspace API unreachable",
-                        "error": str(resp),
-                    },
+                    message="Google Workspace API unreachable",
+                    error=str(resp),
                 )
 
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=True,
                 status="healthy",
-                details={
-                    "domain": self.domain,
-                    "message": "Provider is operational",
-                },
+                message="Provider is operational",
+                provider_details={"domain": self.domain},
             )
 
         except IntegrationError as e:
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=False,
                 status="unhealthy",
-                details={
-                    "message": str(e),
-                    "error_code": "API_ERROR",
-                },
+                message=str(e),
+                provider_details={"error_code": "API_ERROR"},
             )
         except Exception as e:
             logger.error(
@@ -438,11 +432,9 @@ class GoogleWorkspaceProvider(PrimaryGroupProvider):
                 error=str(e),
                 error_type=type(e).__name__,
             )
-            return HealthCheckResult(
+            return self._build_health_check_result(
                 healthy=False,
                 status="unhealthy",
-                details={
-                    "message": "Unexpected error during health check",
-                    "error": str(e),
-                },
+                message="Unexpected error during health check",
+                error=str(e),
             )


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new error classification function for provider integration errors and refactors health check result construction for group provider modules to improve consistency and reduce duplication. The main changes are the addition of the `classify_integration_error` function and the introduction of a standardized `_build_health_check_result` helper, which is now used across AWS and Google Workspace provider health checks.

**Error classification improvements:**

* Added `classify_integration_error` to `infrastructure.operations.classifiers`, allowing provider adapters to convert integration layer exceptions into standardized `OperationResult` objects. This centralizes error handling for integration errors and makes it easier to propagate and classify errors from provider integrations.
* Updated documentation and imports in `classifiers.py` and `__init__.py` to include the new `classify_integration_error` function. [[1]](diffhunk://#diff-857c40ef9efffc2d2aa440c24f8183576f586dbaf6fbdd6ed662c93cb5de1cbbL3-R17) [[2]](diffhunk://#diff-de89bd31b1561a45f57148f26a01fcc0df0527bd263917c65124572116bbd201R11) [[3]](diffhunk://#diff-de89bd31b1561a45f57148f26a01fcc0df0527bd263917c65124572116bbd201R21)

**Health check result standardization:**

* Introduced `_build_health_check_result` helper in `base.py` to construct standardized `HealthCheckResult` objects with consistent structure and provider-specific details. This reduces code duplication and provides a single place to customize result formatting.
* Refactored AWS Identity Center and Google Workspace provider health checks to use `_build_health_check_result`, ensuring uniform formatting of health check results and simplifying error handling logic. [[1]](diffhunk://#diff-9cbe97e7a630069df184c8b2c60dfaeca87baef475d08cd92a65d34575fd5451L697-R745) [[2]](diffhunk://#diff-6968ab6c724fb8bad2a46816a037c3f3547acd23a06aa4496c083355ca2b9f1fL408-R439)