### PR TITLE
feat: add singleton providers for infrastructure settings

### DIFF
--- a/app/infrastructure/configuration/infrastructure/__init__.py
+++ b/app/infrastructure/configuration/infrastructure/__init__.py
@@ -1,27 +1,45 @@
 """Infrastructure settings __init__ - exports all infrastructure settings."""
 
-from infrastructure.configuration.infrastructure.idempotency import IdempotencySettings
-from infrastructure.configuration.infrastructure.retry import RetrySettings
-from infrastructure.configuration.infrastructure.directory import DirectorySettings
+from infrastructure.configuration.infrastructure.idempotency import (
+    IdempotencySettings,
+    get_idempotency_settings,
+)
+from infrastructure.configuration.infrastructure.retry import (
+    RetrySettings,
+    get_retry_settings,
+)
+from infrastructure.configuration.infrastructure.directory import (
+    DirectorySettings,
+    get_directory_settings,
+)
 from infrastructure.configuration.infrastructure.server import (
     ServerSettings,
     DevSettings,
+    get_server_settings,
+    get_dev_settings,
 )
 from infrastructure.configuration.infrastructure.platforms import (
     PlatformsSettings,
     SlackPlatformSettings,
     TeamsPlatformSettings,
     DiscordPlatformSettings,
+    get_platforms_settings,
 )
 
 __all__ = [
     "IdempotencySettings",
+    "get_idempotency_settings",
     "RetrySettings",
+    "get_retry_settings",
     "DirectorySettings",
+    "get_directory_settings",
     "ServerSettings",
     "DevSettings",
+    "get_server_settings",
+    "get_dev_settings",
     "PlatformsSettings",
     "SlackPlatformSettings",
     "TeamsPlatformSettings",
     "DiscordPlatformSettings",
+    "get_platforms_settings",
 ]

--- a/app/infrastructure/configuration/infrastructure/directory.py
+++ b/app/infrastructure/configuration/infrastructure/directory.py
@@ -1,5 +1,6 @@
 """Directory infrastructure settings."""
 
+from functools import lru_cache
 from typing import Literal
 
 from pydantic import Field
@@ -77,3 +78,9 @@ class DirectorySettings(InfrastructureSettings):
         alias="DIRECTORY_STARTUP_WARMUP_TIMEOUT_SECONDS",
         description="Timeout for the lightweight startup warmup probe",
     )
+
+
+@lru_cache(maxsize=1)
+def get_directory_settings() -> DirectorySettings:
+    """Singleton provider for directory infrastructure settings."""
+    return DirectorySettings()

--- a/app/infrastructure/configuration/infrastructure/idempotency.py
+++ b/app/infrastructure/configuration/infrastructure/idempotency.py
@@ -1,5 +1,7 @@
 """Idempotency infrastructure settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import InfrastructureSettings
@@ -23,3 +25,9 @@ class IdempotencySettings(InfrastructureSettings):
     """
 
     IDEMPOTENCY_TTL_SECONDS: int = Field(default=3600, alias="IDEMPOTENCY_TTL_SECONDS")
+
+
+@lru_cache(maxsize=1)
+def get_idempotency_settings() -> IdempotencySettings:
+    """Singleton provider for idempotency infrastructure settings."""
+    return IdempotencySettings()

--- a/app/infrastructure/configuration/infrastructure/platforms.py
+++ b/app/infrastructure/configuration/infrastructure/platforms.py
@@ -3,6 +3,7 @@
 Configuration for collaboration platform integrations (Slack, Teams, Discord).
 """
 
+from functools import lru_cache
 from typing import Optional
 
 from pydantic import Field, model_validator
@@ -276,3 +277,9 @@ class PlatformsSettings(InfrastructureSettings):
         default_factory=DiscordPlatformSettings,
         description="Discord platform provider settings",
     )
+
+
+@lru_cache(maxsize=1)
+def get_platforms_settings() -> PlatformsSettings:
+    """Singleton provider for platform provider infrastructure settings."""
+    return PlatformsSettings()

--- a/app/infrastructure/configuration/infrastructure/retry.py
+++ b/app/infrastructure/configuration/infrastructure/retry.py
@@ -1,5 +1,7 @@
 """Retry system infrastructure settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import InfrastructureSettings
