### PR TITLE
Fix/access config override

### DIFF
--- a/app/packages/access/catalog/providers.py
+++ b/app/packages/access/catalog/providers.py
@@ -30,23 +30,21 @@ def get_catalog_settings() -> AccessCatalogSettings:
 def _build_parser_map() -> Dict[str, CatalogSlugParser]:
     """Build the platform key → parser mapping from runtime config.
 
-    Parser config (``known_envs``) is read from the ``catalog`` extension
-    block in the Access Sync runtime config JSON when present.  Platforms
-    without parser config fall back to ``FallbackCatalogSlugParser``.
+    Parser config (``known_envs``) is read from the typed ``catalog_extensions``
+    in the Access runtime config when present.  Platforms without parser config
+    fall back to ``FallbackCatalogSlugParser``.
     """
     runtime_config = get_access_runtime_config()
-    catalog_ext = getattr(runtime_config, "catalog", None)
     parsers: Dict[str, CatalogSlugParser] = {}
 
     for platform_key in runtime_config.platforms:
-        parser_config = None
-        if catalog_ext and hasattr(catalog_ext, "parsers"):
-            parser_config = getattr(catalog_ext.parsers, platform_key, None)
+        known_envs = set()
+        if runtime_config.catalog_extensions:
+            parser_config = runtime_config.catalog_extensions.parsers.get(platform_key)
+            if parser_config:
+                known_envs = set(parser_config.known_envs)
 
         if platform_key == "aws":
-            known_envs = set()
-            if parser_config and hasattr(parser_config, "known_envs"):
-                known_envs = set(parser_config.known_envs)
             parsers[platform_key] = AwsCatalogSlugParser(known_envs=known_envs)
         else:
             parsers[platform_key] = FallbackCatalogSlugParser()
@@ -59,20 +57,18 @@ def get_catalog_service() -> CatalogService:
     """Return the singleton CatalogService.
 
     Wires together:
-    - AccessSyncRuntimeConfig (platform policy and group naming).
+    - AccessRuntimeConfig (platform policy and group naming).
     - DirectoryProvider (IDP group discovery and membership checks).
     - Parser map (token decomposition per platform).
-    - Display names from catalog extension config (optional).
+    - Display names from typed catalog extensions (optional).
     """
     runtime_config = get_access_runtime_config()
     directory = get_directory_provider()
     parser_map = _build_parser_map()
 
     display_names: Dict[str, str] = {}
