### PR TITLE
fix(configuration): update app settings import and usage in server.py

### DIFF
--- a/app/server/server.py
+++ b/app/server/server.py
@@ -3,13 +3,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from sns_message_validator import SNSMessageValidator  # type: ignore
 
 from api.router import api_router
-from infrastructure.configuration import get_settings
+from infrastructure.configuration.app import get_app_settings
 from infrastructure.security import setup_rate_limiter
 from server.lifespan import lifespan
 
 sns_message_validator = SNSMessageValidator()
-settings = get_settings()
-
+app_settings = get_app_settings()
 
 handler = FastAPI(lifespan=lifespan)
 setup_rate_limiter(handler)
@@ -21,7 +20,7 @@ class ConfigurationError(Exception):
 
 allow_origins = (
     ["*"]
-    if settings.is_production
+    if app_settings.is_production
     else [
         "http://localhost:8000",
         "http://127.0.0.1:8000",


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the server configuration to use the new `get_app_settings` function from `infrastructure.configuration.app` instead of the previous `get_settings` function. This change ensures the server is using the correct application settings, which is important for environment-specific configuration such as CORS origins.

Configuration changes:

* Updated the import to use `get_app_settings` from `infrastructure.configuration.app` in `app/server/server.py`, replacing the previous `get_settings` import.
* Replaced all usages of `settings` with `app_settings` to ensure the correct settings are referenced, including in the CORS `allow_origins` logic.