### PR TITLE
Feat/infra hookspec rename

### DIFF
--- a/app/infrastructure/hookspecs/features.py
+++ b/app/infrastructure/hookspecs/features.py
@@ -35,29 +35,35 @@ class BackgroundJobRegistry(Protocol):
 
 
 @hookspec
-def register_slack_commands(provider: "SlackPlatformProvider") -> None:
-    """Register Slack commands with the provider.
+def register_slack_interactions(provider: "SlackPlatformProvider") -> None:
+    """Register Slack interactions (commands, actions, views) with the provider.
+
+    Renamed from register_slack_commands per ADR-0089 Standard 3.
 
     Args:
-        provider: Slack provider instance to register commands with.
+        provider: Slack provider instance to register interactions with.
     """
 
 
 @hookspec
-def register_teams_commands(provider: "TeamsPlatformProvider") -> None:
-    """Register Teams commands with the provider.
+def register_teams_interactions(provider: "TeamsPlatformProvider") -> None:
+    """Register Teams interactions (commands, adaptive cards) with the provider.
+
+    Renamed from register_teams_commands per ADR-0089 Standard 3.
 
     Args:
-        provider: Teams provider instance to register commands with.
+        provider: Teams provider instance to register interactions with.
     """
 
 
 @hookspec
-def register_discord_commands(provider: "DiscordPlatformProvider") -> None:
-    """Register Discord commands with the provider.
+def register_discord_interactions(provider: "DiscordPlatformProvider") -> None:
+    """Register Discord interactions (slash commands, etc.) with the provider.
+
+    Renamed from register_discord_commands per ADR-0089 Standard 3.
 
     Args:
