### PR TITLE
fix(lifespan): update settings import for lifespan

### DIFF
--- a/app/server/lifespan.py
+++ b/app/server/lifespan.py
@@ -10,7 +10,6 @@ from slack_bolt import App
 from structlog.stdlib import BoundLogger
 
 from infrastructure.configuration.app import AppSettings, get_app_settings
-from infrastructure.configuration.settings import Settings
 from infrastructure.configuration.infrastructure.directory import (
     DirectorySettings,
     get_directory_settings,
@@ -19,7 +18,10 @@ from infrastructure.configuration.infrastructure.server import (
     ServerSettings,
     get_server_settings,
 )
-from infrastructure.configuration.features.sre_ops import get_sre_ops_settings
+from infrastructure.configuration.features.sre_ops import (
+    SreOpsSettings,
+    get_sre_ops_settings,
+)
 from infrastructure.directory import get_directory_provider
 from infrastructure.i18n import (
     I18nResourceRegistry,
@@ -61,6 +63,7 @@ def _list_configs_from_sections(
     app_settings: AppSettings,
     server_settings: ServerSettings,
     directory_settings: DirectorySettings,
+    sre_ops_settings: SreOpsSettings,
     logger: BoundLogger,
 ) -> None:
     config_settings: dict[str, tuple[object, ...]] = {
@@ -74,6 +77,7 @@ def _list_configs_from_sections(
     config_settings["app"] = tuple(app_settings.model_dump().keys())
     config_settings["server"] = tuple(server_settings.model_dump().keys())
     config_settings["directory"] = tuple(directory_settings.model_dump().keys())
+    config_settings["sre_ops"] = tuple(sre_ops_settings.model_dump().keys())
 
     logger.info("configuration_initialized", base_settings=config_settings["settings"])
     for key, value in config_settings.items():
@@ -218,14 +222,13 @@ def _initialize_translation_service(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    settings = Settings()
     app_settings = get_app_settings()
     server_settings = get_server_settings()
     directory_settings = get_directory_settings()
     sre_ops_settings = get_sre_ops_settings()
     logger = _get_logger_from_app(app_settings)
 
-    app.state.settings = settings
+    app.state.settings = app_settings
     app.state.logger = logger
 
     logger.info("application_startup")
@@ -233,6 +236,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app_settings,
         server_settings,
         directory_settings,
+        sre_ops_settings,
         logger,
     )
 

--- a/app/server/server.py
+++ b/app/server/server.py
@@ -20,7 +20,7 @@ class ConfigurationError(Exception):
 
 allow_origins = (
     ["*"]
-    if app_settings.is_production
+    if not bool(app_settings.PREFIX)
     else [
         "http://localhost:8000",
         "http://127.0.0.1:8000",

--- a/app/tests/integration/server/test_lifespan.py
+++ b/app/tests/integration/server/test_lifespan.py
@@ -72,12 +72,15 @@ def test_lifespan_list_configs_logs_settings(mock_settings):
     mock_server_settings.model_dump.return_value = {"PORT": 8080}
     mock_directory_settings = MagicMock()
     mock_directory_settings.model_dump.return_value = {"require_startup_warmup": True}
+    mock_sre_ops_settings = MagicMock()
+    mock_sre_ops_settings.model_dump.return_value = {"SRE_OPS_CHANNEL_ID": ""}
 
     # Act
     _list_configs_from_sections(
         mock_settings,
         mock_server_settings,
         mock_directory_settings,
+        mock_sre_ops_settings,
         mock_logger,
     )
 

--- a/app/tests/integration/test_app_state_initialization.py
+++ b/app/tests/integration/test_app_state_initialization.py
@@ -40,20 +40,17 @@ def test_app_state_has_all_required_attributes(app_with_lifespan):
 
 @pytest.mark.integration
 def test_app_state_settings_is_valid(app_with_lifespan):
-    """Validate that settings object is properly initialized.
+    """Validate that app-level settings object is properly initialized.
 
-    Settings should be a valid Settings instance with all required
-    configuration loaded from environment.
+    The lifespan should store the narrow app settings slice on app.state.
     """
     settings = app_with_lifespan.app.state.settings
 
     assert settings is not None, "settings must not be None"
-    # Verify it's a Settings instance by checking it has expected attributes
-    assert hasattr(settings, "is_production"), "settings missing is_production"
-    assert hasattr(settings, "slack"), "settings missing slack"
-    assert hasattr(settings, "aws"), "settings missing aws"
+    assert hasattr(settings, "PREFIX"), "settings missing PREFIX"
     assert hasattr(settings, "LOG_LEVEL"), "settings missing LOG_LEVEL"
-    # Verify is_production is a boolean
+    assert hasattr(settings, "GIT_SHA"), "settings missing GIT_SHA"
+    assert hasattr(settings, "is_production"), "settings missing is_production"
     assert isinstance(settings.is_production, bool), "is_production must be a boolean"
 
 

--- a/app/tests/unit/infrastructure/configuration/test_settings.py
+++ b/app/tests/unit/infrastructure/configuration/test_settings.py
@@ -8,7 +8,11 @@ Tests cover:
 
 import pytest
 
-from infrastructure.configuration.settings import RetrySettings, Settings, get_settings
+from infrastructure.configuration.infrastructure.retry import (
+    RetrySettings,
+    get_retry_settings,
+)
+from infrastructure.configuration.settings import Settings
 
 
 class TestRetrySettings:
@@ -125,13 +129,10 @@ class TestSettingsIntegration:
         assert retry.backend == "dynamodb"
         assert retry.max_attempts == 10
 
-    def test_settings_singleton_behavior(self):
-        """Test settings from get_settings returns singleton instance."""
+    def test_settings_reuses_retry_singleton(self):
+        """Test Settings delegates retry config to the retry singleton."""
 
-        settings1 = get_settings()
-        settings2 = get_settings()
+        settings = Settings()
+        retry_settings = get_retry_settings()
 
-        assert settings1 is not None
-        assert isinstance(settings1, Settings)
-        assert isinstance(settings2, Settings)
-        assert settings1 is settings2  # Same instance (singleton)
+        assert settings.retry is retry_settings


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the server startup process to include SRE Ops configuration in the application lifecycle and makes a fix to the CORS configuration logic. The main changes are focused on improving configuration visibility and correcting environment-based behavior.

Configuration management improvements:

* Added `SreOpsSettings` to the imports and updated the `_list_configs_from_sections` function to accept and log the SRE Ops configuration keys, ensuring SRE Ops settings are included in the configuration summary at startup (`app/server/lifespan.py`). [[1]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bL22-R24) [[2]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bR66) [[3]](diffhunk://#diff-6c019b8920056a66025242f842ee1faef65893c3e8f8a0560ea0d7e2a657955bR80)
* Updated the `lifespan` function to use `app_settings` as the main settings object on `app.state`, removing the previous use of a generic `Settings` object (`app/server/lifespan.py`).

Bug fix:

* Corrected the CORS origins logic to allow all origins only if `app_settings.PREFIX` is not set, instead of relying on the production environment flag (`app/server/server.py`).