### PR TITLE
feat: implement idempotency protocol

### DIFF
--- a/app/infrastructure/idempotency/__init__.py
+++ b/app/infrastructure/idempotency/__init__.py
@@ -27,7 +27,8 @@ Usage:
 from infrastructure.idempotency.cache import IdempotencyCache
 from infrastructure.idempotency.dynamodb import DynamoDBCache
 from infrastructure.idempotency.key_builder import IdempotencyKeyBuilder
-from infrastructure.idempotency.service import IdempotencyService
+from infrastructure.idempotency.protocol import IdempotencyService
+from infrastructure.idempotency.service import DynamoDBIdempotencyService
 
 # Factory functions available via direct import to avoid circular deps
 from infrastructure.idempotency.factory import get_cache, reset_cache
@@ -37,6 +38,7 @@ __all__ = [
     "DynamoDBCache",
     "IdempotencyKeyBuilder",
     "IdempotencyService",
+    "DynamoDBIdempotencyService",
     "get_cache",
     "reset_cache",
 ]

--- a/app/infrastructure/idempotency/protocol.py
+++ b/app/infrastructure/idempotency/protocol.py
@@ -1,0 +1,68 @@
+"""Protocol contract for idempotency services.
+
+Defines the runtime-checkable interface consumed by features and
+infrastructure. Concrete implementations can vary by backing store.
+"""
+
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from infrastructure.idempotency.cache import IdempotencyCache
+
+
+@runtime_checkable
+class IdempotencyService(Protocol):
+    """Idempotency service contract.
+
+    Abstracts storage and retrieval of responses for idempotent operations
+    across retries. Implementation must be distributed-cache-safe for
+    multi-instance deployments.
+    """
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """Get cached response for idempotency key.
+
+        Args:
+            key: Idempotency key (typically request ID or operation hash)
+
+        Returns:
+            Cached response dict or None if not found/expired
+        """
+        ...
+
+    def set(self, key: str, response: Dict[str, Any], ttl_seconds: int) -> None:
+        """Cache a response for the given idempotency key.
+
+        Args:
+            key: Idempotency key
+            response: Response dict to cache
+            ttl_seconds: Time-to-live in seconds
+        """
+        ...
+
+    def clear(self) -> None:
+        """Clear all cached entries.
+
+        Warning: This may be expensive in distributed caches.
+        Primarily intended for testing.
+        """
+        ...
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get cache statistics.
+
+        Returns:
+            Dict with cache statistics (implementation-specific)
+        """
+        ...
+
+    @property
+    def cache(self) -> IdempotencyCache:
+        """Access underlying IdempotencyCache instance.
+
+        Provided for advanced use cases that need direct access
+        to the cache implementation.
+
+        Returns:
+            The underlying IdempotencyCache instance
+        """
+        ...

--- a/app/infrastructure/idempotency/service.py
+++ b/app/infrastructure/idempotency/service.py
@@ -1,6 +1,8 @@
-"""Idempotency service for dependency injection.
+"""Concrete idempotency service implementation.
 
 Provides a class-based interface to the idempotency cache for easier DI and testing.
+This is the DynamoDB-backed concrete implementation. The Protocol contract is defined
+in infrastructure.idempotency.protocol.
 """
 
 from typing import Any, Dict, Optional
@@ -8,8 +10,8 @@ from typing import Any, Dict, Optional
 from infrastructure.idempotency.cache import IdempotencyCache
 
 
-class IdempotencyService:
-    """Class-based idempotency service.
+class DynamoDBIdempotencyService:
+    """DynamoDB-backed idempotency service.
 
     Wraps the IdempotencyCache interface with a service class to support
     dependency injection and easier testing with mocks.
@@ -35,10 +37,9 @@ class IdempotencyService:
             return result
 
         # Direct instantiation
-        from infrastructure.idempotency import IdempotencyService
+        from infrastructure.idempotency.service import DynamoDBIdempotencyService
 