-    catalog_ext = getattr(runtime_config, "catalog", None)
-    if catalog_ext and hasattr(catalog_ext, "platform_display_names"):
-        raw = getattr(catalog_ext, "platform_display_names", {})
-        display_names = dict(raw) if raw else {}
+    if runtime_config.catalog_extensions:
+        display_names = dict(runtime_config.catalog_extensions.platform_display_names)
 
     return CatalogService(
         runtime_config=runtime_config,

--- a/app/packages/access/common/config/__init__.py
+++ b/app/packages/access/common/config/__init__.py
@@ -11,6 +11,8 @@ from packages.access.common.config.loaders import (
 )
 from packages.access.common.config.settings import (
     AccessRuntimeConfig,
+    CatalogExtensions,
+    CatalogParserConfig,
     EntitlementMode,
     EntitlementModeOverride,
     EntitlementRule,
@@ -28,6 +30,8 @@ __all__ = [
     "normalize_target_key",
     # runtime config models
     "AccessRuntimeConfig",
+    "CatalogExtensions",
+    "CatalogParserConfig",
     "EntitlementMode",
     "EntitlementModeOverride",
     "EntitlementRule",

--- a/app/packages/access/common/config/loaders.py
+++ b/app/packages/access/common/config/loaders.py
@@ -23,6 +23,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config.settings import (
     AccessRuntimeConfig,
+    CatalogExtensions,
+    CatalogParserConfig,
     EntitlementMode,
     PlatformPolicy,
 )
@@ -69,6 +71,19 @@ class PlatformPolicyConfigModel(BaseModel):
     mode_overrides: Dict[str, EntitlementMode] = Field(default_factory=dict)
 
 
+class CatalogParserConfigModel(BaseModel):
+    """Typed schema for one platform parser config in extensions."""
+
+    known_envs: list[str] = Field(default_factory=list)
+
+
+class CatalogExtensionsConfigModel(BaseModel):
+    """Typed schema for catalog extensions block in runtime config."""
+
+    parsers: Dict[str, CatalogParserConfigModel] = Field(default_factory=dict)
+    platform_display_names: Dict[str, str] = Field(default_factory=dict)
+
+
 class RuntimeConfigJsonModel(BaseModel):
     """Top-level schema for the access runtime config JSON document.
 
@@ -82,6 +97,14 @@ class RuntimeConfigJsonModel(BaseModel):
               "authn_token": "authn",
               "authn_removal_mode": "delete",
               "mode_overrides": {"breakglass-admin": "ephemeral"}
+            }
+          },
+          "extensions": {
+            "catalog": {
+              "parsers": {
+                "aws": {"known_envs": ["prod", "staging"]}
+              },
+              "platform_display_names": {"aws": "Amazon Web Services"}
             }
           }
         }
@@ -113,11 +136,26 @@ def _build_runtime_config(
             adapter_type=raw_policy.adapter_type,
             mode_overrides=dict(raw_policy.mode_overrides),
         )
+
+    catalog_ext: CatalogExtensions | None = None
+    if extensions and "catalog" in extensions:
+        cat_model = CatalogExtensionsConfigModel.model_validate(extensions["catalog"])
+        parsers = {}
+        for platform_key, parser_cfg in cat_model.parsers.items():
+            parsers[platform_key] = CatalogParserConfig(
+                known_envs=list(parser_cfg.known_envs)
+            )
+        catalog_ext = CatalogExtensions(
+            parsers=parsers,
+            platform_display_names=dict(cat_model.platform_display_names),
+        )
+
     return AccessRuntimeConfig(
         dir_prefix=dir_prefix,
         dir_separator=dir_separator,
         platforms=platforms,
         extensions=dict(extensions or {}),
+        catalog_extensions=catalog_ext,
     )
 
 
@@ -134,12 +172,19 @@ def _validate_runtime_config_payload(
             message=f"{error_prefix}_invalid_policy: {exc}",
             error_code="CONFIG_INVALID_SHAPE",
         )
-    config = _build_runtime_config(
-        dir_prefix=validated.dir_prefix,
-        dir_separator=validated.dir_separator,
-        platforms_model=validated.platforms,
-        extensions=validated.extensions,
-    )
+    try:
+        config = _build_runtime_config(
+            dir_prefix=validated.dir_prefix,
+            dir_separator=validated.dir_separator,
+            platforms_model=validated.platforms,
+            extensions=validated.extensions,
+        )
+    except ValidationError as exc:
+        return OperationResult.error(
+            status=OperationStatus.PERMANENT_ERROR,
+            message=f"{error_prefix}_invalid_extensions: {exc}",
+            error_code="CONFIG_INVALID_SHAPE",
+        )
     return OperationResult.success(
         data=config,
         message=f"{error_prefix}_loaded platforms={len(config.platforms)}",

--- a/app/packages/access/common/config/settings.py
+++ b/app/packages/access/common/config/settings.py
@@ -33,6 +33,21 @@ class PlatformPolicy:
 
 
 @dataclass(frozen=True)
+class CatalogParserConfig:
+    """Runtime configuration for a platform's catalog token parser."""
+
+    known_envs: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CatalogExtensions:
+    """Typed runtime extensions for the catalog sub-feature."""
+
+    parsers: Dict[str, CatalogParserConfig] = field(default_factory=dict)
+    platform_display_names: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class EntitlementModeOverride:
     """Runtime per-group entitlement mode override record."""
 
@@ -54,8 +69,9 @@ class AccessRuntimeConfig:
     entitlement_mode_overrides: List[EntitlementModeOverride] = field(
         default_factory=list
     )
-    # Optional extension bag for package-specific read-only configuration.
+    # Typed extensions for catalog feature; empty dict when not present.
     extensions: Dict[str, Any] = field(default_factory=dict)
+    catalog_extensions: Optional[CatalogExtensions] = None
 
     def group_prefix(self, platform: str) -> str:
         """Return the IDP group slug prefix for a given platform."""
@@ -75,10 +91,9 @@ class AccessRuntimeConfig:
         )
 
     @property
-    def catalog(self) -> Optional[Any]:
-        """Return optional catalog extension configuration."""
-        value = self.extensions.get("catalog")
-        return value
+    def catalog(self) -> Optional[CatalogExtensions]:
+        """Return typed catalog extension configuration."""
+        return self.catalog_extensions
 
 
 # This file contains only runtime domain models loaded from an external config

--- a/app/packages/access/request/policies.py
+++ b/app/packages/access/request/policies.py
@@ -60,9 +60,6 @@ def check_entitlement_mode(
         token = normalized_slug[len(prefix) :]
 
     override = platform_policy.mode_overrides.get(token)
-    if override is None:
-        # Compatibility fallback for pre-standardization documents.
-        override = platform_policy.mode_overrides.get(normalized_slug)
     if override is not None:
         return override
     return "sync_managed"

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_providers.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_providers.py
@@ -1,0 +1,74 @@
+"""Behavior tests for access catalog provider wiring."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from packages.access.catalog import providers
+from packages.access.common.config import InlineJsonConfigLoader
+
+
+def _runtime_config_from_payload() -> object:
+    payload = {
+        "dir_prefix": "sg",
+        "dir_separator": "-",
+        "platforms": {
+            "aws": {
+                "authn_token": "authn",
+                "authn_removal_mode": "delete",
+                "mode_overrides": {},
+            }
+        },
+        "extensions": {
+            "catalog": {
+                "parsers": {"aws": {"known_envs": ["prod", "staging"]}},
+                "platform_display_names": {"aws": "Amazon Web Services"},
+            }
+        },
+    }
+    result = InlineJsonConfigLoader().load(json.dumps(payload))
+    assert result.is_success
+    assert result.data is not None
+    return result.data
+
+
+@pytest.mark.unit
+def test_build_parser_map_applies_known_envs_from_runtime_extensions(monkeypatch):
+    providers._build_parser_map.cache_clear()
+
+    monkeypatch.setattr(
+        providers,
+        "get_access_runtime_config",
+        _runtime_config_from_payload,
+    )
+
+    parsers = providers._build_parser_map()
+    parsed = parsers["aws"].parse("billing-prod-admin")
+
+    assert parsed.parsed is True
+    assert parsed.env == "prod"
+
+    providers._build_parser_map.cache_clear()
+
+
+@pytest.mark.unit
+def test_get_catalog_service_applies_display_names_from_runtime_extensions(monkeypatch):
+    providers._build_parser_map.cache_clear()
+    providers.get_catalog_service.cache_clear()
+
+    monkeypatch.setattr(
+        providers,
+        "get_access_runtime_config",
+        _runtime_config_from_payload,
+    )
+    monkeypatch.setattr(providers, "get_directory_provider", lambda: MagicMock())
+
+    result = providers.get_catalog_service().list_platforms()
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data[0].display_name == "Amazon Web Services"
+
+    providers._build_parser_map.cache_clear()
+    providers.get_catalog_service.cache_clear()

--- a/app/tests/unit/packages/access/catalog/test_service.py
+++ b/app/tests/unit/packages/access/catalog/test_service.py
@@ -1,14 +1,17 @@
 """Unit tests for packages.access.catalog.service."""
 
+import json
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 from infrastructure.directory.models import DirectoryGroup, MembershipCheckResult
 from infrastructure.operations import OperationResult, OperationStatus
+from packages.access.catalog import providers as catalog_providers
 from packages.access.catalog.domain import ParsedEntitlementToken
 from packages.access.catalog.service import CatalogService
 from packages.access.common.config import (
     AccessRuntimeConfig as AccessSyncRuntimeConfig,
+    InlineJsonConfigLoader,
     PlatformPolicy,
 )
 
@@ -153,6 +156,48 @@ def test_list_platforms_should_fall_back_to_platform_key_as_display_name():
     # Assert
     assert result.is_success
     assert result.data[0].display_name == "aws"
+
+
+def test_list_platforms_should_use_display_name_from_runtime_extensions_via_provider_assembly(
+    monkeypatch,
+):
+    payload = {
+        "dir_prefix": "sg",
+        "dir_separator": "-",
+        "platforms": {
+            "aws": {
+                "authn_token": "authn",
+                "authn_removal_mode": "delete",
+                "mode_overrides": {},
+            }
+        },
+        "extensions": {
+            "catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}
+        },
+    }
+    result = InlineJsonConfigLoader().load(json.dumps(payload))
+    assert result.is_success
+    assert result.data is not None
+
+    catalog_providers._build_parser_map.cache_clear()
+    catalog_providers.get_catalog_service.cache_clear()
+    monkeypatch.setattr(
+        catalog_providers,
+        "get_access_runtime_config",
+        lambda: result.data,
+    )
+    monkeypatch.setattr(
+        catalog_providers,
+        "get_directory_provider",
+        lambda: _FakeDirectory(),
+    )
+
+    service = catalog_providers.get_catalog_service()
+    platforms = service.list_platforms()
+
+    assert platforms.is_success
+    assert platforms.data is not None
+    assert platforms.data[0].display_name == "Amazon Web Services"
 
 
 def test_list_platforms_should_derive_authn_group_slug_from_config():

--- a/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
+++ b/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
@@ -52,7 +52,7 @@ def _runtime_config(mode_overrides: dict[str, str]) -> AccessRuntimeConfig:
 def _catalog_mode(config: AccessRuntimeConfig) -> tuple[str, bool]:
     service = CatalogService(
         runtime_config=config,
-        directory=_FakeDirectory(
+        directory=_FakeDirectory(  # type: ignore[arg-type]
             groups=[
                 DirectoryGroup(
                     group_email="sg-aws-admins@example.com",

--- a/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
+++ b/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
@@ -1,0 +1,221 @@
+"""Contract tests for mode_overrides semantics across access sub-features."""
+
+from dataclasses import dataclass
+
+from infrastructure.directory.models import DirectoryGroup, MembershipCheckResult
+from infrastructure.operations import OperationResult
+from packages.access.catalog.service import CatalogService
+from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
+from packages.access.request.policies import check_entitlement_mode
+from packages.access.sync.policies import resolve_effective_policy
+
+
+@dataclass
+class _FakeDirectory:
+    """Simple deterministic directory stub for catalog checks."""
+
+    groups: list[DirectoryGroup]
+
+    def list_groups(self, query: str) -> OperationResult[list[DirectoryGroup]]:
+        return OperationResult.success(data=list(self.groups))
+
+    def check_membership(
+        self,
+        group_email: str,
+        user_email: str,
+    ) -> OperationResult[MembershipCheckResult]:
+        return OperationResult.success(
+            data=MembershipCheckResult(
+                group_email=group_email,
+                group_slug=group_email.split("@", 1)[0],
+                provider_group_id="gid-001",
+                user_email=user_email,
+                is_member=False,
+            )
+        )
+
+
+def _runtime_config(mode_overrides: dict[str, str]) -> AccessRuntimeConfig:
+    return AccessRuntimeConfig(
+        dir_prefix="sg",
+        dir_separator="-",
+        platforms={
+            "aws": PlatformPolicy(
+                authn_token="authn",
+                authn_removal_mode="delete",
+                mode_overrides=mode_overrides,  # type: ignore[arg-type]
+            )
+        },
+    )
+
+
+def _catalog_mode(config: AccessRuntimeConfig) -> tuple[str, bool]:
+    service = CatalogService(
+        runtime_config=config,
+        directory=_FakeDirectory(
+            groups=[
+                DirectoryGroup(
+                    group_email="sg-aws-admins@example.com",
+                    group_slug="sg-aws-admins",
+                    provider_group_id="gid-001",
+                )
+            ]
+        ),
+        parsers={},
+    )
+    result = service.list_entitlements(platform="aws", user_email="user@example.com")
+    assert result.is_success
+    assert result.data is not None
+    assert len(result.data) == 1
+    entry = result.data[0]
+    return entry.mode, entry.requestable
+
+
+def test_mode_override_contract_token_key_is_consistent_across_request_sync_and_catalog():
+    config = _runtime_config(mode_overrides={"admins": "deactivated"})
+
+    request_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="sg-aws-admins",
+    )
+    effective = resolve_effective_policy(
+        config=config,
+        platform="aws",
+        discovered_slugs={"sg-aws-admins"},
+    )
+    catalog_mode, requestable = _catalog_mode(config)
+
+    assert request_mode == "deactivated"
+    assert effective.entitlement_rules == []
+    assert catalog_mode == "deactivated"
+    assert requestable is False
+
+
+def test_mode_override_contract_full_slug_key_is_not_matched():
+    """Full slug keys in mode_overrides are NOT matched; token-only keys are canonical."""
+    config = _runtime_config(mode_overrides={"sg-aws-admins": "deactivated"})
+
+    request_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="sg-aws-admins",
+    )
+    effective = resolve_effective_policy(
+        config=config,
+        platform="aws",
+        discovered_slugs={"sg-aws-admins"},
+    )
+    catalog_mode, requestable = _catalog_mode(config)
+
+    assert request_mode == "sync_managed"
+    assert len(effective.entitlement_rules) == 1
+    assert catalog_mode == "sync_managed"
+    assert requestable is True
+
+
+def test_mode_override_contract_partial_prefix_not_matched():
+    """Partial prefixes like 'aws-' or 'sg-' are NOT matched as tokens."""
+    config = _runtime_config(mode_overrides={"aws-admins": "deactivated"})
+
+    request_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="sg-aws-admins",
+    )
+    effective = resolve_effective_policy(
+        config=config,
+        platform="aws",
+        discovered_slugs={"sg-aws-admins"},
+    )
+
+    assert request_mode == "sync_managed"
+    assert len(effective.entitlement_rules) == 1
+
+
+def test_mode_override_contract_multiple_tokens_isolated():
+    """Different tokens are isolated; override on one doesn't affect others."""
+    config = _runtime_config(
+        mode_overrides={
+            "admins": "deactivated",
+            "developers": "ephemeral",
+            "guests": "sync_managed",
+        }
+    )
+
+    admins_mode = check_entitlement_mode(
+        config, platform="aws", group_slug="sg-aws-admins"
+    )
+    devs_mode = check_entitlement_mode(
+        config, platform="aws", group_slug="sg-aws-developers"
+    )
+    guests_mode = check_entitlement_mode(
+        config, platform="aws", group_slug="sg-aws-guests"
+    )
+
+    assert admins_mode == "deactivated"
+    assert devs_mode == "ephemeral"
+    assert guests_mode == "sync_managed"
+
+
+def test_mode_override_contract_case_insensitivity():
+    """Token matching is case-insensitive (slug normalized internally)."""
+    config = _runtime_config(mode_overrides={"admins": "deactivated"})
+
+    upper_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="SG-AWS-ADMINS",
+    )
+    lower_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="sg-aws-admins",
+    )
+    mixed_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="Sg-Aws-Admins",
+    )
+
+    assert upper_mode == "deactivated"
+    assert lower_mode == "deactivated"
+    assert mixed_mode == "deactivated"
+
+
+def test_mode_override_contract_sync_excludes_ephemeral_and_deactivated():
+    """Sync effective policy excludes ephemeral/deactivated; catalog includes with mode flag."""
+    config = _runtime_config(
+        mode_overrides={
+            "admins": "deactivated",
+            "breakglass": "ephemeral",
+            "standard": "sync_managed",
+        }
+    )
+
+    effective = resolve_effective_policy(
+        config=config,
+        platform="aws",
+        discovered_slugs={
+            "sg-aws-admins",
+            "sg-aws-breakglass",
+            "sg-aws-standard",
+        },
+    )
+
+    tokens = {rule.entitlement_id for rule in effective.entitlement_rules}
+    assert tokens == {"standard"}
+    assert all(rule.mode == "sync_managed" for rule in effective.entitlement_rules)
+
+
+def test_mode_override_contract_whitespace_stripped():
+    """Token lookup strips whitespace from group slugs."""
+    config = _runtime_config(mode_overrides={"admins": "deactivated"})
+
+    with_spaces_mode = check_entitlement_mode(
+        config,
+        platform="aws",
+        group_slug="  sg-aws-admins  ",
+    )
+
+    assert with_spaces_mode == "deactivated"

