### PR TITLE
feat: add standalone SlackBot service for interaction registration

### DIFF
--- a/app/infrastructure/hookspecs/features.py
+++ b/app/infrastructure/hookspecs/features.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from infrastructure.platforms.providers.slack import SlackPlatformProvider
     from infrastructure.platforms.providers.teams import TeamsPlatformProvider
     from infrastructure.platforms.providers.discord import DiscordPlatformProvider
+    from infrastructure.slack.service import SlackBot
     from infrastructure.i18n.resources import I18nResourceRegistry
 
 hookspec = pluggy.HookspecMarker("sre_bot")
@@ -40,6 +41,18 @@ def register_slack_commands(provider: "SlackPlatformProvider") -> None:
 
     Args:
         provider: Slack provider instance to register commands with.
+    """
+
+
+@hookspec
+def register_slack_agent_interactions(provider: "SlackBot") -> None:
+    """Register Slack agent interactions via the standalone SlackBot service.
+
+    This hookspec supports agent-first interaction registration through the
+    standalone SlackBot service while preserving legacy hookspec compatibility.
+
+    Args:
+        provider: Standalone SlackBot service used by feature hookimpls.
     """
 
 

--- a/app/infrastructure/services/dependencies.py
+++ b/app/infrastructure/services/dependencies.py
@@ -21,12 +21,11 @@ from infrastructure.notifications.service import NotificationService
 from infrastructure.storage.protocol import StorageService
 from infrastructure.audit.protocol import AuditTrailService
 from infrastructure.platforms.service import PlatformService
-from infrastructure.platforms.clients import (
-    SlackClientFacade,
-    TeamsClientFacade,
-    DiscordClientFacade,
-)
+from infrastructure.platforms.clients.slack import SlackClientFacade
+from infrastructure.platforms.clients.teams import TeamsClientFacade
+from infrastructure.platforms.clients.discord import DiscordClientFacade
 from infrastructure.directory.provider import DirectoryProvider
+from infrastructure.slack.service import SlackBot
 from infrastructure.services.providers import (
     get_app_settings,
     get_settings,
@@ -42,6 +41,7 @@ from infrastructure.services.providers import (
     get_storage_service,
     get_audit_trail_service,
     get_platform_service,
+    get_slack_bot,
     get_slack_client,
     get_teams_client,
     get_discord_client,
@@ -108,6 +108,9 @@ AuditTrailServiceDep = Annotated[AuditTrailService, Depends(get_audit_trail_serv
 PlatformServiceDep = Annotated[PlatformService, Depends(get_platform_service)]
 
 # Platform client facades - wrap platform SDKs with OperationResult APIs
+# Standalone Slack bot dependency
+SlackBotDep = Annotated[SlackBot, Depends(get_slack_bot)]
+
 # Slack client facade dependency
 SlackClientDep = Annotated[SlackClientFacade, Depends(get_slack_client)]
 
@@ -134,6 +137,7 @@ __all__ = [
     "NotificationServiceDep",
     "StorageServiceDep",
     "PlatformServiceDep",
+    "SlackBotDep",
     "SlackClientDep",
     "TeamsClientDep",
     "DiscordClientDep",

--- a/app/infrastructure/services/plugins/manager.py
+++ b/app/infrastructure/services/plugins/manager.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from infrastructure.platforms.providers.slack import SlackPlatformProvider
     from infrastructure.platforms.providers.teams import TeamsPlatformProvider
     from infrastructure.platforms.providers.discord import DiscordPlatformProvider
+    from infrastructure.slack.service import SlackBot
 
 logger = structlog.get_logger()
 
@@ -70,6 +71,7 @@ def collect_feature_i18n_resources(
 def register_feature_integrations(
     app: "FastAPI",
     logger: "BoundLogger",
+    slack_bot: "SlackBot | None" = None,
     slack_provider: "SlackPlatformProvider | None" = None,
     teams_provider: "TeamsPlatformProvider | None" = None,
     discord_provider: "DiscordPlatformProvider | None" = None,
@@ -94,6 +96,10 @@ def register_feature_integrations(
         pm.hook.register_slack_commands(provider=slack_provider)
         logger.info("slack_commands_registered")
 
+    if slack_bot:
+        pm.hook.register_slack_agent_interactions(provider=slack_bot)
+        logger.info("slack_agent_interactions_registered")
+
     if teams_provider:
         pm.hook.register_teams_commands(provider=teams_provider)
         logger.info("teams_commands_registered")
@@ -116,6 +122,7 @@ def register_feature_integrations(
 def discover_and_init_features(
     app: "FastAPI",
     logger: "BoundLogger",
+    slack_bot: "SlackBot | None" = None,
     slack_provider: "SlackPlatformProvider | None" = None,
     teams_provider: "TeamsPlatformProvider | None" = None,
     discord_provider: "DiscordPlatformProvider | None" = None,
@@ -134,6 +141,7 @@ def discover_and_init_features(
     register_feature_integrations(
         app=app,
         logger=logger,
+        slack_bot=slack_bot,
         slack_provider=slack_provider,
         teams_provider=teams_provider,
         discord_provider=discord_provider,

--- a/app/infrastructure/services/providers.py
+++ b/app/infrastructure/services/providers.py
@@ -6,6 +6,7 @@ Provides application-scoped singleton providers for core infrastructure services
 
 from functools import lru_cache
 from typing import Any
+import warnings
 from infrastructure.platforms.exceptions import ProviderNotFoundError
 from typing import cast
 
@@ -55,12 +56,13 @@ from infrastructure.platforms.providers import (
     DiscordPlatformProvider,
 )
 from infrastructure.platforms.clients import (
-    SlackClientFacade,
     TeamsClientFacade,
     DiscordClientFacade,
 )
+from infrastructure.platforms.clients.slack import SlackClientFacade
 from infrastructure.directory.factory import build_google_directory_provider
 from infrastructure.directory.provider import DirectoryProvider
+from infrastructure.slack.service import SlackBot
 
 
 @lru_cache(maxsize=1)
@@ -86,8 +88,8 @@ def get_settings() -> Settings:
         Settings: Cached settings instance loaded from environment.
 
     Note:
-        Deprecated in ADR-0055 Standard 4. Prefer domain-specific settings
-        providers (for example get_slack_settings(), get_server_settings()).
+        Deprecated. Prefer domain-specific settings providers
+        (for example get_slack_settings(), get_server_settings()).
     """
     return Settings()
 
