### PR TITLE
fix(dev): update devcontainer, add root Makefile + issues sync script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,7 +54,8 @@
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "20"
-		}
+		},
+		"ghcr.io/devcontainers/features/github-cli:1.1.0": {}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Repo-level entry point. Repo-wide targets live here; anything else is
+# forwarded to app/Makefile so dev commands work from the repo root
+# (e.g. `make test`, `make lint`, `make dev`).
+
+.DEFAULT_GOAL := help
+
+.PHONY: help sync-issues sync-issues-apply backlog-board
+
+help:
+	@echo "Repo-level targets:"
+	@echo "  sync-issues        dry-run sync of backlog tasks -> GitHub issues"
+	@echo "  sync-issues-apply  apply the sync (creates/updates/closes issues)"
+	@echo "  backlog-board      Backlog.md web UI at http://localhost:6421"
+	@echo ""
+	@echo "Any other target is forwarded to app/Makefile (test, lint, fmt, dev, ...)."
+
+sync-issues:
+	uv run --script bin/backlog_issue_sync.py
+
+sync-issues-apply:
+	uv run --script bin/backlog_issue_sync.py --apply
+
+backlog-board:
+	backlog browser --no-open --port 6421
+
+.DEFAULT:
+	@$(MAKE) -C app $@

--- a/app/Makefile
+++ b/app/Makefile
@@ -85,8 +85,8 @@ fmt-ci:
 audit-client-usage-matrix:
 	bash bin/generate_client_usage_matrix.sh
 
-backlog-board: # Backlog.md web UI (Kanban board) at http://localhost:6420
-	cd .. && backlog browser
+backlog-board: # Backlog.md web UI (Kanban board) at http://localhost:6421
+	cd .. && backlog browser --no-open --port 6421
 
 run:
 	uv run uvicorn main:server_app

--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -1,4 +1,4 @@
-project_name: "sentinel"
+project_name: "SRE Bot"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 labels: []

--- a/backlog/tasks/task-1 - Introduce-typed-ENVIRONMENT-setting-and-remove-PREFIX-derived-environment-logic.md
+++ b/backlog/tasks/task-1 - Introduce-typed-ENVIRONMENT-setting-and-remove-PREFIX-derived-environment-logic.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-07 19:56'
+updated_date: '2026-07-08 15:03'
 labels:
   - security
   - phase-0
@@ -14,6 +15,7 @@ dependencies: []
 references:
   - decisions/configuration.md
   - decisions/security.md
+  - 'https://github.com/cds-snc/sre-bot/issues/1254'
 priority: high
 ordinal: 1000
 ---

--- a/backlog/tasks/task-44 - Consolidate-dev-tooling-at-the-repo-root-uv-project-layout-and-single-Makefile-entry-point.md
+++ b/backlog/tasks/task-44 - Consolidate-dev-tooling-at-the-repo-root-uv-project-layout-and-single-Makefile-entry-point.md
@@ -1,0 +1,37 @@
+---
+id: TASK-44
+title: >-
+  Consolidate dev tooling at the repo root: uv project layout and single
+  Makefile entry point
+status: To Do
+assignee: []
+created_date: '2026-07-08 15:04'
+labels:
+  - toolchain
+dependencies: []
+references:
+  - Makefile
+  - app/Makefile
+  - app/pyproject.toml
+priority: medium
+ordinal: 44000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A root Makefile now forwards unknown targets to app/Makefile (added 2026-07-08) so dev commands work from the repo root, which is the conventional pattern. That is a stopgap: the underlying layout still has pyproject.toml, uv.lock, and all tooling config living in app/ while backlog/, decisions/, terraform/, and tests/ live at the root.
+
+Decide and implement the durable structure:
+1. Evaluate moving pyproject.toml + uv.lock to the repo root (uv supports running against a nested project via --project/--directory, and root-level metadata is what most tools — ruff, mypy, pytest, pre-commit, Renovate, IDEs — resolve by default). Alternative: a uv workspace with app/ as a member if more packages are expected.
+2. Align every consumer of the current layout: Dockerfile build context, CI workflows, devcontainer, and any script assuming cwd=app/.
+3. Keep root Makefile as the single entry point; app/Makefile either disappears or becomes internal.
+4. Record the outcome in decisions/ (toolchain or structure decision record).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All routine dev commands (test, lint, fmt, dev, install) run from the repo root without cd app/
+- [ ] #2 uv resolves the project from the repo root (root pyproject/workspace or documented --project pattern); CI, Dockerfile, and devcontainer updated accordingly
+- [ ] #3 Decision record in decisions/ documents the chosen layout and why
+<!-- AC:END -->

