### PR TITLE
fix(aws): refactor imports to use get_aws_settings for AWS configuration

### DIFF
--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -1,18 +1,19 @@
 from functools import wraps
 
-import structlog
 import boto3  # type: ignore
+import structlog
 from botocore.client import BaseClient  # type: ignore
 from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 
 logger = structlog.get_logger()
-
-SYSTEM_ADMIN_PERMISSIONS = settings.aws.SYSTEM_ADMIN_PERMISSIONS
-VIEW_ONLY_PERMISSIONS = settings.aws.VIEW_ONLY_PERMISSIONS
-AWS_REGION = settings.aws.AWS_REGION
-THROTTLING_ERRS = settings.aws.THROTTLING_ERRS
-RESOURCE_NOT_FOUND_ERRS = settings.aws.RESOURCE_NOT_FOUND_ERRS
+settings = get_aws_settings()
+SYSTEM_ADMIN_PERMISSIONS = settings.SYSTEM_ADMIN_PERMISSIONS
+VIEW_ONLY_PERMISSIONS = settings.VIEW_ONLY_PERMISSIONS
+AWS_REGION = settings.AWS_REGION
+THROTTLING_ERRS = settings.THROTTLING_ERRS
+RESOURCE_NOT_FOUND_ERRS = settings.RESOURCE_NOT_FOUND_ERRS
 
 
 def handle_aws_api_errors(func):

--- a/app/integrations/aws/client_next.py
+++ b/app/integrations/aws/client_next.py
@@ -29,21 +29,23 @@ Notes:
 """
 
 import time
-from typing import Any, List, Optional, Callable, cast
+from typing import Any, Callable, List, Optional, cast
 
-import structlog
 import boto3  # type: ignore
+import structlog
 from botocore.client import BaseClient  # type: ignore
 from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 
 from infrastructure.operations.result import OperationResult
 
 logger = structlog.get_logger()
+settings = get_aws_settings()
 
-AWS_REGION = settings.aws.AWS_REGION
-THROTTLING_ERRS = settings.aws.THROTTLING_ERRS
-RESOURCE_NOT_FOUND_ERRS = settings.aws.RESOURCE_NOT_FOUND_ERRS
+AWS_REGION = settings.AWS_REGION
+THROTTLING_ERRS = settings.THROTTLING_ERRS
+RESOURCE_NOT_FOUND_ERRS = settings.RESOURCE_NOT_FOUND_ERRS
 
 ERROR_CONFIG = {
     "non_critical_errors": {

--- a/app/integrations/aws/dynamodb.py
+++ b/app/integrations/aws/dynamodb.py
@@ -1,19 +1,23 @@
 """AWS DynamoDB API client"""
 
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.app import get_app_settings
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import (
     execute_aws_api_call,
     handle_aws_api_errors,
 )
 
 logger = structlog.get_logger()
+settings = get_aws_settings()
+app_settings = get_app_settings()
 
 client_config = dict(
-    region_name=settings.aws.AWS_REGION,
+    region_name=settings.AWS_REGION,
 )
 
-if settings.PREFIX:
+if app_settings.PREFIX:
     client_config["endpoint_url"] = "http://dynamodb-local:8000"
 
 

--- a/app/integrations/aws/dynamodb_next.py
+++ b/app/integrations/aws/dynamodb_next.py
@@ -21,13 +21,14 @@ Usage:
 from typing import Any, Dict
 
 import structlog
-from core.config import settings
-from integrations.aws.client_next import execute_aws_api_call
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from infrastructure.operations.result import OperationResult
+from integrations.aws.client_next import execute_aws_api_call
 
 logger = structlog.get_logger()
-
-AWS_REGION = settings.aws.AWS_REGION
+settings = get_aws_settings()
+AWS_REGION = settings.AWS_REGION
 
 
 def get_item(

--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -1,16 +1,16 @@
 """AWS Identity Store module"""
 
-import structlog
-from core.config import settings
-
 import pandas as pd
+import structlog
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 from utils import filters
 
-INSTANCE_ID = settings.aws.INSTANCE_ID
-ROLE_ARN = settings.aws.ORG_ROLE_ARN
-
 logger = structlog.get_logger()
+settings = get_aws_settings()
+INSTANCE_ID = settings.INSTANCE_ID
+ROLE_ARN = settings.ORG_ROLE_ARN
 
 
 def resolve_identity_store_id(kwargs):

--- a/app/integrations/aws/identity_store_next.py
+++ b/app/integrations/aws/identity_store_next.py
@@ -15,19 +15,20 @@ not through this module.
 """
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict, List, Optional, Mapping
+from typing import Any, Dict, List, Mapping, Optional
 
 import structlog
-from core.config import settings
-from integrations.aws.client_next import execute_aws_api_call
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
-
-# Configuration from settings
-AWS_IDENTITY_STORE_ID = settings.aws.INSTANCE_ID
-ROLE_ARN = settings.aws.ORG_ROLE_ARN
+from integrations.aws.client_next import execute_aws_api_call
 
 logger = structlog.get_logger()
+# Configuration from settings
+settings = get_aws_settings()
+AWS_IDENTITY_STORE_ID = settings.INSTANCE_ID
+ROLE_ARN = settings.ORG_ROLE_ARN
 
 
 # User Management Functions

--- a/app/integrations/aws/organizations.py
+++ b/app/integrations/aws/organizations.py
@@ -1,10 +1,11 @@
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
-ORG_ROLE_ARN = settings.aws.ORG_ROLE_ARN
-
 logger = structlog.get_logger()
