### PR TITLE
Feat/infra audit trail

### DIFF
--- a/app/infrastructure/audit/__init__.py
+++ b/app/infrastructure/audit/__init__.py
@@ -8,6 +8,6 @@ This package provides:
 """
 
 from infrastructure.audit.models import AuditEvent
-from infrastructure.audit.service import AuditTrailService
+from infrastructure.audit.protocol import AuditTrailService
 
 __all__ = ["AuditEvent", "AuditTrailService"]

--- a/app/infrastructure/audit/protocol.py
+++ b/app/infrastructure/audit/protocol.py
@@ -1,0 +1,85 @@
+"""Protocol contract for audit trail services.
+
+Defines the runtime-checkable interface for audit event storage and retrieval.
+Concrete implementations can vary by backing store (DynamoDB, CloudWatch Logs, etc.).
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from infrastructure.audit.models import AuditEvent
+
+
+@runtime_checkable
+class AuditTrailService(Protocol):
+    """Audit trail operations abstracted over the backing store."""
+
+    def write_audit_event(
+        self,
+        audit_event: AuditEvent,
+        retention_days: int = 90,
+    ) -> bool:
+        """Write an audit event to persistent storage.
+
+        Args:
+            audit_event: The structured event to persist (AuditEvent model).
+            retention_days: DynamoDB TTL retention window (default 90 days).
+
+        Returns:
+            True if the write succeeded, False otherwise.
+        """
+        ...
+
+    def get_audit_trail(
+        self,
+        resource_id: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Get audit trail for a resource.
+
+        Args:
+            resource_id: Partition key (e.g. group email or resource GUID).
+            start_time: Optional lower bound on sort key.
+            end_time: Unused — included for API symmetry.
+            limit: Maximum results capped at 100.
+
+        Returns:
+            List of deserialized event dicts, newest first.
+        """
+        ...
+
+    def get_user_audit_trail(
+        self,
+        user_email: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Get audit trail for a user via GSI (user_email-timestamp-index).
+
+        Args:
+            user_email: User email to query.
+            start_time: Optional lower bound on timestamp.
+            end_time: Unused — included for API symmetry.
+            limit: Maximum results capped at 100.
+
+        Returns:
+            List of deserialized event dicts, newest first.
+        """
+        ...
+
+    def get_by_correlation_id(
+        self,
+        correlation_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Lookup one audit event by correlation ID via GSI (correlation_id-index).
+
+        Args:
+            correlation_id: The distributed-tracing correlation ID.
+
+        Returns:
+            Deserialized event dict if found, None otherwise.
+        """
+        ...

--- a/app/infrastructure/audit/service.py
+++ b/app/infrastructure/audit/service.py
@@ -25,8 +25,8 @@ def _compute_ttl_timestamp(retention_days: int) -> int:
     return int(expiry.timestamp())
 
 
-class AuditTrailService:
-    """Audit trail service for structured event storage and retrieval.
+class DynamoDBAuditTrailService:
+    """DynamoDB implementation of audit trail service for structured event storage and retrieval.
 
     Uses ``StorageService`` for all DynamoDB I/O so serialization,
     pagination, and error normalisation are handled consistently.
@@ -39,6 +39,7 @@ class AuditTrailService:
         def write_event(audit_trail: AuditTrailServiceDep, event: AuditEvent):
             success = audit_trail.write_audit_event(event)
             return {"written": success}
+
     """
 
     def __init__(self, storage: "StorageService") -> None:

--- a/app/infrastructure/services/dependencies.py
+++ b/app/infrastructure/services/dependencies.py
@@ -19,7 +19,7 @@ from infrastructure.idempotency.service import IdempotencyService
 from infrastructure.resilience.service import ResilienceService
 from infrastructure.notifications.service import NotificationService
 from infrastructure.storage.protocol import StorageService
-from infrastructure.audit.service import AuditTrailService
+from infrastructure.audit.protocol import AuditTrailService
 from infrastructure.platforms.service import PlatformService
 from infrastructure.platforms.clients import (
     SlackClientFacade,

--- a/app/infrastructure/services/providers.py
+++ b/app/infrastructure/services/providers.py
@@ -45,7 +45,8 @@ from infrastructure.notifications.channels.email import EmailChannel
 from infrastructure.notifications.channels.sms import SMSChannel
 from infrastructure.storage.protocol import StorageService
 from infrastructure.storage.service import DynamoDBStorageService
-from infrastructure.audit.service import AuditTrailService
+from infrastructure.audit.protocol import AuditTrailService
+from infrastructure.audit.service import DynamoDBAuditTrailService
 from infrastructure.platforms import PlatformService
 from infrastructure.platforms.providers import (
     SlackPlatformProvider,
@@ -417,8 +418,9 @@ def get_storage_service() -> StorageService:
 def get_audit_trail_service() -> AuditTrailService:
     """Get application-scoped audit trail service singleton.
 
-    Returns an AuditTrailService instance for writing and querying audit
-    events in DynamoDB.
+    Returns an AuditTrailService Protocol instance for writing and querying audit
+    events. The implementation uses DynamoDB, but can be swapped for alternative
+    audit backends that satisfy the Protocol.
 
     Usage:
         from infrastructure.services import AuditTrailServiceDep
@@ -432,10 +434,10 @@ def get_audit_trail_service() -> AuditTrailService:
             return {"written": success}
 
     Returns:
-        AuditTrailService: Cached audit trail service instance
+        AuditTrailService: Cached audit trail service instance (implements Protocol)
     """
     storage = get_storage_service()
-    return AuditTrailService(storage=storage)
+    return DynamoDBAuditTrailService(storage=storage)
 
 
 @lru_cache(maxsize=1)

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -7,6 +7,8 @@ application lifespan initialization.
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
+from server.server import handler
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +21,7 @@ def _autouse_mock_dynamodb_audit(monkeypatch):
     """
     mock = MagicMock()
     monkeypatch.setattr(
-        "infrastructure.audit.service.AuditTrailService.write_audit_event",
+        "infrastructure.audit.service.DynamoDBAuditTrailService.write_audit_event",
         mock,
         raising=False,
     )
@@ -129,9 +131,6 @@ def app_with_lifespan(monkeypatch):
     Returns:
         TestClient: FastAPI TestClient with real app initialized
     """
-    from fastapi.testclient import TestClient
-    from server.server import handler
-
     mock_directory_provider = MagicMock()
     mock_directory_provider.warmup.return_value = MagicMock(
         is_success=True,

--- a/app/tests/unit/infrastructure/audit/test_audit_protocol.py
+++ b/app/tests/unit/infrastructure/audit/test_audit_protocol.py
@@ -1,0 +1,131 @@
+"""Tests for AuditTrailService Protocol contract and implementation.
+
+Verifies:
+- Protocol has @runtime_checkable
+- DynamoDBAuditTrailService satisfies the Protocol
+- Fake implementations can be injected
+- DI override works for testing
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+from infrastructure.audit.models import AuditEvent
+from infrastructure.audit.protocol import AuditTrailService
+from infrastructure.audit.service import DynamoDBAuditTrailService
+from infrastructure.operations.result import OperationResult
+from infrastructure.storage.protocol import StorageService
+
+
+class FakeAuditTrailService:
+    """Fake in-memory audit trail for testing."""
+
+    def __init__(self) -> None:
+        self._events: List[Dict[str, Any]] = []
+
+    def write_audit_event(
+        self,
+        audit_event: AuditEvent,
+        retention_days: int = 90,
+    ) -> bool:
+        """Write event to fake store."""
+        self._events.append(
+            {
+                "resource_id": audit_event.resource_id,
+                "timestamp": audit_event.timestamp,
+                "action": audit_event.action,
+            }
+        )
+        return True
+
+    def get_audit_trail(
+        self,
+        resource_id: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Get audit trail for resource."""
+        return [e for e in self._events if e["resource_id"] == resource_id][:limit]
+
+    def get_user_audit_trail(
+        self,
+        user_email: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Get audit trail for user."""
+        return []
+
+    def get_by_correlation_id(
+        self,
+        correlation_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Get event by correlation ID."""
+        return None
+
+
+def test_protocol_is_runtime_checkable() -> None:
+    """AuditTrailService Protocol has @runtime_checkable."""
+    assert hasattr(AuditTrailService, "_is_runtime_protocol")
+
+
+def test_dynamodb_audit_satisfies_protocol() -> None:
+    """DynamoDBAuditTrailService satisfies AuditTrailService Protocol."""
+    mock_storage = MagicMock(spec=StorageService)
+    mock_storage.put.return_value = OperationResult.success(data=None)
+
+    impl = DynamoDBAuditTrailService(storage=mock_storage)
+    assert isinstance(impl, AuditTrailService)
+
+
+def test_fake_audit_satisfies_protocol() -> None:
+    """In-memory fake satisfies AuditTrailService Protocol."""
+    fake = FakeAuditTrailService()
+    assert isinstance(fake, AuditTrailService)
+
+
+def test_audit_dep_override_with_fake() -> None:
+    """Dependency override with fake implementation works."""
+    # This is a structure test — verifies that the Protocol type
+    # allows duck-typing and DI override in tests
+    fake = FakeAuditTrailService()
+
+    event = AuditEvent(
+        resource_id="test-group",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        correlation_id="corr-123",
+        user_email="user@example.com",
+        action="CREATE",
+        result="success",
+    )
+
+    # Verify the fake can be used as a drop-in replacement
+    written = fake.write_audit_event(event)
+    assert written is True
+
+    trail = fake.get_audit_trail("test-group")
+    assert len(trail) == 1
+    assert trail[0]["action"] == "CREATE"
+
+
+def test_protocol_has_write_audit_event_method() -> None:
+    """AuditTrailService Protocol defines write_audit_event."""
+    assert hasattr(AuditTrailService, "write_audit_event")
+
+
+def test_protocol_has_get_audit_trail_method() -> None:
+    """AuditTrailService Protocol defines get_audit_trail."""
+    assert hasattr(AuditTrailService, "get_audit_trail")
+
+
+def test_protocol_has_get_user_audit_trail_method() -> None:
+    """AuditTrailService Protocol defines get_user_audit_trail."""
+    assert hasattr(AuditTrailService, "get_user_audit_trail")
+
+
+def test_protocol_has_get_by_correlation_id_method() -> None:
+    """AuditTrailService Protocol defines get_by_correlation_id."""
+    assert hasattr(AuditTrailService, "get_by_correlation_id")

--- a/app/tests/unit/infrastructure/audit/test_service.py
+++ b/app/tests/unit/infrastructure/audit/test_service.py
@@ -11,7 +11,8 @@ from uuid import uuid4
 import pytest
 
 from infrastructure.audit.models import AuditEvent
-from infrastructure.audit.service import AuditTrailService
+from infrastructure.audit.protocol import AuditTrailService
+from infrastructure.audit.service import DynamoDBAuditTrailService
 from infrastructure.operations.result import OperationResult
 
 
@@ -28,7 +29,7 @@ def _make_event(**kwargs) -> AuditEvent:
 
 
 def _make_service(storage: MagicMock) -> AuditTrailService:
-    return AuditTrailService(storage=storage)
+    return DynamoDBAuditTrailService(storage=storage)
 
 
 @pytest.mark.unit

--- a/app/tests/unit/infrastructure/test_intra_layer_compliance.py
+++ b/app/tests/unit/infrastructure/test_intra_layer_compliance.py
@@ -14,7 +14,7 @@ from typing import Set
 from unittest.mock import MagicMock, patch
 
 import pytest
-from infrastructure.audit.service import AuditTrailService
+from infrastructure.audit.service import DynamoDBAuditTrailService
 from infrastructure.notifications.channels.chat import ChatChannel
 from infrastructure.notifications.channels.email import EmailChannel
 from infrastructure.notifications.channels.sms import SMSChannel
@@ -110,7 +110,7 @@ class TestAuditServiceCompliance:
     def test_audit_service_accepts_storage_via_constructor(self):
         """AuditTrailService still accepts a StorageService via its constructor."""
         mock_storage = MagicMock()
-        service = AuditTrailService(storage=mock_storage)
+        service = DynamoDBAuditTrailService(storage=mock_storage)
         assert service is not None
 
 


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the audit trail service to use a Protocol-based abstraction for improved flexibility, dependency injection, and testability. The main changes involve introducing a new `AuditTrailService` Protocol, updating the DynamoDB implementation to `DynamoDBAuditTrailService`, and ensuring all references and tests use the new abstraction.

**Audit Trail Service Abstraction and Refactoring**

* Introduced a new `AuditTrailService` Protocol in `protocol.py` to define the contract for audit trail operations, allowing for runtime type checking and easier swapping of implementations.
* Renamed the concrete DynamoDB implementation to `DynamoDBAuditTrailService` and updated all usages and imports to refer to the Protocol or the new class as appropriate [[1]](diffhunk://#diff-0c15475c723c267de5b9efb1c11ce8ddeef0048e160c3c7e3f34d473d6a150e7L28-R29) [[2]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L48-R49) [[3]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0L22-R22) [[4]](diffhunk://#diff-15b28bb3d3c82672cee752c92206d363d3aba0864d1ffd8d02704bfe632be229L11-R11).

**Dependency Injection and Providers**

* Updated the audit trail service provider to return an instance conforming to the `AuditTrailService` Protocol, specifically returning `DynamoDBAuditTrailService`, and clarified docstrings to reflect the Protocol-based design [[1]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L420-R423) [[2]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L435-R440).

**Testing Improvements**

* Added a new unit test module `test_audit_protocol.py` to verify the Protocol, ensure the DynamoDB implementation and fakes satisfy the contract, and demonstrate dependency injection override.
* Updated all existing tests and fixtures to use `DynamoDBAuditTrailService` instead of the old class name, and to patch/mock accordingly [[1]](diffhunk://#diff-1e818699fffe3a53777bec5b7ca7651aa9d92dc109d1ca663baecd5dc40763feL22-R24) [[2]](diffhunk://#diff-1e818699fffe3a53777bec5b7ca7651aa9d92dc109d1ca663baecd5dc40763feL132-L134) [[3]](diffhunk://#diff-4dbac77198ead6583fcb8d9338b187120b999814550c5a20d2da095349620429L14-R15) [[4]](diffhunk://#diff-4dbac77198ead6583fcb8d9338b187120b999814550c5a20d2da095349620429L31-R32) [[5]](diffhunk://#diff-6cdccb664e600b3688aa5125c617c125cbbb79f51d3a4081037537d10ac5779fL17-R17) [[6]](diffhunk://#diff-6cdccb664e600b3688aa5125c617c125cbbb79f51d3a4081037537d10ac5779fL113-R113).