### PR TITLE
Feat/typed environment shim

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -47,6 +47,7 @@ jobs:
         working-directory: ./app
         run: make test
         env:
+          ENVIRONMENT: ci
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}

--- a/app/infrastructure/configuration/app.py
+++ b/app/infrastructure/configuration/app.py
@@ -1,6 +1,7 @@
 """Application-level settings and singleton provider."""
 
 from functools import lru_cache
+from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,13 +12,15 @@ class AppSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     PREFIX: str = ""
+    ENVIRONMENT: Literal["local", "ci", "dev", "staging", "production"] = "local"
+    DEV_BYPASS_ENABLED: bool = False
     LOG_LEVEL: str = "INFO"
     GIT_SHA: str = "Unknown"
 
     @property
     def is_production(self) -> bool:
-        """True when PREFIX is empty (production deployment)."""
-        return not bool(self.PREFIX)
+        """True when ENVIRONMENT is production."""
+        return self.ENVIRONMENT == "production"
 
 
 @lru_cache(maxsize=1)

--- a/app/tests/integrations/notify/test_notify_client.py
+++ b/app/tests/integrations/notify/test_notify_client.py
@@ -177,8 +177,10 @@ def test_post_event(mock_auth_header, mock_post, mock_notify_settings):
 
 # Test the revoke_api_key function when NOTIFY_API_URL is None
 @patch("integrations.notify.client.notify_settings", new_callable=MagicMock)
+@patch("integrations.notify.client.settings", new_callable=MagicMock)
 @patch("integrations.notify.client.logger")
-def test_revoke_api_key_missing_url(mock_logger, mock_notify_settings):
+def test_revoke_api_key_missing_url(mock_logger, mock_settings, mock_notify_settings):
+    mock_settings.is_production = True
     mock_notify_settings.NOTIFY_API_URL = None
     bound_logger_mock = mock_logger.bind.return_value
     result = notify.revoke_api_key("api-key-123", "api-type", "github.com/repo", "test")
@@ -192,8 +194,12 @@ def test_revoke_api_key_missing_url(mock_logger, mock_notify_settings):
 # Test successful API key revocation (status code 201)
 @patch("integrations.notify.client.notify_settings", new_callable=MagicMock)
 @patch("integrations.notify.client.post_event")
+@patch("integrations.notify.client.settings", new_callable=MagicMock)
 @patch("integrations.notify.client.logger")
-def test_revoke_api_key_success(mock_logger, mock_post_event, mock_notify_settings):
+def test_revoke_api_key_success(
+    mock_logger, mock_settings, mock_post_event, mock_notify_settings
+):
+    mock_settings.is_production = True
     # Mock successful response
     mock_response = MagicMock()
     mock_response.status_code = 201