+settings = get_aws_settings()
+ORG_ROLE_ARN = settings.ORG_ROLE_ARN
 
 
 @handle_aws_api_errors

--- a/app/integrations/aws/sso_admin.py
+++ b/app/integrations/aws/sso_admin.py
@@ -1,14 +1,15 @@
 import structlog
-from core.config import settings
+
+from infrastructure.configuration.integrations.aws import get_aws_settings
 from integrations.aws.client import execute_aws_api_call, handle_aws_api_errors
 
-
+settings = get_aws_settings()
 logger = structlog.get_logger()
 
-ROLE_ARN = settings.aws.ORG_ROLE_ARN
-INSTANCE_ARN = settings.aws.INSTANCE_ARN
-SYSTEM_ADMIN_PERMISSIONS = settings.aws.SYSTEM_ADMIN_PERMISSIONS
-VIEW_ONLY_PERMISSIONS = settings.aws.VIEW_ONLY_PERMISSIONS
+ROLE_ARN = settings.ORG_ROLE_ARN
+INSTANCE_ARN = settings.INSTANCE_ARN
+SYSTEM_ADMIN_PERMISSIONS = settings.SYSTEM_ADMIN_PERMISSIONS
+VIEW_ONLY_PERMISSIONS = settings.VIEW_ONLY_PERMISSIONS
 
 
 def get_predefined_permission_sets(permission_set_name):


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how AWS-related configuration settings are imported and accessed across several integration modules. The main improvement is replacing direct imports from a central `core.config` with calls to new getter functions from the `infrastructure.configuration.integrations.aws` module. This change standardizes configuration access and improves modularity and maintainability.

Configuration refactoring:

* Replaced all direct imports of AWS settings from `core.config` with usage of the `get_aws_settings()` function from `infrastructure.configuration.integrations.aws` in the following files: `client.py`, `client_next.py`, `dynamodb.py`, `dynamodb_next.py`, `identity_store.py`, `identity_store_next.py`, `organizations.py`, and `sso_admin.py`. All references to settings are now accessed via the returned `settings` object. [[1]](diffhunk://#diff-dea0ee50a2ee5acfbc0bae081b5062475d0b9098b7c2ed471635e1502aea1cfaL3-R16) [[2]](diffhunk://#diff-8e81820c0193b6ee2d16bf1075841c0bcd256691b9462ec858acf666c61d6c82L32-R48) [[3]](diffhunk://#diff-902fc16084aa2078653e46763326d77f09bfa028cde1296baf6093155e2336ffL4-R20) [[4]](diffhunk://#diff-68f3cbd81902adcd55baa573a90f19f01fa5f198ab6658fb7ad750bd7bc54e7cL24-R31) [[5]](diffhunk://#diff-685a6a4daa0f776bde753ec9e392444825f57657841b6e2b9c9159fbbc690fd7R3-R13) [[6]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879L18-R31) [[7]](diffhunk://#diff-1b0fa2e0ed32b5faf0ebab948a3a4da7bdbd68eb38a09267c168595f7b33e170L2-R8) [[8]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955L2-R12)

Code consistency and cleanup:

* Updated variable assignments and usages throughout the affected modules to reference the new `settings` object, ensuring consistent configuration access patterns. [[1]](diffhunk://#diff-dea0ee50a2ee5acfbc0bae081b5062475d0b9098b7c2ed471635e1502aea1cfaL3-R16) [[2]](diffhunk://#diff-8e81820c0193b6ee2d16bf1075841c0bcd256691b9462ec858acf666c61d6c82L32-R48) [[3]](diffhunk://#diff-902fc16084aa2078653e46763326d77f09bfa028cde1296baf6093155e2336ffL4-R20) [[4]](diffhunk://#diff-68f3cbd81902adcd55baa573a90f19f01fa5f198ab6658fb7ad750bd7bc54e7cL24-R31) [[5]](diffhunk://#diff-685a6a4daa0f776bde753ec9e392444825f57657841b6e2b9c9159fbbc690fd7R3-R13) [[6]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879L18-R31) [[7]](diffhunk://#diff-1b0fa2e0ed32b5faf0ebab948a3a4da7bdbd68eb38a09267c168595f7b33e170L2-R8) [[8]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955L2-R12)
* Removed redundant or outdated imports and adjusted import order for clarity and PEP8 compliance. [[1]](diffhunk://#diff-dea0ee50a2ee5acfbc0bae081b5062475d0b9098b7c2ed471635e1502aea1cfaL3-R16) [[2]](diffhunk://#diff-8e81820c0193b6ee2d16bf1075841c0bcd256691b9462ec858acf666c61d6c82L32-R48) [[3]](diffhunk://#diff-902fc16084aa2078653e46763326d77f09bfa028cde1296baf6093155e2336ffL4-R20) [[4]](diffhunk://#diff-68f3cbd81902adcd55baa573a90f19f01fa5f198ab6658fb7ad750bd7bc54e7cL24-R31) [[5]](diffhunk://#diff-685a6a4daa0f776bde753ec9e392444825f57657841b6e2b9c9159fbbc690fd7R3-R13) [[6]](diffhunk://#diff-799bcdffe4a1b7304340af0005f19343f6b87d41141c1a65a92266addd2a9879L18-R31) [[7]](diffhunk://#diff-1b0fa2e0ed32b5faf0ebab948a3a4da7bdbd68eb38a09267c168595f7b33e170L2-R8) [[8]](diffhunk://#diff-20fa304c77dc97b860cf12916c1d7b372019cccd4491160f0d82ae3372a31955L2-R12)

These changes make the codebase more modular and prepare it for future configuration management improvements.