### PR TITLE
test: fix mock assertion usage in provisioning groups test

### DIFF
--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -329,7 +329,7 @@ def test_list_groups_with_members_filtered(
         google_directory.list_groups_with_members(groups_filters=groups_filters)
         == groups_with_users
     )
-    assert mock_filter_by_condition.called_once_with(groups, groups_filters)
+    mock_filter_by_condition.assert_called_once_with(groups, groups_filters[0])
     assert mock_retry_request.call_count == 2
     assert mock_list_users.call_count == 1
 

--- a/app/tests/modules/provisioning/test_provisioning_groups.py
+++ b/app/tests/modules/provisioning/test_provisioning_groups.py
@@ -18,8 +18,9 @@ def test_get_groups_from_integration_google(
 
     assert response == google_groups
 
-    assert mock_google_list_groups_with_members.called_once_with(
-        query=None, members_details=True
+    mock_google_list_groups_with_members.assert_called_once_with(
+        groups_filters=[],
+        query=None
     )
     assert not mock_filters.filter_by_condition.called
     assert not mock_aws_list_groups_with_memberships.called
@@ -43,8 +44,9 @@ def test_get_groups_from_integration_google_query(
 
     assert response == google_groups[:3]
 
-    assert mock_google_list_groups_with_members.called_once_with(
-        query="email:aws-*", members_details=True
+    mock_google_list_groups_with_members.assert_called_once_with(
+        groups_filters=[],
+        query="email:aws-*"
     )
     assert not mock_filters.filter_by_condition.called
     assert not mock_aws_list_groups_with_memberships.called
@@ -66,7 +68,7 @@ def test_get_groups_from_integration_case_aws(
 
     assert response == aws_groups
 
-    assert mock_aws_list_groups_with_memberships.called_once_with(members_details=True)
+    mock_aws_list_groups_with_memberships.assert_called_once_with(groups_filters=[])
     assert not mock_filters.filter_by_condition.called
     assert not mock_google_list_groups_with_members.called
 
@@ -86,8 +88,9 @@ def test_get_groups_from_integration_empty_groups(
 
     assert response == google_groups
 
-    assert mock_google_list_groups_with_members.called_once_with(
-        query=None, members_details=True
+    mock_google_list_groups_with_members.assert_called_once_with(
+        groups_filters=[],
+        query=None
     )
     assert not mock_filters.filter_by_condition.called
     assert not mock_aws_list_groups_with_memberships.called
@@ -137,14 +140,11 @@ def test_get_groups_from_integration_filters_applied(
 
     assert response == []
 
-    assert mock_filters.filter_by_condition.call_count == 2
-    assert mock_filters.filter_by_condition.called_once_with(
-        aws_groups, post_processing_filters
-    )
-    assert mock_filters.filter_by_condition.called_once_with(
-        aws_groups_prefix, post_processing_filters
-    )
-    assert mock_aws_list_groups_with_memberships.called_once_with(members_details=True)
+    mock_filters.filter_by_condition.assert_has_calls([
+        call(aws_groups, post_processing_filters[0]),
+        call(aws_groups_prefix, post_processing_filters[1]),
+    ])
+    mock_aws_list_groups_with_memberships.assert_called_once_with(groups_filters=[])
     assert not mock_google_list_groups_with_members.called
 
 
@@ -175,13 +175,14 @@ def test_get_groups_from_integration_filters_returns_subset(
     assert response == aws_groups_prefix
 
     assert mock_filters.filter_by_condition.call_count == 1
-    assert mock_filters.filter_by_condition.called_once_with(
-        aws_groups, post_processing_filters
+    mock_filters.filter_by_condition.assert_called_once_with(
+        aws_groups, post_processing_filters[0]
     )
-    assert mock_filters.filter_by_condition.called_once_with(
-        aws_groups_prefix, post_processing_filters
+
+    mock_aws_list_groups_with_memberships.assert_called_once_with(
+        groups_filters=[]
     )
-    assert mock_aws_list_groups_with_memberships.called_once_with(members_details=True)
+
     assert not mock_google_list_groups_with_members.called
 
 


### PR DESCRIPTION
# Summary | Résumé

Previous test coverage ran with ```pytest tests/modules/provisioning/test_provisioning_groups.py``` and fails with this error:
```
=========================================================================== short test summary info ============================================================================
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_google - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_google_query - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_case_aws - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_empty_groups - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_filters_applied - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
FAILED tests/modules/provisioning/test_provisioning_groups.py::test_get_groups_from_integration_filters_returns_subset - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_...
=================================================================== 6 failed, 6 passed, 17 warnings in 3.09s ===================================================================
```

called_once_with seems to be a common typo that failed silently up to Python 3.12, references:
https://github.com/apache/airflow/issues/20453
https://github.com/apache/airflow/pull/20428#issuecomment-998714275

Quote: ```(it just seems to create a new mock ad-hoc..)This means the affected tests don't actually assert anything, making them pass although they shouldn't.```

After solving the silent fail, a couple failures remained such as:

```
assert mock_google_list_groups_with_members.called_once_with(
    query=None, members_details=True
)
```
Checking workspace/app/modules/provisioning/groups.py we can see members_details isn't used, but groups_filters
```
groups = google_directory.list_groups_with_members(
    groups_filters=pre_processing_filters,
    query=query,
)
```


---

# Test instructions | Instructions pour tester la modification

Confirm tests fail with original environment with ```pytest tests/modules/provisioning/test_provisioning_groups.py```
Verify tests with ```pytest tests/modules/provisioning/test_provisioning_groups.py``` succeed after these changes 
