### PR TITLE
Add source alert links to incident channels

### DIFF
--- a/app/models/incidents.py
+++ b/app/models/incidents.py
@@ -46,6 +46,7 @@ class IncidentPayload(BaseModel):
     channel_name: str
     slug: str
     severity: Optional[str] = None
+    source_alert_permalink: Optional[str] = None
 
     class Config:  # noqa
         extra = "forbid"

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -540,6 +540,18 @@ def initiate_resources_creation(
     text = f":lapage: An incident report has been created at: {document_link}"
     client.chat_postMessage(text=text, channel=incident_payload.channel_id)
 
+    if incident_payload.source_alert_permalink:
+        client.bookmarks_add(
+            channel_id=incident_payload.channel_id,
+            title="Source alert",
+            type="link",
+            link=incident_payload.source_alert_permalink,
+        )
+        client.chat_postMessage(
+            text=f"Source alert: <{incident_payload.source_alert_permalink}|View original alert>",
+            channel=incident_payload.channel_id,
+        )
+
     # Gather all user IDs in a list to ensure uniqueness
     users_to_invite = []
 

--- a/app/modules/incident/incident.py
+++ b/app/modules/incident/incident.py
@@ -1,3 +1,4 @@
+import json
 import re
 import i18n  # type: ignore
 from slack_sdk import WebClient
@@ -53,12 +54,12 @@ def _incident_modal_loading_view():
 
 def open_create_incident_modal(client: WebClient, ack, command, body):
     ack()
-    # private_metadata = json.dumps(
-    #     {
-    #         "channel_id": body["channel"]["id"],
-    #         "message_ts": body["message_ts"],
-    #     }
-    # )
+    private_metadata = command.get("private_metadata")
+    if isinstance(private_metadata, dict):
+        private_metadata = json.dumps(private_metadata)
+    elif not isinstance(private_metadata, str):
+        private_metadata = None
+
     logger.info(
         "incident_command_called",
         command=command,
@@ -80,7 +81,9 @@ def open_create_incident_modal(client: WebClient, ack, command, body):
         }
         for i in folders
     ]
-    loaded_view = generate_incident_modal_view(command, options, None, locale)
+    loaded_view = generate_incident_modal_view(
+        command, options, private_metadata, locale
+    )
     client.views_update(view_id=view["id"], view=loaded_view)
 
 
@@ -103,8 +106,40 @@ def handle_change_locale_button(ack, client, body):
     command = {"text": body["view"]["state"]["values"]["name"]["name"]["value"]}
     if command["text"] is None:
         command["text"] = ""
-    view = generate_incident_modal_view(command, options, None, locale)
+    private_metadata = body["view"].get("private_metadata")
+    view = generate_incident_modal_view(command, options, private_metadata, locale)
     client.views_update(view_id=body["view"]["id"], view=view)
+
+
+def _get_source_alert_permalink(client: WebClient, view: dict) -> str | None:
+    private_metadata = view.get("private_metadata")
+    if not private_metadata:
+        return None
+
+    try:
+        metadata = json.loads(private_metadata)
+    except (TypeError, json.JSONDecodeError) as e:
+        logger.warning("source_alert_metadata_invalid", error=str(e))
+        return None
+
+    source_channel_id = metadata.get("source_channel_id")
+    source_message_ts = metadata.get("source_message_ts")
+    if not source_channel_id or not source_message_ts:
+        return None
+
+    try:
+        return client.chat_getPermalink(
+            channel=source_channel_id,
+            message_ts=source_message_ts,
+        )["permalink"]
+    except Exception as e:
+        logger.warning(
+            "source_alert_permalink_failed",
+            source_channel_id=source_channel_id,
+            source_message_ts=source_message_ts,
+            error=str(e),
+        )
+        return None
 
 
 def submit(ack: Ack, view, say, body, client: WebClient):  # noqa: C901
@@ -140,10 +175,8 @@ def submit(ack: Ack, view, say, body, client: WebClient):  # noqa: C901
     channel_name = None
     slug = None
     user_id = body["user"]["id"]
