### PR TITLE
Feat/plan typed environment

### DIFF
--- a/backlog/tasks/task-1 - Introduce-typed-ENVIRONMENT-setting-and-remove-PREFIX-derived-environment-logic.md
+++ b/backlog/tasks/task-1 - Introduce-typed-ENVIRONMENT-setting-and-remove-PREFIX-derived-environment-logic.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-07 19:56'
-updated_date: '2026-07-08 15:03'
+updated_date: '2026-07-17 16:15'
 labels:
   - security
   - phase-0
@@ -39,6 +39,34 @@ Steps:
 - [ ] #3 Dev-bypass requires the two independent guards (non-production ENVIRONMENT and DEV_BYPASS_ENABLED=true) and logs each use
 - [ ] #4 Unit tests cover: valid values accepted, invalid value rejected at boot, dev-bypass denied when either guard is off
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+This task is decomposed into two subtasks due to the single-PR size gate (3 subsystems crossed: app Python code + terraform + CI; additive change mixed with behavior change).
+
+Subtask execution order (enforced by dependency wiring):
+1. TASK-1.1 — Add ENVIRONMENT + DEV_BYPASS_ENABLED to AppSettings; update all deployment configs (purely additive, no behavior change)
+2. TASK-1.2 — Migrate all environment checks from PREFIX/is_production to ENVIRONMENT; enforce dual dev-bypass guard; remove is_production shim
+
+TASK-1 ACs are satisfied when both subtasks are done:
+- AC #1 → TASK-1.1 (field added, validation enforced)
+- AC #2 → TASK-1.2 (all PREFIX env-derivation replaced)
+- AC #3 → TASK-1.2 (dual guard enforced in current_user.py)
+- AC #4 → TASK-1.1 + TASK-1.2 (unit tests in both slices)
+- DoD #2 → TASK-1.1 (manifests updated)
+- DoD #3 → TASK-1.2 PR description must reference SEC-10 and decisions/configuration.md
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @planner
+created: 2026-07-17 16:15
+---
+AC #2 grep scope is narrower than the actual call-site surface. Current grep target (PREFIX ==) misses: PREFIX !=, bool(PREFIX), if app_settings.PREFIX: (truthy check). TASK-1.2 will target all four forms. Suggest widening AC #2 to: grep -rn 'PREFIX' app/ --include='*.py' and manually excluding URL-prefix uses, OR replacing with: grep -rn 'is_production' app/ --include='*.py' returns no hits (TASK-1.2 AC #1 already covers this). Human approval needed before AC #2 wording is changed.
+---
+<!-- COMMENTS:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
+++ b/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
@@ -1,0 +1,101 @@
+---
+id: TASK-1.1
+title: >-
+  Add ENVIRONMENT and DEV_BYPASS_ENABLED to AppSettings; set in all deployment
+  configs
+status: To Do
+assignee: []
+created_date: '2026-07-17 16:14'
+updated_date: '2026-07-17 16:15'
+labels:
+  - phase-0
+milestone: m-0
+dependencies: []
+references:
+  - decisions/configuration.md
+  - decisions/security.md
+parent_task_id: TASK-1
+priority: high
+ordinal: 45000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expand phase for TASK-1. Purely additive: add ENVIRONMENT: Literal["local","ci","dev","staging","production"] = "local" and DEV_BYPASS_ENABLED: bool = False to AppSettings. Keep is_production as a forwarding shim (return self.ENVIRONMENT == "production") so all existing callers compile. Set ENVIRONMENT in terraform/templates/sre-bot.json.tpl (production) and .github/workflows/ci_code.yml (ci). No behavior change; shim preserves all existing logic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 AppSettings.ENVIRONMENT is Literal["local","ci","dev","staging","production"] with default "local"; AppSettings(ENVIRONMENT="uat") raises pydantic ValidationError at construction
+- [ ] #2 AppSettings.DEV_BYPASS_ENABLED: bool = False by default
+- [ ] #3 is_production property kept as forwarding shim: return self.ENVIRONMENT == "production"
+- [ ] #4 terraform/templates/sre-bot.json.tpl has ENVIRONMENT=production entry in environment array
+- [ ] #5 .github/workflows/ci_code.yml has ENVIRONMENT: ci in the test step env block
+- [ ] #6 All existing tests pass; new unit tests cover valid enum values accepted, invalid value rejected at boot, DEV_BYPASS_ENABLED default, shim correctness
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Ordered steps — all changes are purely additive; is_production shim preserves every existing caller.
+
+Step 1 — app/infrastructure/configuration/app.py
+  - Add `from typing import Literal` import
+  - Add field: ENVIRONMENT: Literal["local","ci","dev","staging","production"] = "local"
+  - Add field: DEV_BYPASS_ENABLED: bool = False
+  - Update is_production property body: return self.ENVIRONMENT == "production"
+  - No other changes; lru_cache singleton provider unchanged
+  - Maps to AC #1, AC #2, AC #3
+
+Step 2 — terraform/templates/sre-bot.json.tpl
+  - In the "environment" JSON array (currently only BACKEND_URL), append:
+    {"name": "ENVIRONMENT", "value": "production"}
+  - No terraform variable needed — value is the literal string "production"
+  - Maps to AC #4
+
+Step 3 — .github/workflows/ci_code.yml
+  - In the Test step's env: block, add:
+    ENVIRONMENT: ci
+  - Maps to AC #5
+
+Step 4 — app/tests/unit/infrastructure/configuration/test_app_settings.py
+  - Add TestAppSettingsEnvironment class (or extend existing TestAppSettings):
+    - test_environment_default_is_local: AppSettings().ENVIRONMENT == "local"
+    - test_environment_all_valid_values: parametrize ["local","ci","dev","staging","production"] — each constructs without error
+    - test_environment_invalid_value_raises_validation_error: AppSettings(ENVIRONMENT="uat") raises ValidationError
+    - test_dev_bypass_enabled_default_false: AppSettings().DEV_BYPASS_ENABLED is False
+    - test_dev_bypass_enabled_can_be_set_true: AppSettings(DEV_BYPASS_ENABLED=True).DEV_BYPASS_ENABLED is True
+    - test_is_production_shim_true_when_production: AppSettings(ENVIRONMENT="production").is_production is True
+    - test_is_production_shim_false_when_local: AppSettings(ENVIRONMENT="local").is_production is False
+    - test_is_production_shim_false_when_ci: AppSettings(ENVIRONMENT="ci").is_production is False
+  - Maps to AC #6
+
+AC traceability:
+  AC #1 (ENVIRONMENT field + validation) — Steps 1, 4
+  AC #2 (DEV_BYPASS_ENABLED default) — Steps 1, 4
+  AC #3 (is_production shim) — Steps 1, 4
+  AC #4 (terraform manifest) — Step 2
+  AC #5 (CI env) — Step 3
+  AC #6 (tests pass) — Step 4
+
+Test matrix:
+  Happy: AppSettings() constructs with defaults; each of the 5 valid ENVIRONMENT values accepted
+  Boundary: ENVIRONMENT="staging" accepted (future-proofing; not currently deployed)
+  Failure: ENVIRONMENT="uat" raises pydantic ValidationError at construction time
+  Default: DEV_BYPASS_ENABLED=False; ENVIRONMENT="local"
+  Shim: is_production=True only when ENVIRONMENT=="production"; False for all other 4 values
+  Regression: existing PREFIX and LOG_LEVEL tests continue to pass unchanged
+
+Assumptions and verification:
+  1. `from typing import Literal` is not yet imported in app.py — verify with read before editing
+  2. terraform/ecs.tf does NOT need a new variable for ENVIRONMENT; the template uses a hardcoded literal "production" value which is correct since this template only runs for prod — verify by checking ecs.tf for existing variable bindings
+  3. .devcontainer/docker-compose.yml already has ENVIRONMENT: 'dev' — confirmed; no change needed
+  4. The `lru_cache` on get_app_settings means ENVIRONMENT is read once at startup; tests that use AppSettings() directly bypass the cache and are unaffected
+
+Blast radius and rollback:
+  - Change is purely additive; is_production shim returns identical results to current PREFIX-based logic (for any real deployment: prod sets ENVIRONMENT=production → is_production=True; all others have PREFIX != "" → is_production was False → shim returns False)
+  - CRITICAL ordering: app code and terraform/CI changes must ship in the same PR so production never sees ENVIRONMENT defaulting to "local" (which would make is_production=False)
+  - Single git revert of this PR fully restores previous state; TASK-1.2 cannot compile without TASK-1.1 (ENVIRONMENT and DEV_BYPASS_ENABLED fields would be missing)
+  - No routing or security logic changes; any revert is clean
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
+++ b/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
@@ -1,0 +1,36 @@
+---
+id: TASK-1.2
+title: >-
+  Migrate all environment checks to ENVIRONMENT; enforce dual dev-bypass guard;
+  remove is_production
+status: To Do
+assignee: []
+created_date: '2026-07-17 16:14'
+labels:
+  - phase-0
+milestone: m-0
+dependencies:
+  - TASK-1.1
+references:
+  - decisions/configuration.md
+  - decisions/security.md
+parent_task_id: TASK-1
+priority: high
+ordinal: 46000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate + contract phase for TASK-1. Replace every is_production and PREFIX-derived environment check across 9 production files with reads of AppSettings.ENVIRONMENT. Apply the dual dev-bypass guard in current_user.py (ENVIRONMENT != "production" AND DEV_BYPASS_ENABLED). Fix SNS validation gap (aws_sns.py skipped validation when not is_production — must validate in all environments). Set local DynamoDB endpoint for ENVIRONMENT in (local, dev, ci) only. Remove is_production shim. Update all test fixtures that mocked is_production.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 grep -rn "is_production" app/ --include="*.py" returns no hits outside test files that assert the property is gone
+- [ ] #2 grep -rn "PREFIX\s*[!<>=]\|bool(PREFIX)\|if.*PREFIX\b" app/ --include="*.py" returns no environment-derivation hits (PREFIX may remain for URL-prefix use only)
+- [ ] #3 current_user.py dev-bypass requires ENVIRONMENT != production AND DEV_BYPASS_ENABLED=true; either guard alone blocks bypass; each use is logged
+- [ ] #4 aws_sns.py validate_sns_payload validates in all environments (no is_production skip)
+- [ ] #5 dynamodb local endpoint activates only for ENVIRONMENT in (local, dev, ci); staging and production use real AWS
+- [ ] #6 All existing tests plus new dual-guard tests pass
+<!-- AC:END -->