-        service = IdempotencyService()
-        cached_response = service.get(key)
+        service = DynamoDBIdempotencyService(cache)
     """
 
     def __init__(

--- a/app/infrastructure/services/dependencies.py
+++ b/app/infrastructure/services/dependencies.py
@@ -15,7 +15,7 @@ from infrastructure.clients.google_workspace import GoogleWorkspaceClients
 from infrastructure.clients.maxmind import MaxMindClient
 from infrastructure.events.service import EventDispatcher
 from infrastructure.i18n.service import TranslationService
-from infrastructure.idempotency.service import IdempotencyService
+from infrastructure.idempotency.protocol import IdempotencyService
 from infrastructure.resilience.service import ResilienceService
 from infrastructure.notifications.service import NotificationService
 from infrastructure.storage.protocol import StorageService

--- a/app/infrastructure/services/providers.py
+++ b/app/infrastructure/services/providers.py
@@ -36,7 +36,8 @@ from infrastructure.clients.maxmind import MaxMindClient
 from infrastructure.i18n.service import TranslationService
 from infrastructure.i18n.models import Locale, TranslationKey
 from infrastructure.events.service import EventDispatcher
-from infrastructure.idempotency.service import IdempotencyService
+from infrastructure.idempotency.service import DynamoDBIdempotencyService
+from infrastructure.idempotency.protocol import IdempotencyService
 from infrastructure.idempotency.dynamodb import DynamoDBCache
 from infrastructure.resilience.service import ResilienceService
 from infrastructure.notifications.service import NotificationService
@@ -307,7 +308,7 @@ def get_idempotency_service() -> IdempotencyService:
     Returns:
         IdempotencyService: Cached idempotency service instance
     """