-        provider: Discord provider instance to register commands with.
+        provider: Discord provider instance to register interactions with.
     """
 
 

--- a/app/infrastructure/services/plugins/manager.py
+++ b/app/infrastructure/services/plugins/manager.py
@@ -91,16 +91,16 @@ def register_feature_integrations(
     pm = get_plugin_manager()
 
     if slack_provider:
-        pm.hook.register_slack_commands(provider=slack_provider)
-        logger.info("slack_commands_registered")
+        pm.hook.register_slack_interactions(provider=slack_provider)
+        logger.info("slack_interactions_registered")
 
     if teams_provider:
-        pm.hook.register_teams_commands(provider=teams_provider)
-        logger.info("teams_commands_registered")
+        pm.hook.register_teams_interactions(provider=teams_provider)
+        logger.info("teams_interactions_registered")
 
     if discord_provider:
-        pm.hook.register_discord_commands(provider=discord_provider)
-        logger.info("discord_commands_registered")
+        pm.hook.register_discord_interactions(provider=discord_provider)
+        logger.info("discord_interactions_registered")
 
     if event_dispatcher:
         pm.hook.register_event_handlers(dispatcher=event_dispatcher)

--- a/app/packages/access/sync/__init__.py
+++ b/app/packages/access/sync/__init__.py
@@ -22,8 +22,8 @@ from packages.access.sync.interactions.http import router as access_sync_router
 
 
 @hookimpl
-def register_slack_commands(provider) -> None:
-    """Register access-sync Slack commands."""
+def register_slack_interactions(provider) -> None:
+    """Register access-sync Slack interactions."""
     slack.register_commands(provider)
 
 

--- a/app/packages/geolocate/__init__.py
+++ b/app/packages/geolocate/__init__.py
@@ -11,8 +11,8 @@ from packages.geolocate.platforms import slack, teams
 
 
 @hookimpl
-def register_slack_commands(provider):
-    """Register geolocate Slack commands.
+def register_slack_interactions(provider):
+    """Register geolocate Slack interactions.
 
     Args:
         provider: Slack platform provider instance.
@@ -21,8 +21,8 @@ def register_slack_commands(provider):
 
 
 @hookimpl
-def register_teams_commands(provider):
-    """Register geolocate Teams commands (experimental).
+def register_teams_interactions(provider):
+    """Register geolocate Teams interactions (experimental).
 
     Args:
         provider: Teams platform provider instance.

--- a/app/tests/integration/packages/access/test_access_plugin_discovery_registration.py
+++ b/app/tests/integration/packages/access/test_access_plugin_discovery_registration.py
@@ -54,7 +54,7 @@ def test_access_plugins_register_routes_and_slack_commands_from_interactions() -
     slack_provider = _FakeSlackProvider()
 
     pm.hook.register_routes(app=app)
-    pm.hook.register_slack_commands(provider=slack_provider)
+    pm.hook.register_slack_interactions(provider=slack_provider)
 
     expected_routers = [
         importlib.import_module("packages.access.catalog.interactions.http").router,

--- a/app/tests/unit/infrastructure/hookspecs/test_hookspec_renames.py
+++ b/app/tests/unit/infrastructure/hookspecs/test_hookspec_renames.py
@@ -1,0 +1,93 @@
+"""Unit tests for PR-18 hookspec renames (ADR-0089 Standard 3).
+
+Verifies that:
+  - New interaction hookspec names exist on features module and plugin manager.
+  - register_event_handlers exists (ADR-0083 S3).
+  - Old *_commands names are removed.
+"""
+
+import pluggy
+import pytest
+
+from infrastructure.hookspecs import features
+
+
+@pytest.mark.unit
+def test_register_slack_interactions_hookspec_exists() -> None:
+    assert hasattr(features, "register_slack_interactions")
+
+
+@pytest.mark.unit
+def test_register_teams_interactions_hookspec_exists() -> None:
+    assert hasattr(features, "register_teams_interactions")
+
+
+@pytest.mark.unit
+def test_register_discord_interactions_hookspec_exists() -> None:
+    assert hasattr(features, "register_discord_interactions")
+
+
+@pytest.mark.unit
+def test_register_event_handlers_hookspec_exists() -> None:
+    assert hasattr(features, "register_event_handlers")
+
+
+@pytest.mark.unit
+def test_old_slack_commands_hookspec_removed() -> None:
+    assert not hasattr(features, "register_slack_commands")
+
+
+@pytest.mark.unit
+def test_old_teams_commands_hookspec_removed() -> None:
+    assert not hasattr(features, "register_teams_commands")
+
+
+@pytest.mark.unit
+def test_old_discord_commands_hookspec_removed() -> None:
+    assert not hasattr(features, "register_discord_commands")
+
+
+@pytest.mark.unit
+def test_plugin_manager_exposes_register_slack_interactions() -> None:
+    pm = pluggy.PluginManager("sre_bot")
+    pm.add_hookspecs(features)
+
+    hook = getattr(pm.hook, "register_slack_interactions", None)
+    assert hook is not None
+    assert callable(hook)
+
+
+@pytest.mark.unit
+def test_plugin_manager_exposes_register_teams_interactions() -> None:
+    pm = pluggy.PluginManager("sre_bot")
+    pm.add_hookspecs(features)
+
+    hook = getattr(pm.hook, "register_teams_interactions", None)
+    assert hook is not None
+    assert callable(hook)
+
+
+@pytest.mark.unit
+def test_plugin_manager_exposes_register_discord_interactions() -> None:
+    pm = pluggy.PluginManager("sre_bot")
+    pm.add_hookspecs(features)
+
+    hook = getattr(pm.hook, "register_discord_interactions", None)
+    assert hook is not None
+    assert callable(hook)
+
+
+@pytest.mark.unit
+def test_plugin_manager_does_not_expose_old_slack_commands() -> None:
+    pm = pluggy.PluginManager("sre_bot")
+    pm.add_hookspecs(features)
+
+    assert not hasattr(pm.hook, "register_slack_commands")
+
+
+@pytest.mark.unit
+def test_plugin_manager_does_not_expose_old_teams_commands() -> None:
+    pm = pluggy.PluginManager("sre_bot")
+    pm.add_hookspecs(features)
+
+    assert not hasattr(pm.hook, "register_teams_commands")


### PR DESCRIPTION
# Summary | Résumé

This pull request standardizes the naming of plugin hooks related to chat platform integrations by renaming all `*_commands` hooks and implementations to `*_interactions`. It updates the corresponding usages throughout the codebase, ensures backward-incompatible hooks are removed, and adds comprehensive unit tests to verify the changes.

**Hooks and Implementation Renames:**

* Renamed hooks in `infrastructure/hookspecs/features.py` from `register_slack_commands`, `register_teams_commands`, and `register_discord_commands` to `register_slack_interactions`, `register_teams_interactions`, and `register_discord_interactions`, updating their docstrings and arguments accordingly.
* Updated all plugin implementations in `packages/access/sync/__init__.py` and `packages/geolocate/__init__.py` to use the new `*_interactions` hook names for Slack and Teams. [[1]](diffhunk://#diff-94560a417560c273a0195e2930daf2e3a1b5e5e0370eb66463ab9918c9daf2bdL25-R26) [[2]](diffhunk://#diff-4c9023672c067bae09944e675e979d7ca89c4263fac727cea90b94253865ea85L14-R15) [[3]](diffhunk://#diff-4c9023672c067bae09944e675e979d7ca89c4263fac727cea90b94253865ea85L24-R25)

**Codebase Usage Updates:**

* Modified `services/plugins/manager.py` to call the new `*_interactions` hooks instead of the old `*_commands` hooks, and updated logging statements to match.
* Updated test code in `tests/integration/packages/access/test_access_plugin_discovery_registration.py` to use the new hook names.

**Testing and Verification:**

* Added a new unit test file `tests/unit/infrastructure/hookspecs/test_hookspec_renames.py` to verify that:
  - The new `*_interactions` hooks exist on both the features module and the plugin manager.
  - The old `*_commands` hooks are fully removed.
  - The plugin manager exposes only the new hooks, not the old ones.