@@ -95,3 +97,9 @@ class RetrySettings(InfrastructureSettings):
         alias="RETRY_CLAIM_LEASE_SECONDS",
         description="Duration to hold claim on retry record (seconds, 5 minutes)",
     )
+
+
+@lru_cache(maxsize=1)
+def get_retry_settings() -> RetrySettings:
+    """Singleton provider for retry infrastructure settings."""
+    return RetrySettings()

--- a/app/infrastructure/configuration/infrastructure/server.py
+++ b/app/infrastructure/configuration/infrastructure/server.py
@@ -1,5 +1,6 @@
 """Server and development infrastructure settings."""
 
+from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from pydantic import Field, field_validator
@@ -75,3 +76,15 @@ class DevSettings(InfrastructureSettings):
     """
 
     SLACK_DEV_MSG_CHANNEL: str = Field(default="", alias="SLACK_DEV_MSG_CHANNEL")
+
+
+@lru_cache(maxsize=1)
+def get_server_settings() -> ServerSettings:
+    """Singleton provider for server infrastructure settings."""
+    return ServerSettings()
+
+
+@lru_cache(maxsize=1)
+def get_dev_settings() -> DevSettings:
+    """Singleton provider for development infrastructure settings."""
+    return DevSettings()

--- a/app/tests/unit/infrastructure/configuration/test_infra_settings_singletons.py
+++ b/app/tests/unit/infrastructure/configuration/test_infra_settings_singletons.py
@@ -1,0 +1,142 @@
+"""Unit tests for infrastructure settings singleton providers (PR-3)."""
+
+from infrastructure.configuration.infrastructure.server import (
+    ServerSettings,
+    DevSettings,
+    get_server_settings,
+    get_dev_settings,
+)
+from infrastructure.configuration.infrastructure.idempotency import (
+    IdempotencySettings,
+    get_idempotency_settings,
+)
+from infrastructure.configuration.infrastructure.retry import (
+    RetrySettings,
+    get_retry_settings,
+)
+from infrastructure.configuration.infrastructure.platforms import (
+    PlatformsSettings,
+    get_platforms_settings,
+)
+from infrastructure.configuration.infrastructure.directory import (
+    DirectorySettings,
+    get_directory_settings,
+)
+
+
+class TestServerSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_server_settings.cache_clear()
+        assert get_server_settings() is get_server_settings()
+
+    def test_has_required_model_config(self):
+        config = ServerSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("BACKEND_URL", "http://example.com:9000")
+        settings = ServerSettings()
+        assert settings.BACKEND_URL == "http://example.com:9000"
+
+
+class TestDevSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_dev_settings.cache_clear()
+        assert get_dev_settings() is get_dev_settings()
+
+    def test_has_required_model_config(self):
+        config = DevSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("SLACK_DEV_MSG_CHANNEL", "C_TEST123")
+        settings = DevSettings()
+        assert settings.SLACK_DEV_MSG_CHANNEL == "C_TEST123"
+
+
+class TestIdempotencySettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_idempotency_settings.cache_clear()
+        assert get_idempotency_settings() is get_idempotency_settings()
+
+    def test_has_required_model_config(self):
+        config = IdempotencySettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("IDEMPOTENCY_TTL_SECONDS", "7200")
+        settings = IdempotencySettings()
+        assert settings.IDEMPOTENCY_TTL_SECONDS == 7200
+
+
+class TestRetrySettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_retry_settings.cache_clear()
+        assert get_retry_settings() is get_retry_settings()
+
+    def test_has_required_model_config(self):
+        config = RetrySettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("RETRY_MAX_ATTEMPTS", "10")
+        settings = RetrySettings()
+        assert settings.max_attempts == 10
+
+
+class TestPlatformsSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_platforms_settings.cache_clear()
+        assert get_platforms_settings() is get_platforms_settings()
+
+    def test_has_required_model_config(self):
+        config = PlatformsSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_default_providers_disabled(self):
+        settings = PlatformsSettings()
+        assert settings.slack.ENABLED is False
+        assert settings.teams.ENABLED is False
+        assert settings.discord.ENABLED is False
+
+
+class TestDirectorySettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_directory_settings.cache_clear()
+        assert get_directory_settings() is get_directory_settings()
+
+    def test_has_required_model_config(self):
+        config = DirectorySettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("DIRECTORY_PROVIDER", "entra_id")
+        settings = DirectorySettings()
+        assert settings.provider == "entra_id"
+
+
+class TestInfraSettingsExportedFromInit:
+    """Verify all providers are accessible from the infrastructure package."""
+
+    def test_all_providers_importable(self):
+        from infrastructure.configuration.infrastructure import (
+            get_server_settings,
+            get_dev_settings,
+            get_idempotency_settings,
+            get_retry_settings,
+            get_platforms_settings,
+            get_directory_settings,
+        )
+
+        assert callable(get_server_settings)
+        assert callable(get_dev_settings)
+        assert callable(get_idempotency_settings)
+        assert callable(get_retry_settings)
+        assert callable(get_platforms_settings)
+        assert callable(get_directory_settings)


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces singleton provider functions for all infrastructure settings classes, ensuring that each settings object is instantiated only once and reused throughout the application. These providers use `functools.lru_cache` to implement the singleton pattern. The PR also updates the package's `__init__.py` to export these new provider functions and adds comprehensive unit tests to verify their behavior and accessibility.

Key changes:

**Singleton provider functions for infrastructure settings:**
* Added `get_server_settings`, `get_dev_settings`, `get_idempotency_settings`, `get_retry_settings`, `get_platforms_settings`, and `get_directory_settings` functions to their respective modules, each decorated with `@lru_cache(maxsize=1)` to ensure singleton behavior. [[1]](diffhunk://#diff-f2f32d69a684e9fce4aa6495c50e351e4f6edd6184db1d6c728e6f8dd3f77262R79-R90) [[2]](diffhunk://#diff-2a20531c799ce36c1fd72086d873c36430e4bf343a4f6abaeacc46a4d8b2128bR28-R33) [[3]](diffhunk://#diff-1adc936362ae2ce8dab6127eb693caf548828e03d7c3b841d90de3b82b2819b8R100-R105) [[4]](diffhunk://#diff-0e743e48b42281e36aa5f02c1fd40b15cd640829eb0f24afb2320619059e96d0R280-R285) [[5]](diffhunk://#diff-bc2e1d18310f975c08278fa1f6620e81684c54b3801d4987fead1736c7a15b75R81-R86)

**Exports and accessibility:**
* Updated `app/infrastructure/configuration/infrastructure/__init__.py` to export all new singleton provider functions, making them available for import throughout the codebase.

**Testing:**
* Added `app/tests/unit/infrastructure/configuration/test_infra_settings_singletons.py` with unit tests for each singleton provider, verifying singleton behavior, model configuration, environment variable reading, and package exports.

**Imports and code hygiene:**
* Added necessary imports for `lru_cache` in all relevant modules to support the singleton providers. [[1]](diffhunk://#diff-f2f32d69a684e9fce4aa6495c50e351e4f6edd6184db1d6c728e6f8dd3f77262R3) [[2]](diffhunk://#diff-2a20531c799ce36c1fd72086d873c36430e4bf343a4f6abaeacc46a4d8b2128bR3-R4) [[3]](diffhunk://#diff-1adc936362ae2ce8dab6127eb693caf548828e03d7c3b841d90de3b82b2819b8R3-R4) [[4]](diffhunk://#diff-0e743e48b42281e36aa5f02c1fd40b15cd640829eb0f24afb2320619059e96d0R6) [[5]](diffhunk://#diff-bc2e1d18310f975c08278fa1f6620e81684c54b3801d4987fead1736c7a15b75R3)