### PR TITLE
[codex] Link webhook IPs to geolocation

### DIFF
--- a/app/api/v1/routes/webhooks.py
+++ b/app/api/v1/routes/webhooks.py
@@ -10,7 +10,7 @@ from integrations.sentinel import log_to_sentinel
 from models.webhooks import WebhookPayload
 from modules.slack import webhooks
 from modules.webhooks.base import handle_webhook_payload
-from modules.webhooks.slack import map_emails_to_slack_users
+from modules.webhooks.slack import hydrate_ip_addresses, map_emails_to_slack_users
 
 
 logger = structlog.get_logger()
@@ -89,6 +89,7 @@ def handle_webhook(
     ):
         webhook_payload = webhook_result.payload
         webhook_payload = map_emails_to_slack_users(webhook_payload)
+        webhook_payload = hydrate_ip_addresses(webhook_payload)
         webhook_payload.channel = webhook["channel"]["S"]
         hook_type = webhook.get("hook_type", {}).get(
             "S", "alert"

--- a/app/modules/webhooks/slack.py
+++ b/app/modules/webhooks/slack.py
@@ -57,7 +57,7 @@ def link_ip_addresses_to_geolocate(text: str, base_url: str | None = None) -> st
         except ValueError:
             return ip_address
 
-        return _geolocate_url(ip_address, base_url)
+        return f"<{_geolocate_url(ip_address, base_url)}|{ip_address}>"
 
     return IP_ADDRESS_PATTERN.sub(replace_match, text)
 

--- a/app/modules/webhooks/slack.py
+++ b/app/modules/webhooks/slack.py
@@ -57,7 +57,7 @@ def link_ip_addresses_to_geolocate(text: str, base_url: str | None = None) -> st
         except ValueError:
             return ip_address
 
-        return f"<{_geolocate_url(ip_address, base_url)}|{ip_address}>"
+        return _geolocate_url(ip_address, base_url)
 
     return IP_ADDRESS_PATTERN.sub(replace_match, text)
 

--- a/app/modules/webhooks/slack.py
+++ b/app/modules/webhooks/slack.py
@@ -1,8 +1,23 @@
+import ipaddress
+import re
+from urllib.parse import quote
+
+from infrastructure.configuration import get_settings
 from integrations.slack.users import (
     replace_users_emails_in_dict,
     replace_users_emails_with_mention,
 )
 from models.webhooks import WebhookPayload
+
+IP_ADDRESS_PATTERN = re.compile(
+    r"(?<![\w./:-])"
+    r"("
+    r"(?:\d{1,3}\.){3}\d{1,3}"
+    r"|"
+    r"(?:[0-9A-Fa-f]{1,4}:){2,}[0-9A-Fa-f:.]*"
+    r")"
+    r"(?![\w/:-])"
+)
 
 
 def map_emails_to_slack_users(webhook_payload: WebhookPayload) -> WebhookPayload:
@@ -12,4 +27,57 @@ def map_emails_to_slack_users(webhook_payload: WebhookPayload) -> WebhookPayload
         webhook_payload.text = replace_users_emails_with_mention(webhook_payload.text)
     if webhook_payload.blocks:
         webhook_payload.blocks = replace_users_emails_in_dict(webhook_payload.blocks)
+    return webhook_payload
+
+
+def _is_inside_slack_link(text: str, start: int) -> bool:
+    last_open = text.rfind("<", 0, start)
+    last_close = text.rfind(">", 0, start)
+    return last_open > last_close
+
+
+def _geolocate_url(ip_address: str, base_url: str | None = None) -> str:
+    if base_url is None:
+        base_url = get_settings().server.BACKEND_URL
+    return (
+        f"{base_url.rstrip('/')}/v1/geolocate?ip_address={quote(ip_address, safe='')}"
+    )
+
+
+def link_ip_addresses_to_geolocate(text: str, base_url: str | None = None) -> str:
+    """Replace valid IP addresses in Slack text with geolocation links."""
+
+    def replace_match(match: re.Match) -> str:
+        ip_address = match.group(1)
+        if _is_inside_slack_link(text, match.start(1)):
+            return ip_address
+
+        try:
+            ipaddress.ip_address(ip_address)
+        except ValueError:
+            return ip_address
+
+        return f"<{_geolocate_url(ip_address, base_url)}|{ip_address}>"
+
+    return IP_ADDRESS_PATTERN.sub(replace_match, text)
+
+
+def link_ip_addresses_in_dict(data, base_url: str | None = None):
+    """Recursively replace IP addresses in all string values with Slack links."""
+    if isinstance(data, dict):
+        return {k: link_ip_addresses_in_dict(v, base_url) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [link_ip_addresses_in_dict(item, base_url) for item in data]
+    elif isinstance(data, str):
+        return link_ip_addresses_to_geolocate(data, base_url)
+    else:
+        return data
+
+
+def hydrate_ip_addresses(webhook_payload: WebhookPayload) -> WebhookPayload:
+    """Link IP addresses in a Slack webhook payload to the geolocation endpoint."""
+    if isinstance(webhook_payload.text, str) and webhook_payload.text:
+        webhook_payload.text = link_ip_addresses_to_geolocate(webhook_payload.text)
+    if isinstance(webhook_payload.blocks, (dict, list)) and webhook_payload.blocks:
+        webhook_payload.blocks = link_ip_addresses_in_dict(webhook_payload.blocks)
     return webhook_payload

--- a/app/modules/webhooks/slack.py
+++ b/app/modules/webhooks/slack.py
@@ -39,9 +39,7 @@ def _is_inside_slack_link(text: str, start: int) -> bool:
 def _geolocate_url(ip_address: str, base_url: str | None = None) -> str:
     if base_url is None:
         base_url = get_settings().server.BACKEND_URL
-    return (
-        f"{base_url.rstrip('/')}/v1/geolocate?ip_address={quote(ip_address, safe='')}"
-    )
+    return f"{base_url.rstrip('/')}/geolocate/{quote(ip_address, safe='')}"
 
 
 def link_ip_addresses_to_geolocate(text: str, base_url: str | None = None) -> str:

--- a/app/tests/modules/webhooks/test_webhooks_slack.py
+++ b/app/tests/modules/webhooks/test_webhooks_slack.py
@@ -81,7 +81,7 @@ def test_link_ip_addresses_to_geolocate():
 
     assert (
         result
-        == "source https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8 hit https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1"
+        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8> hit <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>"
     )
 
 
@@ -111,7 +111,7 @@ def test_link_ip_addresses_to_geolocate_supports_ipv6():
 
     assert (
         result
-        == "resolver https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888"
+        == "resolver <https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888|2001:4860:4860::8888>"
     )
 
 
@@ -134,14 +134,14 @@ def test_hydrate_ip_addresses_links_text_and_block_strings():
 
     assert (
         result.text
-        == "source https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8"
+        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8>"
     )
     assert result.blocks == [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "destination https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1",
+                "text": "destination <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>",
             },
         }
     ]

