### PR TITLE
Fix/infra aws client endpoint logic

### DIFF
--- a/app/.flake8
+++ b/app/.flake8
@@ -5,7 +5,7 @@
 # In most cases Black follows the rules below, but there are some exceptions
 # E203: whitespace before ':'
 # E501: line too long
-exclude = venv*, __pycache__, node_modules, cache, migrations, build
+exclude = venv*, .venv, __pycache__, node_modules, cache, migrations, build
 ignore = W503, W504, E203, E501
 per-file-ignores =
     # E704: Protocol stub methods use single-line `...` form (black-formatted)

--- a/app/infrastructure/clients/aws/dynamodb.py
+++ b/app/infrastructure/clients/aws/dynamodb.py
@@ -224,7 +224,11 @@ class DynamoDBClient:
         Performs a cheap `list_tables` call to verify the service is reachable.
         Returns OperationResult.success on success, or an error OperationResult.
         """
-        client_kwargs = self._session_provider.build_client_kwargs(role_arn=role_arn)
+        effective_role = role_arn or self._default_role_arn
+        client_kwargs = self._session_provider.build_client_kwargs(
+            service_name=self._service_name,
+            role_arn=effective_role,
+        )
         return execute_aws_api_call(
             "dynamodb",
             "list_tables",

--- a/app/infrastructure/clients/aws/identity_store.py
+++ b/app/infrastructure/clients/aws/identity_store.py
@@ -11,6 +11,7 @@ import structlog
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
 from infrastructure.clients.aws.session_provider import SessionProvider
+from infrastructure.operations import OperationStatus
 from infrastructure.operations.result import OperationResult
 
 logger = structlog.get_logger()
@@ -495,7 +496,7 @@ class IdentityStoreClient:
         client_kwargs = self._session_provider.build_client_kwargs(
             service_name=self._service_name, role_arn=role_arn
         )
-        return execute_aws_api_call(
+        result = execute_aws_api_call(
             "identitystore",
             "get_group_membership_id",
             IdentityStoreId=store_id,
@@ -504,6 +505,13 @@ class IdentityStoreClient:
             **client_kwargs,
             **kwargs,
         )
+        if result.error_code == "ResourceNotFoundException":
+            return OperationResult.error(
+                OperationStatus.NOT_FOUND,
+                message="Group membership not found",
+                error_code="GROUP_MEMBERSHIP_NOT_FOUND",
+            )
+        return result
 
     def get_user_id_by_username(
         self,

--- a/app/infrastructure/clients/aws/session_provider.py
+++ b/app/infrastructure/clients/aws/session_provider.py
@@ -35,6 +35,16 @@ class SessionProvider:
         self.service_role_map = service_role_map
         self.endpoint_url = endpoint_url
 
+    @staticmethod
+    def _should_apply_endpoint_override(service_name: Optional[str]) -> bool:
+        """Return whether a custom endpoint override applies to the service.
+
+        The shared AWS endpoint override is reserved for local DynamoDB testing.
+        Applying it to all services routes calls like Identity Store to DynamoDB
+        Local, which fails with AWS API `InvalidAction` errors.
+        """
+        return service_name == "dynamodb"
+
     def get_role_arn_for_service(self, service_name: str) -> Optional[str]:
         """Get the role ARN to assume for the given AWS service.
 
@@ -83,7 +93,7 @@ class SessionProvider:
             session_config["region_name"] = self.region
             client_config["region_name"] = self.region
 
-        if self.endpoint_url:
+        if self.endpoint_url and self._should_apply_endpoint_override(service_name):
             client_config["endpoint_url"] = self.endpoint_url
 
         logger.debug(

--- a/app/infrastructure/configuration/integrations/aws.py
+++ b/app/infrastructure/configuration/integrations/aws.py
@@ -47,7 +47,7 @@ class AwsSettings(IntegrationSettings):
         default=None,
         alias="AWS_ENDPOINT_URL",
         description=(
-            "Override endpoint URL for all AWS clients. "
+            "Override endpoint URL for DynamoDB clients only. "
             "Set to http://dynamodb-local:8000 for local development."
         ),
     )

--- a/app/infrastructure/directory/google.py
+++ b/app/infrastructure/directory/google.py
@@ -90,6 +90,59 @@ class GoogleDirectoryProvider:
 
         return ""
 
