### PR TITLE
fix(google_service): refactor to use centralized settings

### DIFF
--- a/app/integrations/google_workspace/google_service.py
+++ b/app/integrations/google_workspace/google_service.py
@@ -21,17 +21,20 @@ import structlog
 from google.oauth2 import service_account  # type: ignore
 from googleapiclient.discovery import Resource, build  # type: ignore
 from googleapiclient.errors import HttpError  # type: ignore
-from integrations.utils.api import convert_kwargs_to_camel_case
-from core.config import settings
 
-# Define the default arguments
-GOOGLE_WORKSPACE_CUSTOMER_ID = settings.google_workspace.GOOGLE_WORKSPACE_CUSTOMER_ID
-GCP_SRE_SERVICE_ACCOUNT_KEY_FILE = (
-    settings.google_workspace.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
+from infrastructure.configuration.integrations.google import (
+    get_google_resources_config,
+    get_google_workspace_settings,
 )
-SRE_BOT_EMAIL = settings.google_workspace.SRE_BOT_EMAIL
-INCIDENT_TEMPLATE = settings.google_resources.incident_template_id
+from integrations.utils.api import convert_kwargs_to_camel_case
 
+# Define the default arguments - do not delete currently used in sibling modules
+settings = get_google_workspace_settings()
+resources = get_google_resources_config()
+GOOGLE_WORKSPACE_CUSTOMER_ID = settings.GOOGLE_WORKSPACE_CUSTOMER_ID
+GCP_SRE_SERVICE_ACCOUNT_KEY_FILE = settings.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
+SRE_BOT_EMAIL = settings.SRE_BOT_EMAIL
+INCIDENT_TEMPLATE = resources.incident_template_id
 logger = structlog.get_logger()
 
 
@@ -54,7 +57,7 @@ def get_google_service(
         Resource: The authenticated Google service resource.
     """
 
-    creds_json = GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
+    creds_json = settings.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
 
     if not creds_json:
         logger.error("credentials_json_missing")
@@ -192,7 +195,7 @@ def execute_google_api_call(
         Any: The result of the API call. If paginate is True, returns a list of all results.
     """
     if delegated_user_email is None:
-        delegated_user_email = SRE_BOT_EMAIL
+        delegated_user_email = settings.SRE_BOT_EMAIL
     service = get_google_service(
         service_name,
         version,

--- a/app/integrations/google_workspace/google_service_next.py
+++ b/app/integrations/google_workspace/google_service_next.py
@@ -33,27 +33,29 @@ Key Functions:
 
 import json
 import time
-
 from functools import wraps
 from json import JSONDecodeError
 from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
 import structlog
-from core.config import settings
 from google.oauth2 import service_account
 from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
+
+from infrastructure.configuration.integrations.google import (
+    get_google_workspace_settings,
+)
 
 # OperationResult and status for standardized response modeling
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
 
 # Define the default arguments
-GOOGLE_WORKSPACE_CUSTOMER_ID = settings.google_workspace.GOOGLE_WORKSPACE_CUSTOMER_ID
-GCP_SRE_SERVICE_ACCOUNT_KEY_FILE = (
-    settings.google_workspace.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
-)
-SRE_BOT_EMAIL = settings.google_workspace.SRE_BOT_EMAIL
+settings = get_google_workspace_settings()
+GOOGLE_WORKSPACE_CUSTOMER_ID = settings.GOOGLE_WORKSPACE_CUSTOMER_ID
+GCP_SRE_SERVICE_ACCOUNT_KEY_FILE = settings.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE
+SRE_BOT_EMAIL = settings.SRE_BOT_EMAIL
+
 
 logger = structlog.get_logger()
 

--- a/app/tests/integrations/google_workspace/test_google_service.py
+++ b/app/tests/integrations/google_workspace/test_google_service.py
@@ -8,12 +8,13 @@ from google.auth.exceptions import RefreshError  # type: ignore
 from integrations.google_workspace import google_service
 
 
-@patch(
-    "integrations.google_workspace.google_service.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
-    "{}",
-)
 @patch("integrations.google_workspace.google_service.build")
 @patch("integrations.google_workspace.google_service.service_account")
+@patch.object(
+    google_service.settings,
+    "GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
+    new="{}",
+)
 def test_get_google_service_returns_build_object(mock_service_account, build_mock):
     """
     Test case to verify that the function returns a build object.
@@ -30,12 +31,13 @@ def test_get_google_service_returns_build_object(mock_service_account, build_moc
     )
 
 
-@patch(
-    "integrations.google_workspace.google_service.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
-    "{}",
-)
 @patch("integrations.google_workspace.google_service.build")
 @patch("integrations.google_workspace.google_service.service_account")
+@patch.object(
+    google_service.settings,
+    "GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
+    new="{}",
+)
 def test_get_google_service_with_delegated_user_email(
     mock_service_account, _build_mock
 ):
@@ -53,12 +55,13 @@ def test_get_google_service_with_delegated_user_email(
     )
 
 
-@patch(
-    "integrations.google_workspace.google_service.GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
-    "{}",
-)
 @patch("integrations.google_workspace.google_service.build")
 @patch("integrations.google_workspace.google_service.service_account")
+@patch.object(
+    google_service.settings,
+    "GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
+    new="{}",
+)
 def test_get_google_service_with_scopes(mock_service_account, _build_mock):
     """
     Test case to verify that the function works correctly with scopes.
@@ -73,7 +76,7 @@ def test_get_google_service_with_scopes(mock_service_account, _build_mock):
 
 
 @patch.object(
-    google_service,
+    google_service.settings,
     "GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
     new="",
 )
@@ -88,25 +91,18 @@ def test_get_google_service_raises_exception_if_credentials_json_not_set():
 
 
 @patch.object(
-    google_service,
+    google_service.settings,
     "GCP_SRE_SERVICE_ACCOUNT_KEY_FILE",
     new="invalid",
 )
 @patch("integrations.google_workspace.google_service.logger")
-@patch("integrations.google_workspace.google_service.service_account")
-@patch("integrations.google_workspace.google_service.build")
 def test_get_google_service_raises_exception_if_credentials_json_is_invalid(
-    _build_mock,
-    mocked_service_account,
     mocked_logger,
 ):
     """
     Test case to verify that the function raises an exception if:
      - GCP_SRE_SERVICE_ACCOUNT_KEY_FILE is invalid.
     """
-    mocked_service_account.Credentials.from_service_account_info.side_effect = (
-        JSONDecodeError("Invalid credentials JSON", "", 0)
-    )
     with pytest.raises(JSONDecodeError) as e:
         google_service.get_google_service("drive", "v3")
     assert "Invalid credentials JSON" in str(e.value)
@@ -258,13 +254,16 @@ def test_handle_google_api_errors_processes_unsupported_params(
 
     assert result == "test"
     mock_func.assert_called_once()
-    mocked_logger.warningassert_called_once_with(
-        "Unknown parameters in 'mock_module:mock_func' were detected: unsupported"
+    mocked_logger.warning.assert_called_once_with(
+        "unsupported_parameters_warning",
+        function="mock_func",
+        module="mock_module",
+        unsupported_params="unsupported",
     )
 
 
-@patch("integrations.google_workspace.google_service.SRE_BOT_EMAIL", "sre_bot_email")
 @patch("integrations.google_workspace.google_service.get_google_service")
+@patch.object(google_service.settings, "SRE_BOT_EMAIL", new="sre_bot_email")
 def test_execute_google_api_call_calls_get_google_service(mock_get_google_service):
     google_service.execute_google_api_call(
         "service_name", "version", "resource", "method"
@@ -274,8 +273,8 @@ def test_execute_google_api_call_calls_get_google_service(mock_get_google_servic
     )
 
 
-@patch("integrations.google_workspace.google_service.SRE_BOT_EMAIL", "sre_bot_email")
 @patch("integrations.google_workspace.google_service.get_google_service")
+@patch.object(google_service.settings, "SRE_BOT_EMAIL", new="sre_bot_email")
 def test_execute_google_api_call_calls_get_google_service_with_delegated_user_email(
     mock_get_google_service,
 ):

--- a/app/tests/integrations/google_workspace/test_google_service_next.py
+++ b/app/tests/integrations/google_workspace/test_google_service_next.py
@@ -8,7 +8,9 @@ from tests.fixtures.google_clients import FakeGoogleService
 
 # --- Fixtures ---
 @pytest.fixture
-@patch("integrations.google_workspace.google_service_next.settings")
+@patch(
+    "integrations.google_workspace.google_service_next.get_google_workspace_settings"
+)
 def fake_settings(settings_mock):
     class FakeGoogleWorkspace:
         GOOGLE_WORKSPACE_CUSTOMER_ID = "fake_customer_id"


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the configuration loading for Google Workspace integrations to use new configuration helper functions, replacing direct imports from the global settings object. It also updates the corresponding tests to patch the new configuration access patterns. The changes improve modularity and make the codebase more maintainable.

**Configuration Refactoring:**

* Replaced direct imports of `settings` from `core.config` with calls to `get_google_workspace_settings` and `get_google_resources_config` from `infrastructure.configuration.integrations.google` in both `google_service.py` and `google_service_next.py`. All references to configuration variables such as `GCP_SRE_SERVICE_ACCOUNT_KEY_FILE` and `SRE_BOT_EMAIL` now use the new `settings` object returned by these helpers. [[1]](diffhunk://#diff-06849457228b568bcc7ad0d71447e593ad420a1e639d270d07615c5218a687b5L24-R37) [[2]](diffhunk://#diff-344251a1599402f142d8b2d49562ab44704a29e154be4d346ace084db19622a7L36-R58)

* Updated usages of configuration variables within functions (such as `get_google_service` and `execute_google_api_call`) to reference the new `settings` object instead of module-level constants. [[1]](diffhunk://#diff-06849457228b568bcc7ad0d71447e593ad420a1e639d270d07615c5218a687b5L57-R60) [[2]](diffhunk://#diff-06849457228b568bcc7ad0d71447e593ad420a1e639d270d07615c5218a687b5L195-R198)

**Test Updates:**

* Updated tests in `test_google_service.py` to patch attributes on the new `settings` object using `@patch.object`, instead of patching module-level constants. This affects tests for credential file handling and SRE bot email. [[1]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L11-R17) [[2]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L33-R40) [[3]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L56-R64) [[4]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L76-R79) [[5]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L91-L109) [[6]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L261-R266) [[7]](diffhunk://#diff-2317cbc76424647c9dbd271ea9971c352b1d6f8543e94c12282b6d187558cd61L277-R277)

* Updated the fixture in `test_google_service_next.py` to patch the new `get_google_workspace_settings` function, aligning with the refactored configuration access pattern.