--- a/app/tests/modules/webhooks/test_webhooks_slack.py
+++ b/app/tests/modules/webhooks/test_webhooks_slack.py
@@ -81,7 +81,7 @@ def test_link_ip_addresses_to_geolocate():
 
     assert (
         result
-        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8> hit <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>"
+        == "source https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8 hit https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1"
     )
 
 
@@ -111,7 +111,7 @@ def test_link_ip_addresses_to_geolocate_supports_ipv6():
 
     assert (
         result
-        == "resolver <https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888|2001:4860:4860::8888>"
+        == "resolver https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888"
     )
 
 
@@ -134,14 +134,14 @@ def test_hydrate_ip_addresses_links_text_and_block_strings():
 
     assert (
         result.text
-        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8>"
+        == "source https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8"
     )
     assert result.blocks == [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "destination <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>",
+                "text": "destination https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1",
             },
         }
     ]

--- a/app/tests/modules/webhooks/test_webhooks_slack.py
+++ b/app/tests/modules/webhooks/test_webhooks_slack.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
 from models.webhooks import WebhookPayload
-from modules.webhooks.slack import map_emails_to_slack_users
+from modules.webhooks.slack import (
+    hydrate_ip_addresses,
+    link_ip_addresses_to_geolocate,
+    map_emails_to_slack_users,
+)
 
 
 @patch("modules.webhooks.slack.replace_users_emails_with_mention")