--- a/app/tests/unit/packages/access/common/test_access_runtime_config_extensions.py
+++ b/app/tests/unit/packages/access/common/test_access_runtime_config_extensions.py
@@ -1,0 +1,64 @@
+"""Behavior tests for runtime-config extensions contracts."""
+
+import json
+
+from packages.access.common.config import InlineJsonConfigLoader
+
+
+def test_runtime_config_extensions_catalog_is_typed_and_attribute_accessible():
+    payload = {
+        "dir_prefix": "sg",
+        "dir_separator": "-",
+        "platforms": {
+            "aws": {
+                "authn_token": "authn",
+                "authn_removal_mode": "delete",
+                "mode_overrides": {},
+            }
+        },
+        "extensions": {
+            "catalog": {
+                "parsers": {"aws": {"known_envs": ["prod", "staging"]}},
+                "platform_display_names": {"aws": "Amazon Web Services"},
+            }
+        },
+    }
+
+    result = InlineJsonConfigLoader().load(json.dumps(payload))
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.catalog is not None
+    assert not isinstance(result.data.catalog, dict)
+    assert hasattr(result.data.catalog, "parsers")
+    assert "aws" in result.data.catalog.parsers
+    assert result.data.catalog.parsers["aws"].known_envs == ["prod", "staging"]
+    assert result.data.catalog.platform_display_names["aws"] == "Amazon Web Services"
+
+
+def test_runtime_config_extensions_invalid_parser_known_envs_shape_fails():
+    payload = {
+        "dir_prefix": "sg",
+        "dir_separator": "-",
+        "platforms": {
+            "aws": {
+                "authn_token": "authn",
+                "authn_removal_mode": "delete",
+                "mode_overrides": {},
+            }
+        },
+        "extensions": {
+            "catalog": {
+                "parsers": {
+                    "aws": {
+                        "known_envs": "prod",
+                    }
+                }
+            }
+        },
+    }
+
+    result = InlineJsonConfigLoader().load(json.dumps(payload))
+
+    assert not result.is_success
+    assert result.error_code == "CONFIG_INVALID_SHAPE"

