### PR TITLE
Feat/access common

### DIFF
--- a/app/packages/access/catalog/providers.py
+++ b/app/packages/access/catalog/providers.py
@@ -20,7 +20,7 @@ from packages.access.catalog.parsers import (
     FallbackCatalogSlugParser,
 )
 from packages.access.catalog.service import CatalogService
-from packages.access.sync.providers import get_access_sync_runtime_config
+from packages.access.sync.providers import get_access_runtime_config
 
 
 class CatalogSettings(BaseSettings):
@@ -56,7 +56,7 @@ def _build_parser_map() -> Dict[str, CatalogSlugParser]:
     block in the Access Sync runtime config JSON when present.  Platforms
     without parser config fall back to ``FallbackCatalogSlugParser``.
     """
-    runtime_config = get_access_sync_runtime_config()
+    runtime_config = get_access_runtime_config()
     catalog_ext = getattr(runtime_config, "catalog", None)
     parsers: Dict[str, CatalogSlugParser] = {}
 
@@ -86,7 +86,7 @@ def get_catalog_service() -> CatalogService:
     - Parser map (token decomposition per platform).
     - Display names from catalog extension config (optional).
     """
-    runtime_config = get_access_sync_runtime_config()
+    runtime_config = get_access_runtime_config()
     directory = get_directory_provider()
     parser_map = _build_parser_map()
 

--- a/app/packages/access/catalog/service.py
+++ b/app/packages/access/catalog/service.py
@@ -22,7 +22,7 @@ from packages.access.catalog.parsers import CatalogSlugParser, FallbackCatalogSl
 
 if TYPE_CHECKING:
     from infrastructure.directory.provider import DirectoryProvider
-    from packages.access.sync.config.settings import AccessSyncRuntimeConfig
+    from packages.access.common.config import AccessRuntimeConfig
 
 logger = structlog.get_logger()
 
