### PR TITLE
fix: update Slack client initialization to use LegacySlackBootstrap

### DIFF
--- a/app/modules/ops/notifications.py
+++ b/app/modules/ops/notifications.py
@@ -2,7 +2,7 @@ from slack_sdk.errors import SlackApiError
 from structlog import get_logger
 
 from infrastructure.configuration.features.sre_ops import get_sre_ops_settings
-from integrations.slack.client import SlackClientManager
+from integrations.slack.bootstrap import LegacySlackBootstrap
 
 logger = get_logger()
 
@@ -17,7 +17,8 @@ def log_ops_message(message: str):
     """
     log = logger.bind(ops_message=message)
     ops_channel_id = get_sre_ops_settings().SRE_OPS_CHANNEL_ID
-    client = SlackClientManager.get_client()
+    app = LegacySlackBootstrap().create_app()
+    client = app.client
     if not client:
         log.error(
             "slack_client_not_initialized",

--- a/app/tests/modules/ops/test_ops_notifications.py
+++ b/app/tests/modules/ops/test_ops_notifications.py
@@ -6,11 +6,11 @@ from modules.ops import notifications
 
 
 @patch("modules.ops.notifications.get_sre_ops_settings")
-@patch("modules.ops.notifications.SlackClientManager.get_client")
+@patch("modules.ops.notifications.LegacySlackBootstrap.create_app")
 @patch("modules.ops.notifications.logger")
-def test_log_ops_message(mock_logger, mock_get_client, mock_get_sre_ops_settings):
+def test_log_ops_message(mock_logger, mock_slack_app, mock_get_sre_ops_settings):
     client = MagicMock()
-    mock_get_client.return_value = client
+    mock_slack_app.return_value.client = client
     mock_get_sre_ops_settings.return_value.SRE_OPS_CHANNEL_ID = "C0123456ABC"
 
     # Patch logger.bind() to return a mock with .info/.error/.warning
@@ -33,13 +33,13 @@ def test_log_ops_message(mock_logger, mock_get_client, mock_get_sre_ops_settings
 
 
 @patch("modules.ops.notifications.get_sre_ops_settings")
-@patch("modules.ops.notifications.SlackClientManager.get_client")
+@patch("modules.ops.notifications.LegacySlackBootstrap.create_app")
 @patch("modules.ops.notifications.logger")
 def test_log_ops_message_no_client(
-    mock_logger, mock_get_client, mock_get_sre_ops_settings
+    mock_logger, mock_slack_app, mock_get_sre_ops_settings
 ):
     msg = "foo bar baz"
-    mock_get_client.return_value = None
+    mock_slack_app.return_value.client = None
     mock_get_sre_ops_settings.return_value.SRE_OPS_CHANNEL_ID = "C0123456ABC"
     bound_logger = MagicMock()
     mock_logger.bind.return_value = bound_logger
@@ -51,14 +51,14 @@ def test_log_ops_message_no_client(
 
 
 @patch("modules.ops.notifications.get_sre_ops_settings")
-@patch("modules.ops.notifications.SlackClientManager.get_client")
+@patch("modules.ops.notifications.LegacySlackBootstrap.create_app")
 @patch("modules.ops.notifications.logger")
 def test_log_ops_message_no_channel(
-    mock_logger, mock_get_client, mock_get_sre_ops_settings
+    mock_logger, mock_slack_app, mock_get_sre_ops_settings
 ):
     msg = "foo bar baz"
     mock_get_sre_ops_settings.return_value.SRE_OPS_CHANNEL_ID = None
-    mock_get_client.return_value = MagicMock()
+    mock_slack_app.return_value.client = MagicMock()
     bound_logger = MagicMock()
     mock_logger.bind.return_value = bound_logger
 
@@ -69,13 +69,13 @@ def test_log_ops_message_no_channel(
 
 
 @patch("modules.ops.notifications.get_sre_ops_settings")
-@patch("modules.ops.notifications.SlackClientManager.get_client")
+@patch("modules.ops.notifications.LegacySlackBootstrap.create_app")
 @patch("modules.ops.notifications.logger")
 def test_log_ops_message_slack_api_error(
-    mock_logger, mock_get_client, mock_get_sre_ops_settings
+    mock_logger, mock_slack_app, mock_get_sre_ops_settings
 ):
     client = MagicMock()
-    mock_get_client.return_value = client
+    mock_slack_app.return_value.client = client
     mock_get_sre_ops_settings.return_value.SRE_OPS_CHANNEL_ID = "C0123456ABC"
     bound_logger = MagicMock()
     mock_logger.bind.return_value = bound_logger


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how the Slack client is initialized and used within the ops notifications module and updates the corresponding tests to match the new approach. The main change is moving from using `SlackClientManager.get_client()` to initializing the client via `LegacySlackBootstrap().create_app().client`, which affects both the implementation and the test mocks.

Slack client initialization refactor:

* Replaced usage of `SlackClientManager.get_client()` with `LegacySlackBootstrap().create_app().client` in `log_ops_message`, updating the import and client initialization logic. [[1]](diffhunk://#diff-2b5cccecf651e32f2457dcdd380474c23eafa1682a6a69af84a6ffc2876a3f2fL5-R5) [[2]](diffhunk://#diff-2b5cccecf651e32f2457dcdd380474c23eafa1682a6a69af84a6ffc2876a3f2fL20-R21)

Test updates for new Slack client initialization:

* Updated all tests in `test_ops_notifications.py` to patch and mock `LegacySlackBootstrap.create_app` and its `client` attribute instead of `SlackClientManager.get_client`. This includes changes in test function arguments and mock setup. [[1]](diffhunk://#diff-0d4f28b98413a121817cdfb4e0df5f654035621b729acaf2bc6fe75f8dcc17c1L9-R13) [[2]](diffhunk://#diff-0d4f28b98413a121817cdfb4e0df5f654035621b729acaf2bc6fe75f8dcc17c1L36-R42) [[3]](diffhunk://#diff-0d4f28b98413a121817cdfb4e0df5f654035621b729acaf2bc6fe75f8dcc17c1L54-R61) [[4]](diffhunk://#diff-0d4f28b98413a121817cdfb4e0df5f654035621b729acaf2bc6fe75f8dcc17c1L72-R78)