### PR TITLE
fix: set the BACKEND_URL env

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -15,6 +15,7 @@ data "template_file" "sre-bot" {
     awslogs-region                   = "ca-central-1"
     awslogs-stream-prefix            = "ecs-sre-bot"
     image                            = "${aws_ecr_repository.sre-bot.repository_url}:latest"
+    backend_url                      = "https://${aws_route53_zone.sre_bot.name}"
     fargate_cpu                      = var.fargate_cpu
     fargate_memory                   = var.fargate_memory
     aws_region                       = "ca-central-1"

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -39,7 +39,12 @@
       }
     ],
     "cpu": 0,
-    "environment": [],
+    "environment": [
+      {
+        "name": "BACKEND_URL",
+        "value": "${backend_url}"
+      }
+    ],
     "essential": true,
     "mountPoints": [],
     "systemControls": [],


### PR DESCRIPTION
Closes #1218 

This pull request updates the configuration for the `sre-bot` service to ensure the backend URL is properly set and passed as an environment variable to the container. The main changes involve defining and wiring up the `BACKEND_URL` environment variable in the ECS task definition.

Configuration improvements:

* Added a `backend_url` variable to the `template_file` data source in `terraform/ecs.tf`, setting its value to the Route53 zone name for the SRE bot.
* Updated the ECS task definition template (`sre-bot.json.tpl`) to include the `BACKEND_URL` environment variable, passing the value from the new `backend_url` variable.