### PR TITLE
feat: add singleton providers for feature settings

### DIFF
--- a/app/infrastructure/configuration/features/__init__.py
+++ b/app/infrastructure/configuration/features/__init__.py
@@ -1,17 +1,38 @@
 """Feature settings __init__ - exports all feature settings."""
 
-from infrastructure.configuration.features.groups import GroupsFeatureSettings
-from infrastructure.configuration.features.commands import CommandsSettings
-from infrastructure.configuration.features.incident import IncidentFeatureSettings
-from infrastructure.configuration.features.aws_ops import AWSFeatureSettings
-from infrastructure.configuration.features.atip import AtipSettings
-from infrastructure.configuration.features.sre_ops import SreOpsSettings
+from infrastructure.configuration.features.groups import (
+    GroupsFeatureSettings,
+    get_groups_settings,
+)
+from infrastructure.configuration.features.commands import (
+    CommandsSettings,
+    get_commands_settings,
+)
+from infrastructure.configuration.features.incident import (
+    IncidentFeatureSettings,
+    get_incident_settings,
+)
+from infrastructure.configuration.features.aws_ops import (
+    AWSFeatureSettings,
+    get_aws_feature_settings,
+)
+from infrastructure.configuration.features.atip import AtipSettings, get_atip_settings
+from infrastructure.configuration.features.sre_ops import (
+    SreOpsSettings,
+    get_sre_ops_settings,
+)
 
 __all__ = [
     "GroupsFeatureSettings",
+    "get_groups_settings",
     "CommandsSettings",
+    "get_commands_settings",
     "IncidentFeatureSettings",
+    "get_incident_settings",
     "AWSFeatureSettings",
+    "get_aws_feature_settings",
     "AtipSettings",
+    "get_atip_settings",
     "SreOpsSettings",
+    "get_sre_ops_settings",
 ]

--- a/app/infrastructure/configuration/features/atip.py
+++ b/app/infrastructure/configuration/features/atip.py
@@ -1,5 +1,7 @@
 """ATIP feature settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import FeatureSettings
@@ -24,3 +26,9 @@ class AtipSettings(FeatureSettings):
     ATIP_ANNOUNCE_CHANNEL: str | None = Field(
         default=None, alias="ATIP_ANNOUNCE_CHANNEL"
     )
+
+
+@lru_cache(maxsize=1)
+def get_atip_settings() -> AtipSettings:
+    """Singleton provider for ATIP feature settings."""
+    return AtipSettings()

--- a/app/infrastructure/configuration/features/aws_ops.py
+++ b/app/infrastructure/configuration/features/aws_ops.py
@@ -1,5 +1,7 @@
 """AWS operations feature settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import FeatureSettings
@@ -27,3 +29,9 @@ class AWSFeatureSettings(FeatureSettings):
         default=["sre-ifs@cds-snc.ca"], alias="AWS_ADMIN_GROUPS"
     )
     AWS_OPS_GROUP_NAME: str = Field(default="", alias="AWS_OPS_GROUP_NAME")
+
+
+@lru_cache(maxsize=1)
+def get_aws_feature_settings() -> AWSFeatureSettings:
+    """Singleton provider for AWS operations feature settings."""
+    return AWSFeatureSettings()

--- a/app/infrastructure/configuration/features/commands.py
+++ b/app/infrastructure/configuration/features/commands.py
@@ -1,6 +1,7 @@
 """Commands feature settings."""
 
 import json
+from functools import lru_cache
 from typing import Any, Optional
 
 from pydantic import Field, field_validator
@@ -76,3 +77,9 @@ class CommandsSettings(FeatureSettings):
                     f"Invalid COMMAND_PROVIDERS JSON: {e} (value: {s[:80]}...)"
                 ) from e
         raise ValueError("COMMAND_PROVIDERS must be a JSON string or a mapping")
+
+
+@lru_cache(maxsize=1)
+def get_commands_settings() -> CommandsSettings:
+    """Singleton provider for commands feature settings."""
+    return CommandsSettings()

--- a/app/infrastructure/configuration/features/groups.py
+++ b/app/infrastructure/configuration/features/groups.py
@@ -1,6 +1,7 @@
 """Groups module feature settings."""
 
 import json
