### PR TITLE
feat: plan typed environment migration

### DIFF
--- a/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
+++ b/backlog/tasks/task-1.2 - Migrate-all-environment-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard-remove-is_production.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-17 16:14'
-updated_date: '2026-07-17 16:22'
+updated_date: '2026-07-17 19:43'
 labels:
   - phase-0
 milestone: m-0
@@ -35,3 +35,23 @@ Migrate + contract phase for TASK-1. Replace every is_production and PREFIX-deri
 - [ ] #5 All existing tests plus new dual-guard tests pass
 - [ ] #6 aws_sns.py validate_sns_payload skips validation when ENVIRONMENT != 'production' (local/dev/ci never receive real SNS payloads from the internet); validation is always enforced when ENVIRONMENT == 'production'
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+TASK-1.2 is further decomposed into three right-sized slices (single-PR gate re-triggered: 16 production files, 3 subsystem layers, mechanical + behavioral mixed).
+
+SNS deviation: AC #6 reflects an approved operational deviation from decisions/security.md. Local/dev/ci instances are not internet-reachable and never receive real SNS payloads; production-only enforcement is the confirmed design. This deviation is explicit and recorded here.
+
+Subtask execution order:
+1. TASK-1.2.1 — Security/Auth + Transport: current_user.py dual-guard, aws_sns.py env-check, api_key_detected.py, notify/client.py
+2. TASK-1.2.2 — Runtime Infra Gates: DynamoDB local endpoint, scheduled-tasks gate, CORS gate
+3. TASK-1.2.3 — Legacy env branches + is_production contract removal: dev/platforms/slack.py, incident/core.py, incident_conversation.py, shim deletion from app.py/settings.py/logging/setup.py
+
+TASK-1.2 ACs satisfied when all subtasks done:
+- AC #1 (is_production gone) and AC #2 (PREFIX env-derivation gone) verified after TASK-1.2.3
+- AC #3 (dual bypass guard) verified after TASK-1.2.1
+- AC #4 (DynamoDB env matrix) verified after TASK-1.2.2
+- AC #5 (tests pass) verified per slice
+- AC #6 (SNS deviation) verified after TASK-1.2.1
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1.2.1 - Migrate-security-auth-and-transport-env-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard.md
+++ b/backlog/tasks/task-1.2.1 - Migrate-security-auth-and-transport-env-checks-to-ENVIRONMENT-enforce-dual-dev-bypass-guard.md
@@ -1,0 +1,129 @@
+---
+id: TASK-1.2.1
+title: >-
+  Migrate security/auth and transport env checks to ENVIRONMENT; enforce dual
+  dev-bypass guard
+status: To Do
+assignee: []
+created_date: '2026-07-17 19:44'
+updated_date: '2026-07-17 19:51'
+labels:
+  - phase-0
+milestone: m-0
+dependencies:
+  - TASK-1.2
+references:
+  - decisions/configuration.md
+  - decisions/security.md
+parent_task_id: TASK-1.2
+priority: high
+ordinal: 47000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 1 of TASK-1.2. Replace is_production with explicit ENVIRONMENT reads in the four highest-priority files: the JWT auth dependency (dual-guard), SNS validation (approved deviation: skip in non-production), notify-channel routing (api_key_detected.py), and notify API key revocation (notify/client.py). Also update the integration/webhooks/conftest.py SNS fixture which currently uses a PropertyMock on is_production. The is_production shim on AppSettings is NOT removed in this slice — that happens in TASK-1.2.3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 current_user.py dev-bypass guard is ENVIRONMENT != production AND DEV_BYPASS_ENABLED=true AND token matches; either guard alone blocks bypass; each granted bypass logs dev_bypass_token_used
+- [ ] #2 aws_sns.py validate_sns_payload uses app_settings.ENVIRONMENT != production for the non-production skip (approved deviation: local/dev/ci are not internet-reachable); no is_production reference remains in the file
+- [ ] #3 api_key_detected.py routes to test vs ops channel using ENVIRONMENT != production; no is_production reference remains in the file
+- [ ] #4 integrations/notify/client.py revoke_api_key gate uses settings.ENVIRONMENT != production; no is_production reference remains in the file
+- [ ] #5 integration/webhooks/conftest.py mock_sns_signature_validation_disabled fixture monkeypatches AppSettings(ENVIRONMENT=local) instead of PropertyMock on is_production
+- [ ] #6 New unit tests cover all 4 dev-bypass scenarios: production+enabled+match denied; non-prod+disabled+match denied; non-prod+enabled+mismatch denied; non-prod+enabled+match allowed and logged
+- [ ] #7 Full non-smoke test suite passes
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Ordered steps — is_production shim stays on AppSettings throughout this slice.
+
+Step 1 — app/infrastructure/security/current_user.py (lines 27, 103–105)
+  Replace docstring mention: "Blocked when PREFIX="" (production)" →
+    "Blocked when ENVIRONMENT == 'production' or DEV_BYPASS_ENABLED is False."
+  Replace single guard at line 103:
+    Before: if not app_settings.is_production and server_settings.DEV_BYPASS_TOKEN:
+    After:  if (app_settings.ENVIRONMENT != "production"
+                and app_settings.DEV_BYPASS_ENABLED
+                and server_settings.DEV_BYPASS_TOKEN):
+  Inner credential-match check, log.warning, and return User(...) are unchanged.
+  Maps to AC #1.
+
+Step 2 — app/modules/webhooks/aws_sns.py (line 84)
+  Replace:
+    Before: if not app_settings.is_production:
+    After:  if app_settings.ENVIRONMENT != "production":
+  Add comment above the guard:
+    # Approved deviation: local/dev/ci instances are not internet-reachable
+    # and never receive real SNS payloads; validation skipped for operational reasons.
+  Maps to AC #2.
+
+Step 3 — app/modules/webhooks/patterns/aws_sns_notification/api_key_detected.py (line 20)
+  Replace:
+    Before: if not app_settings.is_production:
+    After:  if app_settings.ENVIRONMENT != "production":
+  Maps to AC #3.
+
+Step 4 — app/integrations/notify/client.py (line 116)
+  Replace:
+    Before: if not settings.is_production:
+    After:  if settings.ENVIRONMENT != "production":
+  (settings is module-level get_app_settings() — already has ENVIRONMENT field from TASK-1.1)
+  Maps to AC #4.
+
+Step 5 — app/tests/integration/webhooks/conftest.py (lines 211–231)
+  Update mock_sns_signature_validation_disabled fixture:
+    Remove: type(mock_settings).is_production = PropertyMock(return_value=False)
+    Remove: mock_settings = MagicMock()
+    Replace with: monkeypatch.setattr("modules.webhooks.aws_sns.app_settings", AppSettings(ENVIRONMENT="local"))
+    Add import: from infrastructure.configuration.app import AppSettings
+  Maps to AC #5.
+
+Step 6 — app/tests/unit/infrastructure/security/test_current_user_bypass.py (new file)
+  4 behavior tests for the dual-guard, each using MagicMock for server_settings
+  and real AppSettings for app_settings to confirm guard semantics:
+  - test_bypass_denied_when_environment_is_production:
+      AppSettings(ENVIRONMENT="production", DEV_BYPASS_ENABLED=True)
+      + matching token → function does not return bypass User
+  - test_bypass_denied_when_bypass_disabled:
+      AppSettings(ENVIRONMENT="local", DEV_BYPASS_ENABLED=False)
+      + matching token → function does not return bypass User
+  - test_bypass_denied_when_token_mismatch:
+      AppSettings(ENVIRONMENT="local", DEV_BYPASS_ENABLED=True)
+      + wrong token → function does not return bypass User
+  - test_bypass_allowed_and_logged:
+      AppSettings(ENVIRONMENT="local", DEV_BYPASS_ENABLED=True)
+      + matching token → returns User with user_id="dev@local" and logger warns dev_bypass_token_used
+  Maps to AC #6.
+
+AC traceability:
+  AC #1 (dual guard) — Steps 1, 6
+  AC #2 (SNS env check) — Step 2
+  AC #3 (api_key_detected env check) — Step 3
+  AC #4 (notify/client env check) — Step 4
+  AC #5 (conftest fixture update) — Step 5
+  AC #6 (bypass unit tests) — Step 6
+  AC #7 (full suite green) — validated after all steps
+
+Test matrix:
+  Bypass guard: 4 scenarios (all 4 combinations of guard state)
+  Channel routing: non-production → test channel; production → ops channel
+  SNS skip: non-production → early return without validation; production → full validation path
+  Revoke gate: non-production → "error" skip log; production → real call
+
+Assumptions and verification:
+  1. settings = get_app_settings() in notify/client.py (confirmed: line 15) — already has ENVIRONMENT after TASK-1.1.
+  2. app_settings = get_app_settings() already imported and used in aws_sns.py, api_key_detected.py, current_user.py — no import changes needed.
+  3. integration/webhooks/conftest.py currently uses PropertyMock on MagicMock — confirmed at line 224. It has no return/yield statement but the fixture works; the replacement uses monkeypatch.setattr which is cleaner and needs no explicit return.
+  4. Bypass unit tests require importing get_current_user and mocking three injected dependencies (credentials, jwks_manager, server_settings) via unittest.mock.patch; use real AppSettings for environment/bypass control.
+
+Blast radius and rollback:
+  - All four source edits are 1-line replacements; single git revert of this PR restores every call site.
+  - conftest.py fixture change breaks only if SNS tests depend on is_production shim still working — it does (shim stays until TASK-1.2.3), but tests must not rely on the PropertyMock path after this change.
+  - is_production shim is NOT removed; TASK-1.2.2 and TASK-1.2.3 both depend on it still being present after this PR merges.
+  - Full non-smoke suite must be green before merging.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1.2.2 - Migrate-runtime-infra-environment-gates-to-ENVIRONMENT-DynamoDB-startup-CORS.md
+++ b/backlog/tasks/task-1.2.2 - Migrate-runtime-infra-environment-gates-to-ENVIRONMENT-DynamoDB-startup-CORS.md
@@ -1,0 +1,37 @@
+---
+id: TASK-1.2.2
+title: >-
+  Migrate runtime infra environment gates to ENVIRONMENT (DynamoDB, startup,
+  CORS)
+status: To Do
+assignee: []
+created_date: '2026-07-17 19:44'
+labels:
+  - phase-0
+milestone: m-0
+dependencies:
+  - TASK-1.2.1
+references:
+  - decisions/configuration.md
+parent_task_id: TASK-1.2
+priority: high
+ordinal: 48000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 2 of TASK-1.2. Replace PREFIX-based environment derivation in AWS DynamoDB client selection, scheduled-task startup gate, and CORS allow-origins selection. Three DynamoDB paths are independent entry-points that all set local endpoint when PREFIX is truthy; each must check ENVIRONMENT in (local, dev, ci) instead. Scheduled tasks currently skip when PREFIX != ''; must check ENVIRONMENT == production instead. server.py CORS currently uses not bool(PREFIX); must use ENVIRONMENT. is_production shim still NOT removed — that happens in TASK-1.2.3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 integrations/aws/dynamodb.py local endpoint set only when ENVIRONMENT in (local, dev, ci); no PREFIX reference remains for environment decisions
+- [ ] #2 integrations/aws/client_next.py get_aws_client DynamoDB local endpoint set only when ENVIRONMENT in (local, dev, ci); no PREFIX reference remains for environment decisions
+- [ ] #3 modules/aws/aws_access_requests.py _get_dynamodb_client uses ENVIRONMENT in (local, dev, ci) for local endpoint; no PREFIX reference remains for environment decisions
+- [ ] #4 server/lifespan.py _start_scheduled_tasks skips when ENVIRONMENT == production; no PREFIX reference remains
+- [ ] #5 server/server.py CORS allow_origins computed from ENVIRONMENT == production not from bool(PREFIX); wildcard is returned for non-production, explicit list for production
+- [ ] #6 Unit tests cover DynamoDB endpoint matrix: local/dev/ci get local URL; staging/production get None
+- [ ] #7 Lifespan integration test updated: PREFIX-based skip test replaced with ENVIRONMENT-based skip test
+- [ ] #8 Full non-smoke test suite passes
+<!-- AC:END -->