@@ -67,3 +71,77 @@ def test_map_emails_to_slack_users_empty_text_and_blocks(
     assert not result.blocks
     mock_replace_users_emails_with_mention.assert_not_called()
     mock_replace_users_emails_in_dict.assert_not_called()
+
+
+def test_link_ip_addresses_to_geolocate():
+    result = link_ip_addresses_to_geolocate(
+        "source 8.8.8.8 hit 1.1.1.1",
+        base_url="https://sre-bot.example.com/",
+    )
+
+    assert (
+        result
+        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8> hit <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>"
+    )
+
+
+def test_link_ip_addresses_to_geolocate_ignores_invalid_ip_and_urls():
+    result = link_ip_addresses_to_geolocate(
+        "invalid 999.999.999.999 url https://8.8.8.8/path",
+        base_url="https://sre-bot.example.com",
+    )
+
+    assert result == "invalid 999.999.999.999 url https://8.8.8.8/path"
+
+
+def test_link_ip_addresses_to_geolocate_ignores_existing_slack_links():
+    result = link_ip_addresses_to_geolocate(
+        "already <https://example.com|8.8.8.8>",
+        base_url="https://sre-bot.example.com",
+    )
+
+    assert result == "already <https://example.com|8.8.8.8>"
+
+
+def test_link_ip_addresses_to_geolocate_supports_ipv6():
+    result = link_ip_addresses_to_geolocate(
+        "resolver 2001:4860:4860::8888",
+        base_url="https://sre-bot.example.com",
+    )
+
+    assert (
+        result
+        == "resolver <https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888|2001:4860:4860::8888>"
+    )
+
+
+def test_hydrate_ip_addresses_links_text_and_block_strings():
+    payload = WebhookPayload(
+        text="source 8.8.8.8",
+        blocks=[
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "destination 1.1.1.1"},
+            }
+        ],
+    )
+
+    with patch("modules.webhooks.slack.get_settings") as mock_get_settings:
+        mock_get_settings.return_value.server.BACKEND_URL = (
+            "https://sre-bot.example.com"
+        )
+        result = hydrate_ip_addresses(payload)
+
+    assert (
+        result.text
+        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8>"
+    )
+    assert result.blocks == [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "destination <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>",
+            },
+        }
+    ]

--- a/app/tests/modules/webhooks/test_webhooks_slack.py
+++ b/app/tests/modules/webhooks/test_webhooks_slack.py
@@ -81,7 +81,7 @@ def test_link_ip_addresses_to_geolocate():
 
     assert (
         result
-        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8> hit <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>"
+        == "source <https://sre-bot.example.com/geolocate/8.8.8.8|8.8.8.8> hit <https://sre-bot.example.com/geolocate/1.1.1.1|1.1.1.1>"
     )
 
 
@@ -111,7 +111,7 @@ def test_link_ip_addresses_to_geolocate_supports_ipv6():
 
     assert (
         result
-        == "resolver <https://sre-bot.example.com/v1/geolocate?ip_address=2001%3A4860%3A4860%3A%3A8888|2001:4860:4860::8888>"
+        == "resolver <https://sre-bot.example.com/geolocate/2001%3A4860%3A4860%3A%3A8888|2001:4860:4860::8888>"
     )
 
 
@@ -133,15 +133,14 @@ def test_hydrate_ip_addresses_links_text_and_block_strings():
         result = hydrate_ip_addresses(payload)
 
     assert (
-        result.text
-        == "source <https://sre-bot.example.com/v1/geolocate?ip_address=8.8.8.8|8.8.8.8>"
+        result.text == "source <https://sre-bot.example.com/geolocate/8.8.8.8|8.8.8.8>"
     )
     assert result.blocks == [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "destination <https://sre-bot.example.com/v1/geolocate?ip_address=1.1.1.1|1.1.1.1>",
+                "text": "destination <https://sre-bot.example.com/geolocate/1.1.1.1|1.1.1.1>",
             },
         }
     ]


### PR DESCRIPTION
## Summary
- hydrate IP addresses in webhook Slack payload text and blocks with links to the geolocation endpoint
- validate candidate IPv4/IPv6 addresses before linking
- avoid rewriting IPs inside URLs or existing Slack links

Fixes #1214

## Testing
- .venv/bin/python -m ruff check api/v1/routes/webhooks.py modules/webhooks/slack.py tests/modules/webhooks/test_webhooks_slack.py
- .venv/bin/python -m pytest tests/modules/webhooks tests/api/v1/test_webhooks.py