### PR TITLE
Feat: add AppSettings and dependency injection 

### DIFF
--- a/app/infrastructure/configuration/__init__.py
+++ b/app/infrastructure/configuration/__init__.py
@@ -25,7 +25,8 @@ Example:
     ```
 """
 
+from infrastructure.configuration.app import AppSettings, get_app_settings
 from infrastructure.configuration.settings import Settings
 from infrastructure.configuration.infrastructure.retry import RetrySettings
 
-__all__ = ["Settings", "RetrySettings"]
+__all__ = ["AppSettings", "Settings", "RetrySettings", "get_app_settings"]

--- a/app/infrastructure/configuration/app.py
+++ b/app/infrastructure/configuration/app.py
@@ -1,0 +1,26 @@
+"""Application-level settings and singleton provider."""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppSettings(BaseSettings):
+    """Minimal app-level settings: prefix, log level, git SHA."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    PREFIX: str = ""
+    LOG_LEVEL: str = "INFO"
+    GIT_SHA: str = "Unknown"
+
+    @property
+    def is_production(self) -> bool:
+        """True when PREFIX is empty (production deployment)."""
+        return not bool(self.PREFIX)
+
+
+@lru_cache(maxsize=1)
+def get_app_settings() -> AppSettings:
+    """Singleton provider for app-level settings."""
+    return AppSettings()

--- a/app/infrastructure/services/__init__.py
+++ b/app/infrastructure/services/__init__.py
@@ -5,6 +5,7 @@ Provides type aliases and provider functions for FastAPI dependency injection.
 """
 
 from infrastructure.services.dependencies import (
+    AppSettingsDep,
     SettingsDep,
     IdentityServiceDep,
     JWKSManagerDep,
@@ -27,6 +28,7 @@ from infrastructure.services.dependencies import (
     DirectoryProviderDep,
 )
 from infrastructure.services.providers import (
+    get_app_settings,
     get_settings,
     get_identity_service,
     get_jwks_manager,
@@ -54,7 +56,6 @@ from infrastructure.services.providers import (
 from infrastructure.security.rate_limiter import get_limiter, setup_rate_limiter
 from infrastructure.security.current_user import get_current_user
 
-
 # Plugin infrastructure
 from infrastructure.services.plugins import (
     hookimpl,
@@ -64,9 +65,9 @@ from infrastructure.services.plugins import (
     register_feature_integrations,
 )
 
-
 __all__ = [
     # Core dependencies
+    "AppSettingsDep",
     "SettingsDep",
     "IdentityServiceDep",
     "JWKSManagerDep",
@@ -89,6 +90,7 @@ __all__ = [
     "DiscordClientDep",
     "DirectoryProviderDep",
     # Core providers
+    "get_app_settings",
     "get_settings",
     "get_identity_service",
     "get_jwks_manager",

--- a/app/infrastructure/services/dependencies.py
+++ b/app/infrastructure/services/dependencies.py
@@ -6,7 +6,7 @@ Provides annotated type hints for common infrastructure dependencies.
 
 from typing import Annotated
 from fastapi import Depends, Security
-from infrastructure.configuration import Settings
+from infrastructure.configuration import AppSettings, Settings
 from infrastructure.identity.models import User
 from infrastructure.identity.service import IdentityService
 from infrastructure.security.jwks import JWKSManager
@@ -30,6 +30,7 @@ from infrastructure.platforms.clients import (
 )
 from infrastructure.directory.provider import DirectoryProvider
 from infrastructure.services.providers import (
+    get_app_settings,
     get_settings,
     get_identity_service,
     get_jwks_manager,
@@ -53,6 +54,7 @@ from infrastructure.services.providers import (
 
 # Settings dependency
 SettingsDep = Annotated[Settings, Depends(get_settings)]
+AppSettingsDep = Annotated[AppSettings, Depends(get_app_settings)]
 
 # Identity service dependency
 IdentityServiceDep = Annotated[IdentityService, Depends(get_identity_service)]
@@ -130,6 +132,7 @@ DirectoryProviderDep = Annotated[DirectoryProvider, Depends(get_directory_provid
 
 __all__ = [
     "SettingsDep",
+    "AppSettingsDep",
     "IdentityServiceDep",
     "JWKSManagerDep",
     "CurrentUserDep",

--- a/app/infrastructure/services/providers.py
+++ b/app/infrastructure/services/providers.py
@@ -11,6 +11,10 @@ from typing import cast
 
 
 from infrastructure.configuration import Settings
+from infrastructure.configuration.app import (
+    AppSettings,
+    get_app_settings as _get_app_settings,
+)
 from infrastructure.identity.service import IdentityService
 from infrastructure.security.jwks import JWKSManager
 from infrastructure.clients.aws import AWSClients
@@ -63,6 +67,11 @@ def get_settings() -> Settings:
         Settings: Cached settings instance loaded from environment.
     """
     return Settings()
+
+
+def get_app_settings() -> AppSettings:
+    """Get application-scoped app settings singleton."""
+    return _get_app_settings()
 
 
 @lru_cache(maxsize=1)

--- a/app/tests/unit/infrastructure/configuration/test_app_settings.py
+++ b/app/tests/unit/infrastructure/configuration/test_app_settings.py
@@ -1,0 +1,52 @@
+"""Unit tests for app-level settings singleton."""
+
+from infrastructure.configuration.app import AppSettings, get_app_settings
+
+
+class TestAppSettings:
+    """Test suite for AppSettings configuration."""
+
+    def test_app_settings_defaults(self):
+        """AppSettings should provide stable defaults."""
+        settings = AppSettings()
+
+        assert settings.PREFIX == ""
+        assert settings.LOG_LEVEL == "INFO"
+        assert settings.GIT_SHA == "Unknown"
+
+    def test_app_settings_is_production_when_prefix_empty(self):
+        """is_production should be True when PREFIX is empty."""
+        settings = AppSettings(PREFIX="")
+
+        assert settings.is_production is True
+
+    def test_app_settings_is_not_production_when_prefix_set(self):
+        """is_production should be False when PREFIX is set."""
+        settings = AppSettings(PREFIX="dev")
+
+        assert settings.is_production is False
+
+    def test_app_settings_ignores_extra_env_vars(self, monkeypatch):
+        """Unknown environment variables should be ignored during settings loading."""
+        monkeypatch.setenv("UNKNOWN_VAR", "x")
+
+        settings = AppSettings()
+
+        assert settings.PREFIX == ""
+
+    def test_app_settings_singleton_returns_same_instance(self):
+        """Provider should return same cached singleton instance."""
+        get_app_settings.cache_clear()
+
+        instance1 = get_app_settings()
+        instance2 = get_app_settings()
+
+        assert instance1 is instance2
+
+    def test_app_settings_reads_from_env(self, monkeypatch):
+        """Environment variables should override defaults."""
+        monkeypatch.setenv("PREFIX", "staging")
+
+        settings = AppSettings()
+
+        assert settings.PREFIX == "staging"

--- a/app/tests/unit/infrastructure/services/test_app_settings_di.py
+++ b/app/tests/unit/infrastructure/services/test_app_settings_di.py
@@ -1,0 +1,36 @@
+"""Unit tests for AppSettings dependency injection wiring."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from infrastructure.configuration import AppSettings
+from infrastructure.services import AppSettingsDep, get_app_settings
+
+
+def test_app_settings_dep_override():
+    """AppSettingsDep should support FastAPI dependency overrides."""
+    app = FastAPI()
+
+    @app.get("/app-config")
+    def read_config(settings: AppSettingsDep) -> dict[str, str]:
+        return {
+            "prefix": settings.PREFIX,
+            "log_level": settings.LOG_LEVEL,
+            "git_sha": settings.GIT_SHA,
+        }
+
+    override = AppSettings(PREFIX="dev", LOG_LEVEL="DEBUG", GIT_SHA="abc123")
+    app.dependency_overrides[get_app_settings] = lambda: override
+
+    try:
+        with TestClient(app) as client:
+            response = client.get("/app-config")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "prefix": "dev",
+            "log_level": "DEBUG",
+            "git_sha": "abc123",
+        }
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new application-level settings configuration system centered around the `AppSettings` class and its singleton provider, and integrates these into the dependency injection (DI) framework. It also includes comprehensive unit tests for both the settings logic and its DI wiring. The changes improve configuration management by providing a clear separation between app-level and infrastructure-level settings, and by ensuring robust test coverage.

**App-level settings and provider:**

- Introduced `AppSettings` class in `app.py` for minimal app-level configuration (e.g., `PREFIX`, `LOG_LEVEL`, `GIT_SHA`), with a property to detect production mode, and a singleton provider function `get_app_settings` using `lru_cache`.
- Updated `infrastructure/configuration/__init__.py` to export `AppSettings` and `get_app_settings`.

**Dependency injection integration:**

- Added `AppSettingsDep` as a FastAPI dependency for `AppSettings`, and registered it in `dependencies.py` and `services/__init__.py`. [[1]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R57) [[2]](diffhunk://#diff-e36cd87daed4041e52609549cecf004489d1eba368abf0c1d74319f7745bb959R8) [[3]](diffhunk://#diff-e36cd87daed4041e52609549cecf004489d1eba368abf0c1d74319f7745bb959L67-R70) [[4]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R135)
- Registered `get_app_settings` provider in `services/providers.py` and exported it in `services/__init__.py`. [[1]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890R72-R76) [[2]](diffhunk://#diff-e36cd87daed4041e52609549cecf004489d1eba368abf0c1d74319f7745bb959R31) [[3]](diffhunk://#diff-e36cd87daed4041e52609549cecf004489d1eba368abf0c1d74319f7745bb959R93)

**Testing:**

- Added unit tests for `AppSettings` and its singleton provider, covering default values, environment variable overrides, singleton behavior, and extra variable handling.
- Added unit test for DI wiring, ensuring `AppSettingsDep` can be overridden in FastAPI for testing.

**Internal imports and code organization:**

- Updated imports throughout the codebase to use the new `AppSettings` and provider where appropriate. [[1]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0L9-R9) [[2]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R33) [[3]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890R14-R17)

These changes lay the groundwork for more robust and testable application-level configuration management.