-    return IdempotencyService(
+    return DynamoDBIdempotencyService(
         cache=DynamoDBCache(idempotency_settings=get_idempotency_settings())
     )
 

--- a/app/tests/unit/infrastructure/idempotency/test_idempotency_protocol.py
+++ b/app/tests/unit/infrastructure/idempotency/test_idempotency_protocol.py
@@ -1,0 +1,139 @@
+"""Tests for IdempotencyService Protocol.
+
+Validates that the Protocol contract is properly defined and that
+implementations conform to the runtime-checkable interface.
+"""
+
+from typing import Any, Dict, Optional
+
+from infrastructure.idempotency.cache import IdempotencyCache
+from infrastructure.idempotency.protocol import IdempotencyService
+from infrastructure.idempotency.service import DynamoDBIdempotencyService
+
+
+class FakeIdempotencyCache(IdempotencyCache):
+    """In-memory fake implementation of IdempotencyCache for testing."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        return self._store.get(key)
+
+    def set(self, key: str, response: Dict[str, Any], ttl_seconds: int) -> None:
+        self._store[key] = response
+
+    def clear(self) -> None:
+        self._store.clear()
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {"size": len(self._store)}
+
+
+class FakeIdempotencyService:
+    """In-memory fake implementation of IdempotencyService for testing."""
+
+    def __init__(self, cache: IdempotencyCache) -> None:
+        self._cache = cache
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        return self._cache.get(key)
+
+    def set(self, key: str, response: Dict[str, Any], ttl_seconds: int) -> None:
+        self._cache.set(key, response, ttl_seconds)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def get_stats(self) -> Dict[str, Any]:
+        return self._cache.get_stats()
+
+    @property
+    def cache(self) -> IdempotencyCache:
+        return self._cache
+
+
+class TestIdempotencyProtocol:
+    """Test suite for IdempotencyService Protocol."""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """Verify that IdempotencyService Protocol has @runtime_checkable."""
+        # The Protocol must be importable and checkable at runtime
+        assert IdempotencyService is not None
+        # If it's runtime checkable, isinstance checks should work
+        fake_service = FakeIdempotencyService(FakeIdempotencyCache())
+        assert isinstance(fake_service, IdempotencyService)
+
+    def test_dynamodb_idempotency_satisfies_protocol(self) -> None:
+        """Verify that DynamoDBIdempotencyService satisfies the Protocol."""
+        fake_cache = FakeIdempotencyCache()
+        service = DynamoDBIdempotencyService(cache=fake_cache)
+        assert isinstance(service, IdempotencyService)
+
+    def test_fake_idempotency_satisfies_protocol(self) -> None:
+        """Verify that a minimal fake implementation satisfies the Protocol."""
+        fake_cache = FakeIdempotencyCache()
+        fake = FakeIdempotencyService(cache=fake_cache)
+        assert isinstance(fake, IdempotencyService)
+
+    def test_protocol_get_method_signature(self) -> None:
+        """Verify that Protocol includes get method with correct signature."""
+        # Create a minimal service that implements the Protocol
+        cache = FakeIdempotencyCache()
+        cache.set("test_key", {"result": "data"}, ttl_seconds=3600)
+
+        service = DynamoDBIdempotencyService(cache=cache)
+
+        # Call get method
+        result = service.get("test_key")
+        assert result == {"result": "data"}
+
+        # Call get with missing key
+        result = service.get("nonexistent")
+        assert result is None
+
+    def test_protocol_set_method_signature(self) -> None:
+        """Verify that Protocol includes set method with correct signature."""
+        cache = FakeIdempotencyCache()
+        service = DynamoDBIdempotencyService(cache=cache)
+
+        # Call set method
+        response_data = {"status": "success", "id": 123}
+        service.set("request_key", response_data, ttl_seconds=3600)
+
+        # Verify the data was cached
+        cached = service.get("request_key")
+        assert cached == response_data
+
+    def test_protocol_clear_method_signature(self) -> None:
+        """Verify that Protocol includes clear method with correct signature."""
+        cache = FakeIdempotencyCache()
+        service = DynamoDBIdempotencyService(cache=cache)
+
+        # Set and verify
+        service.set("key1", {"data": "value"}, ttl_seconds=3600)
+        assert service.get("key1") is not None
+
+        # Clear
+        service.clear()
+
+        # Verify cleared
+        assert service.get("key1") is None
+
+    def test_protocol_get_stats_method_signature(self) -> None:
+        """Verify that Protocol includes get_stats method with correct signature."""
+        cache = FakeIdempotencyCache()
+        service = DynamoDBIdempotencyService(cache=cache)
+
+        # Call get_stats method
+        stats = service.get_stats()
+        assert isinstance(stats, dict)
+
+    def test_protocol_cache_property_signature(self) -> None:
+        """Verify that Protocol includes cache property with correct return type."""
+        cache = FakeIdempotencyCache()
+        service = DynamoDBIdempotencyService(cache=cache)
+
+        # Access cache property
+        returned_cache = service.cache
+        assert returned_cache is cache

--- a/app/tests/unit/infrastructure/idempotency/test_narrow_slice.py
+++ b/app/tests/unit/infrastructure/idempotency/test_narrow_slice.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock
 
 from infrastructure.idempotency.cache import IdempotencyCache
 from infrastructure.idempotency.dynamodb import DynamoDBCache
-from infrastructure.idempotency.service import IdempotencyService
+from infrastructure.idempotency.protocol import IdempotencyService
+from infrastructure.idempotency.service import DynamoDBIdempotencyService
 from infrastructure.configuration.infrastructure.idempotency import IdempotencySettings
 
 pytestmark = pytest.mark.unit
@@ -35,32 +36,34 @@ class TestDynamoDBCacheAcceptsInjectedSettings:
 
 
 class TestIdempotencyServiceReceivesConstructedCache:
-    """IdempotencyService accepts only a pre-built cache (composition root in providers.py)."""
+    """DynamoDBIdempotencyService accepts only a pre-built cache (composition root in providers.py)."""
 
     def test_service_constructs_with_pre_built_cache(self):
-        """IdempotencyService constructs with an injected cache."""
+        """DynamoDBIdempotencyService constructs with an injected cache."""
         mock_cache = MagicMock(spec=IdempotencyCache)
-        service = IdempotencyService(cache=mock_cache)
+        service = DynamoDBIdempotencyService(cache=mock_cache)
         assert service is not None
 
     def test_service_delegates_get_to_cache(self):
-        """IdempotencyService.get() delegates to the injected cache."""
+        """DynamoDBIdempotencyService.get() delegates to the injected cache."""
         mock_cache = MagicMock(spec=IdempotencyCache)
         mock_cache.get.return_value = {"status": "ok"}
-        service = IdempotencyService(cache=mock_cache)
+        service = DynamoDBIdempotencyService(cache=mock_cache)
         result = service.get("some-key")
         mock_cache.get.assert_called_once_with("some-key")
         assert result == {"status": "ok"}
 
     def test_service_delegates_set_to_cache(self):
-        """IdempotencyService.set() delegates to the injected cache."""
+        """DynamoDBIdempotencyService.set() delegates to the injected cache."""
         mock_cache = MagicMock(spec=IdempotencyCache)
-        service = IdempotencyService(cache=mock_cache)
+        service = DynamoDBIdempotencyService(cache=mock_cache)
         service.set("key", {"data": 1}, ttl_seconds=3600)
         mock_cache.set.assert_called_once_with("key", {"data": 1}, 3600)
 
     def test_service_no_idempotency_settings_parameter(self):
-        """IdempotencyService no longer accepts idempotency_settings (moved to providers)."""
+        """DynamoDBIdempotencyService no longer accepts idempotency_settings (moved to providers)."""
         mock_cache = MagicMock(spec=IdempotencyCache)
         with pytest.raises(TypeError):
-            IdempotencyService(idempotency_settings=MagicMock(), cache=mock_cache)
+            DynamoDBIdempotencyService(
+                idempotency_settings=MagicMock(), cache=mock_cache
+            )

--- a/app/tests/unit/infrastructure/idempotency/test_narrow_slice.py
+++ b/app/tests/unit/infrastructure/idempotency/test_narrow_slice.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 
 from infrastructure.idempotency.cache import IdempotencyCache
 from infrastructure.idempotency.dynamodb import DynamoDBCache
-from infrastructure.idempotency.protocol import IdempotencyService
 from infrastructure.idempotency.service import DynamoDBIdempotencyService
 from infrastructure.configuration.infrastructure.idempotency import IdempotencySettings
 

--- a/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
+++ b/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
@@ -19,7 +19,6 @@ from infrastructure.configuration.integrations.slack import SlackSettings
 from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
 from infrastructure.configuration.integrations.notify import NotifySettings
 from infrastructure.clients.maxmind.client import MaxMindClient
-from infrastructure.idempotency.protocol import IdempotencyService
 from infrastructure.idempotency.service import DynamoDBIdempotencyService
 from infrastructure.resilience.service import ResilienceService
 from infrastructure.notifications.service import NotificationService

--- a/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
+++ b/app/tests/unit/infrastructure/services/test_narrow_slice_providers.py
@@ -19,7 +19,8 @@ from infrastructure.configuration.integrations.slack import SlackSettings
 from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
 from infrastructure.configuration.integrations.notify import NotifySettings
 from infrastructure.clients.maxmind.client import MaxMindClient
-from infrastructure.idempotency.service import IdempotencyService
+from infrastructure.idempotency.protocol import IdempotencyService
+from infrastructure.idempotency.service import DynamoDBIdempotencyService
 from infrastructure.resilience.service import ResilienceService
 from infrastructure.notifications.service import NotificationService
 from infrastructure.platforms.service import PlatformService
@@ -60,25 +61,27 @@ class TestMaxMindClientNarrowSlice:
 
 
 class TestIdempotencyServiceNarrowSlice:
-    """IdempotencyService accepts only a pre-constructed cache (no settings)."""
+    """DynamoDBIdempotencyService accepts only a pre-constructed cache (no settings)."""
 
     def test_accepts_injected_cache(self):
-        """IdempotencyService constructs with a pre-built cache."""
+        """DynamoDBIdempotencyService constructs with a pre-built cache."""
         mock_cache = MagicMock()
-        service = IdempotencyService(cache=mock_cache)
+        service = DynamoDBIdempotencyService(cache=mock_cache)
         assert service is not None
 
     def test_rejects_settings_kwarg(self):
-        """IdempotencyService does not accept 'settings' or 'idempotency_settings' kwargs."""
+        """DynamoDBIdempotencyService does not accept 'settings' or 'idempotency_settings' kwargs."""
         mock_cache = MagicMock()
         with pytest.raises(TypeError):
-            IdempotencyService(settings=MagicMock(), cache=mock_cache)
+            DynamoDBIdempotencyService(settings=MagicMock(), cache=mock_cache)
 
     def test_rejects_idempotency_settings_kwarg(self):
-        """IdempotencyService no longer accepts idempotency_settings (moved to providers)."""
+        """DynamoDBIdempotencyService no longer accepts idempotency_settings (moved to providers)."""
         mock_cache = MagicMock()
         with pytest.raises(TypeError):
-            IdempotencyService(idempotency_settings=MagicMock(), cache=mock_cache)
+            DynamoDBIdempotencyService(
+                idempotency_settings=MagicMock(), cache=mock_cache
+            )
 
 
 class TestResilienceServiceNarrowSlice:


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the idempotency service architecture to introduce a formal protocol interface and clarify the distinction between the protocol and its DynamoDB-backed implementation. It also updates all references and tests to use the new naming and structure, ensuring clearer dependency injection and improved testability.

**Idempotency Service Protocolization and Implementation Separation**

* Introduced a new `IdempotencyService` Protocol in `protocol.py` to define the contract for idempotency services, supporting runtime type checking and enabling multiple interchangeable implementations.
* Renamed the concrete class in `service.py` to `DynamoDBIdempotencyService`, making the implementation explicit and aligning with the new protocol-based design.
* Updated imports and usage throughout the codebase to reference the protocol and the new concrete class appropriately, including in `__init__.py`, `dependencies.py`, `providers.py`, and all relevant tests. [[1]](diffhunk://#diff-2e0e35447aeaaa6f7c276b4cbd733db249ff315e97d10ab25ad86dfaa96203e5L30-R31) [[2]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0L18-R18) [[3]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L39-R40) [[4]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L310-R311) [[5]](diffhunk://#diff-2e0e35447aeaaa6f7c276b4cbd733db249ff315e97d10ab25ad86dfaa96203e5R41)

**Testing and Validation**

* Added a comprehensive unit test suite for the new `IdempotencyService` Protocol, verifying runtime checkability, method signatures, and compatibility with real and fake implementations.
* Updated existing tests to use the new `DynamoDBIdempotencyService` class and ensure that only pre-constructed caches are accepted, with settings now handled at the provider level. [[1]](diffhunk://#diff-a93d38adf2a5e1b0cade2808795db48c366fe53fc04a4f3225b52a80c0d48f32L8-R9) [[2]](diffhunk://#diff-a93d38adf2a5e1b0cade2808795db48c366fe53fc04a4f3225b52a80c0d48f32L38-R69) [[3]](diffhunk://#diff-f1a9dadb4362dbd7422bf53292a322639327577430f2f6207a41de3c59af340aL22-R23) [[4]](diffhunk://#diff-f1a9dadb4362dbd7422bf53292a322639327577430f2f6207a41de3c59af340aL63-R84)