+from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from pydantic import Field, field_validator
@@ -222,3 +223,9 @@ class GroupsFeatureSettings(FeatureSettings):
         if "providers" in kwargs and "GROUP_PROVIDERS" not in kwargs:
             kwargs["GROUP_PROVIDERS"] = kwargs.pop("providers")
         super().__init__(**kwargs)
+
+
+@lru_cache(maxsize=1)
+def get_groups_settings() -> GroupsFeatureSettings:
+    """Singleton provider for groups feature settings."""
+    return GroupsFeatureSettings()

--- a/app/infrastructure/configuration/features/incident.py
+++ b/app/infrastructure/configuration/features/incident.py
@@ -1,5 +1,7 @@
 """Incident feature settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import FeatureSettings
@@ -27,3 +29,9 @@ class IncidentFeatureSettings(FeatureSettings):
     SLACK_SECURITY_USER_GROUP_ID: str | None = Field(
         default=None, alias="SLACK_SECURITY_USER_GROUP_ID"
     )
+
+
+@lru_cache(maxsize=1)
+def get_incident_settings() -> IncidentFeatureSettings:
+    """Singleton provider for incident feature settings."""
+    return IncidentFeatureSettings()

--- a/app/infrastructure/configuration/features/sre_ops.py
+++ b/app/infrastructure/configuration/features/sre_ops.py
@@ -1,5 +1,7 @@
 """SRE operations feature settings."""
 
+from functools import lru_cache
+
 from pydantic import Field
 
 from infrastructure.configuration.base import FeatureSettings
@@ -22,3 +24,9 @@ class SreOpsSettings(FeatureSettings):
     """
 
     SRE_OPS_CHANNEL_ID: str = Field(default="", alias="SRE_OPS_CHANNEL_ID")
+
+
+@lru_cache(maxsize=1)
+def get_sre_ops_settings() -> SreOpsSettings:
+    """Singleton provider for SRE operations feature settings."""
+    return SreOpsSettings()

--- a/app/tests/unit/infrastructure/configuration/test_feature_settings_singletons.py
+++ b/app/tests/unit/infrastructure/configuration/test_feature_settings_singletons.py
@@ -1,0 +1,122 @@
+"""Unit tests for feature settings singleton providers (PR-4)."""
+
+from infrastructure.configuration.features.groups import (
+    GroupsFeatureSettings,
+    get_groups_settings,
+)
+from infrastructure.configuration.features.commands import (
+    CommandsSettings,
+    get_commands_settings,
+)
+from infrastructure.configuration.features.incident import (
+    IncidentFeatureSettings,
+    get_incident_settings,
+)
+from infrastructure.configuration.features.aws_ops import (
+    AWSFeatureSettings,
+    get_aws_feature_settings,
+)
+from infrastructure.configuration.features.atip import (
+    AtipSettings,
+    get_atip_settings,
+)
+from infrastructure.configuration.features.sre_ops import (
+    SreOpsSettings,
+    get_sre_ops_settings,
+)
+
+
+class TestGroupsFeatureSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_groups_settings.cache_clear()
+        assert get_groups_settings() is get_groups_settings()
+
+    def test_has_required_model_config(self):
+        config = GroupsFeatureSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("GROUP_DOMAIN", "example.com")
+        settings = GroupsFeatureSettings()
+        assert settings.group_domain == "example.com"
+
+
+class TestCommandsSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_commands_settings.cache_clear()
+        assert get_commands_settings() is get_commands_settings()
+
+    def test_has_required_model_config(self):
+        config = CommandsSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("COMMAND_PROVIDERS", '{"slack": {"enabled": true}}')
+        settings = CommandsSettings()
+        assert "slack" in settings.providers
+
+
+class TestIncidentFeatureSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_incident_settings.cache_clear()
+        assert get_incident_settings() is get_incident_settings()
+
+    def test_has_required_model_config(self):
+        config = IncidentFeatureSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("INCIDENT_CHANNEL", "C_INCIDENT")
+        settings = IncidentFeatureSettings()
+        assert settings.INCIDENT_CHANNEL == "C_INCIDENT"
+
+
+class TestAWSFeatureSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_aws_feature_settings.cache_clear()
+        assert get_aws_feature_settings() is get_aws_feature_settings()
+
+    def test_has_required_model_config(self):
+        config = AWSFeatureSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_OPS_GROUP_NAME", "aws-ops-team")
+        settings = AWSFeatureSettings()
+        assert settings.AWS_OPS_GROUP_NAME == "aws-ops-team"
+
+
+class TestAtipSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_atip_settings.cache_clear()
+        assert get_atip_settings() is get_atip_settings()
+
+    def test_has_required_model_config(self):
+        config = AtipSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("ATIP_ANNOUNCE_CHANNEL", "C_ATIP")
+        settings = AtipSettings()
+        assert settings.ATIP_ANNOUNCE_CHANNEL == "C_ATIP"
+
+
+class TestSreOpsSettingsSingleton:
+    def test_singleton_returns_same_instance(self):
+        get_sre_ops_settings.cache_clear()
+        assert get_sre_ops_settings() is get_sre_ops_settings()
+
+    def test_has_required_model_config(self):
+        config = SreOpsSettings.model_config
+        assert config.get("env_file") == ".env"
+        assert config.get("extra") == "ignore"
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("SRE_OPS_CHANNEL_ID", "C_SRE")
+        settings = SreOpsSettings()
+        assert settings.SRE_OPS_CHANNEL_ID == "C_SRE"


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces singleton provider functions for all feature settings classes in the `infrastructure.configuration.features` module. These providers use `functools.lru_cache` to ensure that only one instance of each settings class is created and reused throughout the application. Additionally, the PR updates the module's exports to include these new providers and adds comprehensive unit tests to verify their singleton behavior and environment variable integration.