--- a/app/tests/unit/packages/access/request/test_policies.py
+++ b/app/tests/unit/packages/access/request/test_policies.py
@@ -115,7 +115,7 @@ def test_check_entitlement_mode_returns_sync_managed_by_default():
 
 @pytest.mark.unit
 def test_check_entitlement_mode_returns_override_when_set():
-    config = make_config(platform="aws", mode_overrides={"sg-aws-admins": "ephemeral"})
+    config = make_config(platform="aws", mode_overrides={"admins": "ephemeral"})
     mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-admins")
     assert mode == "ephemeral"
 
@@ -129,16 +129,14 @@ def test_check_entitlement_mode_returns_deactivated_for_unknown_platform():
 
 @pytest.mark.unit
 def test_check_entitlement_mode_deactivated_override():
-    config = make_config(
-        platform="aws", mode_overrides={"sg-aws-admins": "deactivated"}
-    )
+    config = make_config(platform="aws", mode_overrides={"admins": "deactivated"})
     mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-admins")
     assert mode == "deactivated"
 
 
 @pytest.mark.unit
 def test_check_entitlement_mode_other_slug_not_overridden():
-    config = make_config(platform="aws", mode_overrides={"sg-aws-admins": "ephemeral"})
+    config = make_config(platform="aws", mode_overrides={"admins": "ephemeral"})
     mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-devs")
     assert mode == "sync_managed"
 

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -148,10 +148,10 @@ def make_service(
             OperationResult.success()
         )  # IDP write succeeds by default
     service = AccessRequestService(
-        repository=repo,
+        repository=repo,  # type: ignore[arg-type]
         directory=directory,
         runtime_config=config or make_config(),
-        dispatcher=dispatcher,
+        dispatcher=dispatcher,  # type: ignore[arg-type]
         fallback_approver_slug=fallback_approver_slug,
         min_approver_count=min_approver_count,
     )