--- a/backlog/tasks/task-44 - Consolidate-dev-tooling-at-the-repo-root-uv-project-layout-and-single-Makefile-entry-point.md
+++ b/backlog/tasks/task-44 - Consolidate-dev-tooling-at-the-repo-root-uv-project-layout-and-single-Makefile-entry-point.md
@@ -6,8 +6,10 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-08 15:04'
+updated_date: '2026-07-08 16:27'
 labels:
   - toolchain
+milestone: m-1
 dependencies: []
 references:
   - Makefile

--- a/bin/backlog_issue_sync.py
+++ b/bin/backlog_issue_sync.py
@@ -48,15 +48,8 @@ BACKLOG_DIR = REPO_ROOT / "backlog"
 MARKER_RE = re.compile(r"<!-- backlog-sync: (task-[\w.-]+) -->")
 FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\Z", re.S)
 
-SYNC_LABEL = "backlog"
-LABEL_COLORS = {
-    SYNC_LABEL: "5319e7",
-    "priority: high": "d93f0b",
-    "priority: medium": "fbca04",
-    "priority: low": "c2e0c6",
-    "status: in-progress": "1d76db",
-}
-DEFAULT_LABEL_COLOR = "ededed"
+# GitHub issues stay deliberately plain: title + body + open/closed state.
+# Rich metadata (labels, priority, milestone) lives only in the backlog.
 
 
 @dataclass
@@ -154,33 +147,9 @@ def load_tasks() -> dict[str, Task]:
     return tasks
 
 
-def load_milestone_titles() -> dict[str, str]:
-    titles: dict[str, str] = {}
-    directory = BACKLOG_DIR / "milestones"
-    if not directory.is_dir():
-        return titles
-    for path in directory.glob("*.md"):
-        match = FRONTMATTER_RE.match(path.read_text(encoding="utf-8"))
-        if not match:
-            continue
-        meta = yaml.safe_load(match.group(1)) or {}
-        if meta.get("id") and meta.get("title"):
-            titles[str(meta["id"]).lower()] = str(meta["title"]).strip()
-    return titles
-
-
 def task_sort_key(task_id: str):
     match = re.search(r"(\d+)", task_id)
     return (int(match.group(1)) if match else 0, task_id)
-
-
-def desired_labels(task: Task) -> set[str]:
-    labels = set(task.labels) | {SYNC_LABEL}
-    if task.priority:
-        labels.add(f"priority: {task.priority}")
-    if task.status.strip().lower() == "in progress":
-        labels.add("status: in-progress")
-    return labels
 
 
 def render_body(task: Task, issue_by_task: dict[str, int], nwo: str) -> str:
@@ -225,31 +194,6 @@ def normalize(text: str) -> str:
     return text.replace("\r\n", "\n").strip()
 
 
