### PR TITLE
feat: Adds links to open maps based on geo coordinates

### DIFF
--- a/app/api/v1/routes/geolocate.py
+++ b/app/api/v1/routes/geolocate.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from integrations import maxmind
 from infrastructure.security import get_limiter
+from packages.geolocate.schemas import build_open_source_map_links
 
 router = APIRouter(tags=["Geolocation"])
 limiter = get_limiter()
@@ -19,4 +20,8 @@ def geolocate(ip):
             "city": city,
             "latitude": latitude,
             "longitude": longitude,
+            "map_links": build_open_source_map_links(
+                latitude=latitude,
+                longitude=longitude,
+            ).model_dump(),
         }

--- a/app/packages/geolocate/platforms/slack.py
+++ b/app/packages/geolocate/platforms/slack.py
@@ -121,12 +121,17 @@ def _format_success_blocks(
     if data.postal_code:
         label = t("geolocate.result.postal_code_label", locale, "Postal Code")
         fields.append({"type": "mrkdwn", "text": f"*{label}:*\n{data.postal_code}"})
-    if data.latitude and data.longitude:
+    if data.latitude is not None and data.longitude is not None:
         label = t("geolocate.result.coordinates_label", locale, "Coordinates")
+        coordinates_text = f"{data.latitude}, {data.longitude}"
+        if data.map_links:
+            coordinates_text = (
+                f"{coordinates_text}\n<{data.map_links.openstreetmap}|OpenStreetMap>"
+            )
         fields.append(
             {
                 "type": "mrkdwn",
-                "text": f"*{label}:*\n{data.latitude}, {data.longitude}",
+                "text": f"*{label}:*\n{coordinates_text}",
             }
         )
     if data.time_zone:

--- a/app/packages/geolocate/schemas.py
+++ b/app/packages/geolocate/schemas.py
@@ -3,7 +3,7 @@
 import ipaddress
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class GeolocateRequest(BaseModel):
@@ -26,6 +26,21 @@ class GeolocateRequest(BaseModel):
             raise ValueError(f"Invalid IP address format: {v}")
 
 
+class OpenSourceMapLinks(BaseModel):
+    """Open-source map links for a coordinate pair."""
+
+    openstreetmap: str = Field(..., description="OpenStreetMap URL for the coordinates")
+    opentopomap: str = Field(..., description="OpenTopoMap URL for the coordinates")
+
+
+def build_open_source_map_links(latitude: float, longitude: float) -> OpenSourceMapLinks:
+    """Build links to open-source mapping sites for a coordinate pair."""
+    return OpenSourceMapLinks(
+        openstreetmap=f"https://www.openstreetmap.org/?mlat={latitude}&mlon={longitude}#map=12/{latitude}/{longitude}",
+        opentopomap=f"https://opentopomap.org/#map=12/{latitude}/{longitude}",
+    )
+
+
 class GeolocateResponse(BaseModel):
     """Response from IP geolocation."""
 
@@ -38,6 +53,10 @@ class GeolocateResponse(BaseModel):
                 "country_code": "US",
                 "latitude": 37.386,
                 "longitude": -122.0838,
+                "map_links": {
+                    "openstreetmap": "https://www.openstreetmap.org/?mlat=37.386&mlon=-122.0838#map=12/37.386/-122.0838",
+                    "opentopomap": "https://opentopomap.org/#map=12/37.386/-122.0838",
+                },
                 "postal_code": "94035",
                 "time_zone": "America/Los_Angeles",
             }
@@ -50,5 +69,19 @@ class GeolocateResponse(BaseModel):
     country_code: Optional[str] = Field(None, description="ISO country code")
     latitude: Optional[float] = Field(None, description="Latitude")
     longitude: Optional[float] = Field(None, description="Longitude")
+    map_links: Optional[OpenSourceMapLinks] = Field(
+        None,
+        description="Links to open-source mapping sites for the coordinates",
+    )
     postal_code: Optional[str] = Field(None, description="Postal/ZIP code")
     time_zone: Optional[str] = Field(None, description="IANA time zone")
