### PR TITLE
Improve/access sync

### DIFF
--- a/app/packages/access/sync/schemas.py
+++ b/app/packages/access/sync/schemas.py
@@ -80,6 +80,34 @@ class PlatformSyncResponse(BaseModel):
     requires_manual_action_count: Optional[int] = None
 
 
+class PlatformSyncJobAcceptedResponse(BaseModel):
+    """HTTP 202 response returned immediately when a platform sync job is enqueued."""
+
+    success: bool
+    sync_type: Literal["platform"] = "platform"
+    job_id: str
+    platform: str
+    dry_run: bool = False
+    status: Literal["in_progress"] = "in_progress"
+    started_at: str
+
+
+class PlatformSyncJobStatusResponse(BaseModel):
+    """HTTP response for polling the status of an enqueued platform sync job."""
+
+    job_id: str
+    platform: str
+    dry_run: bool
+    status: str
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    users_synced: Optional[int] = None
+    users_converged: Optional[int] = None
+    orphans_found: Optional[int] = None
+    requires_manual_action_count: Optional[int] = None
+    error: Optional[str] = None
+
+
 AccessSyncResponse = Annotated[
     Union[UserSyncResponse, PlatformSyncResponse],
     Field(discriminator="sync_type"),

--- a/app/packages/access/sync/transport/routes.py
+++ b/app/packages/access/sync/transport/routes.py
@@ -11,13 +11,18 @@ in ``providers.py``.  Route handlers consume them through type-annotated
 protocols so they are test-substitutable without monkey-patching FastAPI.
 """
 
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated, Any, Protocol, Union
+
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Security
-from typing import Annotated, Protocol
+from fastapi import APIRouter, Depends, HTTPException, Response, Security
 
 from infrastructure.identity.models import User
+from infrastructure.idempotency import IdempotencyService
 from infrastructure.operations import OperationResult, OperationStatus
-from infrastructure.services import get_current_user
+from infrastructure.services import get_current_user, get_idempotency_service
 from packages.access.sync.coordinator import AccessSyncCoordinatorPort
 from packages.access.sync.providers import (
     get_access_sync_coordinator,
@@ -26,14 +31,111 @@ from packages.access.sync.providers import (
 from packages.access.sync.domain import ReconciliationOutcome, SyncOutcome
 from packages.access.sync.schemas import (
     AccessSyncRequest,
-    AccessSyncResponse,
-    PlatformSyncResponse,
+    PlatformSyncJobAcceptedResponse,
+    PlatformSyncJobStatusResponse,
     UserSyncResponse,
     UserSyncRequest,
 )
 
+# How long a completed / failed platform sync job record is kept in the cache.
+_PLATFORM_SYNC_JOB_TTL_SECONDS = 86400  # 24 h
+
 logger = structlog.get_logger()
 router = APIRouter(prefix="/access", tags=["Access Management"])
+
+
+def _run_platform_sync_job(
+    coordinator: AccessSyncCoordinatorPort,
+    idempotency: IdempotencyService,
+    job_id: str,
+    platform: str,
+    dry_run: bool,
+    request_id: str,
+    started_at: str,
+) -> None:
+    """Background thread target: run platform sync and persist the outcome."""
+    log = logger.bind(job_id=job_id, platform=platform, dry_run=dry_run)
+    payload: dict[str, Any]
+    log.info(
+        "platform_sync_job_started",
+        correlation_id=request_id,
+        poll_path=f"/api/v1/access/sync-runs/{job_id}",
+    )
+    idempotency.set(
+        job_id,
+        {
+            "job_id": job_id,
+            "platform": platform,
+            "dry_run": dry_run,
+            "status": "running",
+            "phase": "syncing",
+            "started_at": started_at,
+        },
+        ttl_seconds=_PLATFORM_SYNC_JOB_TTL_SECONDS,
+    )
+    try:
+        result = coordinator.sync_platform(
+            platform=platform,
+            dry_run=dry_run,
+            request_id=request_id,
+        )
+        completed_at = datetime.now(timezone.utc).isoformat()
+        if result.is_success:
+            recon: ReconciliationOutcome = result.data  # type: ignore[assignment]
+            payload = {
+                "job_id": job_id,
+                "platform": platform,
+                "dry_run": dry_run,
+                "status": "completed",
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "users_synced": recon.users_synced if recon else 0,
+                "users_converged": recon.users_converged if recon else 0,
+                "orphans_found": recon.orphans_found if recon else 0,
+                "requires_manual_action_count": (
+                    recon.requires_manual_action_count if recon else 0
+                ),
+            }
+            log.info(
+                "platform_sync_job_completed",
+                users_synced=payload["users_synced"],
+                users_converged=payload["users_converged"],
+                orphans_found=payload["orphans_found"],
+                requires_manual_action_count=payload["requires_manual_action_count"],
+                dry_run=dry_run,
+            )
+        else:
+            payload = {
+                "job_id": job_id,
+                "platform": platform,
+                "dry_run": dry_run,
+                "status": "failed",
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "error": result.message or "sync_failed",
+            }
+            log.warning(
+                "platform_sync_job_failed",
+                error=result.message,
+                error_code=result.error_code,
+            )
+    except Exception as exc:
+        completed_at = datetime.now(timezone.utc).isoformat()
+        payload = {
+            "job_id": job_id,
+            "platform": platform,
+            "dry_run": dry_run,
+            "status": "failed",
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "error": str(exc),
+        }
+        log.error(
+            "platform_sync_job_error",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+    idempotency.set(job_id, payload, ttl_seconds=_PLATFORM_SYNC_JOB_TTL_SECONDS)
 
 
 class _AccessSyncSettingsPort(Protocol):
@@ -44,17 +146,19 @@ class _AccessSyncSettingsPort(Protocol):
 
 @router.post(
     "/sync-runs",
-    response_model=AccessSyncResponse,
+    response_model=Union[UserSyncResponse, PlatformSyncJobAcceptedResponse],
     summary="Sync access",
     description=(
         "Converge user or platform access state to match IDP group membership policy. "
         "Use sync_type='user' for on-demand single-user sync (triggered by events, "
-        "webhooks, or API calls). Use sync_type='platform' for a full batch "
-        "convergence pass across all users on a platform."
+        "webhooks, or API calls). Use sync_type='platform' to enqueue a full batch "
+        "convergence pass across all users on a platform; returns 202 with a job_id "
+        "that can be polled via GET /access/sync-runs/{job_id}."
     ),
 )
 def sync_endpoint(
     request: AccessSyncRequest,
+    response: Response,
     coordinator: Annotated[
         AccessSyncCoordinatorPort, Depends(get_access_sync_coordinator)
     ],
@@ -62,7 +166,7 @@ def sync_endpoint(
     current_user: Annotated[
         User, Security(get_current_user, scopes=["sre-bot:access-sync"])
     ],
-) -> AccessSyncResponse:
+) -> Union[UserSyncResponse, PlatformSyncJobAcceptedResponse]:
     """Trigger an on-demand user sync or a full platform sync."""
     log = logger.bind(
         sync_type=request.sync_type,
@@ -83,32 +187,70 @@ def sync_endpoint(
             dry_run=request.dry_run,
             request_id=request.request_id or "",
         )
-    else:
-        result = coordinator.sync_platform(
-            platform=request.platform,
-            dry_run=request.dry_run,
-            request_id=request.request_id or "",
-        )
 
-    if result.is_success:
-        return _build_response(request, result.data)
+        if result.is_success:
+            return _build_user_response(request, result.data)
 
-    status_code, detail = _to_public_error(result)
-    if status_code >= 500:
-        log.error(
-            "sync_request_failed",
-            status=str(result.status),
-            error_code=result.error_code,
-            error=result.message,
-        )
-    else:
-        log.warning(
-            "sync_request_failed",
-            status=str(result.status),
-            error_code=result.error_code,
-            error=result.message,
-        )
-    raise HTTPException(status_code=status_code, detail=detail)
+        status_code, detail = _to_public_error(result)
+        if status_code >= 500:
+            log.error(
+                "sync_request_failed",
+                status=str(result.status),
+                error_code=result.error_code,
+                error=result.message,
+            )
+        else:
+            log.warning(
+                "sync_request_failed",
+                status=str(result.status),
+                error_code=result.error_code,
+                error=result.message,
+            )
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    # Platform sync — enqueue as a background job and return 202 immediately.
+    # job_id is always server-generated so the caller has a stable polling key.
+    # The caller's request_id (if any) is forwarded as a tracing correlation ID only.
+    job_id = str(uuid.uuid4())
+    correlation_id = request.request_id or job_id
+    started_at = datetime.now(timezone.utc).isoformat()
+    idempotency = get_idempotency_service()
+    idempotency.set(
+        job_id,
+        {
+            "job_id": job_id,
+            "platform": request.platform,
+            "dry_run": request.dry_run,
+            "status": "in_progress",
+            "started_at": started_at,
+        },
+        ttl_seconds=_PLATFORM_SYNC_JOB_TTL_SECONDS,
+    )
+    thread = threading.Thread(
+        target=_run_platform_sync_job,
+        kwargs={
+            "coordinator": coordinator,
+            "idempotency": idempotency,
+            "job_id": job_id,
+            "platform": request.platform,
+            "dry_run": request.dry_run,
+            "request_id": correlation_id,
+            "started_at": started_at,
+        },
+        daemon=True,
+        name=f"platform-sync-{job_id[:8]}",
+    )
+    thread.start()
+    log.info("platform_sync_job_enqueued", job_id=job_id, correlation_id=correlation_id)
+    response.status_code = 202
+    return PlatformSyncJobAcceptedResponse(
+        success=True,
+        job_id=job_id,
+        platform=request.platform,
+        dry_run=request.dry_run,
+        status="in_progress",
+        started_at=started_at,
+    )
 
 
 def _to_public_error(result: OperationResult) -> tuple[int, str]:
@@ -124,30 +266,42 @@ def _to_public_error(result: OperationResult) -> tuple[int, str]:
     return 500, "Access sync request failed due to an internal error"
 
 
-def _build_response(
-    request: AccessSyncRequest, data: object  # type: ignore[valid-type]
-) -> AccessSyncResponse:
-    """Map service result data to the correct response model."""
-    if isinstance(request, UserSyncRequest):
-        outcome: SyncOutcome = data  # type: ignore[assignment]
-        return UserSyncResponse(
-            success=True,
-            platform=request.platform,
-            user_email=request.user_email,
-            dry_run=request.dry_run,
-            actions_planned=outcome.planned_actions if outcome else [],
-            actions_applied=outcome.applied_actions if outcome else [],
-            requires_manual_action=outcome.requires_manual_action if outcome else False,
-        )
-    recon: ReconciliationOutcome = data  # type: ignore[assignment]
-    return PlatformSyncResponse(
+@router.get(
+    "/sync-runs/{job_id}",
+    response_model=PlatformSyncJobStatusResponse,
+    summary="Get platform sync job status",
+    description=(
+        "Poll the status of an enqueued platform sync job. "
+        "Returns the current state (in_progress, completed, or failed) "
+        "and, once finished, the reconciliation outcome. "
+        "Records expire after 24 hours."
+    ),
+)
+def get_sync_job_status(
+    job_id: str,
+    current_user: Annotated[
+        User, Security(get_current_user, scopes=["sre-bot:access-sync"])
+    ],
+) -> PlatformSyncJobStatusResponse:
+    """Return the current status and outcome of a platform sync job."""
+    idempotency = get_idempotency_service()
+    record = idempotency.get(job_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Sync job not found or has expired")
+    return PlatformSyncJobStatusResponse(**record)
+
+
+def _build_user_response(
+    request: UserSyncRequest, data: object  # type: ignore[valid-type]
+) -> UserSyncResponse:
+    """Map sync_user result data to the HTTP response model."""
+    outcome: SyncOutcome = data  # type: ignore[assignment]
+    return UserSyncResponse(
         success=True,
         platform=request.platform,
+        user_email=request.user_email,
         dry_run=request.dry_run,
-        users_synced=recon.users_synced if recon else 0,
-        users_converged=recon.users_converged if recon else 0,
-        orphans_found=recon.orphans_found if recon else 0,
-        requires_manual_action_count=(
-            recon.requires_manual_action_count if recon else 0
-        ),
+        actions_planned=outcome.planned_actions if outcome else [],
+        actions_applied=outcome.applied_actions if outcome else [],
+        requires_manual_action=outcome.requires_manual_action if outcome else False,
     )

--- a/app/tests/unit/packages/access/sync/test_routes.py
+++ b/app/tests/unit/packages/access/sync/test_routes.py
@@ -1,7 +1,7 @@
 """Unit tests for access sync route error sanitization."""
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 from infrastructure.identity.models import IdentitySource, User
 from infrastructure.operations import OperationResult, OperationStatus
@@ -68,6 +68,7 @@ def test_sync_endpoint_not_found_masks_internal_error():
     with pytest.raises(HTTPException) as exc_info:
         sync_endpoint(
             _make_request(),
+            response=Response(),
             coordinator=_FakeCoordinator(
                 OperationResult.error(
                     OperationStatus.NOT_FOUND,
@@ -89,6 +90,7 @@ def test_sync_endpoint_permanent_error_masks_internal_error():
     with pytest.raises(HTTPException) as exc_info:
         sync_endpoint(
             _make_request(),
+            response=Response(),
             coordinator=_FakeCoordinator(
                 OperationResult.error(
                     OperationStatus.PERMANENT_ERROR,
@@ -110,6 +112,7 @@ def test_sync_endpoint_unauthorized_masks_internal_error():
     with pytest.raises(HTTPException) as exc_info:
         sync_endpoint(
             _make_request(),
+            response=Response(),
             coordinator=_FakeCoordinator(
                 OperationResult.error(
                     OperationStatus.UNAUTHORIZED,
@@ -131,6 +134,7 @@ def test_sync_endpoint_internal_error_masks_internal_error():
     with pytest.raises(HTTPException) as exc_info:
         sync_endpoint(
             _make_request(),
+            response=Response(),
             coordinator=_FakeCoordinator(
                 OperationResult.error(
                     OperationStatus.TRANSIENT_ERROR,
@@ -154,6 +158,7 @@ def test_sync_endpoint_feature_disabled_returns_service_unavailable():
     with pytest.raises(HTTPException) as exc_info:
         sync_endpoint(
             _make_request(),
+            response=Response(),
             coordinator=_FakeCoordinator(OperationResult.success()),
             settings=_Settings(enabled=False),
             current_user=_make_user(),


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces asynchronous, background processing for platform sync jobs in the access sync API. Instead of blocking the API call until a platform sync completes, sync jobs are now enqueued and processed in a separate thread. The API immediately returns a 202 response with a job ID, which clients can poll for status and results. This improves scalability and responsiveness for long-running platform sync operations. The user sync flow remains synchronous and unchanged.

Key changes:

**Asynchronous platform sync job processing:**

* Added new response models: `PlatformSyncJobAcceptedResponse` (for immediate 202 responses when a job is enqueued) and `PlatformSyncJobStatusResponse` (for polling job status/results). (`app/packages/access/sync/schemas.py`)
* Refactored the `/sync-runs` POST endpoint to enqueue platform sync jobs as background threads, returning a job ID and 202 status immediately. (`app/packages/access/sync/transport/routes.py`) [[1]](diffhunk://#diff-b00aba158a32a09699cb7305b0b3dd30109519c43019eccf40566033cb12bfd3L47-R169) [[2]](diffhunk://#diff-b00aba158a32a09699cb7305b0b3dd30109519c43019eccf40566033cb12bfd3R211-R254)
* Implemented a new `/sync-runs/{job_id}` GET endpoint to poll the status and outcome of a platform sync job. (`app/packages/access/sync/transport/routes.py`)
* Introduced a TTL (24h) for job status records in the idempotency cache. (`app/packages/access/sync/transport/routes.py`)

**Supporting changes and test updates:**

* Updated imports and dependency injection to support the new background job and idempotency handling. (`app/packages/access/sync/transport/routes.py`)
* Adjusted unit tests to pass the new required `response` parameter to the sync endpoint. (`app/tests/unit/packages/access/sync/test_routes.py`) [[1]](diffhunk://#diff-91eade2f01cbc71cf5f6026e4ff31d4bef0b60e1cfbf8b752c6c2e565d7a3fcbR71) [[2]](diffhunk://#diff-91eade2f01cbc71cf5f6026e4ff31d4bef0b60e1cfbf8b752c6c2e565d7a3fcbR93) [[3]](diffhunk://#diff-91eade2f01cbc71cf5f6026e4ff31d4bef0b60e1cfbf8b752c6c2e565d7a3fcbR115) [[4]](diffhunk://#diff-91eade2f01cbc71cf5f6026e4ff31d4bef0b60e1cfbf8b752c6c2e565d7a3fcbR137) [[5]](diffhunk://#diff-91eade2f01cbc71cf5f6026e4ff31d4bef0b60e1cfbf8b752c6c2e565d7a3fcbR161)