@@ -55,7 +55,7 @@ class CatalogService:
 
     def __init__(
         self,
-        runtime_config: "AccessSyncRuntimeConfig",
+        runtime_config: "AccessRuntimeConfig",
         directory: "DirectoryProvider",
         parsers: Dict[str, CatalogSlugParser],
         display_names: Optional[Dict[str, str]] = None,

--- a/app/packages/access/common/__init__.py
+++ b/app/packages/access/common/__init__.py
@@ -1,0 +1,5 @@
+"""Shared access-domain contracts.
+
+This package contains cross-sub-package contracts only (types and constants).
+It is intentionally not a feature plugin and must not expose hookimpl functions.
+"""

--- a/app/packages/access/common/config/__init__.py
+++ b/app/packages/access/common/config/__init__.py
@@ -1,0 +1,19 @@
+"""Shared access-domain config contracts."""
+
+from packages.access.common.config.loaders import AccessConfigLoader
+from packages.access.common.config.settings import (
+    AccessRuntimeConfig,
+    EntitlementMode,
+    EntitlementModeOverride,
+    EntitlementRule,
+    PlatformPolicy,
+)
+
+__all__ = [
+    "AccessConfigLoader",
+    "AccessRuntimeConfig",
+    "EntitlementMode",
+    "EntitlementModeOverride",
+    "EntitlementRule",
+    "PlatformPolicy",
+]

--- a/app/packages/access/common/config/loaders.py
+++ b/app/packages/access/common/config/loaders.py
@@ -1,0 +1,14 @@
+"""Shared loader protocol for access runtime configuration."""
+
+from typing import Protocol
+
+from infrastructure.operations import OperationResult
+from packages.access.common.config.settings import AccessRuntimeConfig
+
+
+class AccessConfigLoader(Protocol):
+    """Protocol for loading access runtime configuration."""
+
+    def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
+        """Load access runtime configuration by source-specific reference."""
+        ...

--- a/app/packages/access/common/config/settings.py
+++ b/app/packages/access/common/config/settings.py
@@ -1,0 +1,80 @@
+"""Shared access-domain runtime config models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from packages.access.common.naming import AccessGroupNaming
+
+
+EntitlementMode = Literal["sync_managed", "ephemeral", "deactivated"]
+
+
+@dataclass(frozen=True)
+class EntitlementRule:
+    """Runtime binding of an IDP group slug to one platform entitlement."""
+
+    group_slug: str
+    entitlement_id: str
+    entitlement_type: str = "group"
+    mode: EntitlementMode = "sync_managed"
+
+
+@dataclass(frozen=True)
+class PlatformPolicy:
+    """Per-platform policy loaded from runtime configuration."""
+
+    authn_token: str = "authn"
+    authn_removal_mode: str = "delete"  # disable | delete | entitlement_only
+    mode_overrides: Dict[str, EntitlementMode] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EntitlementModeOverride:
+    """Runtime per-group entitlement mode override record."""
+
+    platform: str
+    group_slug: str
+    mode: EntitlementMode
+    reason: Optional[str] = None
+    requested_by: Optional[str] = None
+    expires_at: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class AccessRuntimeConfig:
+    """Fully-resolved runtime configuration shared across access sub-packages."""
+
+    dir_prefix: str
+    dir_separator: str = "-"
+    platforms: Dict[str, PlatformPolicy] = field(default_factory=dict)
+    entitlement_mode_overrides: List[EntitlementModeOverride] = field(
+        default_factory=list
+    )
+    # Optional extension bag for package-specific read-only configuration.
+    extensions: Dict[str, Any] = field(default_factory=dict)
+
+    def group_prefix(self, platform: str) -> str:
+        """Return the IDP group slug prefix for a given platform."""
+        return AccessGroupNaming(
+            dir_prefix=self.dir_prefix,
+            dir_separator=self.dir_separator,
+        ).group_prefix(platform)
+
+    def authn_group_slug(self, platform: str) -> str:
+        """Return the full authn group slug for a given platform."""
+        return AccessGroupNaming(
+            dir_prefix=self.dir_prefix,
+            dir_separator=self.dir_separator,
+        ).authn_group_slug(
+            platform=platform,
+            authn_token=self.platforms[platform].authn_token,
+        )
+
+    @property
+    def catalog(self) -> Optional[Any]:
+        """Return optional catalog extension configuration."""
+        value = self.extensions.get("catalog")
+        return value

--- a/app/packages/access/common/events.py
+++ b/app/packages/access/common/events.py
@@ -1,0 +1,11 @@
+"""Shared cross-sub-package Access event names.
+
+These are the contract strings used at package boundaries.
+"""
+
+# Emitted by packages/access/request/, subscribed by packages/access/sync/
+REQUEST_APPROVED = "access_request_approved"
+
+# Emitted by packages/access/sync/, subscribed by packages/access/request/
+SYNC_COMPLETED = "access_sync.sync_completed"
+SYNC_FAILED = "access_sync.sync_failed"

--- a/app/packages/access/common/naming.py
+++ b/app/packages/access/common/naming.py
@@ -1,0 +1,30 @@
+"""Shared access-domain naming helpers."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccessGroupNaming:
+    """Compute canonical IDP group names for a platform.
+
+    Args:
+        dir_prefix: Organization-wide group prefix (for example, ``sg``).
+        dir_separator: Group slug segment separator (for example, ``-``).
+    """
+
+    dir_prefix: str
+    dir_separator: str = "-"
+
+    def group_prefix(self, platform: str) -> str:
+        """Return the group slug prefix for a platform.
+
+        Example: ``sg-aws-``.
+        """
+        return f"{self.dir_prefix}{self.dir_separator}{platform}{self.dir_separator}"
+
+    def authn_group_slug(self, platform: str, authn_token: str = "authn") -> str:
+        """Return the authn lifecycle group slug for a platform.
+
+        Example: ``sg-aws-authn``.
+        """
+        return f"{self.group_prefix(platform)}{authn_token}"

--- a/app/packages/access/sync/__init__.py
+++ b/app/packages/access/sync/__init__.py
@@ -9,6 +9,7 @@ Exports the FastAPI router for registration in the main application.
 
 from infrastructure.events import register_event_handler
 from infrastructure.services import hookimpl
+from packages.access.common.events import REQUEST_APPROVED
 from packages.access.sync.transport import slack
 from packages.access.sync.providers import (
     get_access_sync_coordinator,
@@ -23,7 +24,7 @@ def register_slack_commands(provider) -> None:
     slack.register_commands(provider)
 
 
-@register_event_handler("access_request_approved")
+@register_event_handler(REQUEST_APPROVED)
 def on_access_request_approved(event) -> None:
     """Trigger on-demand sync when an access request is approved."""
     get_access_sync_coordinator().sync_user(

--- a/app/packages/access/sync/config/__init__.py
+++ b/app/packages/access/sync/config/__init__.py
@@ -10,6 +10,7 @@ from packages.access.sync.config.settings import (
     AccessSyncSettings,
     EntitlementModeOverride,
 )
+from packages.access.common.config import AccessRuntimeConfig
 from packages.access.sync.config.loaders import (
     AccessSyncConfigLoader,
     BundleConfigLoader,
@@ -23,6 +24,7 @@ from packages.access.sync.config.loaders import (
 __all__ = [
     # settings
     "AccessSyncSettings",
+    "AccessRuntimeConfig",
     "AccessSyncRuntimeConfig",
     "EntitlementModeOverride",
     # loaders

--- a/app/packages/access/sync/config/loaders.py
+++ b/app/packages/access/sync/config/loaders.py
@@ -17,14 +17,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, Protocol
+from typing import Dict
 
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from infrastructure.operations import OperationResult, OperationStatus
-from packages.access.sync.config.settings import AccessSyncRuntimeConfig
-from packages.access.sync.policies import (
+from packages.access.common.config import (
+    AccessConfigLoader,
+    AccessRuntimeConfig,
     EntitlementMode,
     PlatformPolicy,
 )
@@ -102,31 +103,15 @@ class RuntimeConfigJsonSettings(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class AccessSyncConfigLoader(Protocol):
-    """Protocol for Access Sync config loaders.
-
-    Each loader knows how to fetch and deserialise one runtime config document
-    from its backing store.
-    """
-
-    def load(self, ref: str) -> OperationResult[AccessSyncRuntimeConfig]:
-        """Load the runtime config identified by *ref*.
-
-        Args:
-            ref: Source-specific reference (table PK, S3 key, SSM path, bundle name).
-
-        Returns:
-            OperationResult[AccessSyncRuntimeConfig] — success with data, or error.
-        """
-        ...
+AccessSyncConfigLoader = AccessConfigLoader
 
 
 def _build_runtime_config(
     dir_prefix: str,
     dir_separator: str,
     platforms_model: Dict[str, PlatformPolicyConfigModel],
-) -> AccessSyncRuntimeConfig:
-    """Convert validated JSON platform models into ``AccessSyncRuntimeConfig``."""
+) -> AccessRuntimeConfig:
+    """Convert validated JSON platform models into ``AccessRuntimeConfig``."""
     platforms: Dict[str, PlatformPolicy] = {}
 
     for key, raw_policy in platforms_model.items():
@@ -137,7 +122,7 @@ def _build_runtime_config(
         )
         platforms[normalize_target_key(key)] = policy
 
-    return AccessSyncRuntimeConfig(
+    return AccessRuntimeConfig(
         dir_prefix=dir_prefix,
         dir_separator=dir_separator,
         platforms=platforms,
@@ -147,7 +132,7 @@ def _build_runtime_config(
 def _validate_runtime_config_payload(
     payload: object,
     error_prefix: str,
-) -> OperationResult[AccessSyncRuntimeConfig]:
+) -> OperationResult[AccessRuntimeConfig]:
     """Validate parsed JSON payload and build runtime config."""
     try:
         validated = RuntimeConfigJsonSettings.model_validate(payload)
@@ -182,7 +167,7 @@ class BundleConfigLoader:
     Operators wire real platforms via an external source (dynamodb / s3 / ssm).
     """
 
-    def load(self, ref: str) -> OperationResult[AccessSyncRuntimeConfig]:
+    def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
         """Return an empty bundle config with no pre-configured platforms.
 
         Args:
@@ -193,7 +178,7 @@ class BundleConfigLoader:
             platforms dict. The feature will be in waiting mode until an
             external config source provides platform policies.
         """
-        config = AccessSyncRuntimeConfig(dir_prefix="", platforms={})
+        config = AccessRuntimeConfig(dir_prefix="", platforms={})
         return OperationResult.success(
             data=config,
             message=f"bundle_config_loaded ref={ref} platforms=0 (waiting mode)",
@@ -203,7 +188,7 @@ class BundleConfigLoader:
 class InlineJsonConfigLoader:
     """Config loader that parses runtime policy from ACCESS_SYNC_CONFIG_REF JSON."""
 
-    def load(self, ref: str) -> OperationResult[AccessSyncRuntimeConfig]:
+    def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
         """Parse *ref* as JSON and build AccessSyncRuntimeConfig.
 
         Expected shape::
@@ -260,7 +245,7 @@ class EnvConfigLoader:
             extra="ignore",
         )
 
-    def load(self, ref: str) -> OperationResult[AccessSyncRuntimeConfig]:
+    def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
         env = self._EnvModel()
 
         if not env.dir_prefix:
@@ -292,7 +277,7 @@ class EnvConfigLoader:
 class FileJsonConfigLoader:
     """Config loader that parses runtime policy from a JSON file path in ref."""
 
-    def load(self, ref: str) -> OperationResult[AccessSyncRuntimeConfig]:
+    def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
         """Read *ref* as a JSON file path and build AccessSyncRuntimeConfig."""
         path = Path(ref)
         if not path.exists():
@@ -342,7 +327,7 @@ class FileJsonConfigLoader:
 # ---------------------------------------------------------------------------
 
 
-def get_access_sync_config_loader(source: str) -> AccessSyncConfigLoader:
+def get_access_sync_config_loader(source: str) -> AccessConfigLoader:
     """Return the config loader for the given source string.
 
     Args:

--- a/app/packages/access/sync/config/settings.py
+++ b/app/packages/access/sync/config/settings.py
@@ -1,22 +1,23 @@
-"""Access Sync bootstrap settings and runtime domain models.
+"""Access Sync bootstrap settings and compatibility aliases.
 
 AccessSyncSettings reads env vars that select the runtime config source and
 control feature flags.
 
-Runtime domain models (AccessSyncRuntimeConfig, EntitlementModeOverride) live
-here because they depend only on policies.py and stdlib — no loader logic needed.
+Runtime domain models were moved to ``packages.access.common.config`` and are
+re-exported here for compatibility during the transition.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Dict, List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from packages.access.sync.policies import PlatformPolicy
+from packages.access.common.config import (
+    AccessRuntimeConfig,
+    EntitlementModeOverride as CommonEntitlementModeOverride,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -77,58 +78,7 @@ class AccessSyncSettings(BaseSettings):
 
 
 # ---------------------------------------------------------------------------
-# Runtime Domain Models
+# Compatibility aliases (transition)
 # ---------------------------------------------------------------------------
-@dataclass(frozen=True)
-class EntitlementModeOverride:
-    """Runtime per-group entitlement mode override record.
-
-    Written by Access Sync Admin and consumed by the runtime config loader to
-    amend the effective mode of individual entitlement groups at runtime without
-    code deploys.
-    """
-
-    platform: str
-    group_slug: str
-    mode: Literal["sync_managed", "ephemeral", "deactivated"]
-    reason: Optional[str] = None
-    requested_by: Optional[str] = None
-    expires_at: Optional[datetime] = None
-
-
-@dataclass(frozen=True)
-class AccessSyncRuntimeConfig:
-    """Fully-resolved runtime configuration for Access Sync.
-
-    Loaded once at startup via the config loader selected by bootstrap settings.
-    Contains the organization-wide group naming convention and per-platform
-    policies.  Slug construction -- platform prefix, authn group slug -- is
-    derived from ``dir_prefix``, ``dir_separator``, and the per-platform
-    ``PlatformPolicy.authn_token`` rather than stored explicitly.
-
-    Infrastructure clients (AWS, Google Workspace, etc.) are obtained separately
-    from infrastructure.services and come pre-configured with all needed bootstrap
-    settings (e.g., AWS_SSO_INSTANCE_ID). Feature configuration is limited to
-    group naming and policy definitions.
-    """
-
-    dir_prefix: str
-    dir_separator: str = "-"
-    platforms: Dict[str, PlatformPolicy] = field(default_factory=dict)
-    entitlement_mode_overrides: List[EntitlementModeOverride] = field(
-        default_factory=list
-    )
-
-    def group_prefix(self, platform: str) -> str:
-        """Return the IDP group slug prefix for a given platform.
-
-        Example: dir_prefix="sg", dir_separator="-", platform="aws" -> "sg-aws-".
-        """
-        return f"{self.dir_prefix}{self.dir_separator}{platform}{self.dir_separator}"
-
-    def authn_group_slug(self, platform: str) -> str:
-        """Return the full authn group slug for a given platform.
-
-        Example: "sg-aws-authn" when authn_token="authn".
-        """
-        return f"{self.group_prefix(platform)}{self.platforms[platform].authn_token}"
+AccessSyncRuntimeConfig = AccessRuntimeConfig
+EntitlementModeOverride = CommonEntitlementModeOverride

--- a/app/packages/access/sync/coordinator.py
+++ b/app/packages/access/sync/coordinator.py
@@ -26,13 +26,13 @@ import structlog
 
 from infrastructure.events import Event, EventDispatcher
 from infrastructure.operations import OperationResult, OperationStatus
+from packages.access.common.config import AccessRuntimeConfig
 from packages.access.sync import events as sync_events
 from packages.access.sync.adapters import (
     AccessSyncAdapter,
     BulkGroupMembershipAdapter,
     EntitlementCanonicalizingAdapter,
 )
-from packages.access.sync.config.settings import AccessSyncRuntimeConfig
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
 from packages.access.sync.domain import (
     DesiredUserState,
@@ -95,7 +95,7 @@ class AccessSyncCoordinator:
     def __init__(
         self,
         adapters: Mapping[str, AccessSyncAdapter],
-        config: AccessSyncRuntimeConfig,
+        config: AccessRuntimeConfig,
         membership_builder: DirectoryMembershipBuilder,
         repository: "Optional[SyncRunRepository]" = None,
         dispatcher: Optional[EventDispatcher] = None,

--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -25,7 +25,7 @@ from packages.access.sync.policies import (
 
 if TYPE_CHECKING:
     from infrastructure.directory.provider import DirectoryProvider
-    from packages.access.sync.config.settings import AccessSyncRuntimeConfig
+    from packages.access.common.config import AccessRuntimeConfig
 
 logger = structlog.get_logger()
 
@@ -158,7 +158,7 @@ class DirectoryMembershipBuilder:
 
     def discover_group_slugs(
         self,
-        config: "AccessSyncRuntimeConfig",
+        config: "AccessRuntimeConfig",
         platform: str,
     ) -> Set[str]:
         """Discover IDP group slugs for a platform by querying with the platform prefix.

--- a/app/packages/access/sync/events.py
+++ b/app/packages/access/sync/events.py
@@ -4,11 +4,16 @@ Use these constants when dispatching or subscribing to Access Sync events
 via ``EventDispatcher`` from ``infrastructure.events``.  String literals
 must not be used directly in coordinator or transport code.
 
-This module contains string constants only — no imports, no logic.
+This module contains event name constants only.
 """
 
-SYNC_COMPLETED = "access_sync.sync_completed"
-SYNC_FAILED = "access_sync.sync_failed"
+from packages.access.common.events import (
+    SYNC_COMPLETED as COMMON_SYNC_COMPLETED,
+    SYNC_FAILED as COMMON_SYNC_FAILED,
+)
+
+SYNC_COMPLETED = COMMON_SYNC_COMPLETED
+SYNC_FAILED = COMMON_SYNC_FAILED
 
 PLATFORM_SYNC_STARTED = "access_sync.platform_sync_started"
 PLATFORM_SYNC_COMPLETED = "access_sync.platform_sync_completed"

--- a/app/packages/access/sync/policies.py
+++ b/app/packages/access/sync/policies.py
@@ -26,71 +26,21 @@ Two layers of policy are defined here:
 Adapters must not duplicate any logic from this module.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional, Set, TYPE_CHECKING
 
+from packages.access.common.config import (
+    EntitlementMode,
+    EntitlementRule,
+    PlatformPolicy,
+)
+
 if TYPE_CHECKING:
-    from packages.access.sync.config.settings import AccessSyncRuntimeConfig
+    from packages.access.common.config import AccessRuntimeConfig
 
-
-EntitlementMode = Literal["sync_managed", "ephemeral", "deactivated"]
-
-
-@dataclass(frozen=True)
-class EntitlementRule:
-    """Runtime binding of an IDP group slug to one platform entitlement.
-
-    ``group_slug`` -- the full IDP security group slug (e.g.
-    ``sg-aws-finops-readonly``).  Used by the desired-state builder to check
-    membership via the IDP directory.
-
-    ``entitlement_id`` -- the platform token (e.g. ``finops-readonly``).
-    Passed to the adapter which resolves it to a platform-native identifier
-    (e.g. an AWS IC GroupId via the group index).
-
-    ``entitlement_type`` -- platform capability type; defaults to ``"group"``
-    (v1 only supports group membership sync).
-
-    ``mode`` -- always ``"sync_managed"`` in the effective policy; ephemeral
-    and deactivated tokens are excluded at resolution time.
-    """
-
-    group_slug: str
-    entitlement_id: str
-    entitlement_type: str = "group"
-    mode: EntitlementMode = "sync_managed"
-
-
-@dataclass(frozen=True)
-class PlatformPolicy:
-    """Minimal per-platform configuration loaded from runtime config.
-
-    All slug construction is delegated to ``AccessSyncRuntimeConfig`` which
-    holds the organization-wide ``dir_prefix`` and ``dir_separator``.
-
-    ``authn_token`` -- the token segment identifying the lifecycle (authn)
-    group.  Combined with ``dir_prefix``, ``dir_separator``, and platform name
-    to derive the full authn group slug.  Defaults to ``"authn"``.
-
-    ``authn_removal_mode`` -- what to do when a user leaves the authn group:
-
-    * ``disable``           -- deactivate the user account on the platform.
-    * ``delete``            -- remove the user from the platform entirely.
-    * ``entitlement_only``  -- remove only managed entitlements; account left
-      intact and flagged for manual follow-up.
-
-    ``mode_overrides`` -- static config-time overrides for specific entitlement
-    tokens.  A token declared here with mode ``ephemeral`` or ``deactivated``
-    is silently excluded from the effective rule set; Access Sync will not
-    observe or touch those platform groups.  This is the only place where
-    token-level lifecycle exceptions are declared; there is no zero-config
-    auto-discovery -- the platform entry itself is the security authorization
-    decision.
-    """
-
-    authn_token: str = "authn"
-    authn_removal_mode: str = "delete"  # disable | delete | entitlement_only
-    mode_overrides: Dict[str, EntitlementMode] = field(default_factory=dict)
+# Backward-compatible re-exports for existing imports.
+PolicyEntitlementMode = EntitlementMode
+PolicyPlatformPolicy = PlatformPolicy
 
 
 @dataclass(frozen=True)
@@ -118,7 +68,7 @@ class EffectivePlatformPolicy:
 
 
 def resolve_effective_policy(
-    config: "AccessSyncRuntimeConfig",
+    config: "AccessRuntimeConfig",
     platform: str,
     discovered_slugs: Set[str],
 ) -> EffectivePlatformPolicy:

--- a/app/packages/access/sync/providers.py
+++ b/app/packages/access/sync/providers.py
@@ -20,11 +20,11 @@ from infrastructure.services import (
     get_directory_provider,
     get_storage_service,
 )
+from packages.access.common.config import AccessRuntimeConfig
 from packages.access.sync.adapters.aws_identity_center import AwsIdentityCenterAdapter
 from packages.access.sync.adapters.fake_platform import FakePlatformAdapter
 from packages.access.sync.adapters import AccessSyncAdapter
 from packages.access.sync.config import (
-    AccessSyncRuntimeConfig,
     AccessSyncSettings,
     get_access_sync_config_loader,
 )
@@ -40,7 +40,7 @@ def get_access_sync_settings() -> AccessSyncSettings:
 
 
 @lru_cache(maxsize=1)
-def get_access_sync_runtime_config() -> AccessSyncRuntimeConfig:
+def get_access_runtime_config() -> AccessRuntimeConfig:
     """Load typed runtime config from the source selected by bootstrap settings.
 
     Returns feature-level configuration (policies, per-group overrides).
@@ -56,13 +56,19 @@ def get_access_sync_runtime_config() -> AccessSyncRuntimeConfig:
     loader = get_access_sync_config_loader(
         source=settings.config_source,
     )
-    result: OperationResult[AccessSyncRuntimeConfig] = loader.load(
+    result: OperationResult[AccessRuntimeConfig] = loader.load(
         ref=settings.config_ref,
     )
-    config: Optional[AccessSyncRuntimeConfig] = result.data
+    config: Optional[AccessRuntimeConfig] = result.data
     if not result.is_success or config is None:
         raise RuntimeError(f"access_sync_config_load_failed: {result.message}")
     return config
+
+
+@lru_cache(maxsize=1)
+def get_access_sync_runtime_config() -> AccessRuntimeConfig:
+    """Compatibility wrapper for renamed runtime config provider."""
+    return get_access_runtime_config()
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new shared configuration contract for the access domain, consolidating runtime config models and loader protocols into a new `packages.access.common.config` package. The main goal is to unify configuration types and logic across sub-packages, reduce duplication, and improve maintainability. The changes also update references throughout the codebase to use the new shared models, and introduce shared event and naming helpers.

**Shared configuration and contract extraction:**

* Introduced `packages.access.common.config` with shared models (`AccessRuntimeConfig`, `EntitlementMode`, `PlatformPolicy`, etc.), loader protocol (`AccessConfigLoader`), and moved runtime config logic out of `access.sync.config.settings`. (`[[1]](diffhunk://#diff-7960a0bd13cb0243170576caa660541a4829ff0aae6f94c318f1bfcac1484fe2R1-R19)`, `[[2]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R1-R14)`, `[[3]](diffhunk://#diff-c664832ff9ec305d0eec2fdc2ac88300baac8323d2e82bea8778f7d74b3c7b7eR1-R80)`)
* Updated `access.sync.config` to use and re-export the new shared models for compatibility, and removed now-redundant model definitions. (`[[1]](diffhunk://#diff-a4a2d948902e81ef09514c022a40946cee718a82bb62832b0ceff871cd314654R13)`, `[[2]](diffhunk://#diff-a4a2d948902e81ef09514c022a40946cee718a82bb62832b0ceff871cd314654R27)`, `[[3]](diffhunk://#diff-5608226252374f0bd49929da48654179132953635513be56b2fbeb5d16968061L1-R20)`)
* Refactored all relevant imports and type annotations in `access.sync.config.loaders`, `access.catalog.service`, and `access.catalog.providers` to use the new shared models and loader protocol. (`[[1]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL25-R25)`, `[[2]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL58-R58)`, `[[3]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL23-R23)`, `[[4]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL59-R59)`, `[[5]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL89-R89)`, `[[6]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L20-R28)`, `[[7]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L105-R114)`, `[[8]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L140-R125)`, `[[9]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L150-R135)`, `[[10]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L185-R170)`, `[[11]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L196-R181)`, `[[12]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L206-R191)`, `[[13]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L263-R248)`, `[[14]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L295-R280)`, `[[15]](diffhunk://#diff-8a3fb5a1e4a2777116848166a82937c5b9a5aaf439164aa7acc3deb0acc0cda4L345-R330)`)

**New shared helpers:**

* Added `packages.access.common.events` for cross-package event name constants, and refactored event handler registration in `access.sync` to use these constants. (`[[1]](diffhunk://#diff-39805628e2457c432eb9abe1ab6c4efae0b6f4cf13bbb4a64b38a122a2cda2f9R1-R11)`, `[[2]](diffhunk://#diff-94560a417560c273a0195e2930daf2e3a1b5e5e0370eb66463ab9918c9daf2bdR12)`, `[[3]](diffhunk://#diff-94560a417560c273a0195e2930daf2e3a1b5e5e0370eb66463ab9918c9daf2bdL26-R27)`)
* Added `packages.access.common.naming` containing `AccessGroupNaming` for canonical group slug computation, now used by the shared config models. (`[app/packages/access/common/naming.pyR1-R30](diffhunk://#diff-e0a3b77d978f4c1a7eca34c12e175e6b0cee53b7c700b5bfc04b2ca5651b665cR1-R30)`)
* Added `__init__.py` files with documentation for new shared packages. (`[app/packages/access/common/__init__.pyR1-R5](diffhunk://#diff-d851bd51a0451124975771e02cc791ce23d4a6e41424eb876315d0f7f887dcfaR1-R5)`)

These changes lay the groundwork for improved modularity and consistency across the access domain, making it easier to maintain and extend configuration handling.