### PR TITLE
fix(aws): refactor imports to use get_aws_settings for configuration

### DIFF
--- a/app/integrations/aws/config.py
+++ b/app/integrations/aws/config.py
@@ -1,10 +1,11 @@
 import structlog
 
-from core.config import settings
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
 logger = structlog.get_logger()
-AUDIT_ROLE_ARN = settings.aws.AUDIT_ROLE_ARN
+settings = get_aws_settings()
+AUDIT_ROLE_ARN = settings.AUDIT_ROLE_ARN
 
 
 @handle_aws_api_errors

--- a/app/integrations/aws/cost_explorer.py
+++ b/app/integrations/aws/cost_explorer.py
@@ -1,11 +1,13 @@
 """Cost Explorer API integration."""
 
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
 logger = structlog.get_logger()
-ORG_ROLE_ARN = settings.aws.ORG_ROLE_ARN
+settings = get_aws_settings()
+ORG_ROLE_ARN = settings.ORG_ROLE_ARN
 
 
 @handle_aws_api_errors

--- a/app/integrations/aws/guard_duty.py
+++ b/app/integrations/aws/guard_duty.py
@@ -1,11 +1,13 @@
 """AWS GuardDuty integration module."""
 
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
 logger = structlog.get_logger()
-LOGGING_ROLE_ARN = settings.aws.LOGGING_ROLE_ARN
+settings = get_aws_settings()
+LOGGING_ROLE_ARN = settings.LOGGING_ROLE_ARN
 
 
 @handle_aws_api_errors

--- a/app/integrations/aws/security_hub.py
+++ b/app/integrations/aws/security_hub.py
@@ -1,9 +1,11 @@
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
 logger = structlog.get_logger()
-LOGGING_ROLE_ARN = settings.aws.LOGGING_ROLE_ARN
+settings = get_aws_settings()
+LOGGING_ROLE_ARN = settings.LOGGING_ROLE_ARN
 
 
 @handle_aws_api_errors


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how AWS settings are imported and accessed in several AWS integration modules. Instead of importing settings directly from `core.config`, the modules now use the `get_aws_settings` function from `infrastructure.configuration.integrations.aws`. This improves modularity and centralizes AWS configuration management.

**Refactoring AWS settings access:**

* Replaced direct imports from `core.config` with the `get_aws_settings` function in the following modules:
  - `app/integrations/aws/config.py`
  - `app/integrations/aws/cost_explorer.py`
  - `app/integrations/aws/guard_duty.py`
  - `app/integrations/aws/security_hub.py`
* Updated how AWS role ARNs are retrieved, now accessing them from the `settings` object returned by `get_aws_settings` in each module. [[1]](diffhunk://#diff-d8019a014bcfaad960c3224a8b3aa1a09b7a7c3e3940f654bc327510b380d4daL3-R8) [[2]](diffhunk://#diff-c53125c69878ac9525d056bcdecd1b9dcff619a00db11a498fc8034de8dd86b0L4-R10) [[3]](diffhunk://#diff-95ddb59abde86049f6922b0d67984cc869a5804bcf0b0a3636f5dd329263698bL4-R10) [[4]](diffhunk://#diff-4b0f02d0a1593cec9893373e2c2594d2fc4f7e0d9fc6fcbb53e48b7ad516e202L2-R8)