@@ -309,6 +309,7 @@ def test_submit_request_should_auto_approve_delegated_requests():
     )
 
     assert result.is_success
+    assert result.data is not None
     assert result.data.status == "approved"
     event_types = [e.event_type for e in dispatcher.dispatched]
     assert "access_request_approved" in event_types
@@ -359,6 +360,7 @@ def test_approve_request_should_transition_to_approved():
         entitlement_type="group",
         justification="Need access.",
     )
+    assert submit.data is not None
     request_id = submit.data.request_id
 
     result = service.approve_request(
@@ -390,6 +392,7 @@ def test_approve_request_should_reject_self_approval():
         entitlement_type="group",
         justification="Need access.",
     )
+    assert submit.data is not None
     # Force actor into resolved_approvers for this test
     from dataclasses import replace
 
@@ -420,7 +423,7 @@ def test_approve_request_should_reject_unauthorized_approver():
         entitlement_type="group",
         justification="Need access.",
     )
-
+    assert submit.data is not None
     result = service.approve_request(
         request_id=submit.data.request_id,
         approver_email="not-an-approver@example.com",
@@ -823,6 +826,7 @@ def test_retry_request_should_fail_when_not_in_failed_state():
         entitlement_type="group",
         justification="Need access.",
     )
+    assert submit_result.data is not None
     request_id = submit_result.data.request_id
 
     result = service.retry_request(

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -209,9 +209,7 @@ def test_submit_request_should_reject_when_group_not_found():
 
 @pytest.mark.unit
 def test_submit_request_should_reject_when_mode_is_deactivated():
-    config = make_config(
-        platform="aws", mode_overrides={"sg-aws-admins": "deactivated"}
-    )
+    config = make_config(platform="aws", mode_overrides={"admins": "deactivated"})
     service, _, _ = make_service(config=config)
 
     result = service.submit_request(
@@ -231,7 +229,7 @@ def test_submit_request_should_reject_when_mode_is_deactivated():
 
 @pytest.mark.unit
 def test_submit_request_should_reject_when_mode_is_ephemeral():
-    config = make_config(platform="aws", mode_overrides={"sg-aws-admins": "ephemeral"})
+    config = make_config(platform="aws", mode_overrides={"admins": "ephemeral"})
     service, _, _ = make_service(config=config)
 
     result = service.submit_request(
@@ -247,6 +245,26 @@ def test_submit_request_should_reject_when_mode_is_ephemeral():
 
     assert not result.is_success
     assert result.error_code == "ENTITLEMENT_MODE_EPHEMERAL"
+
+
+@pytest.mark.unit
+def test_submit_request_should_reject_when_mode_is_deactivated_with_token_key_override():
+    config = make_config(platform="aws", mode_overrides={"admins": "deactivated"})
+    service, _, _ = make_service(config=config)
+
+    result = service.submit_request(
+        user_email="user@example.com",
+        actor_email="user@example.com",
+        actor_type="self",
+        request_type="grant",
+        platform="aws",
+        group_slug="sg-aws-admins",
+        entitlement_type="group",
+        justification="Need access.",
+    )
+
+    assert not result.is_success
+    assert result.error_code == "ENTITLEMENT_MODE_DEACTIVATED"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces significant improvements to how catalog-related extensions and configuration are handled in the Access package. It adds typed models for catalog extensions, ensures these are properly loaded and validated from runtime config, and updates provider logic to use the new typed structures. Additionally, it includes comprehensive tests to verify the new behavior and clarifies the contract for `mode_overrides` handling across features.

**Typed catalog extensions and config loading:**

- Introduced new typed dataclasses and Pydantic models for `CatalogExtensions` and `CatalogParserConfig`, and updated `AccessRuntimeConfig` to include a `catalog_extensions` field for strongly-typed access to catalog config. [[1]](diffhunk://#diff-c664832ff9ec305d0eec2fdc2ac88300baac8323d2e82bea8778f7d74b3c7b7eR35-R49) [[2]](diffhunk://#diff-c664832ff9ec305d0eec2fdc2ac88300baac8323d2e82bea8778f7d74b3c7b7eL57-R74) [[3]](diffhunk://#diff-c664832ff9ec305d0eec2fdc2ac88300baac8323d2e82bea8778f7d74b3c7b7eL78-R96) [[4]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R74-R86)
- Updated the runtime config loader to parse and validate the `catalog` extension into the new typed models, with error handling for invalid extension shapes. [[1]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R139-R158) [[2]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R175-R187)
- Updated import/export lists to include the new config types. [[1]](diffhunk://#diff-7960a0bd13cb0243170576caa660541a4829ff0aae6f94c318f1bfcac1484fe2R14-R15) [[2]](diffhunk://#diff-7960a0bd13cb0243170576caa660541a4829ff0aae6f94c318f1bfcac1484fe2R33-R34) [[3]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R26-R27)

**Provider and service logic updates:**

- Refactored `catalog.providers` to use the new `catalog_extensions` for parser config and display names, replacing legacy dynamic access and improving type safety. [[1]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL33-R47) [[2]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL62-R71)

**Testing and contract validation:**

- Added unit tests for the provider wiring to ensure known environments and display names are correctly applied from runtime extensions. [[1]](diffhunk://#diff-32760670a02a4c2adf4bbbc63385019440245b92112a3de247291cfc54e0cec2R1-R74) [[2]](diffhunk://#diff-8e22d3704136cd198415396f33d6d998c2e5dc22cfcd55d4ad632f5d68223541R161-R202)
- Added a new contract test suite for `mode_overrides` to clarify and enforce canonical token-only key matching, case insensitivity, isolation between tokens, and whitespace handling across request, sync, and catalog features.

**Behavioral fixes and compatibility:**

- Removed fallback logic for full-slug key matching in `check_entitlement_mode`, ensuring only token keys are used for overrides as per the contract.

**Documentation and schema examples:**

- Improved docstrings and schema comments to reflect the new structure and provide clear examples of the expected runtime config shape.

These changes collectively improve the reliability, safety, and clarity of catalog extension handling and entitlement mode overrides in the Access system.