--- a/backlog/tasks/task-1.2.3 - Migrate-legacy-env-branches-to-ENVIRONMENT-remove-is_production-shim-contract.md
+++ b/backlog/tasks/task-1.2.3 - Migrate-legacy-env-branches-to-ENVIRONMENT-remove-is_production-shim-contract.md
@@ -1,0 +1,40 @@
+---
+id: TASK-1.2.3
+title: >-
+  Migrate legacy env branches to ENVIRONMENT; remove is_production shim
+  (contract)
+status: To Do
+assignee: []
+created_date: '2026-07-17 19:47'
+labels:
+  - phase-0
+milestone: m-0
+dependencies:
+  - TASK-1.2.2
+references:
+  - decisions/configuration.md
+  - decisions/security.md
+parent_task_id: TASK-1.2
+priority: high
+ordinal: 49000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 3 of TASK-1.2 — contract phase. Migrate three legacy modules still using PREFIX-string comparisons for environment decisions, then remove the is_production forwarding shim from AppSettings and Settings. After this slice all environment-conditional code reads ENVIRONMENT directly and the old is_production property no longer exists. dev/platforms/slack.py gates dev commands with PREFIX != dev-; must gate with ENVIRONMENT == dev. incident/core.py derives environment string for DB records from PREFIX == dev-; must read ENVIRONMENT directly. incident_conversation.py sets channel name prefix from PREFIX == dev-; must use ENVIRONMENT == dev. After migrating all callers, remove is_production from infrastructure/configuration/app.py, infrastructure/configuration/settings.py, and clean the is_production parameter from infrastructure/logging/setup.py. Update all test fixtures that still mock is_production (unit/infrastructure/conftest.py, unit/infrastructure/logging/conftest.py, unit/server/conftest.py, test_settings_structure.py).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 modules/dev/platforms/slack.py _require_dev_environment uses ENVIRONMENT == dev; no PREFIX string comparison remains
+- [ ] #2 modules/incident/core.py _create_database_record environment string reads app_settings.ENVIRONMENT directly; no PREFIX == dev- comparison remains
+- [ ] #3 modules/incident/incident_conversation.py channel name prefix uses ENVIRONMENT == dev; no PREFIX == dev- comparison remains
+- [ ] #4 infrastructure/configuration/app.py is_production property removed
+- [ ] #5 infrastructure/configuration/settings.py is_production property removed
+- [ ] #6 infrastructure/logging/setup.py is_production parameter removed; production mode derives from settings.ENVIRONMENT == production
+- [ ] #7 All test fixtures that set settings.is_production = False updated to use ENVIRONMENT explicitly
+- [ ] #8 grep -rn is_production app/ --include=*.py returns no hits outside comments or historical strings
+- [ ] #9 grep -rn PREFIX app/ --include=*.py returns no environment-derivation hits
+- [ ] #10 Full non-smoke test suite passes
+<!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request adds detailed implementation plans and acceptance criteria for the migration of environment checks to use the `ENVIRONMENT` variable, decomposing TASK-1.2 into three focused subtasks. Each subtask is documented in its own markdown file, specifying the files to update, the rationale for changes, and the testing required. The overall approach ensures a phased and testable migration away from legacy `is_production` and `PREFIX` checks, with explicit traceability and operational notes.