--- a/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
+++ b/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-17 16:14'
+updated_date: '2026-07-17 16:22'
 labels:
   - phase-0
 milestone: m-0
@@ -30,7 +31,7 @@ Migrate + contract phase for TASK-1. Replace every is_production and PREFIX-deri
 - [ ] #1 grep -rn "is_production" app/ --include="*.py" returns no hits outside test files that assert the property is gone
 - [ ] #2 grep -rn "PREFIX\s*[!<>=]\|bool(PREFIX)\|if.*PREFIX\b" app/ --include="*.py" returns no environment-derivation hits (PREFIX may remain for URL-prefix use only)
 - [ ] #3 current_user.py dev-bypass requires ENVIRONMENT != production AND DEV_BYPASS_ENABLED=true; either guard alone blocks bypass; each use is logged
-- [ ] #4 aws_sns.py validate_sns_payload validates in all environments (no is_production skip)
-- [ ] #5 dynamodb local endpoint activates only for ENVIRONMENT in (local, dev, ci); staging and production use real AWS
-- [ ] #6 All existing tests plus new dual-guard tests pass
+- [ ] #4 dynamodb local endpoint activates only for ENVIRONMENT in (local, dev, ci); staging and production use real AWS
+- [ ] #5 All existing tests plus new dual-guard tests pass
+- [ ] #6 aws_sns.py validate_sns_payload skips validation when ENVIRONMENT != 'production' (local/dev/ci never receive real SNS payloads from the internet); validation is always enforced when ENVIRONMENT == 'production'
 <!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