-def ensure_labels(needed: set[str], apply: bool) -> list[str]:
-    existing = {label["name"] for label in gh_json("label", "list", "--limit", "300", "--json", "name")}
-    missing = sorted(needed - existing)
-    for name in missing:
-        if apply:
-            gh(
-                "label", "create", name,
-                "--color", LABEL_COLORS.get(name, DEFAULT_LABEL_COLOR),
-                "--description", "Managed by backlog issue sync",
-            )
-    return missing
-
-
-def ensure_milestones(needed: set[str], apply: bool) -> list[str]:
-    existing = {
-        milestone["title"]
-        for milestone in gh_json("api", "repos/{owner}/{repo}/milestones?state=all&per_page=100")
-    }
-    missing = sorted(needed - existing)
-    for title in missing:
-        if apply:
-            gh("api", "-X", "POST", "repos/{owner}/{repo}/milestones", "-f", f"title={title}")
-    return missing
-
-
 def write_back_reference(task: Task, issue_url: str) -> None:
     """Append the issue URL to the task's references via the backlog CLI.
 
@@ -280,7 +224,6 @@ def main() -> int:
 
     nwo = gh_json("repo", "view", "--json", "nameWithOwner")["nameWithOwner"]
     all_tasks = load_tasks()
-    milestone_titles = load_milestone_titles()
 
     if args.task:
         wanted = {t.lower() for t in args.task}
@@ -292,7 +235,7 @@ def main() -> int:
         selected = all_tasks
 
     issues = gh_json("issue", "list", "--state", "all", "--limit", "1000",
-                     "--json", "number,title,body,state,labels,milestone")
+                     "--json", "number,title,body,state")
     issue_for_task: dict[str, dict] = {}
     unmanaged_open = 0
     for issue in issues:
@@ -309,17 +252,6 @@ def main() -> int:
 
     to_process = [selected[tid] for tid in sorted(selected, key=task_sort_key)]
 
-    needed_labels = set().union(*(desired_labels(task) for task in to_process)) if to_process else set()
-    needed_milestones = {
-        milestone_titles[task.milestone]
-        for task in to_process
-        if task.milestone and task.milestone in milestone_titles
-    }
-    for name in ensure_labels(needed_labels, args.apply):
-        print(f"LABEL     create '{name}'")
-    for title in ensure_milestones(needed_milestones, args.apply):
-        print(f"MILESTONE create '{title}'")
-
     def throttle():
         if args.apply:
             time.sleep(args.throttle)
@@ -332,31 +264,19 @@ def main() -> int:
         if task.id in issue_number_by_task or task.desired_closed:
             continue
         body = render_body(task, issue_number_by_task, nwo)
-        milestone_title = milestone_titles.get(task.milestone, "")
         print(f"CREATE    {task.id}: {task.title[:70]}")
         counts["create"] += 1
         if not args.apply:
             continue
-        create_args = ["issue", "create", "--title", task.title, "--body-file", "-"]
-        for label in sorted(desired_labels(task)):
-            create_args += ["--label", label]
-        if milestone_title:
-            create_args += ["--milestone", milestone_title]
-        url = gh(*create_args, input_text=body)
+        url = gh("issue", "create", "--title", task.title, "--body-file", "-", input_text=body)
         number = int(url.rstrip("/").rsplit("/", 1)[1])
         issue_number_by_task[task.id] = number
         issue_for_task[task.id] = {
             "number": number, "title": task.title, "body": body, "state": "OPEN",
-            "labels": [{"name": label} for label in desired_labels(task)],
-            "milestone": {"title": milestone_title} if milestone_title else None,
         }
         print(f"          -> {url}")
         write_back_reference(task, url)
         throttle()
-
-    # Labels this sync owns and may remove when no longer desired: anything a
-    # backlog task declares, plus the sync's own namespaces.
-    managed_labels = set().union(*(desired_labels(task) for task in all_tasks.values())) if all_tasks else set()
 
     # Pass 2: converge existing issues (including ones just created, whose
     # dependency links may have resolved later in pass 1).
@@ -369,33 +289,17 @@ def main() -> int:
             continue
         number = issue["number"]
         desired_body = render_body(task, issue_number_by_task, nwo)
-        desired = desired_labels(task)
-        current_labels = {label["name"] for label in issue.get("labels") or []}
-        current_milestone = (issue.get("milestone") or {}).get("title") or ""
-        wanted_milestone = milestone_titles.get(task.milestone, "")
-        add_labels = sorted(desired - current_labels)
-        remove_labels = sorted((current_labels & managed_labels) - desired)
         content_differs = (
             normalize(issue.get("body") or "") != normalize(desired_body)
             or issue.get("title", "") != task.title
-            or add_labels or remove_labels
-            or current_milestone != wanted_milestone
         )
 
         if content_differs:
             print(f"UPDATE    #{number} {task.id}")
             counts["update"] += 1
             if args.apply:
-                edit_args = ["issue", "edit", str(number), "--title", task.title, "--body-file", "-"]
-                for label in add_labels:
-                    edit_args += ["--add-label", label]
-                for label in remove_labels:
-                    edit_args += ["--remove-label", label]
-                if wanted_milestone and wanted_milestone != current_milestone:
-                    edit_args += ["--milestone", wanted_milestone]
-                elif current_milestone and not wanted_milestone:
-                    edit_args += ["--remove-milestone"]
-                gh(*edit_args, input_text=desired_body)
+                gh("issue", "edit", str(number), "--title", task.title,
+                   "--body-file", "-", input_text=desired_body)
                 throttle()
 
         is_closed = issue["state"] == "CLOSED"

--- a/bin/backlog_issue_sync.py
+++ b/bin/backlog_issue_sync.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""One-way, idempotent sync of Backlog.md tasks to GitHub issues.
+
+The backlog (backlog/tasks/*.md) is the source of truth. Each synced issue
+carries a hidden ``<!-- backlog-sync: task-N -->`` marker in its body; the
+marker is the durable key between a task and its issue. Issues without a
+marker (community-filed) are never touched.
+
+Behaviour per task:
+  - no marker issue exists            -> create (skipped if the task is already Done)
+  - issue exists, rendered content    -> update title/body/labels/milestone
+    differs from desired
+  - task Done / completed / archived  -> close the issue
+  - task active but issue closed      -> reopen
+  - everything matches                -> skip
+
+Default mode is a dry run that prints the plan without writing anything.
+Pass --apply to execute. Read-only gh calls happen in both modes.
+
+Usage:
+    uv run --script bin/backlog_issue_sync.py                 # dry run, all tasks
+    uv run --script bin/backlog_issue_sync.py --task task-1   # scope to specific tasks
+    uv run --script bin/backlog_issue_sync.py --apply         # do it
+    uv run --script bin/backlog_issue_sync.py --apply --prune # also close orphaned marker issues
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import quote
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKLOG_DIR = REPO_ROOT / "backlog"
+
+MARKER_RE = re.compile(r"<!-- backlog-sync: (task-[\w.-]+) -->")
+FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\Z", re.S)
+
+SYNC_LABEL = "backlog"
+LABEL_COLORS = {
+    SYNC_LABEL: "5319e7",
+    "priority: high": "d93f0b",
+    "priority: medium": "fbca04",
+    "priority: low": "c2e0c6",
+    "status: in-progress": "1d76db",
+}
+DEFAULT_LABEL_COLOR = "ededed"
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    status: str
+    path: Path
+    labels: list[str] = field(default_factory=list)
+    priority: str = ""
+    milestone: str = ""
+    dependencies: list[str] = field(default_factory=list)
+    references: list[str] = field(default_factory=list)
+    description: str = ""
+    acceptance_criteria: str = ""
+    definition_of_done: str = ""
+    terminal: bool = False  # lives in completed/ or archive/
+
+    @property
+    def desired_closed(self) -> bool:
+        return self.terminal or self.status.strip().lower() == "done"
+
+
+def gh(*args: str, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        cwd=REPO_ROOT,
+        input=input_text,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def gh_json(*args: str):
+    out = gh(*args)
+    return json.loads(out) if out else []
+
+
+def extract_section(body: str, begin: str, end: str) -> str:
+    match = re.search(re.escape(begin) + r"(.*?)" + re.escape(end), body, re.S)
+    return match.group(1).strip() if match else ""
+
+
+def strip_item_indexes(text: str) -> str:
+    """Backlog numbers AC/DoD items as '- [ ] #1 ...'; '#1' would autolink to
+    an unrelated issue on GitHub, so drop the index."""
+    return re.sub(r"^(\s*- \[[ xX]\]) #\d+\s+", r"\1 ", text, flags=re.M)
+
+
+def parse_task(path: Path, terminal: bool) -> Task | None:
+    match = FRONTMATTER_RE.match(path.read_text(encoding="utf-8"))
+    if not match:
+        return None
+    meta = yaml.safe_load(match.group(1)) or {}
+    body = match.group(2)
+    task_id = str(meta.get("id", "")).lower()
+    if not task_id.startswith("task-"):
+        return None
+    return Task(
+        id=task_id,
+        title=str(meta.get("title", "")).strip(),
+        status=str(meta.get("status", "")),
+        path=path,
+        labels=[str(label) for label in meta.get("labels") or []],
+        priority=str(meta.get("priority") or ""),
+        milestone=str(meta.get("milestone") or ""),
+        dependencies=[str(dep).lower() for dep in meta.get("dependencies") or []],
+        references=[str(ref) for ref in meta.get("references") or []],
+        description=extract_section(
+            body, "<!-- SECTION:DESCRIPTION:BEGIN -->", "<!-- SECTION:DESCRIPTION:END -->"
+        ),
+        acceptance_criteria=extract_section(body, "<!-- AC:BEGIN -->", "<!-- AC:END -->"),
+        definition_of_done=extract_section(body, "<!-- DOD:BEGIN -->", "<!-- DOD:END -->"),
+        terminal=terminal,
+    )
+
+
+def load_tasks() -> dict[str, Task]:
+    tasks: dict[str, Task] = {}
+    sources = [
+        (BACKLOG_DIR / "tasks", False),
+        (BACKLOG_DIR / "completed", True),
+        (BACKLOG_DIR / "archive" / "tasks", True),
+    ]
+    for directory, terminal in sources:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.md")):
+            task = parse_task(path, terminal)
+            if task:
+                tasks[task.id] = task
+    return tasks
+
+
+def load_milestone_titles() -> dict[str, str]:
+    titles: dict[str, str] = {}
+    directory = BACKLOG_DIR / "milestones"
+    if not directory.is_dir():
+        return titles
+    for path in directory.glob("*.md"):
+        match = FRONTMATTER_RE.match(path.read_text(encoding="utf-8"))
+        if not match:
+            continue
+        meta = yaml.safe_load(match.group(1)) or {}
+        if meta.get("id") and meta.get("title"):
+            titles[str(meta["id"]).lower()] = str(meta["title"]).strip()
+    return titles
+
+
+def task_sort_key(task_id: str):
+    match = re.search(r"(\d+)", task_id)
+    return (int(match.group(1)) if match else 0, task_id)
+
+
+def desired_labels(task: Task) -> set[str]:
+    labels = set(task.labels) | {SYNC_LABEL}
+    if task.priority:
+        labels.add(f"priority: {task.priority}")
+    if task.status.strip().lower() == "in progress":
+        labels.add("status: in-progress")
+    return labels
+
+
+def render_body(task: Task, issue_by_task: dict[str, int], nwo: str) -> str:
+    blob = f"https://github.com/{nwo}/blob/main/"
+    rel_path = task.path.relative_to(REPO_ROOT).as_posix()
+    lines = [
+        "> [!NOTE]",
+        f"> This issue mirrors [`{task.id}`]({blob}{quote(rel_path)}) in this repository's "
+        "[Backlog.md](https://github.com/MrLesk/Backlog.md) backlog, which is the source of "
+        "truth for planned work.",
+        "> Comments are welcome and read by maintainers; the issue body is overwritten on "
+        "every sync.",
+        "",
+        "## Description",
+        "",
+        task.description or "_No description provided._",
+    ]
+    if task.acceptance_criteria:
+        lines += ["", "## Acceptance Criteria", "", strip_item_indexes(task.acceptance_criteria)]
+    if task.definition_of_done:
+        lines += ["", "## Definition of Done", "", strip_item_indexes(task.definition_of_done)]
+    if task.dependencies:
+        lines += ["", "## Dependencies", ""]
+        for dep in task.dependencies:
+            number = issue_by_task.get(dep)
+            lines.append(f"- #{number} (`{dep}`)" if number else f"- `{dep}` (not yet synced)")
+    references = [ref for ref in task.references if f"github.com/{nwo}/issues/" not in ref]
+    if references:
+        lines += ["", "## References", ""]
+        for ref in references:
+            if ref.startswith("http"):
+                lines.append(f"- {ref}")
+            elif (REPO_ROOT / ref).exists():
+                lines.append(f"- [{ref}]({blob}{quote(ref)})")
+            else:
+                lines.append(f"- `{ref}`")
+    lines += ["", f"<!-- backlog-sync: {task.id} -->"]
+    return "\n".join(lines) + "\n"
+
+
+def normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").strip()
+
+
+def ensure_labels(needed: set[str], apply: bool) -> list[str]:
+    existing = {label["name"] for label in gh_json("label", "list", "--limit", "300", "--json", "name")}
+    missing = sorted(needed - existing)
+    for name in missing:
+        if apply:
+            gh(
+                "label", "create", name,
+                "--color", LABEL_COLORS.get(name, DEFAULT_LABEL_COLOR),
+                "--description", "Managed by backlog issue sync",
+            )
+    return missing
+
+
+def ensure_milestones(needed: set[str], apply: bool) -> list[str]:
+    existing = {
+        milestone["title"]
+        for milestone in gh_json("api", "repos/{owner}/{repo}/milestones?state=all&per_page=100")
+    }
+    missing = sorted(needed - existing)
+    for title in missing:
+        if apply:
+            gh("api", "-X", "POST", "repos/{owner}/{repo}/milestones", "-f", f"title={title}")
+    return missing
+
+
+def write_back_reference(task: Task, issue_url: str) -> None:
+    """Append the issue URL to the task's references via the backlog CLI.
+
+    `backlog task edit --ref` REPLACES the reference list, so every existing
+    reference must be passed alongside the new one.
+    """
+    args = ["task", "edit", task.id]
+    for ref in [*task.references, issue_url]:
+        args += ["--ref", ref]
+    result = subprocess.run(["backlog", *args, "--plain"], cwd=REPO_ROOT, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  warning: could not write reference back to {task.id}: {result.stderr.strip()}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--apply", action="store_true", help="execute the plan (default: dry run)")
+    parser.add_argument("--task", action="append", default=[], metavar="TASK_ID",
+                        help="limit sync to specific task ids (repeatable)")
+    parser.add_argument("--prune", action="store_true",
+                        help="close marker issues whose task no longer exists")
+    parser.add_argument("--throttle", type=float, default=2.0,
+                        help="seconds to sleep between mutating calls (default: 2)")
+    args = parser.parse_args()
+
+    if args.prune and args.task:
+        parser.error("--prune cannot be combined with --task (orphan detection needs the full task set)")
+
+    nwo = gh_json("repo", "view", "--json", "nameWithOwner")["nameWithOwner"]
+    all_tasks = load_tasks()
+    milestone_titles = load_milestone_titles()
+
+    if args.task:
+        wanted = {t.lower() for t in args.task}
+        unknown = wanted - all_tasks.keys()
+        if unknown:
+            parser.error(f"unknown task ids: {', '.join(sorted(unknown))}")
+        selected = {tid: all_tasks[tid] for tid in wanted}
+    else:
+        selected = all_tasks
+
+    issues = gh_json("issue", "list", "--state", "all", "--limit", "1000",
+                     "--json", "number,title,body,state,labels,milestone")
+    issue_for_task: dict[str, dict] = {}
+    unmanaged_open = 0
+    for issue in issues:
+        marker = MARKER_RE.search(issue.get("body") or "")
+        if marker:
+            issue_for_task[marker.group(1)] = issue
+        elif issue["state"] == "OPEN":
+            unmanaged_open += 1
+    issue_number_by_task = {tid: issue["number"] for tid, issue in issue_for_task.items()}
+
+    mode = "APPLY" if args.apply else "DRY RUN"
+    print(f"[{mode}] {nwo}: {len(selected)} task(s) selected, "
+          f"{len(issue_for_task)} synced issue(s) found, {unmanaged_open} unmanaged open issue(s) (ignored)\n")
+
+    to_process = [selected[tid] for tid in sorted(selected, key=task_sort_key)]
+
+    needed_labels = set().union(*(desired_labels(task) for task in to_process)) if to_process else set()
+    needed_milestones = {
+        milestone_titles[task.milestone]
+        for task in to_process
+        if task.milestone and task.milestone in milestone_titles
+    }
+    for name in ensure_labels(needed_labels, args.apply):
+        print(f"LABEL     create '{name}'")
+    for title in ensure_milestones(needed_milestones, args.apply):
+        print(f"MILESTONE create '{title}'")
+
+    def throttle():
+        if args.apply:
+            time.sleep(args.throttle)
+
+    counts = {"create": 0, "update": 0, "close": 0, "reopen": 0, "skip": 0, "prune": 0}
+
+    # Pass 1: create missing issues (in task order, so dependency links to
+    # lower-numbered tasks resolve immediately).
+    for task in to_process:
+        if task.id in issue_number_by_task or task.desired_closed:
+            continue
+        body = render_body(task, issue_number_by_task, nwo)
+        milestone_title = milestone_titles.get(task.milestone, "")
+        print(f"CREATE    {task.id}: {task.title[:70]}")
+        counts["create"] += 1
+        if not args.apply:
+            continue
+        create_args = ["issue", "create", "--title", task.title, "--body-file", "-"]
+        for label in sorted(desired_labels(task)):
+            create_args += ["--label", label]
+        if milestone_title:
+            create_args += ["--milestone", milestone_title]
+        url = gh(*create_args, input_text=body)
+        number = int(url.rstrip("/").rsplit("/", 1)[1])
+        issue_number_by_task[task.id] = number
+        issue_for_task[task.id] = {
+            "number": number, "title": task.title, "body": body, "state": "OPEN",
+            "labels": [{"name": label} for label in desired_labels(task)],
+            "milestone": {"title": milestone_title} if milestone_title else None,
+        }
+        print(f"          -> {url}")
+        write_back_reference(task, url)
+        throttle()
+
+    # Labels this sync owns and may remove when no longer desired: anything a
+    # backlog task declares, plus the sync's own namespaces.
+    managed_labels = set().union(*(desired_labels(task) for task in all_tasks.values())) if all_tasks else set()
+
+    # Pass 2: converge existing issues (including ones just created, whose
+    # dependency links may have resolved later in pass 1).
+    for task in to_process:
+        issue = issue_for_task.get(task.id)
+        if issue is None:
+            if task.desired_closed:
+                print(f"SKIP      {task.id}: already done, never synced — not creating")
+                counts["skip"] += 1
+            continue
+        number = issue["number"]
+        desired_body = render_body(task, issue_number_by_task, nwo)
+        desired = desired_labels(task)
+        current_labels = {label["name"] for label in issue.get("labels") or []}
+        current_milestone = (issue.get("milestone") or {}).get("title") or ""
+        wanted_milestone = milestone_titles.get(task.milestone, "")
+        add_labels = sorted(desired - current_labels)
+        remove_labels = sorted((current_labels & managed_labels) - desired)
+        content_differs = (
+            normalize(issue.get("body") or "") != normalize(desired_body)
+            or issue.get("title", "") != task.title
+            or add_labels or remove_labels
+            or current_milestone != wanted_milestone
+        )
+
+        if content_differs:
+            print(f"UPDATE    #{number} {task.id}")
+            counts["update"] += 1
+            if args.apply:
+                edit_args = ["issue", "edit", str(number), "--title", task.title, "--body-file", "-"]
+                for label in add_labels:
+                    edit_args += ["--add-label", label]
+                for label in remove_labels:
+                    edit_args += ["--remove-label", label]
+                if wanted_milestone and wanted_milestone != current_milestone:
+                    edit_args += ["--milestone", wanted_milestone]
+                elif current_milestone and not wanted_milestone:
+                    edit_args += ["--remove-milestone"]
+                gh(*edit_args, input_text=desired_body)
+                throttle()
+
+        is_closed = issue["state"] == "CLOSED"
+        if task.desired_closed and not is_closed:
+            print(f"CLOSE     #{number} {task.id} (task is done)")
+            counts["close"] += 1
+            if args.apply:
+                gh("issue", "close", str(number), "--comment",
+                   f"Closed by backlog sync: `{task.id}` is done.")
+                throttle()
+        elif not task.desired_closed and is_closed:
+            print(f"REOPEN    #{number} {task.id} (task is active in the backlog)")
+            counts["reopen"] += 1
+            if args.apply:
+                gh("issue", "reopen", str(number), "--comment",
+                   f"Reopened by backlog sync: `{task.id}` is active in the backlog.")
+                throttle()
+        elif not content_differs:
+            counts["skip"] += 1
+
+    if args.prune:
+        for task_id, issue in sorted(issue_for_task.items()):
+            if task_id not in all_tasks and issue["state"] == "OPEN":
+                print(f"PRUNE     #{issue['number']} ({task_id} no longer exists in the backlog)")
+                counts["prune"] += 1
+                if args.apply:
+                    gh("issue", "close", str(issue["number"]), "--comment",
+                       f"Closed by backlog sync: `{task_id}` was removed from the backlog.")
+                    throttle()
+
+    print(f"\nSummary: {counts['create']} create, {counts['update']} update, {counts['close']} close, "
+          f"{counts['reopen']} reopen, {counts['prune']} prune, {counts['skip']} unchanged")
+    if not args.apply and any(counts[k] for k in ("create", "update", "close", "reopen", "prune")):
+        print("Dry run — re-run with --apply to execute.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces improvements to developer tooling and project organization, focusing on consolidating dev commands at the repository root for a more conventional workflow. A new root-level `Makefile` is added to forward commands to `app/Makefile`, and related documentation and configuration are updated accordingly. Additionally, a new backlog task is created to further improve and formalize the project's structure.

**Developer Tooling and Project Layout Improvements:**

* Added a root-level `Makefile` that acts as the main entry point for developer commands, forwarding unknown targets to `app/Makefile`. This allows dev commands like `make test` or `make lint` to be run from the repo root, aligning with common conventions.
* Updated the `backlog-board` target in `app/Makefile` to run the board UI on port 6421 and prevent auto-opening in the browser, matching the new workflow.
* Added a new backlog task (`task-44`) to evaluate and implement a more durable project structure, including potentially moving `pyproject.toml` and `uv.lock` to the repo root and updating related tooling and documentation.

**Development Environment Enhancements:**

* Updated `.devcontainer/devcontainer.json` to include the GitHub CLI (`ghcr.io/devcontainers/features/github-cli:1.1.0`) as a feature, improving the development environment.

**Backlog and Documentation Updates:**

* Updated metadata for `task-1` in the backlog, including the `updated_date` and an additional reference to a related GitHub issue. [[1]](diffhunk://#diff-4c5077a31ab7f27fb978f73c756b5440587ec54fe0cd41bc84c1baa68eb60006R9) [[2]](diffhunk://#diff-4c5077a31ab7f27fb978f73c756b5440587ec54fe0cd41bc84c1baa68eb60006R18)