### PR TITLE
test: fix mock assertion usage in google directory test

### DIFF
--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -329,7 +329,7 @@ def test_list_groups_with_members_filtered(
         google_directory.list_groups_with_members(groups_filters=groups_filters)
         == groups_with_users
     )
-    assert mock_filter_by_condition.called_once_with(groups, groups_filters)
+    mock_filter_by_condition.assert_called_once_with(groups, groups_filters[0])
     assert mock_retry_request.call_count == 2
     assert mock_list_users.call_count == 1
 


### PR DESCRIPTION
# Summary | Résumé

Running the test with:
```pytest -s -vv tests/integrations/google_workspace/test_google_directory.py::test_list_groups_with_members_filtered```

yields this error:
```
AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

/usr/local/lib/python3.12/unittest/mock.py:665: AttributeError
```

This has been fixed by calling ```assert_called_once_with``` as intended by the ```unittest.mock``` API: https://docs.python.org/3/library/unittest.mock.html

Additionally, groups_filters was updated from a list to its single filter function to match intended function call behavior. The ```assert``` wrapper around ```assert_called_once_with``` was removed as it returns ```None``` on success, causing the assertion to always fail as well.

# Test Instructions | Instructions pour tester la modification

1. Run the targeted test: 
```pytest -s -vv tests/integrations/google_workspace/test_google_directory.py::test_list_groups_with_members_filtered```
2. Verify:
- test passes
- filter_by_condition is called exactly once
- mock assertions succeed
- no unexpected failures 

