### PR TITLE
feat: add error handling for user lookup in OpsGenie integration

### DIFF
--- a/app/modules/incident/on_call.py
+++ b/app/modules/incident/on_call.py
@@ -30,8 +30,11 @@ def get_on_call_users_from_folder(client: WebClient, folder: str) -> list:
     # Get OpsGenie data
     if "genie_schedule" in folder_metadata:
         for email in get_on_call_users(folder_metadata["genie_schedule"]):
-            r = client.users_lookupByEmail(email=email)
-            if r.get("ok"):
-                oncall.append(r["user"])
+            try:
+                r = client.users_lookupByEmail(email=email)
+                if r.get("ok"):
+                    oncall.append(r["user"])
+            except Exception as e:
+                log.error("error_lookup_user_by_email", email=email, error=str(e))
     log.info("oncall_users_resolved", count=len(oncall))
     return oncall

--- a/app/tests/modules/incident/test_incident_on_call.py
+++ b/app/tests/modules/incident/test_incident_on_call.py
@@ -119,3 +119,29 @@ def test_get_on_call_user_from_folder_any_type(
     assert not result
     mock_opsgenie_get_on_call_users.assert_not_called()
     client.users_lookupByEmail.assert_not_called()
+
+
+@patch("modules.incident.on_call.get_on_call_users")
+@patch("modules.incident.on_call.get_folder_metadata")
+def test_get_on_call_user_from_folder_handles_slack_lookup_exception(
+    mock_get_folder_metadata,
+    mock_opsgenie_get_on_call_users,
+):
+    client = MagicMock()
+    folder = "folder_id"
+    email = "missing-user@example.com"
+
+    mock_get_folder_metadata.return_value = {
+        "appProperties": {"genie_schedule": "schedule_id"}
+    }
+    mock_opsgenie_get_on_call_users.return_value = [email]
+    client.users_lookupByEmail.side_effect = Exception(
+        "The request to the Slack API failed. (url: https://slack.com/api/users.lookupByEmail) "
+        "The server responded with: {'ok': False, 'error': 'users_not_found'}"
+    )
+
+    result = on_call.get_on_call_users_from_folder(client, folder)
+
+    assert result == []
+    mock_opsgenie_get_on_call_users.assert_called_once_with("schedule_id")
+    client.users_lookupByEmail.assert_called_once_with(email=email)


### PR DESCRIPTION
# Summary | Résumé

This pull request improves error handling when looking up on-call users by email and adds a corresponding test to ensure robustness. The main changes are:

Error handling improvements:

* Wrapped the call to `client.users_lookupByEmail` in a try/except block within `get_on_call_users_from_folder` to log errors when user lookup fails, preventing exceptions from interrupting the function.

Testing enhancements:

* Added a new test, `test_get_on_call_user_from_folder_handles_slack_lookup_exception`, to verify that the function handles exceptions from Slack user lookups gracefully and returns an empty list when a user is not found.