Singleton provider functions for feature settings:

* Added `get_groups_settings`, `get_commands_settings`, `get_incident_settings`, `get_aws_feature_settings`, `get_atip_settings`, and `get_sre_ops_settings` functions to their respective modules. Each uses `@lru_cache(maxsize=1)` to ensure a single instance is returned. [[1]](diffhunk://#diff-32a0507c871ba2438714630780978b47afcf386f051dd69271ea1500eaa0c3e6R226-R231) [[2]](diffhunk://#diff-7e9c20e9b0e6414b4b203f761df1d4d97373ff9d212a0c9870b7bec2969f9fb1R80-R85) [[3]](diffhunk://#diff-9777bc818125598828edd4fd48785253a7725535abf1ec52d8c5668b5cafe3adR32-R37) [[4]](diffhunk://#diff-cb39b079050d89e8770de33dc5bf41fc5ee27e08b023835963ab9efe5f6e5eb1R32-R37) [[5]](diffhunk://#diff-d50e3bc4a76697c0e692d71daa9a35893137464f058184f86d4b1cdf0982247cR29-R34) [[6]](diffhunk://#diff-f893a290ff6071a8ccfa91d72bf8da321422f1e2c88790db4ac207dd868fb7e2R27-R32)
* Updated imports and the `__all__` list in `features/__init__.py` to re-export these new singleton provider functions.

Testing and validation:

* Added a new test file `test_feature_settings_singletons.py` with unit tests for each singleton provider, checking that the same instance is returned on repeated calls, that model configs are correct, and that environment variables are read properly.

Internal code improvements:

* Added `from functools import lru_cache` imports to all affected feature settings modules to support the singleton pattern. [[1]](diffhunk://#diff-32a0507c871ba2438714630780978b47afcf386f051dd69271ea1500eaa0c3e6R4) [[2]](diffhunk://#diff-7e9c20e9b0e6414b4b203f761df1d4d97373ff9d212a0c9870b7bec2969f9fb1R4) [[3]](diffhunk://#diff-9777bc818125598828edd4fd48785253a7725535abf1ec52d8c5668b5cafe3adR3-R4) [[4]](diffhunk://#diff-cb39b079050d89e8770de33dc5bf41fc5ee27e08b023835963ab9efe5f6e5eb1R3-R4) [[5]](diffhunk://#diff-d50e3bc4a76697c0e692d71daa9a35893137464f058184f86d4b1cdf0982247cR3-R4) [[6]](diffhunk://#diff-f893a290ff6071a8ccfa91d72bf8da321422f1e2c88790db4ac207dd868fb7e2R3-R4)