### PR TITLE
Fix/debug slack manager client

### DIFF
--- a/app/integrations/slack/client.py
+++ b/app/integrations/slack/client.py
@@ -1,5 +1,5 @@
 from slack_sdk import WebClient
-from core.config import settings
+from integrations.slack.settings import get_slack_settings
 
 
 class SlackClientManager:
@@ -11,5 +11,6 @@ class SlackClientManager:
     def get_client(cls) -> WebClient:
         """Returns a singleton instance of the Slack WebClient."""
         if cls._client is None:
-            cls._client = WebClient(token=settings.slack.SLACK_TOKEN)
+            settings = get_slack_settings()
+            cls._client = WebClient(token=settings.BOT_TOKEN)
         return cls._client

--- a/app/tests/integrations/slack/test_slack_client.py
+++ b/app/tests/integrations/slack/test_slack_client.py
@@ -7,7 +7,9 @@ class TestSlackClientManager(unittest.TestCase):
 
     @patch("integrations.slack.client.get_slack_settings")
     @patch("integrations.slack.client.WebClient")
-    def test_get_client_creates_instance(self, mock_web_client, mock_get_slack_settings):
+    def test_get_client_creates_instance(
+        self, mock_web_client, mock_get_slack_settings
+    ):
         SlackClientManager._client = None  # pylint: disable=protected-access
         mock_get_slack_settings.return_value.BOT_TOKEN = "test-token"
 

--- a/app/tests/integrations/slack/test_slack_client.py
+++ b/app/tests/integrations/slack/test_slack_client.py
@@ -4,10 +4,12 @@ from integrations.slack.client import SlackClientManager
 
 
 class TestSlackClientManager(unittest.TestCase):
-    @patch("integrations.slack.client.settings.slack.SLACK_TOKEN", "test-token")
+
+    @patch("integrations.slack.client.get_slack_settings")
     @patch("integrations.slack.client.WebClient")
-    def test_get_client_creates_instance(self, mock_web_client):
+    def test_get_client_creates_instance(self, mock_web_client, mock_get_slack_settings):
         SlackClientManager._client = None  # pylint: disable=protected-access
+        mock_get_slack_settings.return_value.BOT_TOKEN = "test-token"
 
         # Call get_client and verify a WebClient instance is created
         client = SlackClientManager.get_client()


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how Slack settings are accessed in the `SlackClientManager` and updates the related unit tests to match the new approach. The main goal is to improve configuration management by retrieving Slack settings through a dedicated function rather than importing them directly.

Configuration refactor:

* Replaced direct import of `settings` from `core.config` with the `get_slack_settings` function from `integrations.slack.settings` in `app/integrations/slack/client.py`, ensuring settings are accessed via a dedicated accessor.
* Updated the `SlackClientManager.get_client` method to retrieve the bot token from `settings.BOT_TOKEN` (as returned by `get_slack_settings`) instead of `settings.slack.SLACK_TOKEN`.

Testing updates:

* Modified the unit test in `app/tests/integrations/slack/test_slack_client.py` to patch `get_slack_settings` and set up the mock to provide a `BOT_TOKEN`, aligning the test with the new settings access pattern.