+    def _extract_group_aliases(self, item: dict[str, Any]) -> list[str]:
+        """Return normalized group aliases from Google group payload variants."""
+
+        aliases: list[str] = []
+        for key in ["aliases", "nonEditableAliases"]:
+            raw_aliases = item.get(key)
+            if not isinstance(raw_aliases, list):
+                continue
+            for raw_alias in raw_aliases:
+                if not isinstance(raw_alias, str):
+                    continue
+                normalized_alias = self._normalize_email(raw_alias)
+                if normalized_alias and normalized_alias not in aliases:
+                    aliases.append(normalized_alias)
+        return aliases
+
+    def _extract_managed_group_email(self, item: dict[str, Any]) -> str:
+        """Return the canonical managed-group email, preferring sg-* aliases."""
+
+        primary_email = self._extract_email(item, "email", "groupEmail")
+        aliases = self._extract_group_aliases(item)
+
+        for alias in aliases:
+            local_part, _, domain = alias.partition("@")
+            if not local_part.startswith("sg-"):
+                continue
+            if self._managed_group_domain and domain != self._managed_group_domain:
+                continue
+            return alias
+
+        return primary_email
+
+    def _managed_group_query_prefix(self, query: str) -> str | None:
+        """Return a managed-group prefix for alias-aware discovery queries."""
+
+        normalized_query = query.strip().lower()
+        if not normalized_query:
+            return None
+        if ":" not in normalized_query and "=" not in normalized_query:
+            return normalized_query if normalized_query.startswith("sg-") else None
+        if normalized_query.startswith("email:") and normalized_query.endswith("*"):
+            prefix = normalized_query[len("email:") : -1]
+            return prefix if prefix.startswith("sg-") else None
+        return None
+
+    def _matches_managed_group_prefix(self, item: dict[str, Any], prefix: str) -> bool:
+        """Return whether the group's primary email or aliases match a prefix."""
+
+        candidates = [self._extract_email(item, "email", "groupEmail")]
+        candidates.extend(self._extract_group_aliases(item))
+        normalized_prefix = prefix.strip().lower()
+        return any(candidate.startswith(normalized_prefix) for candidate in candidates)
+
     def _extract_display_name(self, item: dict[str, Any]) -> str | None:
         """Extract a stable display name from provider payload variants."""
 
@@ -190,7 +243,7 @@ class GoogleDirectoryProvider:
     ) -> OperationResult[DirectoryGroup | None]:
         """Convert a Google group record into a canonical directory group."""
 