**Task decomposition and implementation planning:**

* The main migration task (`TASK-1.2`) is now split into three slices—security/auth & transport, runtime infrastructure, and legacy cleanup—with explicit subtask ordering, acceptance criteria, and operational deviations documented.
* Each subtask (`TASK-1.2.1`, `TASK-1.2.2`, `TASK-1.2.3`) has its own markdown file outlining the files to change, the specific replacements (e.g., replacing `is_production` with `ENVIRONMENT` checks), and the required test coverage. [[1]](diffhunk://#diff-0a9ae10365fe12b55c3193ccd9bcd7d1bc4e93612dc6a1a1af79f1d0ffeddd8fR1-R129) [[2]](diffhunk://#diff-d3847e1cd0ec3ccabe4d5f585ee561826526555ed920e9dec3a68984b843c74cR1-R37) [[3]](diffhunk://#diff-4d871acbdf2e64705213740831bd2b4198194e32b433df21a1c997f819e53c58R1-R40)

**Security/auth and transport migration (`TASK-1.2.1`):**

* Details the migration for four key files to use `ENVIRONMENT` for environment checks, introduces a dual-guard for dev bypass, and specifies new unit tests for all bypass scenarios.

**Runtime infrastructure migration (`TASK-1.2.2`):**

* Specifies replacing `PREFIX`-based logic with `ENVIRONMENT` checks in DynamoDB client selection, scheduled task startup, and CORS configuration, with updated unit and integration tests.

**Legacy cleanup and contract phase (`TASK-1.2.3`):**

* Outlines the removal of all remaining `PREFIX` and `is_production` usage, including deleting the `is_production` property from settings and updating all related test fixtures.

**Administrative updates:**

* Updated the `updated_date` field in the main task file to reflect the latest planning changes.