### PR TITLE
feat: adds a dynamo db alert handler

### DIFF
--- a/app/modules/webhooks/patterns/aws_sns_notification/README.md
+++ b/app/modules/webhooks/patterns/aws_sns_notification/README.md
@@ -38,6 +38,7 @@ The following pattern handlers have been implemented:
 | ---------------------- | -------- | --------------------------- | --------------------------------------------- |
 | API Key Detected       | 60       | `api_key_detected.py`       | Handles compromised API key notifications     |
 | Step Functions         | 55       | `step_functions.py`         | Handles Step Functions execution notifications |
+| DynamoDB Access        | 55       | `dynamodb_access.py`        | Handles unexpected DynamoDB access alerts     |
 | CloudWatch Alarm       | 50       | `cloudwatch_alarm.py`       | Handles CloudWatch alarm notifications        |
 | Abuse Notification     | 45       | `abuse_notification.py`     | Handles AWS abuse reports                     |
 | Budget Notification    | 40       | `budget_notification.py`    | Handles budget threshold alerts               |

--- a/app/modules/webhooks/patterns/aws_sns_notification/dynamodb_access.py
+++ b/app/modules/webhooks/patterns/aws_sns_notification/dynamodb_access.py
@@ -1,0 +1,116 @@
+import json
+import re
+from typing import Dict, List, Union
+
+from slack_sdk import WebClient
+
+from models.webhooks import AwsSnsPayload
+from modules.webhooks.aws_sns_notification import AwsNotificationPattern
+
+
+def _message_text(payload: AwsSnsPayload) -> str:
+    message = payload.Message or ""
+    try:
+        decoded_message = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        return message
+
+    if isinstance(decoded_message, str):
+        return decoded_message
+    return message
+
+
+def _extract_fields(message: str) -> tuple[str, Dict[str, str]]:
+    lines = [line.strip() for line in message.splitlines() if line.strip()]
+    title = lines[0] if lines else "Unexpected DynamoDB access"
+    fields: Dict[str, str] = {}
+
+    for line in lines[1:]:
+        match = re.match(r"^(?P<key>[A-Za-z ]+):\s*(?P<value>.*)$", line)
+        if not match:
+            continue
+
+        key = match.group("key").strip().lower().replace(" ", "_")
+        fields[key] = match.group("value").strip()
+
+    return title, fields
+
+
+def _field_line(label: str, value: str) -> str:
+    if not value:
+        return ""
+    return f"*{label}:* `{value}`"
+
+
+def handle_dynamodb_access(payload: AwsSnsPayload, client: WebClient) -> List[Dict]:
+    """
+    Handle unexpected DynamoDB access notifications from AWS SNS.
+
+    The incoming SNS Message may be a JSON-encoded string, so decode it before
+    extracting the line-oriented alert details.
+    """
+    message = _message_text(payload)
+    title, fields = _extract_fields(message)
+
+    detail_lines = [
+        _field_line("Event", fields.get("event", "")),
+        _field_line("Principal", fields.get("principal", "")),
+        _field_line(
+            "Source IP",
+            fields.get("source_ip", "") or fields.get("source_ip_address", ""),
+        ),
+        _field_line("Region", fields.get("region", "")),
+        _field_line("Resource", fields.get("resource", "")),
+        _field_line("Time", fields.get("time", "")),
+    ]
+    details = "\n".join(line for line in detail_lines if line)
+
+    blocks = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": " "}},
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": title[:150]},
+        },
+    ]
+
+    if details:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": details},
+            }
+        )
+    else:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": message},
+            }
+        )
+
+    return blocks
+
+
+def is_dynamodb_access(
+    payload: AwsSnsPayload, parsed_message: Union[str, dict]
+) -> bool:
+    """
+    Check if the AWS SNS message is an unexpected DynamoDB access notification.
+    """
+    if isinstance(parsed_message, str):
+        message = parsed_message
+    else:
+        message = _message_text(payload)
+
+    return "Unexpected DynamoDB access" in message
+
+
+DYNAMODB_ACCESS_HANDLER: AwsNotificationPattern = AwsNotificationPattern(
+    name="dynamodb_access",
+    match_type="callable",
+    match_target="parsed_message",
+    pattern="modules.webhooks.patterns.aws_sns_notification.dynamodb_access.is_dynamodb_access",
+    handler="modules.webhooks.patterns.aws_sns_notification.dynamodb_access.handle_dynamodb_access",
+    priority=55,
+    enabled=True,
+)