@@ -345,7 +347,7 @@ def get_notification_service() -> NotificationService:
     delivery with automatic fallback, idempotency, and circuit breakers.
 
     Channel construction and circuit breaker wiring happen here (composition
-    root — ADR-0076 S3) so NotificationService receives pre-built channels.
+    root) so NotificationService receives pre-built channels.
 
     Usage:
         from infrastructure.services import NotificationServiceDep
@@ -662,10 +664,29 @@ def get_slack_provider() -> SlackPlatformProvider:
     Raises:
         ProviderNotFoundError: If Slack provider has not been registered.
     """
+    warnings.warn(
+        "get_slack_provider() is deprecated; prefer get_slack_bot() for "
+        "standalone Slack interaction registration.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     provider = get_platform_service()._registry.get_provider("slack")
     if provider is None:
         raise ProviderNotFoundError("No provider registered with name 'slack'")
     return cast(SlackPlatformProvider, provider)
+
+
+@lru_cache(maxsize=1)
+def get_slack_bot() -> SlackBot:
+    """Get application-scoped standalone SlackBot singleton.
+
+    Returns:
+        SlackBot: Cached standalone Slack service.
+    """
+    return SlackBot(
+        slack_settings=get_slack_settings(),
+        slack_client=get_slack_client(),
+    )
 
 
 def get_teams_provider() -> TeamsPlatformProvider:

--- a/app/infrastructure/slack/service.py
+++ b/app/infrastructure/slack/service.py
@@ -1,0 +1,95 @@
+"""Standalone SlackBot service for agent-first interaction registration.
+
+This service coexists with the legacy PlatformService-based Slack provider and
+provides a dedicated registration surface for feature hooks.
+"""
+
+from typing import Any, Callable
+
+import structlog
+
+from infrastructure.configuration.integrations.slack import SlackSettings
+from infrastructure.operations import OperationResult
+from infrastructure.platforms.clients.slack import SlackClientFacade
+from infrastructure.platforms.providers.slack import SlackPlatformProvider
+
+logger = structlog.get_logger()
+
+
+class SlackBot:
+    """Dedicated Slack service for feature interaction registration.
+
+    The service wraps the existing SlackPlatformProvider to preserve behavior
+    while offering a standalone dependency boundary for phased monolith
+    decomposition.
+    """
+
+    def __init__(
+        self,
+        slack_settings: SlackSettings,
+        slack_client: SlackClientFacade,
+    ) -> None:
+        self._settings = slack_settings
+        self._slack_client = slack_client
+        self._provider = SlackPlatformProvider(settings=slack_settings)
+        self._view_handlers: dict[str, Callable[..., Any]] = {}
+        self._action_handlers: dict[str, Callable[..., Any]] = {}
+        self._logger = logger.bind(component="slack_bot")
+
+    def initialize_app(self) -> OperationResult:
+        """Initialize Slack transport and bind deferred interaction handlers."""
+        result = self._provider.initialize_app()
+        if not result.is_success:
+            return result
+
+        app = self._provider.app
+        if app is not None:
+            for callback_id, handler in self._view_handlers.items():
+                app.view(callback_id)(handler)
+            for action_id, handler in self._action_handlers.items():
+                app.action(action_id)(handler)
+
+        return result
+
+    def start(self) -> OperationResult:
+        """Start Slack transport lifecycle when socket mode is enabled."""
+        return self._provider.start()
+
+    def stop(self) -> None:
+        """Stop Slack transport lifecycle."""
+        self._provider.stop()
+
+    def register_command(self, *args: Any, **kwargs: Any) -> None:
+        """Register a command using the underlying Slack provider contract."""
+        self._provider.register_command(*args, **kwargs)
+
+    def register_view_handler(
+        self, callback_id: str, handler: Callable[..., Any]
+    ) -> None:
+        """Register a Slack view (modal) handler by callback id."""
+        self._view_handlers[callback_id] = handler
+        if self._provider.app is not None:
+            self._provider.app.view(callback_id)(handler)
+
+    def register_action_handler(
+        self, action_id: str, handler: Callable[..., Any]
+    ) -> None:
+        """Register a Slack block/action handler by action id."""
+        self._action_handlers[action_id] = handler
+        if self._provider.app is not None:
+            self._provider.app.action(action_id)(handler)
+
+    @property
+    def provider(self) -> SlackPlatformProvider:
+        """Expose wrapped provider for phased backward compatibility."""
+        return self._provider
+
+    @property
+    def app(self) -> Any:
+        """Expose managed Slack Bolt app for compatibility with startup wiring."""
+        return self._provider.app
+
+    @property
+    def socket_mode_handler(self) -> Any:
+        """Expose socket mode handler managed by the underlying provider."""
+        return self._provider.socket_mode_handler

--- a/app/tests/unit/infrastructure/hookspecs/test_agent_hookspecs.py
+++ b/app/tests/unit/infrastructure/hookspecs/test_agent_hookspecs.py
@@ -1,0 +1,30 @@
+"""Unit tests for agent-specific hookspecs."""
+
+import inspect
+
+import pluggy
+import pytest
+
+from infrastructure.hookspecs import features
+
+pytestmark = pytest.mark.unit
+
+
+def test_register_slack_agent_interactions_hookspec_exists() -> None:
+    plugin_manager = pluggy.PluginManager("sre_bot")
+    plugin_manager.add_hookspecs(features)
+
+    hook = getattr(plugin_manager.hook, "register_slack_agent_interactions", None)
+    assert hook is not None
+    assert callable(hook)
+
+
+def test_slack_agent_hookspec_parameter_is_slack_service() -> None:
+    signature = inspect.signature(features.register_slack_agent_interactions)
+
+    assert "provider" in signature.parameters
+    assert signature.parameters["provider"].annotation == "SlackBot"
+
+
+def test_legacy_hookspecs_unchanged() -> None:
+    assert hasattr(features, "register_slack_commands")

--- a/app/tests/unit/infrastructure/slack/test_slack_service.py
+++ b/app/tests/unit/infrastructure/slack/test_slack_service.py
@@ -1,0 +1,46 @@
+"""Unit tests for standalone SlackBot infrastructure service."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrastructure.configuration.integrations.slack import SlackSettings
+from infrastructure.platforms.clients.slack import SlackClientFacade
+from infrastructure.platforms.service import PlatformService
+from infrastructure.services.providers import get_slack_bot
+from infrastructure.slack.service import SlackBot
+
+pytestmark = pytest.mark.unit
+
+
+def test_slack_service_constructs_with_settings_and_client() -> None:
+    slack_settings = MagicMock(spec=SlackSettings)
+    slack_settings.ENABLED = True
+    slack_settings.SOCKET_MODE = True
+    slack_settings.APP_TOKEN = "xapp-test"
+    slack_settings.SLACK_TOKEN = "xoxb-test"
+    slack_client = MagicMock(spec=SlackClientFacade)
+
+    slack_bot = SlackBot(slack_settings=slack_settings, slack_client=slack_client)
+
+    assert slack_bot is not None
+
+
+def test_slack_service_is_not_platform_service() -> None:
+    assert not issubclass(SlackBot, PlatformService)
+
+
+def test_get_slack_bot_singleton() -> None:
+    get_slack_bot.cache_clear()
+    first = get_slack_bot()
+    second = get_slack_bot()
+
+    assert first is second
+
+    get_slack_bot.cache_clear()
+
+
+def test_slack_service_exposes_registration_methods() -> None:
+    assert hasattr(SlackBot, "register_command")
+    assert hasattr(SlackBot, "register_view_handler")
+    assert hasattr(SlackBot, "register_action_handler")


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new standalone `SlackBot` service to provide a dedicated and modernized interface for Slack agent interaction registration, while maintaining backward compatibility with legacy Slack provider hooks. The changes include new hookspecs, dependency injection updates, plugin manager integration, and comprehensive unit tests to ensure correctness and smooth migration. Deprecation warnings are also added to guide future development away from the old provider pattern.

