### PR TITLE
feat: standardize notification email settings

### DIFF
--- a/app/infrastructure/notifications/channels/email.py
+++ b/app/infrastructure/notifications/channels/email.py
@@ -29,18 +29,18 @@ class EmailChannel(NotificationChannel):
 
     def __init__(
         self,
-        google_workspace_settings: "GoogleWorkspaceSettings",
+        email_provider_settings: "GoogleWorkspaceSettings",
         circuit_breaker: Optional["CircuitBreaker"] = None,
     ):
         """Initialize Gmail email channel.
 
         Args:
-            google_workspace_settings: Narrow Google Workspace settings slice.
+            email_provider_settings: Narrow email provider settings slice.
             circuit_breaker: Optional circuit breaker for fault tolerance.
                            Injected by providers.py; pass None to disable circuit breaking.
         """
         self._circuit_breaker = circuit_breaker
-        self._sender_email = google_workspace_settings.GOOGLE_DELEGATED_ADMIN_EMAIL
+        self._sender_email = email_provider_settings.GOOGLE_DELEGATED_ADMIN_EMAIL
         self.log = logger.bind(component="email_channel")
         log = self.log.bind(backend="gmail", sender=self._sender_email)
         log.info("initialized_email_channel")

--- a/app/infrastructure/services/providers.py
+++ b/app/infrastructure/services/providers.py
@@ -384,6 +384,8 @@ def get_notification_service() -> NotificationService:
     Returns:
         NotificationService: Cached notification service instance
     """
+    email_provider_settings = get_google_workspace_settings()
+    notify_settings = get_notify_settings()
     resilience_service = get_resilience_service()
     idempotency_service = get_idempotency_service()
 
@@ -400,11 +402,11 @@ def get_notification_service() -> NotificationService:
     channels = {
         "chat": ChatChannel(circuit_breaker=chat_cb),
         "email": EmailChannel(
-            google_workspace_settings=get_google_workspace_settings(),
+            email_provider_settings=email_provider_settings,
             circuit_breaker=email_cb,
         ),
         "sms": SMSChannel(
-            notify_settings=get_notify_settings(),
+            notify_settings=notify_settings,
             circuit_breaker=sms_cb,
         ),
     }

--- a/app/tests/integration/infrastructure/notifications/test_dispatcher_integration.py
+++ b/app/tests/integration/infrastructure/notifications/test_dispatcher_integration.py
@@ -131,7 +131,7 @@ class TestDispatcherWithRealChannels:
             raising=False,
         )
 
-        email_channel = EmailChannel(google_workspace_settings=mock_settings)
+        email_channel = EmailChannel(email_provider_settings=mock_settings)
         dispatcher = NotificationDispatcher(channels={"email": email_channel})
 
         notification = Notification(
@@ -227,7 +227,7 @@ class TestDispatcherWithRealChannels:
         )
 
         chat_channel = ChatChannel()
-        email_channel = EmailChannel(google_workspace_settings=mock_settings)
+        email_channel = EmailChannel(email_provider_settings=mock_settings)
 
         dispatcher = NotificationDispatcher(
             channels={"chat": chat_channel, "email": email_channel},
@@ -525,7 +525,7 @@ class TestDispatcherHealthCheck:
         )
 
         chat_channel = ChatChannel()
-        email_channel = EmailChannel(google_workspace_settings=mock_settings)
+        email_channel = EmailChannel(email_provider_settings=mock_settings)
 
         dispatcher = NotificationDispatcher(
             channels={"chat": chat_channel, "email": email_channel}
@@ -574,7 +574,7 @@ class TestDispatcherHealthCheck:
         )
 
         chat_channel = ChatChannel()
-        email_channel = EmailChannel(google_workspace_settings=mock_settings)
+        email_channel = EmailChannel(email_provider_settings=mock_settings)
 
         dispatcher = NotificationDispatcher(
             channels={"chat": chat_channel, "email": email_channel}

--- a/app/tests/unit/infrastructure/notifications/channels/test_email.py
+++ b/app/tests/unit/infrastructure/notifications/channels/test_email.py
@@ -33,7 +33,7 @@ class TestEmailChannel:
             mock_gmail_next,
             raising=False,
         )
-        channel = EmailChannel(google_workspace_settings=mock_settings)
+        channel = EmailChannel(email_provider_settings=mock_settings)
         return channel
 
     def test_channel_name(self, email_channel):

--- a/app/tests/unit/infrastructure/notifications/test_channel_narrow_slice.py
+++ b/app/tests/unit/infrastructure/notifications/test_channel_narrow_slice.py
@@ -1,0 +1,77 @@
+"""Tests for notification narrow-slice settings injection."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
+from infrastructure.configuration.integrations.notify import NotifySettings
+from infrastructure.notifications.channels.chat import ChatChannel
+from infrastructure.notifications.channels.base import NotificationChannel
+from infrastructure.notifications.channels.email import EmailChannel
+from infrastructure.notifications.channels.sms import SMSChannel
+from infrastructure.notifications.service import NotificationService
+
+
+@pytest.mark.unit
+def test_email_channel_accepts_google_workspace_settings() -> None:
+    """EmailChannel constructs with GoogleWorkspaceSettings slice only."""
+    email_provider_settings = Mock(spec=GoogleWorkspaceSettings)
+    email_provider_settings.GOOGLE_DELEGATED_ADMIN_EMAIL = "sender@example.com"
+
+    channel = EmailChannel(email_provider_settings=email_provider_settings)
+
+    assert channel is not None
+
+
+@pytest.mark.unit
+def test_email_channel_uses_delegated_admin_email() -> None:
+    """EmailChannel reads sender email from narrow settings slice."""
+    email_provider_settings = Mock(spec=GoogleWorkspaceSettings)
+    email_provider_settings.GOOGLE_DELEGATED_ADMIN_EMAIL = "admin@example.com"
+
+    channel = EmailChannel(email_provider_settings=email_provider_settings)
+
+    assert channel._sender_email == "admin@example.com"
+
+
+@pytest.mark.unit
+def test_sms_channel_accepts_notify_settings() -> None:
+    """SMSChannel constructs with NotifySettings slice only."""
+    notify_settings = Mock(spec=NotifySettings)
+    notify_settings.NOTIFY_API_URL = "https://api.notification.canada.ca"
+
+    channel = SMSChannel(notify_settings=notify_settings)
+
+    assert channel is not None
+
+
+@pytest.mark.unit
+def test_sms_channel_uses_notify_api_url() -> None:
+    """SMSChannel reads API URL from narrow settings slice."""
+    notify_settings = Mock(spec=NotifySettings)
+    notify_settings.NOTIFY_API_URL = "https://api.example.com"
+
+    channel = SMSChannel(notify_settings=notify_settings)
+
+    assert channel._api_url == "https://api.example.com"
+
+
+@pytest.mark.unit
+def test_notification_service_no_settings_parameter() -> None:
+    """NotificationService constructs from injected channels without settings kwarg."""
+    channels: dict[str, NotificationChannel] = {"chat": ChatChannel()}
+
+    service = NotificationService(channels=channels)
+
+    assert service is not None
+
+
+@pytest.mark.unit
+def test_notification_service_rejects_legacy_settings_kwarg() -> None:
+    """Legacy settings kwarg is not accepted by NotificationService."""
+    kwargs: dict[str, Any] = {"channels": {"chat": ChatChannel()}, "settings": Mock()}
+
+    with pytest.raises(TypeError):
+        NotificationService(**kwargs)

