### PR TITLE
feat(waf): add scope down statement to exclude webhooks paths from IP…

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -114,6 +114,24 @@ resource "aws_wafv2_web_acl" "sre-bot" {
       managed_rule_group_statement {
         vendor_name = "AWS"
         name        = "AWSManagedRulesAmazonIpReputationList"
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                search_string = "/hook/"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+                positional_constraint = "STARTS_WITH"
+              }
+            }
+          }
+        }
       }
     }
 

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -51,6 +51,23 @@ resource "aws_wafv2_web_acl" "sre-bot" {
       managed_rule_group_statement {
         vendor_name = "AWS"
         name        = "AWSManagedRulesCommonRuleSet"
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                search_string = "/hook/"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+                positional_constraint = "STARTS_WITH"
+              }
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a targeted adjustment to the AWS WAFv2 Web ACL configuration for the `sre-bot` resource. The change adds a scope-down statement to the `AWSManagedRulesAmazonIpReputationList` managed rule group, specifically excluding requests with URIs that start with `/hook/` from being blocked by this rule group.

**WAF rule customization:**

* Added a `scope_down_statement` with a `not_statement` to the `AWSManagedRulesAmazonIpReputationList` rule, so that requests where the URI path starts with `/hook/` are not affected by this rule group.