+    source_alert_permalink = _get_source_alert_permalink(client, view)
 
-    # private_metadata = json.loads(body["view"].get("private_metadata"))
-    # source_channel_id = private_metadata.get("channel_id")
-    # source_message_ts = private_metadata.get("message_ts")
     try:
         channel_created = incident_conversation.create_incident_conversation(
             client, name
@@ -163,16 +196,6 @@ def submit(ack: Ack, view, say, body, client: WebClient):  # noqa: C901
             channel=body["user"]["id"],
         )
         return
-
-    # if private_metadata:
-    #     # private_metadata = json.loads(private_metadata)
-    #     logger.info("private_metadata_found", private_metadata=private_metadata)
-    #     incident_alert.update_alert_with_channel_link(
-    #         client,
-    #         source_channel_id,
-    #         source_message_ts,
-    #         incident_details={"channel_id": channel_id, "channel_name": channel_name},
-    #     )
 
     logger.info(
         "incident_channel_created",
@@ -205,6 +228,7 @@ def submit(ack: Ack, view, say, body, client: WebClient):  # noqa: C901
         channel_name=channel_name,
         slug=slug,
         severity=severity,
+        source_alert_permalink=source_alert_permalink,
     )
     try:
         core.initiate_resources_creation(

--- a/app/modules/incident/incident_alert.py
+++ b/app/modules/incident/incident_alert.py
@@ -6,13 +6,34 @@ from structlog import get_logger
 logger = get_logger()
 
 
+def _get_source_alert_metadata(body):
+    channel_id = body.get("channel", {}).get("id")
+    message_ts = body.get("message_ts")
+
+    container = body.get("container", {})
+    if not channel_id:
+        channel_id = container.get("channel_id")
+    if not message_ts:
+        message_ts = container.get("message_ts")
+
+    return {
+        "source_channel_id": channel_id,
+        "source_message_ts": message_ts,
+    }
+
+
 def handle_incident_action_buttons(client, ack, body):
     delete_block = False
     name = body["actions"][0]["name"]
     value = body["actions"][0]["value"]
     user = body["user"]["id"]
     if name == "call-incident":
-        incident.open_create_incident_modal(client, ack, {"text": value}, body)
+        incident.open_create_incident_modal(
+            client,
+            ack,
+            {"text": value, "private_metadata": _get_source_alert_metadata(body)},
+            body,
+        )
         log_to_sentinel("call_incident_button_pressed", body)
     elif name == "ignore-incident":
         ack()

--- a/app/tests/modules/incident/test_incident.py
+++ b/app/tests/modules/incident/test_incident.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from unittest.mock import ANY, MagicMock, patch, call
 from slack_sdk.errors import SlackApiError
 from models.incidents import IncidentPayload
@@ -45,6 +46,42 @@ def test_incident_open_modal_calls_ack(
         command, ANY, None, "en-US"
     )
     client.views_update.assert_called_once_with(view_id=ANY, view=loaded_view)
+
+
+@patch("modules.incident.incident.generate_incident_modal_view")
+@patch("modules.incident.incident.slack_users.get_user_locale")
+@patch("modules.incident.incident.incident_folder.list_incident_folders")
+def test_incident_open_modal_passes_source_private_metadata(
+    mock_list_incident_folders,
+    mock_get_user_locale,
+    mock_generate_incident_modal_view,
+):
+    mock_get_user_locale.return_value = "en-US"
+    mock_list_incident_folders.return_value = [{"id": "id", "name": "name"}]
+    client = MagicMock()
+    ack = MagicMock()
+    command = {
+        "text": "incident description",
+        "private_metadata": {
+            "source_channel_id": "channel_id",
+            "source_message_ts": "123.456",
+        },
+    }
+    body = {"trigger_id": "trigger_id", "user": {"id": "user_id"}}
+
+    incident.open_create_incident_modal(client, ack, command, body)
+
+    mock_generate_incident_modal_view.assert_called_once_with(
+        command,
+        ANY,
+        json.dumps(
+            {
+                "source_channel_id": "channel_id",
+                "source_message_ts": "123.456",
+            }
+        ),
+        "en-US",
+    )
 
 
 @patch("modules.incident.incident.generate_incident_modal_view")
@@ -163,13 +200,15 @@ def test_incident_locale_button_updates_view_modal_locale_value(
         "trigger_id": "trigger_id",
         "user_id": "user_id",
         "actions": [{"value": "fr-FR"}],
-        "view": helper_generate_view("command_name"),
+        "view": helper_generate_view(
+            "command_name", private_metadata='{"source_channel_id": "channel"}'
+        ),
     }
     incident.handle_change_locale_button(ack, client, body)
 
     ack.assert_called()
     mock_generate_incident_modal_view.assert_called_with(
-        command, options, None, "en-US"
+        command, options, '{"source_channel_id": "channel"}', "en-US"
     )
 
 
@@ -248,6 +287,135 @@ def test_incident_submit_calls_succeeds(
     mock_core.initiate_resources_creation.assert_called_once_with(
         client=client,
         incident_payload=incident_payload,
+    )
+
+
+@patch("modules.incident.incident.core")
+@patch("modules.incident.incident.log_to_sentinel")
+@patch("modules.incident.incident.logger")
+@patch("modules.incident.incident.incident_conversation")
+def test_incident_submit_adds_source_alert_permalink(
+    mock_create_incident_conversation,
+    _mock_logger,
+    _mock_log_to_sentinel,
+    mock_core,
+):
+    ack = MagicMock()
+    view = helper_generate_view(
+        private_metadata=json.dumps(
+            {
+                "source_channel_id": "source_channel",
+                "source_message_ts": "123.456",
+            }
+        )
+    )
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    client = MagicMock()
+    client.chat_getPermalink.return_value = {"permalink": "https://slack/source"}
+    mock_create_incident_conversation.create_incident_conversation.return_value = {
+        "channel_id": "channel_id",
+        "channel_name": "channel_name",
+        "slug": "slug",
+    }
+
+    incident.submit(ack, view, say, body, client)
+
+    client.chat_getPermalink.assert_called_once_with(
+        channel="source_channel", message_ts="123.456"
+    )
+    mock_core.initiate_resources_creation.assert_called_once_with(
+        client=client,
+        incident_payload=IncidentPayload(
+            name="name",
+            folder="folder",
+            product="product",
+            security_incident="yes",
+            user_id="user_id",
+            channel_id="channel_id",
+            channel_name="channel_name",
+            slug="slug",
+            severity="sev-1",
+            source_alert_permalink="https://slack/source",
+        ),
+    )
+
+
+@patch("modules.incident.incident.core")
+@patch("modules.incident.incident.log_to_sentinel")
+@patch("modules.incident.incident.logger")
+@patch("modules.incident.incident.incident_conversation")
+def test_incident_submit_ignores_malformed_source_metadata(
+    mock_create_incident_conversation,
+    mock_logger,
+    _mock_log_to_sentinel,
+    mock_core,
+):
+    ack = MagicMock()
+    view = helper_generate_view(private_metadata="not-json")
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    client = MagicMock()
+    mock_create_incident_conversation.create_incident_conversation.return_value = {
+        "channel_id": "channel_id",
+        "channel_name": "channel_name",
+        "slug": "slug",
+    }
+
+    incident.submit(ack, view, say, body, client)
+
+    client.chat_getPermalink.assert_not_called()
+    mock_logger.warning.assert_called_once()
+    assert (
+        mock_core.initiate_resources_creation.call_args.kwargs[
+            "incident_payload"
+        ].source_alert_permalink
+        is None
+    )
+
+
+@patch("modules.incident.incident.core")
+@patch("modules.incident.incident.log_to_sentinel")
+@patch("modules.incident.incident.logger")
+@patch("modules.incident.incident.incident_conversation")
+def test_incident_submit_continues_when_source_permalink_fails(
+    mock_create_incident_conversation,
+    mock_logger,
+    _mock_log_to_sentinel,
+    mock_core,
+):
+    ack = MagicMock()
+    view = helper_generate_view(
+        private_metadata=json.dumps(
+            {
+                "source_channel_id": "source_channel",
+                "source_message_ts": "123.456",
+            }
+        )
+    )
+    say = MagicMock()
+    body = {"user": {"id": "user_id"}, "trigger_id": "trigger_id", "view": view}
+    client = MagicMock()
+    client.chat_getPermalink.side_effect = Exception("slack error")
+    mock_create_incident_conversation.create_incident_conversation.return_value = {
+        "channel_id": "channel_id",
+        "channel_name": "channel_name",
+        "slug": "slug",
+    }
+
+    incident.submit(ack, view, say, body, client)
+
+    mock_logger.warning.assert_called_once_with(
+        "source_alert_permalink_failed",
+        source_channel_id="source_channel",
+        source_message_ts="123.456",
+        error="slack error",
+    )
+    assert (
+        mock_core.initiate_resources_creation.call_args.kwargs[
+            "incident_payload"
+        ].source_alert_permalink
+        is None
     )
 
 
@@ -434,9 +602,10 @@ def helper_generate_success_modal(channel_url="channel_url", locale="en-US"):
     }
 
 
-def helper_generate_view(name="name", locale="en-US"):
+def helper_generate_view(name="name", locale="en-US", private_metadata=""):
     return {
         "id": "view_id",
+        "private_metadata": private_metadata,
         "blocks": [
             {
                 "elements": [{"value": locale}],

--- a/app/tests/modules/incident/test_incident_alert.py
+++ b/app/tests/modules/incident/test_incident_alert.py
@@ -17,6 +17,8 @@ def test_handle_incident_action_buttons_call_incident(
                 "type": "button",
             }
         ],
+        "channel": {"id": "channel_id"},
+        "message_ts": "123.456",
         "user": {"id": "user_id"},
     }
     incident_alert.handle_incident_action_buttons(
@@ -25,7 +27,54 @@ def test_handle_incident_action_buttons_call_incident(
         body,
     )
     incident_mock.open_create_incident_modal.assert_called_with(
-        client, ack, {"text": "incident_id"}, body
+        client,
+        ack,
+        {
+            "text": "incident_id",
+            "private_metadata": {
+                "source_channel_id": "channel_id",
+                "source_message_ts": "123.456",
+            },
+        },
+        body,
+    )
+    log_to_sentinel_mock.assert_called_with("call_incident_button_pressed", body)
+
+
+@patch("modules.incident.incident_alert.log_to_sentinel")
+@patch("modules.incident.incident_alert.incident")
+def test_handle_incident_action_buttons_call_incident_uses_container_fallback(
+    incident_mock, log_to_sentinel_mock
+):
+    client = MagicMock()
+    ack = MagicMock()
+    body = {
+        "actions": [
+            {
+                "name": "call-incident",
+                "value": "incident_id",
+                "type": "button",
+            }
+        ],
+        "container": {"channel_id": "container_channel", "message_ts": "987.654"},
+        "user": {"id": "user_id"},
+    }
+    incident_alert.handle_incident_action_buttons(
+        client,
+        ack,
+        body,
+    )
+    incident_mock.open_create_incident_modal.assert_called_with(
+        client,
+        ack,
+        {
+            "text": "incident_id",
+            "private_metadata": {
+                "source_channel_id": "container_channel",
+                "source_message_ts": "987.654",
+            },
+        },
+        body,
     )
     log_to_sentinel_mock.assert_called_with("call_incident_button_pressed", body)
 

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -17,6 +17,31 @@ def helper_generate_default_incident_params():
     )
 
 
+def _mock_successful_dependencies(
+    mock_incident_folder,
+    mock_incident_document,
+    mock_google_meet,
+    mock_db_operations,
+    mock_get_on_call_users_from_folder,
+):
+    mock_get_on_call_users_from_folder.return_value = [
+        {
+            "id": "U12345",
+            "profile": {
+                "display_name_normalized": "test user name",
+            },
+        },
+    ]
+    mock_google_meet.create_space.return_value = {
+        "meetingUri": "https://meet.google.com/aaa-bbbb-ccc",
+    }
+    mock_incident_document.create_incident_document.return_value = "document_id"
+    mock_incident_folder.list_incident_folders.return_value = [
+        {"id": "folder", "name": "Team Name"},
+    ]
+    mock_db_operations.create_incident.return_value = "incident_id"
+
+
 @patch("modules.incident.core.INCIDENT_CHANNEL", "incident-channel")
 @patch("modules.incident.core.logger")
 @patch("modules.incident.core.on_call.get_on_call_users_from_folder")
@@ -200,6 +225,81 @@ _Type_ `/sre incident help` _for complete command list_"""
     )
     mock_logger.info.assert_any_call(
         "incident_record_created", incident_id="incident_id"
+    )
+
+
+@patch("modules.incident.core.logger")
+@patch("modules.incident.core.on_call.get_on_call_users_from_folder")
+@patch("modules.incident.core.db_operations")
+@patch("modules.incident.core.meet")
+@patch("modules.incident.core.incident_document")
+@patch("modules.incident.core.incident_folder")
+def test_initiate_resources_creation_adds_source_alert_link(
+    mock_incident_folder,
+    mock_incident_document,
+    mock_google_meet,
+    mock_db_operations,
+    mock_get_on_call_users_from_folder,
+    _mock_logger,
+):
+    incident_payload = helper_generate_default_incident_params()
+    incident_payload.source_alert_permalink = "https://slack/source"
+    client = MagicMock()
+    _mock_successful_dependencies(
+        mock_incident_folder,
+        mock_incident_document,
+        mock_google_meet,
+        mock_db_operations,
+        mock_get_on_call_users_from_folder,
+    )
+
+    core.initiate_resources_creation(client, incident_payload)
+
+    client.bookmarks_add.assert_any_call(
+        channel_id="channel_id",
+        title="Source alert",
+        type="link",
+        link="https://slack/source",
+    )
+    client.chat_postMessage.assert_any_call(
+        text="Source alert: <https://slack/source|View original alert>",
+        channel="channel_id",
+    )
+
+
+@patch("modules.incident.core.logger")
+@patch("modules.incident.core.on_call.get_on_call_users_from_folder")
+@patch("modules.incident.core.db_operations")
+@patch("modules.incident.core.meet")
+@patch("modules.incident.core.incident_document")
+@patch("modules.incident.core.incident_folder")
+def test_initiate_resources_creation_skips_source_alert_link_when_missing(
+    mock_incident_folder,
+    mock_incident_document,
+    mock_google_meet,
+    mock_db_operations,
+    mock_get_on_call_users_from_folder,
+    _mock_logger,
+):
+    incident_payload = helper_generate_default_incident_params()
+    client = MagicMock()
+    _mock_successful_dependencies(
+        mock_incident_folder,
+        mock_incident_document,
+        mock_google_meet,
+        mock_db_operations,
+        mock_get_on_call_users_from_folder,
+    )
+
+    core.initiate_resources_creation(client, incident_payload)
+
+    assert not any(
+        call.kwargs.get("title") == "Source alert"
+        for call in client.bookmarks_add.call_args_list
+    )
+    assert not any(
+        call.kwargs.get("text", "").startswith("Source alert:")
+        for call in client.chat_postMessage.call_args_list
     )
 
 


### PR DESCRIPTION
# Summary | Résumé

Closes #951

This pull request introduces support for linking an incident to its originating alert in Slack, making it easier to trace incidents back to their source messages. The changes propagate alert source metadata through the incident creation flow, add the source alert permalink to the incident payload, and update the Slack channel with a bookmark and message referencing the original alert. Comprehensive tests have been added to ensure correct handling of the new feature and edge cases.

**Incident Source Alert Linking**

- The `IncidentPayload` model now includes an optional `source_alert_permalink` field to store the Slack permalink of the originating alert.
- During incident creation, the system extracts alert source metadata (channel and message timestamp) and attempts to resolve it to a Slack permalink, storing it in the incident payload. [[1]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32L106-R144) [[2]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32R178-L146) [[3]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32R231) [[4]](diffhunk://#diff-cbdd84e728b6fcb70433e9cd7ef07ef5da0e6ce65cff93e3cb74ec033178a38fR9-R36)
- When an incident is created, if a `source_alert_permalink` is present, the system adds a "Source alert" bookmark and posts a message in the incident channel linking to the original alert.

**Metadata Handling and Modal Updates**

- The incident creation modal now properly passes and serializes the source alert metadata through its `private_metadata` field, ensuring this context is available throughout the workflow. [[1]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32L56-R62) [[2]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32L83-R86) [[3]](diffhunk://#diff-31dcc35b8acfe6df8d06afb8389f9647c4876f40faa4c9f490ac972586d04d32L106-R144) [[4]](diffhunk://#diff-cbdd84e728b6fcb70433e9cd7ef07ef5da0e6ce65cff93e3cb74ec033178a38fR9-R36)
- Fallback logic ensures that if the source channel/message is not present at the top level of the event body, it is retrieved from the `container` field. [[1]](diffhunk://#diff-cbdd84e728b6fcb70433e9cd7ef07ef5da0e6ce65cff93e3cb74ec033178a38fR9-R36) [[2]](diffhunk://#diff-32b34cf9bd6ab3d39d7e4add50ea0e24bf2c01d41a6c2fbba17e069f33d4ebbeL28-R77)

**Testing Enhancements**

- New and updated tests verify that the source alert metadata is correctly passed, the permalink is resolved and attached to the incident, and the Slack channel is updated as expected. Tests also cover malformed metadata and error handling. [[1]](diffhunk://#diff-5590246191532685e32f212cfd832cd5d43b82eb6c6e27557d4f6cb130032c3dR51-R86) [[2]](diffhunk://#diff-5590246191532685e32f212cfd832cd5d43b82eb6c6e27557d4f6cb130032c3dL166-R211) [[3]](diffhunk://#diff-5590246191532685e32f212cfd832cd5d43b82eb6c6e27557d4f6cb130032c3dR293-R421) [[4]](diffhunk://#diff-32b34cf9bd6ab3d39d7e4add50ea0e24bf2c01d41a6c2fbba17e069f33d4ebbeR20-R21) [[5]](diffhunk://#diff-32b34cf9bd6ab3d39d7e4add50ea0e24bf2c01d41a6c2fbba17e069f33d4ebbeL28-R77) [[6]](diffhunk://#diff-9e4d1e2c0820f2b3cf352d8e97e849d4b9f5922cc68597a35287a4c2d18475f5R231-R305)
- Helper functions and mocks were added to facilitate testing of the new alert-linking logic. [[1]](diffhunk://#diff-9e4d1e2c0820f2b3cf352d8e97e849d4b9f5922cc68597a35287a4c2d18475f5R20-R44) [[2]](diffhunk://#diff-9e4d1e2c0820f2b3cf352d8e97e849d4b9f5922cc68597a35287a4c2d18475f5R231-R305) [[3]](diffhunk://#diff-5590246191532685e32f212cfd832cd5d43b82eb6c6e27557d4f6cb130032c3dL437-R608)

These changes improve incident traceability and streamline workflows by making it easy for responders to reference the original alert that triggered an incident.

With attached alert:

<img width="709" height="321" alt="Capture d’écran, le 2026-05-21 à 11 43 18" src="https://github.com/user-attachments/assets/a5cc5d0d-6d46-4f0f-aadc-6be12284a511" />

<img width="222" height="259" alt="Capture d’écran, le 2026-05-21 à 11 43 31" src="https://github.com/user-attachments/assets/6f2aba63-ab60-49f9-8f88-722d4655ef14" />

With no alert:

<img width="520" height="109" alt="Capture d’écran, le 2026-05-21 à 11 43 22" src="https://github.com/user-attachments/assets/b37a62ce-d482-4715-9182-d206450850dd" />

<img width="207" height="210" alt="Capture d’écran, le 2026-05-21 à 11 43 36" src="https://github.com/user-attachments/assets/4ea61302-06a4-437f-a227-875f78383211" />