--- a/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
+++ b/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
@@ -15,6 +15,8 @@ from infrastructure.configuration.infrastructure.retry import RetrySettings
 from infrastructure.configuration.infrastructure.platforms import PlatformsSettings
 from infrastructure.configuration.integrations.maxmind import MaxMindSettings
 from infrastructure.configuration.integrations.slack import SlackSettings
+from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
+from infrastructure.configuration.integrations.notify import NotifySettings
 from infrastructure.configuration.features.commands import CommandsSettings
 from infrastructure.identity.service import IdentityService
 from infrastructure.clients.maxmind.client import MaxMindClient
@@ -30,6 +32,7 @@ from infrastructure.services.providers import (
     get_idempotency_service,
     get_jwks_manager,
     get_maxmind_client,
+    get_notification_service,
     get_platform_service,
     get_resilience_service,
     get_slack_client,
@@ -257,6 +260,64 @@ class TestProvidersDontCallGetSettings:
             mock_get_settings.assert_not_called()
             mock_retry.assert_called_once()
         get_resilience_service.cache_clear()
+
+    def test_get_notification_service_uses_narrow_slices(self):
+        """get_notification_service uses domain slices, not get_settings."""
+        get_notification_service.cache_clear()
+        with (
+            patch(
+                "infrastructure.services.providers.get_settings"
+            ) as mock_get_settings,
+            patch(
+                "infrastructure.services.providers.get_google_workspace_settings"
+            ) as mock_google_settings,
+            patch(
+                "infrastructure.services.providers.get_notify_settings"
+            ) as mock_notify_settings,
+            patch(
+                "infrastructure.services.providers.get_resilience_service"
+            ) as mock_resilience,
+            patch(
+                "infrastructure.services.providers.get_idempotency_service"
+            ) as mock_idempotency,
+            patch(
+                "infrastructure.services.providers.EmailChannel.__init__",
+                return_value=None,
+            ) as mock_email_ctor,
+            patch(
+                "infrastructure.services.providers.SMSChannel.__init__",
+                return_value=None,
+            ) as mock_sms_ctor,
+            patch(
+                "infrastructure.services.providers.ChatChannel.__init__",
+                return_value=None,
+            ),
+            patch(
+                "infrastructure.notifications.service.NotificationService.__init__",
+                return_value=None,
+            ) as mock_notification_ctor,
+        ):
+            mock_google_settings.return_value = MagicMock(spec=GoogleWorkspaceSettings)
+            mock_notify_settings.return_value = MagicMock(spec=NotifySettings)
+
+            mock_resilience_service = MagicMock()
+            mock_circuit_breaker = MagicMock()
+            mock_resilience_service.get_or_create_circuit_breaker.return_value = (
+                mock_circuit_breaker
+            )
+            mock_resilience.return_value = mock_resilience_service
+            mock_idempotency.return_value = MagicMock()
+
+            get_notification_service()
+
+            mock_get_settings.assert_not_called()
+            mock_google_settings.assert_called_once()
+            mock_notify_settings.assert_called_once()
+            assert mock_email_ctor.call_count == 1
+            assert mock_sms_ctor.call_count == 1
+            mock_notification_ctor.assert_called_once()
+
+        get_notification_service.cache_clear()
 
     def test_get_command_service_uses_commands_settings(self):
         """get_command_service uses get_commands_settings, not get_settings."""

--- a/app/tests/unit/infrastructure/test_intra_layer_compliance.py
+++ b/app/tests/unit/infrastructure/test_intra_layer_compliance.py
@@ -203,7 +203,7 @@ class TestNotificationChannelCircuitBreakerCompliance:
         mock_settings = MagicMock()
         mock_settings.GOOGLE_DELEGATED_ADMIN_EMAIL = "admin@example.com"
         channel = EmailChannel(
-            google_workspace_settings=mock_settings,
+            email_provider_settings=mock_settings,
             circuit_breaker=None,
         )
         assert channel is not None


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the way notification channel settings are injected, ensuring that each channel receives only its required configuration slice, and adds comprehensive tests to verify this narrow-slice dependency injection. The changes is mostly in preparation to refactor the notification service in line.

**Refactoring settings injection for notification channels:**

* Updated `EmailChannel` to accept an `email_provider_settings` argument (a slice of `GoogleWorkspaceSettings`) instead of a generic `google_workspace_settings`, and updated all instantiations and tests accordingly. (`app/infrastructure/notifications/channels/email.py`, `app/infrastructure/services/providers.py`, various test files) [[1]](diffhunk://#diff-4a8cfd84b3f9973f403c000fe95bf90057bfc0065324c35976cb2afa81bfd427L32-R43) [[2]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890R387-R388) [[3]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L403-R409) [[4]](diffhunk://#diff-3b7ae401e08e86d5f0601815bf65abfff06f7d26209ecc2c323ab9cbc3441448L134-R134) [[5]](diffhunk://#diff-3b7ae401e08e86d5f0601815bf65abfff06f7d26209ecc2c323ab9cbc3441448L230-R230) [[6]](diffhunk://#diff-3b7ae401e08e86d5f0601815bf65abfff06f7d26209ecc2c323ab9cbc3441448L528-R528) [[7]](diffhunk://#diff-3b7ae401e08e86d5f0601815bf65abfff06f7d26209ecc2c323ab9cbc3441448L577-R577) [[8]](diffhunk://#diff-2ee825fe035635fd24acdcda9287887e9230ab81795af28a00ce0fc3109ce0a2L36-R36) [[9]](diffhunk://#diff-6cdccb664e600b3688aa5125c617c125cbbb79f51d3a4081037537d10ac5779fL206-R206)

**Expanded and improved test coverage:**

* Added new unit tests in `test_channel_narrow_slice.py` to verify that `EmailChannel` and `SMSChannel` each accept only their required configuration slices and use the correct internal values, and that `NotificationService` does not accept legacy `settings` kwargs.
* Added a test in `test_narrow_slice_providers.py` to ensure `get_notification_service` uses only domain-specific settings slices (not the legacy `get_settings`), and verifies correct provider wiring and constructor calls.

**Test infrastructure improvements:**

* Added necessary imports and provider wiring in test modules to support the new tests and ensure correct mocking of configuration slices. [[1]](diffhunk://#diff-f1a9dadb4362dbd7422bf53292a322639327577430f2f6207a41de3c59af340aR18-R19) [[2]](diffhunk://#diff-f1a9dadb4362dbd7422bf53292a322639327577430f2f6207a41de3c59af340aR35)