-        group_email = self._extract_email(item, "email", "groupEmail")
+        group_email = self._extract_managed_group_email(item)
         if not group_email:
             if self._directory_settings.enforce_managed_group_email:
                 return OperationResult.permanent_error(
@@ -538,12 +591,20 @@ class GoogleDirectoryProvider:
         Returns:
             OperationResult: success with the matching DirectoryGroup list.
         """
-        if ":" not in query and "=" not in query:
-            google_query = f"email:{query}*"
+        managed_prefix = self._managed_group_query_prefix(query)
+        if managed_prefix is not None:
+            self._logger.info(
+                "listing_groups_alias_aware",
+                query=query,
+                managed_prefix=managed_prefix,
+            )
+            result = self._directory.list_groups()
         else:
-            google_query = query
-
-        result = self._directory.list_groups(query=google_query)
+            if ":" not in query and "=" not in query:
+                google_query = f"email:{query}*"
+            else:
+                google_query = query
+            result = self._directory.list_groups(query=google_query)
         if not result.is_success:
             return self._typed_error(result)
 
@@ -553,8 +614,17 @@ class GoogleDirectoryProvider:
                 error_code="DIRECTORY_GROUPS_PAYLOAD_INVALID",
             )
 
+        raw_groups = result.data
+        if managed_prefix is not None:
+            raw_groups = [
+                item
+                for item in raw_groups
+                if isinstance(item, dict)
+                and self._matches_managed_group_prefix(item, managed_prefix)
+            ]
+
         groups: list[DirectoryGroup] = []
-        for item in result.data:
+        for item in raw_groups:
             if not isinstance(item, dict):
                 return OperationResult.permanent_error(
                     message="Directory groups payload contains an invalid entry",

--- a/app/packages/access/access.local.json
+++ b/app/packages/access/access.local.json
@@ -4,7 +4,10 @@
   "platforms": {
     "aws": {
       "authn_token": "authn",
-      "authn_removal_mode": "delete"
+      "authn_removal_mode": "delete",
+      "mode_overrides": {
+        "scratch": "deactivated"
+      }
     },
     "fake": {
       "authn_token": "authn",

--- a/app/packages/access/sync/adapters/aws_identity_center.py
+++ b/app/packages/access/sync/adapters/aws_identity_center.py
@@ -28,10 +28,19 @@ from packages.access.sync.policies import AdapterCapabilities
 
 logger = structlog.get_logger()
 
+_AWS_GROUP_ID_PATTERN = re.compile(
+    r"^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+)
+
 
 def normalize_group_name(value: str) -> str:
     """Normalize a group display name for case-insensitive comparison."""
     return value.strip().casefold()
+
+
+def _looks_like_group_id(value: str) -> bool:
+    """Return whether the token matches AWS Identity Store GroupId shape."""
+    return bool(_AWS_GROUP_ID_PATTERN.match(value.strip()))
 
 
 @dataclass(frozen=True)
@@ -215,12 +224,13 @@ class AwsIdentityCenterAdapter:
         if cached is not None:
             return OperationResult.success(data=cached)
 
-        # Step 1: UUID — verify with describe_group.
-        describe_result = self._aws.identitystore.describe_group(group_id=candidate)
-        if describe_result.is_success:
-            self._group_id_cache[candidate] = candidate
-            log.info("resolve_group_id_uuid", group_id=candidate)
-            return OperationResult.success(data=candidate)
+        # Step 1: UUID-shaped token — verify with describe_group.
+        if _looks_like_group_id(candidate):
+            describe_result = self._aws.identitystore.describe_group(group_id=candidate)
+            if describe_result.is_success:
+                self._group_id_cache[candidate] = candidate
+                log.info("resolve_group_id_uuid", group_id=candidate)
+                return OperationResult.success(data=candidate)
 
         # Steps 2-5: name-based lookup via group index.
         index_result = self._get_group_index()

--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -78,6 +78,17 @@ class DirectoryMembershipBuilder:
                 rules=effective.sync_managed_rules(),
             )
 
+        logger.bind(user_email=user_email, platform=effective.platform).info(
+            "build_user_state_completed",
+            user_should_exist=authn_result.data,
+            required_entitlement_count=len(required_entitlements),
+            required_entitlement_group_slugs=[
+                rule.group_slug for rule in required_entitlements
+            ],
+            required_entitlement_ids=[
+                rule.entitlement_id for rule in required_entitlements
+            ],
+        )
         return OperationResult.success(
             data=DesiredUserState(
                 user_should_exist=authn_result.data,
@@ -168,22 +179,29 @@ class DirectoryMembershipBuilder:
         failure (non-fatal; the coordinator proceeds with an empty rule set).
         """
         prefix = config.group_prefix(platform)
+        log = logger.bind(platform=platform, group_prefix=prefix)
         list_result = self._directory.list_groups(query=prefix)
         if not list_result.is_success:
-            logger.bind(platform=platform).warning(
+            log.warning(
                 "discover_groups_failed",
                 error=list_result.message,
             )
             return set()
 
         groups = list_result.data if isinstance(list_result.data, list) else []
-        return {
+        discovered = {
             group.group_slug.strip().lower()
             for group in groups
             if group.group_slug
             and isinstance(group.group_slug, str)
             and group.group_slug.strip().lower().startswith(prefix.lower())
         }
+        log.info(
+            "discover_groups_completed",
+            discovered_count=len(discovered),
+            discovered_group_slugs=sorted(discovered),
+        )
+        return discovered
 
     def _check_group_membership(
         self,

--- a/app/tests/unit/infrastructure/clients/aws/test_aws_clients_facade.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_aws_clients_facade.py
@@ -126,13 +126,26 @@ class TestAWSClientsFacade:
         assert clients.organizations._default_role_arn is None
 
     def test_facade_endpoint_url_configuration(self, mock_aws_settings):
-        """Test AWSClients passes endpoint_url configuration to SessionProvider."""
+        """Test AWSClients scopes endpoint_url configuration to DynamoDB clients."""
         mock_aws_settings.ENDPOINT_URL = "https://dynamodb.example.com"
 
         clients = AWSClients(aws_settings=mock_aws_settings)
 
-        # SessionProvider should have endpoint_url set
+        dynamodb_kwargs = clients._session_provider.build_client_kwargs(
+            service_name="dynamodb"
+        )
+        identitystore_kwargs = clients._session_provider.build_client_kwargs(
+            service_name="identitystore"
+        )
+
         assert clients._session_provider.endpoint_url == "https://dynamodb.example.com"
+        assert dynamodb_kwargs["client_config"] == {
+            "region_name": mock_aws_settings.AWS_REGION,
+            "endpoint_url": "https://dynamodb.example.com",
+        }
+        assert identitystore_kwargs["client_config"] == {
+            "region_name": mock_aws_settings.AWS_REGION,
+        }
 
     def test_facade_region_configuration(self, mock_aws_settings):
         """Test AWSClients passes region configuration to SessionProvider."""

--- a/app/tests/unit/infrastructure/clients/aws/test_identity_store_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_identity_store_client.py
@@ -3,10 +3,12 @@
 Validates AWS Identity Store operations with default identity_store_id fallback.
 """
 
+from botocore.exceptions import ClientError
 import pytest
 
 from infrastructure.clients.aws import executor as aws_client
 from infrastructure.clients.aws.identity_store import IdentityStoreClient
+from infrastructure.operations import OperationStatus
 from infrastructure.clients.aws.session_provider import SessionProvider
 
 
@@ -132,3 +134,42 @@ class TestIdentityStoreClient:
 
         result = client.delete_user(user_id="user-123")
         assert result.is_success
+
+    def test_get_group_membership_id_maps_resource_not_found_to_not_found(
+        self, monkeypatch
+    ):
+        """Membership lookup misses should normalize to NOT_FOUND for adapter idempotency."""
+
+        session_provider = SessionProvider(region="us-east-1")
+        client = IdentityStoreClient(
+            session_provider=session_provider,
+            default_identity_store_id="store-1234567890",
+        )
+
+        def mock_boto3_client(
+            service_name, session_config=None, client_config=None, role_arn=None
+        ):
+            class FakeClient:
+                def get_group_membership_id(self, **kwargs):
+                    raise ClientError(
+                        {
+                            "Error": {
+                                "Code": "ResourceNotFoundException",
+                                "Message": "Group membership not found for given Pool/Group/Member.",
+                            }
+                        },
+                        "GetGroupMembershipId",
+                    )
+
+            return FakeClient()
+
+        monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
+
+        result = client.get_group_membership_id(
+            group_id="11111111-2222-3333-4444-555555555555",
+            member_id={"UserId": "user-123"},
+        )
+
+        assert not result.is_success
+        assert result.status == OperationStatus.NOT_FOUND
+        assert result.error_code == "GROUP_MEMBERSHIP_NOT_FOUND"

--- a/app/tests/unit/infrastructure/clients/aws/test_session_provider.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_session_provider.py
@@ -75,3 +75,21 @@ class TestSessionProvider:
 
         assert captured["service_name"] == "identitystore"
         assert captured["role_arn"] == "arn:aws:iam::123456789012:role/Mapped"
+
+    def test_build_client_kwargs_applies_endpoint_override_only_to_dynamodb(self):
+        """Custom endpoints should be scoped to DynamoDB local development only."""
+        provider = SessionProvider(
+            region="ca-central-1",
+            endpoint_url="http://dynamodb-local:8000",
+        )
+
+        dynamodb_kwargs = provider.build_client_kwargs(service_name="dynamodb")
+        identitystore_kwargs = provider.build_client_kwargs(
+            service_name="identitystore"
+        )
+
+        assert dynamodb_kwargs["client_config"] == {
+            "region_name": "ca-central-1",
+            "endpoint_url": "http://dynamodb-local:8000",
+        }
+        assert identitystore_kwargs["client_config"] == {"region_name": "ca-central-1"}

--- a/app/tests/unit/infrastructure/directory/test_google.py
+++ b/app/tests/unit/infrastructure/directory/test_google.py
@@ -820,9 +820,7 @@ class TestListGroups:
                 provider="google",
             ),
         ]
-        mock_google_clients.directory.list_groups.assert_called_once_with(
-            query="email:sg-*"
-        )
+        mock_google_clients.directory.list_groups.assert_called_once_with()
 
     def test_uses_group_alias_fields_when_standard_keys_are_missing(
         self, provider, mock_google_clients
@@ -844,9 +842,7 @@ class TestListGroups:
 
         # Assert
         assert result.is_success
-        mock_google_clients.directory.list_groups.assert_called_once_with(
-            query="email:sg-*"
-        )
+        mock_google_clients.directory.list_groups.assert_called_once_with()
         assert result.data == [
             DirectoryGroup(
                 group_email="sg-ops@example.com",
@@ -858,7 +854,41 @@ class TestListGroups:
             ),
         ]
 
-    def test_returns_error_when_group_email_is_missing(
+    def test_prefers_managed_alias_when_primary_email_uses_old_pattern(
+        self, provider, mock_google_clients
+    ):
+        # Arrange
+        mock_google_clients.directory.list_groups.return_value = (
+            OperationResult.success(
+                data=[
+                    {
+                        "email": "aws-finops@example.com",
+                        "aliases": ["sg-aws-finops@example.com"],
+                        "id": "group-10",
+                        "name": "FinOps",
+                    }
+                ]
+            )
+        )
+
+        # Act
+        result = provider.list_groups(query="sg-aws-")
+
+        # Assert
+        assert result.is_success
+        mock_google_clients.directory.list_groups.assert_called_once_with()
+        assert result.data == [
+            DirectoryGroup(
+                group_email="sg-aws-finops@example.com",
+                group_slug="sg-aws-finops",
+                provider_group_id="group-10",
+                name="FinOps",
+                description=None,
+                provider="google",
+            )
+        ]
+
+    def test_skips_groups_when_email_is_missing_for_alias_aware_discovery(
         self, provider, mock_google_clients
     ):
         # Arrange
@@ -870,8 +900,9 @@ class TestListGroups:
         result = provider.list_groups(query="sg-")
 
         # Assert
-        assert not result.is_success
-        assert result.error_code == "DIRECTORY_GROUP_EMAIL_REQUIRED"
+        assert result.is_success
+        assert result.data == []
+        mock_google_clients.directory.list_groups.assert_called_once_with()
 
     def test_returns_error_when_managed_group_domain_mismatches(
         self, provider, mock_google_clients

--- a/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
+++ b/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
@@ -200,7 +200,11 @@ def test_apply_entitlement_does_not_create_membership_when_lookup_fails() -> Non
     )
     adapter = make_adapter(client)
 
-    result = adapter.apply_entitlement("alice@example.com", "group", "group-123")
+    result = adapter.apply_entitlement(
+        "alice@example.com",
+        "group",
+        "11111111-2222-3333-4444-555555555555",
+    )
 
     assert not result.is_success
     assert result.error_code == "ACCESS_DENIED"
@@ -240,10 +244,12 @@ def test_list_all_provisioned_users_collects_primary_emails() -> None:
 def test_list_members_for_groups_uses_bulk_path() -> None:
     """Bulk group read should map GroupMemberships.UserDetails to email sets."""
     client = FakeIdentityStoreClient()
+    group_1_id = "11111111-2222-3333-4444-555555555555"
+    group_2_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     client.list_groups_with_memberships_result = OperationResult.success(
         data=[
             {
-                "GroupId": "group-1",
+                "GroupId": group_1_id,
                 "GroupMemberships": [
                     {
                         "MemberId": {"UserId": "u-1"},
@@ -260,19 +266,19 @@ def test_list_members_for_groups_uses_bulk_path() -> None:
                 ],
             },
             {
-                "GroupId": "group-2",
+                "GroupId": group_2_id,
                 "GroupMemberships": [],
             },
         ]
     )
     adapter = make_adapter(client)
 
-    result = adapter.list_members_for_groups({"group-1", "group-2"})
+    result = adapter.list_members_for_groups({group_1_id, group_2_id})
 
     assert result.is_success
     assert result.data == {
-        "group-1": {"alice@example.com"},
-        "group-2": set(),
+        group_1_id: {"alice@example.com"},
+        group_2_id: set(),
     }
     assert any(call[0] == "list_groups_with_memberships" for call in client.calls)
 
@@ -281,6 +287,7 @@ def test_list_members_for_groups_uses_bulk_path() -> None:
 def test_list_members_for_groups_falls_back_when_bulk_fails() -> None:
     """Fallback should call list_group_members when bulk orchestration fails."""
     client = FakeIdentityStoreClient()
+    group_1_id = "11111111-2222-3333-4444-555555555555"
     client.list_groups_with_memberships_result = OperationResult.error(
         OperationStatus.TRANSIENT_ERROR,
         message="temporary failure",
@@ -301,10 +308,10 @@ def test_list_members_for_groups_falls_back_when_bulk_fails() -> None:
     )
     adapter = make_adapter(client)
 
-    result = adapter.list_members_for_groups({"group-1"})
+    result = adapter.list_members_for_groups({group_1_id})
 
     assert result.is_success
-    assert result.data == {"group-1": {"alice@example.com"}}
+    assert result.data == {group_1_id: {"alice@example.com"}}
     assert any(call[0] == "list_group_memberships" for call in client.calls)
 
 
@@ -360,15 +367,16 @@ def _make_group_list(*name_id_pairs: tuple[str, str]) -> list[dict[str, str]]:
 def test_resolve_group_id_uuid_passthrough() -> None:
     """A UUID that describe_group confirms should be returned as-is without index."""
     client = FakeIdentityStoreClient()
+    group_id = "11111111-2222-3333-4444-555555555555"
     client.describe_group_result = OperationResult.success(
-        data={"GroupId": "uuid-aaa", "DisplayName": "Admin"}
+        data={"GroupId": group_id, "DisplayName": "Admin"}
     )
     adapter = make_adapter(client)
 
-    result = adapter.canonicalize_entitlement_id("group", "uuid-aaa")
+    result = adapter.canonicalize_entitlement_id("group", group_id)
 
     assert result.is_success
-    assert result.data == "uuid-aaa"
+    assert result.data == group_id
     # list_groups should NOT have been called for UUID resolution
     assert all(call[0] != "list_groups" for call in client.calls)
 

--- a/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
+++ b/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
@@ -392,6 +392,22 @@ def test_resolve_group_id_exact_display_name() -> None:
 
 
 @pytest.mark.unit
+def test_resolve_group_id_non_uuid_skips_describe_group() -> None:
+    """Display-name tokens should not trigger describe_group UUID validation calls."""
+    client = FakeIdentityStoreClient()
+    client.list_groups_result = OperationResult.success(
+        data=_make_group_list(("scratch", "group-scratch-id"))
+    )
+    adapter = make_adapter(client)
+
+    result = adapter.canonicalize_entitlement_id("group", "scratch")
+
+    assert result.is_success
+    assert result.data == "group-scratch-id"
+    assert all(call[0] != "describe_group" for call in client.calls)
+
+
+@pytest.mark.unit
 def test_resolve_group_id_normalized_display_name() -> None:
     """A token whose casefold matches an AWS IC group resolves via the index."""
     client = FakeIdentityStoreClient()


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces several improvements and bug fixes related to AWS client configuration and AWS Identity Center group ID handling. The main focus is to ensure that custom AWS endpoint URLs are only applied to DynamoDB clients (to support local development), and to improve the logic for resolving AWS Identity Center group IDs by more accurately detecting UUID-shaped tokens. The changes also include updates to tests to verify the new behavior.

**AWS Endpoint URL Scoping Improvements:**

* The `endpoint_url` configuration is now scoped to only apply to DynamoDB clients, preventing accidental routing of other AWS service calls (like Identity Store) to the DynamoDB local endpoint. This is enforced in `SessionProvider` via the `_should_apply_endpoint_override` method and corresponding updates in `build_client_kwargs`. [[1]](diffhunk://#diff-9a1675bcb506fb5eeead708e46ac4411854ebb2bef0b7f9686b80b9fe95c8483R38-R47) [[2]](diffhunk://#diff-9a1675bcb506fb5eeead708e46ac4411854ebb2bef0b7f9686b80b9fe95c8483L86-R96) [[3]](diffhunk://#diff-dc26a6725a07009967c7aca2d1b8684ed7b93f48a3ddab3c186346c512859b91L50-R50)
* The `AwsSettings` documentation and related test cases have been updated to clarify and verify that the endpoint override is specific to DynamoDB. [[1]](diffhunk://#diff-dc26a6725a07009967c7aca2d1b8684ed7b93f48a3ddab3c186346c512859b91L50-R50) [[2]](diffhunk://#diff-47319d0faa8b207ea68b3731b8988bc78f8ffa10f61f2d8f6904a2f6f58b3eb2L129-R148) [[3]](diffhunk://#diff-4a3245e432dc9a3fa1da83e4c40fb7d81ccde79e3236572a6689e16babd6f7d5R78-R95)
* The `.flake8` configuration was updated to include `.venv` in the exclude list for linting.

**AWS Identity Center Group ID Resolution Enhancements:**

* Improved the detection of AWS Identity Store group IDs by introducing a stricter regular expression check (`_looks_like_group_id`) to distinguish between UUID-shaped tokens and display names, preventing unnecessary `describe_group` API calls for non-UUID tokens. [[1]](diffhunk://#diff-3f14f8ea980bdceaa013b77eb99bda4d00982cd5695d654517d1cf094b29baadR31-R45) [[2]](diffhunk://#diff-3f14f8ea980bdceaa013b77eb99bda4d00982cd5695d654517d1cf094b29baadL218-R228)
* Added a unit test to verify that non-UUID tokens do not trigger `describe_group` lookups, ensuring efficiency and correctness in group ID resolution logic.