--- a/app/tests/modules/webhooks/patterns/aws_sns_notifications/test_dynamodb_access.py
+++ b/app/tests/modules/webhooks/patterns/aws_sns_notifications/test_dynamodb_access.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import MagicMock
+
+from models.webhooks import AwsSnsPayload
+from modules.webhooks.aws_sns_notification import (
+    NOTIFICATION_HANDLERS,
+    find_matching_handler,
+    register_notification_pattern,
+)
+from modules.webhooks.patterns.aws_sns_notification import dynamodb_access
+
+
+def dynamodb_access_message():
+    return (
+        "Unexpected DynamoDB access in secret-production\n"
+        "Event: Scan\n"
+        "Principal: arn:aws:sts::637287734259:assumed-role/AWSReservedSSO_AWSAdministratorAccess_187a62b857c9ffd5/max.neuvians@cds-snc.ca\n"
+        "Source IP: 142.114.34.223\n"
+        "Region: ca-central-1\n"
+        "Resource: arn:aws:dynamodb:ca-central-1:637287734259:table/secret-production-table\n"
+        "Time: 2026-06-05T15:51:53Z"
+    )
+
+
+def mock_dynamodb_access():
+    return AwsSnsPayload(
+        Type="Notification",
+        MessageId="587dbeca-445c-571c-b1f3-dc56b6bad9aa",
+        TopicArn="arn:aws:sns:ca-central-1:637287734259:internal-sre-alert",
+        Message=json.dumps(dynamodb_access_message()),
+        Timestamp="2026-06-05T15:52:06.262Z",
+        SignatureVersion="1",
+        Signature="signature",
+        SigningCertURL="https://sns.ca-central-1.amazonaws.com/SimpleNotificationService-7506a1e35b36ef5a444dd1a8e7cc3ed8.pem",
+        UnsubscribeURL="https://sns.ca-central-1.amazonaws.com/?Action=Unsubscribe",
+    )
+
+
+def block_text(blocks):
+    text_parts = []
+    for block in blocks:
+        text = block.get("text")
+        if isinstance(text, dict):
+            text_parts.append(text.get("text", ""))
+    return "\n".join(text_parts)
+
+
+def test_dynamodb_access_handler_formats_message():
+    client = MagicMock()
+    payload = mock_dynamodb_access()
+
+    blocks = dynamodb_access.handle_dynamodb_access(payload, client)
+    rendered_text = block_text(blocks)
+
+    assert (
+        blocks[1]["text"]["text"] == "Unexpected DynamoDB access in secret-production"
+    )
+    assert "Scan" in rendered_text
+    assert "arn:aws:sts::637287734259:assumed-role" in rendered_text
+    assert "142.114.34.223" in rendered_text
+    assert "ca-central-1" in rendered_text
+    assert "secret-production-table" in rendered_text
+    assert "2026-06-05T15:51:53Z" in rendered_text
+
+
+def test_dynamodb_access_matcher_accepts_json_encoded_message():
+    payload = mock_dynamodb_access()
+    parsed_message = json.loads(payload.Message)
+
+    assert dynamodb_access.is_dynamodb_access(payload, parsed_message)
+
+
+def test_dynamodb_access_matcher_accepts_plain_message():
+    payload = mock_dynamodb_access()
+    payload.Message = dynamodb_access_message()
+
+    assert dynamodb_access.is_dynamodb_access(payload, payload.Message)
+
+
+def test_dynamodb_access_matcher_rejects_other_messages():
+    payload = AwsSnsPayload(Message="An IAM User was created in an Account")
+
+    assert not dynamodb_access.is_dynamodb_access(payload, payload.Message)
+
+
+def test_dynamodb_access_registry_pattern_matches():
+    original_handlers = list(NOTIFICATION_HANDLERS)
+    try:
+        NOTIFICATION_HANDLERS.clear()
+        register_notification_pattern(dynamodb_access.DYNAMODB_ACCESS_HANDLER)
+        payload = mock_dynamodb_access()
+        parsed_message = json.loads(payload.Message)
+
+        matched_handler = find_matching_handler(payload, parsed_message)
+
+        assert matched_handler is not None
+        assert matched_handler.name == "dynamodb_access"
+    finally:
+        NOTIFICATION_HANDLERS.clear()
+        NOTIFICATION_HANDLERS.extend(original_handlers)


### PR DESCRIPTION
This pull request adds support for handling unexpected DynamoDB access notifications from AWS SNS. It introduces a new pattern handler, implements the logic for parsing and formatting these alerts, and provides comprehensive tests to ensure correct behavior.

**New DynamoDB Access Notification Handler:**

* Added a new handler for unexpected DynamoDB access alerts to the documentation table in `README.md`.
* Implemented `dynamodb_access.py`, which:
  * Parses SNS messages (including JSON-encoded content) for DynamoDB access events.
  * Extracts relevant fields and formats them for Slack notifications.
  * Provides a matcher to identify relevant messages and registers the handler pattern.

**Testing:**

* Added `test_dynamodb_access.py` with tests for:
  * Correct formatting of Slack message blocks.
  * Matcher logic for both JSON and plain string messages.
  * Handler registration and integration with the notification pattern registry.