### PR TITLE
fix(lifespan): update settings import and fix logging setup

### DIFF
--- a/app/infrastructure/logging/setup.py
+++ b/app/infrastructure/logging/setup.py
@@ -22,19 +22,18 @@ Dependencies:
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Mapping, MutableMapping
+from typing import Any
 
 import structlog
 from structlog.processors import CallsiteParameter
 from structlog.stdlib import BoundLogger
-
-if TYPE_CHECKING:
-    from infrastructure.configuration import Settings
+from infrastructure.configuration.app import AppSettings
 
 
 def _apply_otel_code_conventions(
-    logger: Any, method_name: str, event_dict: dict[str, Any]
-) -> dict[str, Any]:
+    logger: Any, method_name: str, event_dict: MutableMapping[str, Any]
+) -> Mapping[str, Any] | str | bytes | bytearray | tuple[Any, ...]:
     """Apply OpenTelemetry semantic conventions for code attributes.
 
     Converts structlog callsite parameters to OTel standard fields:
@@ -102,7 +101,7 @@ def _is_test_environment() -> bool:
 
 
 def configure_logging(
-    settings: "Settings",
+    settings: AppSettings,
     log_level: str | None = None,
     is_production: bool | None = None,
 ) -> BoundLogger:
@@ -115,7 +114,7 @@ def configure_logging(
     - Test environment detection for log suppression
 
     Args:
-        settings: Settings instance (REQUIRED). Must be passed explicitly.
+        settings: AppSettings instance (REQUIRED). Must be passed explicitly.
         log_level: Optional override for log level (DEBUG, INFO, WARNING, etc).
             Defaults to settings.LOG_LEVEL if not provided.
         is_production: Optional override for production mode. Defaults to
@@ -165,7 +164,12 @@ def configure_logging(
 
     # Build processor pipeline per structlog best practices
     # Order matters: context vars first, then enrichment, then formatting
-    processors = [
+    processors: list[
+        Callable[
+            [Any, str, MutableMapping[str, Any]],
+            Mapping[str, Any] | str | bytes | bytearray | tuple[Any, ...],
+        ]
+    ] = [
         # 1. Context propagation (must be first)
         structlog.contextvars.merge_contextvars,
         # 2. Add metadata

--- a/app/server/lifespan.py
+++ b/app/server/lifespan.py
@@ -2,14 +2,19 @@ import sys
 import threading
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncIterator, Optional, cast
+from typing import AsyncIterator, Optional, cast
 
 from fastapi import FastAPI
 from pluggy import PluginManager
 from slack_bolt import App
 from structlog.stdlib import BoundLogger
 
-from infrastructure.configuration import get_settings
+from infrastructure.configuration.app import AppSettings, get_app_settings
+from infrastructure.configuration.settings import Settings
+from infrastructure.configuration.infrastructure.directory import (
+    DirectorySettings,
+    get_directory_settings,
+)
 from infrastructure.configuration.infrastructure.server import (
     ServerSettings,
     get_server_settings,
@@ -42,27 +47,33 @@ from modules import (
     webhook_helper,
 )
 
-if TYPE_CHECKING:
-    from infrastructure.configuration import Settings
-
 
 def _is_test_environment() -> bool:
     """Detect if running in a test environment."""
     return "pytest" in sys.modules
 
 
-def _get_logger(settings: "Settings") -> BoundLogger:
-    return configure_logging(settings=settings)
+def _get_logger_from_app(app_settings: AppSettings) -> BoundLogger:
+    return configure_logging(settings=app_settings)
 
 
-def _list_configs(settings: "Settings", logger: BoundLogger) -> None:
-    config_settings: dict[str, list[object]] = {"settings": []}
+def _list_configs_from_sections(
+    app_settings: AppSettings,
+    server_settings: ServerSettings,
+    directory_settings: DirectorySettings,
+    logger: BoundLogger,
+) -> None:
+    config_settings: dict[str, tuple[object, ...]] = {
+        "settings": (
+            {"PREFIX": app_settings.PREFIX},
+            {"LOG_LEVEL": app_settings.LOG_LEVEL},
+            {"GIT_SHA": app_settings.GIT_SHA},
+        )
+    }
 
-    for key, value in settings.model_dump().items():
-        if isinstance(value, dict):
-            config_settings[key] = list(value.keys())
-        else:
-            config_settings["settings"].append({key: value})
+    config_settings["app"] = tuple(app_settings.model_dump().keys())
+    config_settings["server"] = tuple(server_settings.model_dump().keys())
+    config_settings["directory"] = tuple(directory_settings.model_dump().keys())
 
     logger.info("configuration_initialized", base_settings=config_settings["settings"])
     for key, value in config_settings.items():
@@ -84,10 +95,10 @@ def _register_legacy_handlers(bot: App, logger: BoundLogger) -> None:
 
 def _start_scheduled_tasks(
     bot: App,
-    settings: "Settings",
+    app_settings: AppSettings,
     logger: BoundLogger,
 ) -> Optional[threading.Event]:
-    if settings.PREFIX != "":
+    if app_settings.PREFIX != "":
         logger.info("scheduled_tasks_skipped", reason="prefix_not_empty")
         return None
 
@@ -134,7 +145,7 @@ def _initialize_security_services(
 
 def _initialize_directory_provider(
     app: FastAPI,
-    settings: "Settings",
+    directory_settings: DirectorySettings,
     logger: BoundLogger,
 ) -> None:
     """Build, warm up, and store the directory provider on app.state."""
@@ -143,7 +154,7 @@ def _initialize_directory_provider(
 
     directory_provider = get_directory_provider()
 
-    if settings.directory.require_startup_warmup:
+    if directory_settings.require_startup_warmup:
         warmup = directory_provider.warmup()
         if not warmup.is_success:
             log.error("directory_provider_initialization_failed", error=warmup.message)
@@ -207,19 +218,26 @@ def _initialize_translation_service(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    settings = get_settings()
+    settings = Settings()
+    app_settings = get_app_settings()
     server_settings = get_server_settings()
+    directory_settings = get_directory_settings()
     sre_ops_settings = get_sre_ops_settings()
-    logger = _get_logger(settings)
+    logger = _get_logger_from_app(app_settings)
 
     app.state.settings = settings
     app.state.logger = logger
 
     logger.info("application_startup")
-    _list_configs(settings, logger)
+    _list_configs_from_sections(
+        app_settings,
+        server_settings,
+        directory_settings,
+        logger,
+    )
 
     _initialize_security_services(app, server_settings, logger)
-    _initialize_directory_provider(app, settings, logger)
+    _initialize_directory_provider(app, directory_settings, logger)
 
     app.state.slack_provider = get_slack_provider()
 
@@ -258,7 +276,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 text="SRE Bot has started up in test mode.",
             )
         if not _is_test_environment():
-            scheduled_stop_event = _start_scheduled_tasks(slack_app, settings, logger)
+            scheduled_stop_event = _start_scheduled_tasks(
+                slack_app,
+                app_settings,
+                logger,
+            )
         else:
             scheduled_stop_event = None
 

--- a/app/tests/integration/server/test_lifespan.py
+++ b/app/tests/integration/server/test_lifespan.py
@@ -9,9 +9,9 @@ import pytest
 from server import lifespan as lifespan_module
 from server.lifespan import (
     _initialize_directory_provider,
-    _get_logger,
+    _get_logger_from_app,
     _is_test_environment,
-    _list_configs,
+    _list_configs_from_sections,
     _register_legacy_handlers,
     _start_scheduled_tasks,
     _stop_scheduled_tasks,
@@ -57,7 +57,7 @@ def test_lifespan_get_logger_returns_logger(mock_settings):
     # Arrange
 
     # Act
-    logger = _get_logger(mock_settings)
+    logger = _get_logger_from_app(mock_settings)
 
     # Assert
     assert logger is not None
@@ -68,9 +68,18 @@ def test_lifespan_list_configs_logs_settings(mock_settings):
     """Test that _list_configs logs configuration settings."""
     # Arrange
     mock_logger = MagicMock()
+    mock_server_settings = MagicMock()
+    mock_server_settings.model_dump.return_value = {"PORT": 8080}
+    mock_directory_settings = MagicMock()
+    mock_directory_settings.model_dump.return_value = {"require_startup_warmup": True}
 
     # Act
-    _list_configs(mock_settings, mock_logger)
+    _list_configs_from_sections(
+        mock_settings,
+        mock_server_settings,
+        mock_directory_settings,
+        mock_logger,
+    )
 
     # Assert
     mock_logger.info.assert_called()
@@ -87,7 +96,7 @@ def test_lifespan_get_logger_configures_logging(mock_configure_logging, mock_set
     mock_configure_logging.return_value = mock_logger
 
     # Act
-    logger = _get_logger(mock_settings)
+    logger = _get_logger_from_app(mock_settings)
 
     # Assert
     mock_configure_logging.assert_called_once_with(settings=mock_settings)
@@ -206,7 +215,7 @@ def test_initialize_directory_provider_stores_provider_on_app_state(monkeypatch)
     app.state = MagicMock()
     mock_logger = MagicMock()
     mock_settings = MagicMock()
-    mock_settings.directory.require_startup_warmup = True
+    mock_settings.require_startup_warmup = True
     mock_provider = MagicMock()
     mock_provider.warmup.return_value = MagicMock(is_success=True, message="ok")
 
@@ -228,7 +237,7 @@ def test_initialize_directory_provider_raises_when_required_warmup_fails(monkeyp
     app.state = MagicMock()
     mock_logger = MagicMock()
     mock_settings = MagicMock()
-    mock_settings.directory.require_startup_warmup = True
+    mock_settings.require_startup_warmup = True
     mock_provider = MagicMock()
     mock_provider.warmup.return_value = MagicMock(
         is_success=False,
@@ -250,7 +259,7 @@ def test_initialize_directory_provider_allows_failed_optional_warmup(monkeypatch
     app.state = MagicMock()
     mock_logger = MagicMock()
     mock_settings = MagicMock()
-    mock_settings.directory.require_startup_warmup = False
+    mock_settings.require_startup_warmup = False
     mock_provider = MagicMock()
 
     monkeypatch.setattr("server.lifespan.get_directory_provider", lambda: mock_provider)

--- a/app/tests/unit/infrastructure/logging/conftest.py
+++ b/app/tests/unit/infrastructure/logging/conftest.py
@@ -3,13 +3,13 @@
 import pytest
 from unittest.mock import Mock
 
-from infrastructure.configuration import Settings
+from infrastructure.configuration.app import AppSettings
 
 
 @pytest.fixture
 def mock_settings():
-    """Mock Settings instance for testing."""
-    settings = Mock(spec=Settings)
+    """Mock AppSettings instance for testing."""
+    settings = Mock(spec=AppSettings)
     settings.LOG_LEVEL = "INFO"
     settings.is_production = False
     return settings


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors configuration management and logging setup to improve clarity and modularity. The main focus is on replacing the generic `Settings` object with more specific configuration classes (`AppSettings`, `ServerSettings`, `DirectorySettings`) throughout the logging and server lifespan code. This change enhances type safety and makes configuration handling more explicit. Test code and logging setup are updated accordingly.

**Configuration and Logging Refactor:**

* Replaced usage of the generic `Settings` class with specific configuration classes (`AppSettings`, `ServerSettings`, `DirectorySettings`) in both the logging setup (`configure_logging`) and server lifespan management. This includes updating function signatures, imports, and internal logic for clarity and type safety. [[1]](diffhunk://#diff-525bc3334b5263eb06d4b8463f5fce81872030e655e69e6dbe3a41a8ba4f43c0L25-R36) [[2]](diffhunk://#diff-525bc3334b5263eb06d4b8463f5fce81872030e655e69e6dbe3a41a8ba4f43c0L105-R104) [[3]](diffhunk://#diff-525bc3334b5263eb06d4b8463f5fce81872030e655e69e6dbe3a41a8ba4f43c0L118-R117) [[4]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL5-R17) [[5]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL45-R76)
* Refactored `_list_configs` to `_list_configs_from_sections` to log configuration sections separately, improving visibility into different configuration domains.
* Updated logger initialization to use `AppSettings` via `_get_logger_from_app` for consistency. [[1]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL45-R76) [[2]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL210-R240)

**Server Lifespan and Initialization:**

* Updated all relevant initialization and startup functions (including scheduled tasks and directory provider setup) to use the new configuration classes, ensuring correct configuration is passed to each subsystem. [[1]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL87-R101) [[2]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL137-R148) [[3]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL146-R157) [[4]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL210-R240) [[5]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL261-R283)

**Testing Updates:**

* Modified unit and integration tests to use `AppSettings` mocks and the new function names and signatures, ensuring tests remain valid after the refactor. [[1]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL12-R14) [[2]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL60-R60) [[3]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeR71-R82) [[4]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL90-R99) [[5]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL209-R218) [[6]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL231-R240) [[7]](diffhunk://#diff-ab0e18969a01fd396035f32038b05a73d22bd8f15fbe81efe09e9b952ca997eeL253-R262) [[8]](diffhunk://#diff-06d36213723c4269d8d564feb077580b425f782520f706be40ee017dd5f5fb16L6-R12)