+
+    @model_validator(mode="after")
+    def populate_map_links(self) -> "GeolocateResponse":
+        """Populate map links when both coordinates are present."""
+        if self.latitude is not None and self.longitude is not None and self.map_links is None:
+            self.map_links = build_open_source_map_links(
+                latitude=self.latitude,
+                longitude=self.longitude,
+            )
+        return self

--- a/app/packages/geolocate/schemas.py
+++ b/app/packages/geolocate/schemas.py
@@ -33,7 +33,9 @@ class OpenSourceMapLinks(BaseModel):
     opentopomap: str = Field(..., description="OpenTopoMap URL for the coordinates")
 
 
-def build_open_source_map_links(latitude: float, longitude: float) -> OpenSourceMapLinks:
+def build_open_source_map_links(
+    latitude: float, longitude: float
+) -> OpenSourceMapLinks:
     """Build links to open-source mapping sites for a coordinate pair."""
     return OpenSourceMapLinks(
         openstreetmap=f"https://www.openstreetmap.org/?mlat={latitude}&mlon={longitude}#map=12/{latitude}/{longitude}",
@@ -79,7 +81,11 @@ class GeolocateResponse(BaseModel):
     @model_validator(mode="after")
     def populate_map_links(self) -> "GeolocateResponse":
         """Populate map links when both coordinates are present."""
-        if self.latitude is not None and self.longitude is not None and self.map_links is None:
+        if (
+            self.latitude is not None
+            and self.longitude is not None
+            and self.map_links is None
+        ):
             self.map_links = build_open_source_map_links(
                 latitude=self.latitude,
                 longitude=self.longitude,

--- a/app/tests/api/v1/test_geolocate.py
+++ b/app/tests/api/v1/test_geolocate.py
@@ -8,15 +8,19 @@ test_app = create_test_app(geolocate.router)
 
 @patch("api.v1.routes.geolocate.maxmind.geolocate")
 def test_geolocate_success(mock_geolocate):
-    mock_geolocate.return_value = "country", "city", "latitude", "longitude"
+    mock_geolocate.return_value = "country", "city", 0, 0
     with TestClient(test_app) as client:
         response = client.get("/geolocate/111.111.111.111")
         assert response.status_code == 200
         assert response.json() == {
             "country": "country",
             "city": "city",
-            "latitude": "latitude",
-            "longitude": "longitude",
+            "latitude": 0,
+            "longitude": 0,
+            "map_links": {
+                "openstreetmap": "https://www.openstreetmap.org/?mlat=0&mlon=0#map=12/0/0",
+                "opentopomap": "https://opentopomap.org/#map=12/0/0",
+            },
         }
 
 

--- a/app/tests/integration/packages/geolocate/test_geolocate_routes.py
+++ b/app/tests/integration/packages/geolocate/test_geolocate_routes.py
@@ -28,6 +28,32 @@ def test_get_geolocate_success(client):
         data = response.json()
         assert data["ip_address"] == "8.8.8.8"
         assert data["city"] == "Mountain View"
+        assert data["map_links"] == {
+            "openstreetmap": "https://www.openstreetmap.org/?mlat=37.386&mlon=-122.0838#map=12/37.386/-122.0838",
+            "opentopomap": "https://opentopomap.org/#map=12/37.386/-122.0838",
+        }
+
+
+@pytest.mark.integration
+def test_get_geolocate_success_without_coordinates_has_no_map_links(client):
+    """Test successful geolocation without coordinates omits map links."""
+    mock_result = OperationResult.success(
+        data={
+            "city": "Mountain View",
+            "country": "United States",
+            "country_code": "US",
+            "latitude": None,
+            "longitude": -122.0838,
+        }
+    )
+
+    with patch("packages.geolocate.routes.geolocate_ip") as mock_geolocate:
+        mock_geolocate.return_value = mock_result
+
+        response = client.get("/v1/geolocate?ip_address=8.8.8.8")
+
+        assert response.status_code == 200
+        assert response.json()["map_links"] is None
 
 
 @pytest.mark.integration

--- a/app/tests/unit/packages/geolocate/platforms/test_slack.py
+++ b/app/tests/unit/packages/geolocate/platforms/test_slack.py
@@ -36,6 +36,10 @@ def test_handle_geolocate_command_success():
         assert isinstance(result, CommandResponse)
         assert result.ephemeral is False
         assert result.blocks is not None
+        assert (
+            "<https://www.openstreetmap.org/?mlat=37.386&mlon=-122.0838#map=12/37.386/-122.0838|OpenStreetMap>"
+            in result.blocks[1]["fields"][2]["text"]
+        )
         mock_service.assert_called_once_with(ip_address="8.8.8.8")
 
 

--- a/app/tests/unit/packages/geolocate/test_slack.py
+++ b/app/tests/unit/packages/geolocate/test_slack.py
@@ -32,6 +32,10 @@ def test_handle_geolocate_command_success():
         assert isinstance(result, CommandResponse)
         assert result.ephemeral is False
         assert result.blocks is not None
+        assert (
+            "<https://www.openstreetmap.org/?mlat=37.386&mlon=-122.0838#map=12/37.386/-122.0838|OpenStreetMap>"
+            in result.blocks[1]["fields"][2]["text"]
+        )
         mock_service.assert_called_once_with(ip_address="8.8.8.8")
 
 


### PR DESCRIPTION
This pull request enhances the geolocation API and related Slack integration by adding open-source map links (OpenStreetMap and OpenTopoMap) to geolocation responses when latitude and longitude are available. It introduces a new schema for map links, updates API responses and Slack messages, and adds comprehensive tests to ensure correct behavior.

**Geolocation API and Schema Enhancements:**

- Added a new `OpenSourceMapLinks` schema and a `build_open_source_map_links` utility to generate OpenStreetMap and OpenTopoMap URLs for given coordinates. The geolocation API now includes a `map_links` field in responses when both latitude and longitude are present. (`app/packages/geolocate/schemas.py`, `app/api/v1/routes/geolocate.py`) [[1]](diffhunk://#diff-c5a2bf1b58df8f691603375c470d7bc31b05473be28da39d194119cd05b51d44R29-R43) [[2]](diffhunk://#diff-c5a2bf1b58df8f691603375c470d7bc31b05473be28da39d194119cd05b51d44R56-R59) [[3]](diffhunk://#diff-c5a2bf1b58df8f691603375c470d7bc31b05473be28da39d194119cd05b51d44R72-R87) [[4]](diffhunk://#diff-1d17bc77e80dc91aac882d0a8e87defb0ff8ec08e4594f6595d5bde630df0c18R4) [[5]](diffhunk://#diff-1d17bc77e80dc91aac882d0a8e87defb0ff8ec08e4594f6595d5bde630df0c18R23-R26)
- Updated the geolocation response model to automatically populate `map_links` when coordinates are available, using a Pydantic model validator. (`app/packages/geolocate/schemas.py`)

**Slack Integration Improvements:**

- Modified the Slack formatting logic to display an OpenStreetMap link alongside coordinates if `map_links` is present, improving the user experience for location lookups. (`app/packages/geolocate/platforms/slack.py`)

**Testing and Validation:**

- Expanded and updated API and integration tests to verify the presence and correctness of `map_links` in geolocation responses, including cases where coordinates are missing (ensuring `map_links` is omitted). (`app/tests/api/v1/test_geolocate.py`, `app/tests/integration/packages/geolocate/test_geolocate_routes.py`) [[1]](diffhunk://#diff-5e4e48547d1a1908d12a5ddc2057d5d6857bf5c291eed147868f8a913e4f5434L11-R23) [[2]](diffhunk://#diff-2d8e1ea41022a5f7bf1cae6f8592a0922f5c0facf6124de6baadc65854b31314R31-R56)
- Updated Slack integration unit tests to assert that the OpenStreetMap link appears in the message when appropriate. (`app/tests/unit/packages/geolocate/platforms/test_slack.py`, `app/tests/unit/packages/geolocate/test_slack.py`) [[1]](diffhunk://#diff-f66845f8053c36cabe79e080ed5e846c3553fc5b2b881f60b85c7c083556f795R39-R42) [[2]](diffhunk://#diff-4b8ce024bb87d8b8b44ccd317c5e791e820c487db8fceff64e2d78c265b514e7R35-R38)