@@ -230,9 +236,15 @@ def test_revoke_api_key_success(mock_logger, mock_post_event, mock_notify_settin
 
 
 # Test failed API key revocation (non-201 status code)
+@patch("integrations.notify.client.notify_settings", new_callable=MagicMock)
 @patch("integrations.notify.client.post_event")
+@patch("integrations.notify.client.settings", new_callable=MagicMock)
 @patch("integrations.notify.client.logger")
-def test_revoke_api_key_failure(mock_logger, mock_post_event):
+def test_revoke_api_key_failure(
+    mock_logger, mock_settings, mock_post_event, mock_notify_settings
+):
+    mock_settings.is_production = True
+    mock_notify_settings.NOTIFY_API_URL = "https://notify.example.com"
     # Mock failed response
     mock_response = MagicMock()
     mock_response.status_code = 400
@@ -261,8 +273,12 @@ def test_revoke_api_key_failure(mock_logger, mock_post_event):
 # Test API key not found response (status code 200)
 @patch("integrations.notify.client.notify_settings", new_callable=MagicMock)
 @patch("integrations.notify.client.post_event")
+@patch("integrations.notify.client.settings", new_callable=MagicMock)
 @patch("integrations.notify.client.logger")
-def test_revoke_api_key_not_found(mock_logger, mock_post_event, mock_notify_settings):
+def test_revoke_api_key_not_found(
+    mock_logger, mock_settings, mock_post_event, mock_notify_settings
+):
+    mock_settings.is_production = True
     mock_notify_settings.NOTIFY_API_URL = "https://notify.example.com"
     mock_response = MagicMock()
     mock_response.status_code = 200

--- a/app/tests/modules/webhooks/test_webhooks_aws_sns.py
+++ b/app/tests/modules/webhooks/test_webhooks_aws_sns.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from infrastructure.configuration.app import AppSettings
 from models.webhooks import AwsSnsPayload, WebhookPayload
 from modules.webhooks import aws_sns
 from fastapi import HTTPException
@@ -12,10 +13,18 @@ from sns_message_validator import (
 )
 
 
+@pytest.fixture
+def force_production_app_settings(monkeypatch):
+    monkeypatch.setattr(
+        "modules.webhooks.aws_sns.app_settings",
+        AppSettings(ENVIRONMENT="production"),
+    )
+
+
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_validates_model(
-    validate_message_mock, log_ops_message_mock
+    validate_message_mock, log_ops_message_mock, force_production_app_settings
 ):
     client = MagicMock()
     payload = AwsSnsPayload(
@@ -37,7 +46,10 @@ def test_validate_sns_payload_validates_model(
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_invalid_message_type(
-    validate_message_mock, log_ops_message_mock, logger_mock
+    validate_message_mock,
+    log_ops_message_mock,
+    logger_mock,
+    force_production_app_settings,
 ):
     client = MagicMock()
     payload = AwsSnsPayload(
@@ -62,7 +74,10 @@ def test_validate_sns_payload_invalid_message_type(
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_invalid_signature_version(
-    validate_message_mock, log_ops_message_mock, logger_mock
+    validate_message_mock,
+    log_ops_message_mock,
+    logger_mock,
+    force_production_app_settings,
 ):
     client = MagicMock()
     payload = AwsSnsPayload(
@@ -87,7 +102,10 @@ def test_validate_sns_payload_invalid_signature_version(
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_invalid_signature_url(
-    validate_message_mock, log_ops_message_mock, logger_mock
+    validate_message_mock,
+    log_ops_message_mock,
+    logger_mock,
+    force_production_app_settings,
 ):
     client = MagicMock()
     payload = AwsSnsPayload(
@@ -112,7 +130,10 @@ def test_validate_sns_payload_invalid_signature_url(
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_signature_verification_failure(
-    validate_message_mock, log_ops_message_mock, logger_mock
+    validate_message_mock,
+    log_ops_message_mock,
+    logger_mock,
+    force_production_app_settings,
 ):
     client = MagicMock()
     payload = AwsSnsPayload(
@@ -137,7 +158,10 @@ def test_validate_sns_payload_signature_verification_failure(
 @patch("modules.webhooks.aws_sns.log_ops_message")
 @patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")
 def test_validate_sns_payload_unexpected_exception(
-    validate_message_mock, log_ops_message_mock, logger_mock
+    validate_message_mock,
+    log_ops_message_mock,
+    logger_mock,
+    force_production_app_settings,
 ):
     client = MagicMock()
     payload = AwsSnsPayload(

--- a/app/tests/unit/infrastructure/configuration/test_app_settings.py
+++ b/app/tests/unit/infrastructure/configuration/test_app_settings.py
@@ -17,15 +17,15 @@ class TestAppSettings:
         assert settings.LOG_LEVEL == "INFO"
         assert settings.GIT_SHA == "Unknown"
 
-    def test_app_settings_is_production_when_prefix_empty(self):
-        """is_production should be True when PREFIX is empty."""
-        settings = AppSettings(PREFIX="")
+    def test_app_settings_is_production_when_environment_production(self):
+        """is_production should be True when ENVIRONMENT is production."""
+        settings = AppSettings(ENVIRONMENT="production")
 
         assert settings.is_production is True
 
-    def test_app_settings_is_not_production_when_prefix_set(self):
-        """is_production should be False when PREFIX is set."""
-        settings = AppSettings(PREFIX="dev")
+    def test_app_settings_is_not_production_when_environment_non_production(self):
+        """is_production should be False when ENVIRONMENT is non-production."""
+        settings = AppSettings(ENVIRONMENT="dev")
 
         assert settings.is_production is False
 
@@ -58,8 +58,10 @@ class TestAppSettings:
 class TestAppSettingsEnvironment:
     """Behavior tests for ENVIRONMENT and DEV_BYPASS_ENABLED settings."""
 
-    def test_environment_default_is_local(self):
+    def test_environment_default_is_local(self, monkeypatch):
         """Default environment should be local."""
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
         settings = AppSettings()
 
         assert settings.ENVIRONMENT == "local"

--- a/app/tests/unit/infrastructure/configuration/test_app_settings.py
+++ b/app/tests/unit/infrastructure/configuration/test_app_settings.py
@@ -1,5 +1,8 @@
 """Unit tests for app-level settings singleton."""
 
+import pytest
+from pydantic import ValidationError
+
 from infrastructure.configuration.app import AppSettings, get_app_settings
 
 
@@ -50,3 +53,58 @@ class TestAppSettings:
         settings = AppSettings()
 
         assert settings.PREFIX == "staging"
+
+
+class TestAppSettingsEnvironment:
+    """Behavior tests for ENVIRONMENT and DEV_BYPASS_ENABLED settings."""
+
+    def test_environment_default_is_local(self):
+        """Default environment should be local."""
+        settings = AppSettings()
+
+        assert settings.ENVIRONMENT == "local"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["local", "ci", "dev", "staging", "production"],
+    )
+    def test_environment_all_valid_values(self, value):
+        """All accepted environment values should construct successfully."""
+        settings = AppSettings(ENVIRONMENT=value)
+
+        assert settings.ENVIRONMENT == value
+
+    def test_environment_invalid_value_raises_validation_error(self):
+        """Unknown environment values should fail validation at settings construction."""
+        with pytest.raises(ValidationError):
+            AppSettings(ENVIRONMENT="uat")
+
+    def test_dev_bypass_enabled_default_false(self):
+        """DEV_BYPASS_ENABLED should default to False."""
+        settings = AppSettings()
+
+        assert settings.DEV_BYPASS_ENABLED is False
+
+    def test_dev_bypass_enabled_can_be_set_true(self):
+        """DEV_BYPASS_ENABLED should be configurable to True."""
+        settings = AppSettings(DEV_BYPASS_ENABLED=True)
+
+        assert settings.DEV_BYPASS_ENABLED is True
+
+    def test_is_production_shim_true_when_production(self):
+        """is_production should be True when ENVIRONMENT is production."""
+        settings = AppSettings(ENVIRONMENT="production")
+
+        assert settings.is_production is True
+
+    def test_is_production_shim_false_when_local(self):
+        """is_production should be False when ENVIRONMENT is local."""
+        settings = AppSettings(ENVIRONMENT="local")
+
+        assert settings.is_production is False
+
+    def test_is_production_shim_false_when_ci(self):
+        """is_production should be False when ENVIRONMENT is ci."""
+        settings = AppSettings(ENVIRONMENT="ci")
+
+        assert settings.is_production is False

--- a/app/tests/unit/infrastructure/configuration/test_settings_delegation.py
+++ b/app/tests/unit/infrastructure/configuration/test_settings_delegation.py
@@ -156,7 +156,9 @@ class TestSettingsAppFieldDelegation:
     def test_git_sha_matches_app_settings(self):
         assert Settings().GIT_SHA == get_app_settings().GIT_SHA
 
-    def test_is_production_matches_app_settings(self):
+    def test_is_production_matches_app_settings(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        get_app_settings.cache_clear()
         assert Settings().is_production == get_app_settings().is_production
 
     def test_prefix_override_via_env(self, monkeypatch):

--- a/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
+++ b/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
@@ -3,11 +3,11 @@ id: TASK-1.1
 title: >-
   Add ENVIRONMENT and DEV_BYPASS_ENABLED to AppSettings; set in all deployment
   configs
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-17 16:14'
-updated_date: '2026-07-17 18:20'
+updated_date: '2026-07-17 18:58'
 labels:
   - phase-0
 milestone: m-0

--- a/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
+++ b/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
@@ -3,10 +3,11 @@ id: TASK-1.1
 title: >-
   Add ENVIRONMENT and DEV_BYPASS_ENABLED to AppSettings; set in all deployment
   configs
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-17 16:14'
-updated_date: '2026-07-17 16:15'
+updated_date: '2026-07-17 17:47'
 labels:
   - phase-0
 milestone: m-0

--- a/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
+++ b/backlog/tasks/task-1.1 - Add-ENVIRONMENT-and-DEV_BYPASS_ENABLED-to-AppSettings-set-in-all-deployment-configs.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@me'
 created_date: '2026-07-17 16:14'
-updated_date: '2026-07-17 17:47'
+updated_date: '2026-07-17 18:20'
 labels:
   - phase-0
 milestone: m-0
@@ -28,12 +28,12 @@ Expand phase for TASK-1. Purely additive: add ENVIRONMENT: Literal["local","ci",
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 AppSettings.ENVIRONMENT is Literal["local","ci","dev","staging","production"] with default "local"; AppSettings(ENVIRONMENT="uat") raises pydantic ValidationError at construction
-- [ ] #2 AppSettings.DEV_BYPASS_ENABLED: bool = False by default
-- [ ] #3 is_production property kept as forwarding shim: return self.ENVIRONMENT == "production"
-- [ ] #4 terraform/templates/sre-bot.json.tpl has ENVIRONMENT=production entry in environment array
-- [ ] #5 .github/workflows/ci_code.yml has ENVIRONMENT: ci in the test step env block
-- [ ] #6 All existing tests pass; new unit tests cover valid enum values accepted, invalid value rejected at boot, DEV_BYPASS_ENABLED default, shim correctness
+- [x] #1 AppSettings.ENVIRONMENT is Literal["local","ci","dev","staging","production"] with default "local"; AppSettings(ENVIRONMENT="uat") raises pydantic ValidationError at construction
+- [x] #2 AppSettings.DEV_BYPASS_ENABLED: bool = False by default
+- [x] #3 is_production property kept as forwarding shim: return self.ENVIRONMENT == "production"
+- [x] #4 terraform/templates/sre-bot.json.tpl has ENVIRONMENT=production entry in environment array
+- [x] #5 .github/workflows/ci_code.yml has ENVIRONMENT: ci in the test step env block
+- [x] #6 All existing tests pass; new unit tests cover valid enum values accepted, invalid value rejected at boot, DEV_BYPASS_ENABLED default, shim correctness
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -100,3 +100,9 @@ Blast radius and rollback:
   - Single git revert of this PR fully restores previous state; TASK-1.2 cannot compile without TASK-1.1 (ENVIRONMENT and DEV_BYPASS_ENABLED fields would be missing)
   - No routing or security logic changes; any revert is clean
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented TASK-1.1 expand slice:\n- Added typed AppSettings.ENVIRONMENT Literal[local, ci, dev, staging, production] with default local.\n- Added AppSettings.DEV_BYPASS_ENABLED default False.\n- Updated AppSettings.is_production shim to return ENVIRONMENT == production.\n- Added ENVIRONMENT=production to terraform/templates/sre-bot.json.tpl task environment.\n- Added ENVIRONMENT: ci to .github/workflows/ci_code.yml test job env.\n- Added/updated AppSettings behavior tests and stabilized existing environment-sensitive tests to make behavior explicit under typed ENVIRONMENT.\n\nTest evidence:\n- uv run pytest tests/unit/infrastructure/configuration/test_app_settings.py -q -> 18 passed\n- uv run pytest tests --ignore=tests/smoke -q -> 2856 passed, 37 skipped\n- uv run black --check . -> pass\n\nQuality gates status:\n- mypy . -> fails with pre-existing baseline errors outside this task's changes (modules/incident, modules/webhooks, infrastructure/security/rate_limiter, packages/access/sync, etc.)\n- flake8 -> fails with pre-existing E501 baseline across many existing test files\n\nDoD items left for human verification:\n- Confirm CI workflow change and terraform template change satisfy deployment expectations.\n- Ensure PR description references SEC-10 and decisions/configuration.md.
+<!-- SECTION:NOTES:END -->

--- a/terraform/templates/sre-bot.json.tpl
+++ b/terraform/templates/sre-bot.json.tpl
@@ -43,6 +43,10 @@
       {
         "name": "BACKEND_URL",
         "value": "${backend_url}"
+      },
+      {
+        "name": "ENVIRONMENT",
+        "value": "production"
       }
     ],
     "essential": true,


### PR DESCRIPTION
# Summary | Résumé

This pull request adds typed `ENVIRONMENT` and `DEV_BYPASS_ENABLED` fields to the `AppSettings` configuration, improves environment detection logic, and ensures these settings are correctly set in deployment and CI environments. It also updates and expands unit tests to cover the new configuration behavior and stabilizes environment-sensitive tests. These changes make the application's environment handling more robust and explicit.

**Configuration enhancements:**

* Added `ENVIRONMENT` as a `Literal["local", "ci", "dev", "staging", "production"]` with a default of `"local"` and `DEV_BYPASS_ENABLED` as a boolean defaulting to `False` in `AppSettings`. The `is_production` property now checks if `ENVIRONMENT` is `"production"` instead of relying on `PREFIX`.
* Updated CI workflow (`.github/workflows/ci_code.yml`) and deployment template (`terraform/templates/sre-bot.json.tpl`) to explicitly set the `ENVIRONMENT` variable (`ci` for CI, `production` for deployment). [[1]](diffhunk://#diff-64d23be9821be443eec448190b24f521c72655017281526bc5ec297aa15fe1c2R50) [[2]](diffhunk://#diff-b830b88cd09af26a3c165553c0d205a5cae63597c309dd5f2ef9f2f6276d425eR46-R49)

**Testing improvements:**

* Added and refactored unit tests for `AppSettings` to verify all valid/invalid `ENVIRONMENT` values, default values, and the behavior of `DEV_BYPASS_ENABLED` and `is_production`.
* Updated tests in `test_notify_client.py` and `test_webhooks_aws_sns.py` to explicitly set the environment, ensuring consistent and explicit environment handling during tests. [[1]](diffhunk://#diff-a466187ab1d52c5185512eeb1d39d92bf9f0bc6a8dd64d984641616f35c22948R180-R183) [[2]](diffhunk://#diff-6490add34c722e3554697c2813663844cc32157f86dcf3061f5b406811c974b5R16-R27)

**Documentation and backlog:**

* Marked backlog task as complete and updated acceptance criteria to reflect that all requirements for `ENVIRONMENT` and `DEV_BYPASS_ENABLED` are implemented and tested. Added implementation notes summarizing changes and test evidence. [[1]](diffhunk://#diff-a5e695d9191631a91738eb2e8089fb76b12f91a288ac9cd88996eb886fd7b2aeL6-R10) [[2]](diffhunk://#diff-a5e695d9191631a91738eb2e8089fb76b12f91a288ac9cd88996eb886fd7b2aeL30-R36) [[3]](diffhunk://#diff-a5e695d9191631a91738eb2e8089fb76b12f91a288ac9cd88996eb886fd7b2aeR103-R108)