**SlackBot Service Introduction and Integration:**

* Added a new `SlackBot` class in `infrastructure/slack/service.py`, encapsulating Slack interaction registration and lifecycle management, separate from the legacy `SlackPlatformProvider`. This service offers explicit methods for registering commands, view handlers, and action handlers, and exposes compatibility properties for phased migration.
* Implemented a new `register_slack_agent_interactions` hookspec in `infrastructure/hookspecs/features.py` to support agent-first Slack interaction registration through the standalone `SlackBot` service, while retaining legacy hookspecs for backward compatibility.

**Dependency Injection and Provider Updates:**

* Updated dependency injection in `infrastructure/services/dependencies.py` to include `SlackBotDep`, and adjusted imports to use explicit client modules. [[1]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0L24-R28) [[2]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R44) [[3]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R111-R113) [[4]](diffhunk://#diff-1ca2678f167facc952fd63e1ea798d6d5ae27d6d3469c9ea40ee3fa9c1d258f0R140)
* Added `get_slack_bot()` provider in `infrastructure/services/providers.py` as an application-scoped singleton, and marked `get_slack_provider()` as deprecated with a warning to encourage migration to the new service. [[1]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L58-R65) [[2]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890R667-R691)

**Plugin and Feature Registration:**

* Modified the plugin manager and feature registration logic in `infrastructure/services/plugins/manager.py` to support both the new `slack_bot` and legacy `slack_provider` for registering Slack feature integrations. [[1]](diffhunk://#diff-f4bc0cb429897e22ebb534febe3c45755d25343401be2ef8c1bca62239045fdbR24) [[2]](diffhunk://#diff-f4bc0cb429897e22ebb534febe3c45755d25343401be2ef8c1bca62239045fdbR74) [[3]](diffhunk://#diff-f4bc0cb429897e22ebb534febe3c45755d25343401be2ef8c1bca62239045fdbR99-R102) [[4]](diffhunk://#diff-f4bc0cb429897e22ebb534febe3c45755d25343401be2ef8c1bca62239045fdbR125) [[5]](diffhunk://#diff-f4bc0cb429897e22ebb534febe3c45755d25343401be2ef8c1bca62239045fdbR144)

**Testing:**

* Added unit tests for the new hookspec in `test_agent_hookspecs.py`, verifying its presence, signature, and coexistence with legacy hookspecs.
* Added comprehensive unit tests for the `SlackBot` service in `test_slack_service.py`, covering construction, singleton behavior, and registration method exposure.

**Documentation and Minor Cleanups:**

* Improved and clarified documentation in service provider functions, removing outdated ADR references and updating deprecation notes. [[1]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L89-R92) [[2]](diffhunk://#diff-643d1a6c3345161a8bee51ac1cd44cc503b5147265661b9fb01b6c641a789890L348-R350)

These changes lay the groundwork for a more modular, testable, and future-proof Slack integration architecture, while ensuring a smooth migration path for existing features.