### PR TITLE
fix(slack): update Slack client initialization to use SlackSettings

### DIFF
--- a/app/integrations/slack/client.py
+++ b/app/integrations/slack/client.py
@@ -1,5 +1,4 @@
 from slack_sdk import WebClient
-from core.config import settings
 from infrastructure.configuration.integrations.slack import SlackSettings
 
 

--- a/app/integrations/slack/client.py
+++ b/app/integrations/slack/client.py
@@ -1,5 +1,6 @@
 from slack_sdk import WebClient
 from core.config import settings
+from infrastructure.configuration.integrations.slack import SlackSettings
 
 
 class SlackClientManager:
@@ -11,5 +12,6 @@ class SlackClientManager:
     def get_client(cls) -> WebClient:
         """Returns a singleton instance of the Slack WebClient."""
         if cls._client is None:
-            cls._client = WebClient(token=settings.slack.SLACK_TOKEN)
+            slack_settings = SlackSettings()
+            cls._client = WebClient(token=slack_settings.SLACK_TOKEN)
         return cls._client

--- a/app/tests/integrations/slack/test_slack_client.py
+++ b/app/tests/integrations/slack/test_slack_client.py
@@ -4,10 +4,12 @@ from integrations.slack.client import SlackClientManager
 
 
 class TestSlackClientManager(unittest.TestCase):
-    @patch("integrations.slack.client.settings.slack.SLACK_TOKEN", "test-token")
+
+    @patch("integrations.slack.client.SlackSettings", autospec=True)
     @patch("integrations.slack.client.WebClient")
-    def test_get_client_creates_instance(self, mock_web_client):
+    def test_get_client_creates_instance(self, mock_web_client, mock_slack_settings):
         SlackClientManager._client = None  # pylint: disable=protected-access
+        mock_slack_settings.return_value.SLACK_TOKEN = "test-token"
 
         # Call get_client and verify a WebClient instance is created
         client = SlackClientManager.get_client()


### PR DESCRIPTION
# Summary | Résumé

Cleaning up the old settings imports for the SlackClientManager (to be deprecated itself but fixing dependencies first)