Setting up the plan/tasks to migrate to a typed environment approach instead of using a simple prefix.

This pull request introduces a phased migration to a strongly-typed `ENVIRONMENT` setting and a new `DEV_BYPASS_ENABLED` flag in the application configuration. The work is decomposed into two subtasks: the first adds the new fields and updates deployment configs without changing behavior, while the second migrates all environment checks to use the new `ENVIRONMENT` field, enforces a dual guard for dev-bypass, and removes legacy logic. Each subtask is tracked with detailed acceptance criteria, implementation steps, and test coverage to ensure a safe and reversible rollout.

**Task decomposition and implementation planning:**

* Added a detailed implementation plan to `task-1 - Introduce-typed-ENVIRONMENT-setting-and-remove-PREFIX-derived-environment-logic.md`, splitting the work into two subtasks (TASK-1.1 and TASK-1.2) and mapping each acceptance criterion to the relevant subtask.
* Added a comment clarifying the grep scope for environment checks, suggesting improvements to `AC #2` for more robust coverage of all code paths using `PREFIX`.

**Subtask 1: Additive configuration changes (TASK-1.1):**

* Created `task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md`, specifying the addition of `ENVIRONMENT` (as a `Literal` enum) and `DEV_BYPASS_ENABLED` (bool) to `AppSettings`, updating deployment manifests, and adding comprehensive unit tests.

**Subtask 2: Migration and enforcement (TASK-1.2):**

* Created `task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md`, detailing the migration of all environment checks to use `ENVIRONMENT`, enforcing the dual dev-bypass guard, updating SNS validation logic, and removing the legacy `is_production` shim.