### PR TITLE
docs(backlog): decompose TASK-15 ruff migration into 12 subtasks

### DIFF
--- a/backlog/tasks/task-15 - Adopt-ruff-as-sole-formatter-and-linter-remove-black-and-standalone-bandit.md
+++ b/backlog/tasks/task-15 - Adopt-ruff-as-sole-formatter-and-linter-remove-black-and-standalone-bandit.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-15
 title: Adopt ruff as sole formatter and linter; remove black and standalone bandit
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-07 19:56'
-updated_date: '2026-07-08 16:57'
+updated_date: '2026-07-23 14:20'
 labels:
   - toolchain
   - phase-2
@@ -33,9 +34,9 @@ Steps:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ruff format --check and ruff check pass in CI over the whole tree
-- [ ] #2 black absent from all dependency groups and Makefile targets; bandit workflow deleted
-- [ ] #3 Rule families E,F,W,I,B,UP,C4,SIM,S enabled in pyproject
+- [x] #1 ruff format --check and ruff check pass in CI over the whole tree
+- [x] #2 black absent from all dependency groups and Makefile targets; bandit workflow deleted
+- [x] #3 Rule families E,F,W,I,B,UP,C4,SIM,S enabled in pyproject
 <!-- AC:END -->
 
 ## Definition of Done
@@ -43,3 +44,124 @@ Steps:
 - [ ] #1 Reformat commit separated from any logic change
 - [ ] #2 Tests pass; PR references decisions/toolchain.md
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. app/pyproject.toml (dev deps + lint config):
+   - Remove `"black==24.10.0",` from `[project.optional-dependencies].dev` (line 42).
+   - `[tool.ruff.lint] select = ["E", "F", "W"]` -> `select = ["E", "F", "W", "I", "B", "UP", "C4", "SIM", "S"]`. Keep `ignore = ["E501"]` and `mccabe.max-complexity = 16` unchanged (C90/mccabe stays inert/out of scope; not one of the AC#3 families).
+   - Keep `line-length = 130` unchanged (human-confirmed: decisions/toolchain.md's literal 100-130 range wins even though measurement shows current code was actually black-formatted at width 88 -- see Doubt #1).
+   - Add `[tool.ruff.lint.per-file-ignores]`:
+     - `"tests/**" = ["S101", "S105", "S106", "S107"]` (assert + fixture tokens/secrets are expected in tests).
+     - `"utils/tests.py" = ["S101"]` (test-helper module outside `tests/`; contains real pytest-style asserts, confirmed by reading the file -- not production logic).
+
+2. app/Makefile:
+   - `fmt` (line 15): `uv run black . $(ARGS) --target-version py311` -> `uv run ruff format . $(ARGS)`.
+   - `fmt-ci` (line 83): `uv run black --check . --target-version py311` -> `uv run ruff format --check .`.
+   - `lint` / `lint-ci` targets: unchanged (`uv run ruff check .` already reads the expanded `select` from pyproject automatically). Do NOT touch the `mypy ... || true` soft-fail in `lint-ci` -- that is tracked separately (decisions/toolchain.md migration debt, not an AC of this task); note this explicitly in the PR description so it isn't flagged as missed scope.
+
+3. Delete `.github/workflows/bandit_security_scan.yml` and `.github/workflows/scripts/run_bandit_scan.sh` (the script has no other caller -- confirmed by repo-wide grep).
+
+4. `.github/workflows/log_workflow_error.yml`: remove the line `- Source code security scan using Bandit` (line 6) from the `workflows:` trigger list, since that workflow no longer exists.
+
+5. Commit 1 (config + CI, no source reflow): steps 1-4 above. Run `cd app && uv sync --extra dev` to update the lockfile after removing black.
+
+6. Commit 2 (mechanical, dedicated, no manual edits): from `app/`, run `uv run ruff format .` then `uv run ruff check --fix .` (safe fixes only -- do NOT pass `--unsafe-fixes`). Measured impact: reformats 349/662 files (at line-length=130) and auto-fixes ~1552 of ~1841 non-test-adjacent lint findings (import sorting via I001, typing modernization via UP006/UP045/UP035/UP017/UP037, plus assorted safe B/C4/SIM autofixes). Run `make test` after to confirm zero behavior change; if it fails, the failure is a real regression to fix in commit 2, not to carry into commit 3.
+
+7. Commit 3 (manual findings -- fix behavior-safe ones, noqa-justify framework/false-positive ones per human-approved policy): run `uv run ruff check .` again after commit 2 to get the residual list (starting enumeration below, captured before commit 2 so exact line numbers will shift slightly -- re-derive from the post-fix `ruff check .` output, do not guess line numbers):
+   - Fix (behavior-preserving rewrites, apply ruff's own suggested fix): 
+     - SIM108 (if/else -> ternary): infrastructure/clients/google_workspace/directory.py:1028, infrastructure/directory/google.py:683, integrations/aws/client.py:117 and :164.
+     - SIM102 (combine nested if): bin/check_prefix_command_namespace.py:70, infrastructure/security/current_user.py:106 (re-run `make check-prefix-guardrail` after touching the first file).
+     - SIM103 (inline condition): bin/check_prefix_command_namespace.py:36.
+     - SIM105 (contextlib.suppress): infrastructure/logging/setup.py:195, infrastructure/operations/classifiers.py:89.
+     - B904 (raise ... from e): infrastructure/configuration/integrations/google.py:122, infrastructure/events/models.py:95.
+     - B007 (rename unused loop var): infrastructure/configuration/docs_generator.py:32 (`field_info` -> `_field_info`).
+   - noqa-with-justification (framework idiom / narrowing / non-secret false positives -- add `# noqa: <CODE> -- <reason>` inline):
+     - B008 `Body(...)` default: api/v1/routes/webhooks.py:35 -- FastAPI DI idiom, call must be a parameter default.
+     - S101 type-narrowing asserts (already guarded by the preceding `if error is not None: return error`): packages/access/sync/application.py:159,160,237,238.
+   - Requires individual read-through before deciding fix vs noqa (do not blanket-noqa): the S105/S106/S107 hardcoded-password-string family across integrations/opsgenie/client.py (21,83,85,92,95), integrations/slack/{bootstrap.py:53,87; help.py:103; parser.py:288; provider.py:165,419,890; users.py:67}, integrations/utils/api.py:85, models/utils.py:51,56,62, utils/models.py:53,58,64, modules/aws/{aws_access_requests.py:75,76,95,111; aws_account_health.py:140; identity_center.py:20; spending.py:47}, modules/incident/{core.py:622; incident.py:74,107; incident_alert.py:47; incident_folder.py:364,381; information_update.py:291}, modules/provisioning/groups.py:12,13, modules/role/role.py:359, **modules/secret/secret.py:43,91,96** (the secrets module itself -- review carefully, do not reflexively noqa), modules/slack/webhooks_list.py:262, modules/webhooks/{aws_sns_notification.py:244; patterns/aws_sns_notification/dynamodb_access.py:100; simple_text.py:175,178}, packages/access/{catalog/service.py:233; common/config/loaders.py:68; common/config/settings.py:29; common/naming.py:25; request/policies.py:138}, packages/geolocate/{routes.py:21; schemas.py:26}, server/lifespan.py:282, modules/atip/atip.py:367, integrations/google_workspace/google_calendar.py:145,198, integrations/google_workspace/google_directory_next.py:660. Most are expected to be header/field/env-var *names* (e.g. `"Authorization"`, `"client_secret"` as a dict key) that pattern-match ruff's secret-string heuristic without holding a real credential -- noqa those with a one-line reason; any that turn out to be an actual hardcoded credential is a real security bug, fix it (move to settings/secret manager) and flag it to the human immediately as out-of-scope-discovery before proceeding.
+   - After every fix/noqa, run `uv run ruff check .` until clean, then `make test`.
+
+8. `uv lock` / re-sync: after step 1's dependency removal, run `cd app && uv sync --extra dev` (already step 5) -- no separate action needed.
+
+Assumptions / doubts (with verification):
+- Doubt #1 (line-length): decisions/toolchain.md says "100-130 to match current code," but `app/Makefile`'s black invocation never passed `--line-length`, so black actually applied its default 88 -- confirmed by measuring `ruff format --check` diff size at 88 (45 files), 100 (316 files), 130 (349 files). Human explicitly chose to keep 130 despite this, accepting the larger reflow diff to comply with the decision record's literal range. Verified by direct measurement, not guessed.
+- Doubt #2: `ruff format` is Black-compatible by design (Astral docs: >99.9% line-identical on Black-formatted code) -- the 349-file diff at width 130 is therefore attributable to the width change, not formatter-behavior drift. If `make test` fails after commit 2, treat as a real regression, not an expected formatter quirk.
+- Doubt #3: the exact post-autofix residual list in step 7 will shift line numbers once commit 2 lands (imports reordered, blank lines removed) -- re-run `ruff check .` fresh rather than reusing today's line numbers.
+- Doubt #4: TASK-13 (Python 3.14 convergence) is still In Progress, not Done, but per human confirmation its PR is merging soon and does not block this task's config edits (no overlapping lines other than both touching `[tool.ruff] target-version`, already set to py314 by TASK-13).
+
+AC / DoD <-> step traceability:
+- AC#1 (ruff format --check and ruff check pass in CI over the whole tree) <- steps 1 (per-file-ignores), 6, 7 (drive residual to zero); verified by `make lint-ci` and `make fmt-ci` green locally, then CI green on `.github/workflows/ci_code.yml`.
+- AC#2 (black absent from dependency groups/Makefile; bandit workflow deleted) <- steps 1, 2, 3, 4; verified by `grep -rn black app/pyproject.toml app/Makefile` (no hits) and `test ! -f .github/workflows/bandit_security_scan.yml`.
+- AC#3 (rule families E,F,W,I,B,UP,C4,SIM,S enabled) <- step 1; verified by reading `[tool.ruff.lint] select` in app/pyproject.toml.
+- DoD#1 (reformat commit separated from any logic change) <- commit sequencing in steps 5/6/7 (3 distinct commits: config, mechanical, manual).
+- DoD#2 (tests pass; PR references decisions/toolchain.md) <- `make test` run after each commit (steps 6, 7); PR description references decisions/toolchain.md (human/PR action).
+
+Test matrix:
+- Happy path: `make lint-ci` (ruff check, whole tree) and `make fmt-ci` (ruff format --check, whole tree) both exit 0.
+- Regression: `make test` (existing unit + integration + legacy suites) passes unchanged after commit 2 (mechanical) and again after commit 3 (manual fixes) -- these commits must not change runtime behavior; any test diff is a signal to stop and re-inspect the specific rewrite (esp. the SIM108/SIM105/B904 sites, which touch control flow).
+- Guardrail regression: `make check-prefix-guardrail` after touching bin/check_prefix_command_namespace.py (step 7) -- must still pass.
+- Negative/CI: confirm `.github/workflows/log_workflow_error.yml` still parses (`actionlint` or a workflow_dispatch dry run) after removing the bandit line, and that no other workflow references the deleted bandit workflow/script (already confirmed via repo-wide grep -- zero other references).
+
+Blast radius / rollback:
+- Touches only toolchain/config surfaces (app/pyproject.toml, app/Makefile, app/uv.lock, two deleted GH Actions files, one edited GH Actions file) plus a mechanical reformat + small behavior-preserving rewrites across ~50 production files in app/. No API/schema/runtime-config changes; no terraform; no deploy-time behavior change.
+- Rollback: single `git revert` of the PR restores black + narrow ruff (E,F,W) + the bandit workflow exactly as they are today; the removed bandit Docker-based scan has no state/history dependency (stateless scan step).
+- Residual risk: the manual-fix commit (7) is the only place with real (if small) behavior surface -- keep each fix a single-purpose, easily-revertible diff hunk; if CI or `make test` regresses after commit 3, revert that commit alone rather than the whole PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete (ACs 1-3 verified and checked off).
+
+Summary of changes:
+- Config (commit-1 scope): pyproject.toml ruff select expanded to E,F,W,I,B,UP,C4,SIM,S; black removed from dev deps and Makefile fmt/fmt-ci targets (now ruff format); bandit workflow + script deleted; log_workflow_error.yml trigger list updated to drop the deleted Bandit workflow reference.
+- Mechanical reflow (commit-2 scope): ruff format + ruff check --fix (safe fixes only) applied tree-wide -- 662 files formatted, import sorting (I001) and typing modernization (UP006/UP045/UP035/UP017/UP037) autofixed.
+- Manual fixes (commit-3 scope, ~45 individually-reviewed production findings across ~30 files): UP046 (PEP 695 generics for Event/OperationResult), UP042 (StrEnum for Locale/AuthPrincipalSource/ArgumentType), C408/C417 (dict/list-comprehension rewrites), SIM210/SIM108/SIM102/SIM103 (boolean/conditional simplifications), B006/B008 (mutable/call default-arg fixes), B904 (exception chaining), B018 (dead expression removal), S105/S106/S107/S310/S311/S112 (individually reviewed -- fixed in place where safe, noqa with inline justification only where the value is a non-secret token/hardcoded https scheme/non-security random use).
+- tests/** per-file-ignore additively widened beyond the plan's literal S101/S105/S106/S107 list to also cover B007/B008/B011/B017/B018/B905/C408/C416/C418/SIM116/SIM117/SIM118/UP028 -- these are test-idiom-only codes (no additional S-prefix/security codes), justified as a deviation since a full test-tree scan surfaced these after the plan was written; no business logic touched.
+- Found and fixed a genuine pre-existing circular-import regression exposed by ruff's I001 import-sorting: infrastructure/security/current_user.py and infrastructure/directory/google.py had fragile self-referential imports from their own parent package's __init__.py that depended on manual (now-reordered) import ordering. Fixed by importing directly from the owning submodule (infrastructure.security.jwks, infrastructure.directory.models) instead of re-entering the parent package.
+
+Test evidence:
+- Full suite: uv run pytest tests --ignore=tests/smoke -q -> 2861 passed, 37 skipped, 0 failed.
+- uv run ruff check . -> All checks passed!
+- uv run ruff format --check . -> 662 files already formatted, 0 pending.
+- uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' -> 129 pre-existing errors in 46 files, all unrelated to this change (return-type/Any narrowing debt tracked separately per decisions/toolchain.md migration debt, explicitly out of scope per the approved plan's step 2 note). No new mypy errors attributable to this task's edits.
+
+DoD left for human verification:
+- #1 Reformat commit separated from logic change -- requires the actual git commit structuring (config commit / mechanical reformat commit / manual-fix commit) at PR time; no git operations were performed by the agent.
+- #2 PR description should reference decisions/toolchain.md per repo convention.
+
+No git commits/pushes were made -- all git operations remain user-controlled.
+<!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-07-23 14:20
+---
+DECOMPOSITION (2026-07-23): the fully-migrated branch feat/dev_env_setup_ruff is a 484-file big-bang PR -- too large to review safely. It is retained UNCHANGED as the reference end-state. The migration is now delivered as 12 sequential child PRs (TASK-15.1 .. TASK-15.12), each ~40-60 files, using a parallel-toolchain strategy so main is green after every PR:
+  - LEGACY scope: black (@88) + ruff lint E,F,W keep running over not-yet-migrated paths.
+  - RUFF scope: ruff format (@130) + ruff lint E,F,W,I,B,UP,C4,SIM,S run over the migrated paths.
+  - A path joins the RUFF scope by (a) black [tool.black] force-exclude in app/pyproject.toml and (b) the RUFF_SCOPE variable in app/Makefile. Both run inside the existing ci_code.yml (make lint-ci / make fmt-ci) -- no CI YAML change until the final cutover.
+  - Each PR pulls already-migrated content from the reference branch (git checkout feat/dev_env_setup_ruff -- <paths>), so no file is hand-reformatted and the end state is guaranteed identical.
+
+PR sequence (each branches from main AFTER the previous merges; dependency chain 15.1<-...<-15.12):
+  15.1  scaffold parallel CI + pilot app/api                      (~8)
+  15.2  infrastructure/clients                                    (~49)
+  15.3  infrastructure core (configuration,security,directory,plugins,i18n) (~52)
+  15.4  infrastructure reliability tail -> completes infrastructure/ (~59)
+  15.5  integrations aws + small vendors                          (~51)
+  15.6  integrations google_workspace+slack -> completes integrations/ (~39)
+  15.7  modules incident + atip,secret,role                       (~38)
+  15.8  modules webhooks + aws                                    (~44)
+  15.9  modules tail + misc (utils,models,jobs,bin,server) -> completes modules/ (~39)
+  15.10 packages/access                                           (~60, splittable)
+  15.11 packages/geolocate + remaining tests -> completes app/ reflow (~38)
+  15.12 final cutover: drop black, expand ruff select, delete bandit (~6, config only)
+
+Invariant after 15.11: git diff feat/dev_env_setup_ruff -- app shows only pyproject/Makefile/uv.lock. After 15.12: git diff feat/dev_env_setup_ruff -- app .github is EMPTY.
+
+The AC checkboxes on this umbrella task describe the END state (all three ACs) and remain valid; they are satisfied cumulatively once 15.12 merges. Humans move this task to Done after the final cutover PR.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
+++ b/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
@@ -1,0 +1,94 @@
+---
+id: TASK-15.1
+title: 'Ruff migration 01: scaffold parallel black/ruff CI + migrate app/api'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:11'
+updated_date: '2026-07-23 14:16'
+labels: []
+dependencies:
+  - TASK-15
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 58000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Part of the TASK-15 incremental rollout. Splits the 484-file big-bang ruff migration (reference branch feat/dev_env_setup_ruff) into ~50-file PRs. Each PR moves a slice of the tree from the LEGACY toolchain (black @ width 88 + ruff lint E,F,W) onto RUFF (ruff format @ width 130 + ruff lint E,F,W,I,B,UP,C4,SIM,S). Both toolchains run in the SAME CI over their OWN scope, so main stays green throughout.
+
+This first PR establishes the parallel-CI scaffolding and migrates the smallest slice (app/api + app/tests/api) as a pilot.
+
+=== SHARED RECIPE (every TASK-15.x PR) ===
+1. Branch from latest main AFTER the previous TASK-15.x PR merged:
+     git checkout main && git pull
+     git checkout -b <branch>
+2. Pull already-migrated content for THIS PR's paths from the reference branch (never hand-edit migrated source):
+     git checkout feat/dev_env_setup_ruff -- <PATHS>
+   Unchanged files are byte-identical to main; changed files arrive in their final ruff form.
+3. Move THIS PR's paths into the migrated set in TWO places:
+     a. app/pyproject.toml -> [tool.black] force-exclude regex  (black stops checking them)
+     b. app/Makefile -> RUFF_SCOPE variable                     (ruff starts checking them)
+4. Validate from app/:  make lint-ci && make fmt-ci && make test
+5. Ship ONE mechanical PR; reference decisions/toolchain.md + TASK-15. Migrated content must equal the reference branch.
+
+=== THIS PR: scaffold + pilot ===
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- app/api app/tests/api
+
+Edit app/pyproject.toml:
+  - KEEP [tool.ruff.lint] select = ["E","F","W"] UNCHANGED (do not expand globally yet).
+  - KEEP black in [project.optional-dependencies].dev unchanged.
+  - ADD the tests/idiom per-file-ignores (end-state values; inert for global E,F,W, active only when a test path is scoped-linted):
+      [tool.ruff.lint.per-file-ignores]
+      "tests/**" = ["S101","S105","S106","S107","B007","B008","B011","B017","B018","B905","C408","C416","C418","SIM116","SIM117","SIM118","UP028"]
+      "utils/tests.py" = ["S101"]
+  - ADD the transitional black force-exclude section (grown by every later PR):
+      [tool.black]
+      target-version = ["py311"]
+      force-exclude = '''
+      /(
+          api
+        | tests/api
+      )/
+      '''
+
+Edit app/Makefile -- replace the fmt/lint/fmt-ci/lint-ci targets with the transitional versions below. Each recipe line under a target MUST start with a real TAB (shown here as the >>> marker; keep the dollar-parens Make refs exactly):
+      RUFF_SCOPE := api tests/api
+
+      fmt:
+      >>>uv run black . $(ARGS) --target-version py311
+      >>>uv run ruff format $(RUFF_SCOPE) $(ARGS)
+
+      lint:
+      >>>uv run ruff check .
+      >>>uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
+
+      fmt-ci:
+      >>>uv run black --check . --target-version py311
+      >>>uv run ruff format --check $(RUFF_SCOPE)
+
+      lint-ci:
+      >>>uv run ruff check .
+      >>>uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
+      >>>@command -v uv >/dev/null 2>&1 && uv run mypy . --check-untyped-defs || true
+
+Notes:
+- black --check . reads [tool.black] force-exclude from pyproject, so migrated paths are skipped automatically -- no per-command regex needed.
+- Do NOT delete the bandit workflow here; S (security) rules only cover migrated paths until the final cutover PR (TASK-15.12).
+- Expected size: ~8 files + config. Validate: cd app && make lint-ci && make fmt-ci && make test
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Parallel CI is green: black --check . (legacy scope, migrated paths force-excluded) passes AND ruff format --check plus ruff check --select=E,F,W,I,B,UP,C4,SIM,S over RUFF_SCOPE (api tests/api) pass
+- [ ] #2 app/api and app/tests/api are byte-identical to feat/dev_env_setup_ruff: git diff feat/dev_env_setup_ruff -- app/api app/tests/api is empty
+- [ ] #3 pyproject gains [tool.black] force-exclude + tests per-file-ignores; global ruff select stays [E,F,W]; black still present in dev deps; Makefile has RUFF_SCOPE and dual black+ruff fmt-ci/lint-ci
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
+++ b/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
@@ -1,0 +1,46 @@
+---
+id: TASK-15.10
+title: 'Ruff migration 10: packages/access'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:19'
+labels: []
+dependencies:
+  - TASK-15.9
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 67000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the packages/access feature package and its unit tests.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access
+
+Note: packages/access/sync/application.py carries reviewed S101 type-narrowing noqa markers (asserts guarded by preceding error checks) from the branch -- keep verbatim.
+
+app/pyproject.toml -> add to [tool.black] force-exclude:
+    | packages/access
+    | tests/unit/packages/access
+
+app/Makefile -> append to RUFF_SCOPE:
+    packages/access tests/unit/packages/access
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~60 files. If reviewers require <50, split into two PRs by access sub-package: (a) packages/access/sync + packages/access/common, (b) packages/access/catalog + packages/access/request -- pulling the matching tests/unit/packages/access/* files with each. Keep the force-exclude/RUFF_SCOPE entries at the granular sub-package level in that case.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access is empty
+- [ ] #2 force-exclude + RUFF_SCOPE include packages/access and tests/unit/packages/access; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.11 - Ruff-migration-11-packages-geolocate-remaining-tests-completes-app-reflow.md
+++ b/backlog/tasks/task-15.11 - Ruff-migration-11-packages-geolocate-remaining-tests-completes-app-reflow.md
@@ -1,0 +1,65 @@
+---
+id: TASK-15.11
+title: >-
+  Ruff migration 11: packages/geolocate + remaining tests (completes app/
+  reflow)
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:19'
+labels: []
+dependencies:
+  - TASK-15.10
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 68000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates packages/geolocate plus every remaining test surface (tests/integration, factories, fixtures, tests/utils, smoke, and the two loose tests/*.py files). After this PR ALL app source and test files are byte-identical to the reference branch; only the toolchain config still differs (handled by TASK-15.12).
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/packages/geolocate app/tests/unit/packages/geolocate \
+    app/tests/integration app/tests/factories app/tests/fixtures app/tests/utils app/tests/smoke \
+    app/tests/conftest.py app/tests/test_factory_validation.py
+
+Note: packages/geolocate/routes.py and schemas.py carry reviewed S-family noqa from the branch -- keep verbatim.
+
+CONSOLIDATION (this PR completes packages/ and the entire tests/ tree):
+- app/pyproject.toml [tool.black] force-exclude: REPLACE the 'packages/access' + 'tests/unit/packages/access' entries from TASK-15.10 with 'packages', and replace ALL the granular 'tests/*' alternatives accumulated so far (tests/api, tests/unit/*, tests/modules, tests/integrations, tests/integration, ...) with a single 'tests' entry. The force-exclude block should now read simply:
+      force-exclude = '''
+      /(
+          api
+        | infrastructure
+        | integrations
+        | modules
+        | packages
+        | utils
+        | models
+        | jobs
+        | bin
+        | server
+        | tests
+      )/
+      '''
+- app/Makefile RUFF_SCOPE: collapse to the migrated top-level trees:
+      RUFF_SCOPE := api infrastructure integrations modules packages utils models jobs bin server tests
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Sanity: 'git diff feat/dev_env_setup_ruff -- app' should now show ONLY app/pyproject.toml, app/Makefile, app/uv.lock (config not yet cut over).
+Expected size: ~38 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/packages app/tests is empty (every app source + test file now matches the reference branch)
+- [ ] #2 force-exclude + RUFF_SCOPE consolidated to 'packages' and 'tests'; make lint-ci && make fmt-ci pass over the whole tree
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.12 - Ruff-migration-12-final-cutover-drop-black-expand-ruff-select-delete-bandit.md
+++ b/backlog/tasks/task-15.12 - Ruff-migration-12-final-cutover-drop-black-expand-ruff-select-delete-bandit.md
@@ -1,0 +1,59 @@
+---
+id: TASK-15.12
+title: >-
+  Ruff migration 12: final cutover -- drop black, expand ruff select, delete
+  bandit
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:19'
+labels: []
+dependencies:
+  - TASK-15.11
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 69000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE branch-from-main step, but this PR is CONFIG ONLY -- no source reflow (every file was already migrated by TASK-15.1..11). It removes the transitional scaffolding and lands the end-state toolchain, making the tree byte-identical to feat/dev_env_setup_ruff.
+
+Steps:
+  git checkout main && git pull
+  git checkout -b <branch>
+  # Adopt the end-state config verbatim from the reference branch (this drops the
+  # transitional [tool.black]/force-exclude and RUFF_SCOPE, expands ruff select,
+  # removes black from dev deps, and restores ruff-only fmt/lint targets):
+  git checkout feat/dev_env_setup_ruff -- app/pyproject.toml app/Makefile app/uv.lock .github/workflows/log_workflow_error.yml
+  # Delete the standalone bandit scan (S rules now cover the whole tree):
+  git rm .github/workflows/bandit_security_scan.yml .github/workflows/scripts/run_bandit_scan.sh
+  # Refresh the lock to guarantee consistency after black removal:
+  cd app && uv sync --extra dev
+
+What the checkout lands (for reviewers):
+  - pyproject: select = [E,F,W,I,B,UP,C4,SIM,S]; per-file-ignores for tests + utils/tests.py; NO [tool.black]; black removed from [project.optional-dependencies].dev.
+  - Makefile: fmt = ruff format .; fmt-ci = ruff format --check .; lint/lint-ci = ruff check . (+ mypy soft-fail unchanged); RUFF_SCOPE removed.
+  - log_workflow_error.yml: the '- Source code security scan using Bandit' trigger line removed.
+
+Validate (whole tree, ruff only now):
+  cd app && make lint-ci && make fmt-ci && make test
+Final sanity (must be EMPTY):
+  git diff feat/dev_env_setup_ruff -- app .github
+
+Note: the 'mypy ... || true' soft-fail in lint-ci is intentionally left as-is (tracked separately as toolchain migration debt, out of scope for TASK-15). Call this out in the PR description so it is not flagged as missed scope.
+Expected size: ~6 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 app/pyproject.toml, app/Makefile, app/uv.lock, .github/workflows/log_workflow_error.yml match feat/dev_env_setup_ruff; black absent from all dependency groups and Makefile targets; ruff select is [E,F,W,I,B,UP,C4,SIM,S]
+- [ ] #2 .github/workflows/bandit_security_scan.yml and .github/workflows/scripts/run_bandit_scan.sh are deleted
+- [ ] #3 git diff feat/dev_env_setup_ruff -- app .github is empty (the whole migration now equals the reference branch); make lint-ci && make fmt-ci && make test pass over the whole tree with ruff only
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
+++ b/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
@@ -1,0 +1,48 @@
+---
+id: TASK-15.2
+title: 'Ruff migration 02: infrastructure/clients'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:16'
+labels: []
+dependencies:
+  - TASK-15.1
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 59000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Moves app/infrastructure/clients (+ its unit tests) from black onto ruff. Largest infra client surface; kept in its own PR.
+
+Paths to pull from the reference branch:
+  git checkout feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients
+
+app/pyproject.toml -> add to the [tool.black] force-exclude group (one alternative per line, inside the /( ... )/ block):
+    | infrastructure/clients
+    | tests/unit/infrastructure/clients
+
+app/Makefile -> append to RUFF_SCOPE:
+    infrastructure/clients tests/unit/infrastructure/clients
+
+Validate (from app/):
+  make lint-ci && make fmt-ci
+  uv run pytest tests/unit/infrastructure/clients
+  make test
+
+Expected size: ~49 files. No hand-edits to migrated source -- content must equal the reference branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients is empty
+- [ ] #2 RUFF_SCOPE and [tool.black] force-exclude both include infrastructure/clients and tests/unit/infrastructure/clients; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.3 - Ruff-migration-03-infrastructure-core-configuration-security-directory-plugins-i18n.md
+++ b/backlog/tasks/task-15.3 - Ruff-migration-03-infrastructure-core-configuration-security-directory-plugins-i18n.md
@@ -1,0 +1,58 @@
+---
+id: TASK-15.3
+title: >-
+  Ruff migration 03: infrastructure core (configuration, security, directory,
+  plugins, i18n)
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:17'
+labels: []
+dependencies:
+  - TASK-15.2
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 60000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the infrastructure core services and their unit tests.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/infrastructure/configuration app/infrastructure/security app/infrastructure/directory app/infrastructure/plugins app/infrastructure/i18n \
+    app/tests/unit/infrastructure/configuration app/tests/unit/infrastructure/security app/tests/unit/infrastructure/directory app/tests/unit/infrastructure/plugins app/tests/unit/infrastructure/i18n
+
+IMPORTANT: this slice carries the pre-existing circular-import fix that ruff's I001 import-sorting exposed, in infrastructure/security/current_user.py and infrastructure/directory/google.py (they now import from infrastructure.security.jwks / infrastructure.directory.models directly). That fix arrives automatically via the checkout above -- do not re-introduce the parent-package self-imports. Run the full suite to confirm no import regression.
+
+app/pyproject.toml -> add to the [tool.black] force-exclude group:
+    | infrastructure/configuration
+    | infrastructure/security
+    | infrastructure/directory
+    | infrastructure/plugins
+    | infrastructure/i18n
+    | tests/unit/infrastructure/configuration
+    | tests/unit/infrastructure/security
+    | tests/unit/infrastructure/directory
+    | tests/unit/infrastructure/plugins
+    | tests/unit/infrastructure/i18n
+
+app/Makefile -> append to RUFF_SCOPE:
+    infrastructure/configuration infrastructure/security infrastructure/directory infrastructure/plugins infrastructure/i18n tests/unit/infrastructure/configuration tests/unit/infrastructure/security tests/unit/infrastructure/directory tests/unit/infrastructure/plugins tests/unit/infrastructure/i18n
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~52 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/infrastructure/configuration app/infrastructure/security app/infrastructure/directory app/infrastructure/plugins app/infrastructure/i18n app/tests/unit/infrastructure/configuration app/tests/unit/infrastructure/security app/tests/unit/infrastructure/directory app/tests/unit/infrastructure/plugins app/tests/unit/infrastructure/i18n is empty
+- [ ] #2 RUFF_SCOPE and [tool.black] force-exclude include all five src dirs and their five unit-test dirs; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.4 - Ruff-migration-04-infrastructure-reliability-tail-completes-infrastructure.md
+++ b/backlog/tasks/task-15.4 - Ruff-migration-04-infrastructure-reliability-tail-completes-infrastructure.md
@@ -1,0 +1,48 @@
+---
+id: TASK-15.4
+title: 'Ruff migration 04: infrastructure reliability tail (completes infrastructure/)'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:17'
+labels: []
+dependencies:
+  - TASK-15.3
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 61000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the remaining infrastructure subsystems (resilience, idempotency, logging, audit, operations, events, storage) plus the leftover loose unit-test files, COMPLETING infrastructure/.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/infrastructure/resilience app/infrastructure/idempotency app/infrastructure/logging app/infrastructure/audit app/infrastructure/operations app/infrastructure/events app/infrastructure/storage \
+    app/tests/unit/infrastructure/resilience app/tests/unit/infrastructure/idempotency app/tests/unit/infrastructure/logging app/tests/unit/infrastructure/audit app/tests/unit/infrastructure/operations app/tests/unit/infrastructure/events app/tests/unit/infrastructure/storage app/tests/unit/infrastructure/services \
+    app/tests/unit/infrastructure/conftest.py app/tests/unit/infrastructure/test_operations_result.py app/tests/unit/infrastructure/test_logging.py app/tests/unit/infrastructure/test_circuit_breaker.py
+
+CONSOLIDATION (this PR completes the whole infrastructure/ + tests/unit/infrastructure/ trees):
+- app/pyproject.toml [tool.black] force-exclude: REPLACE all the granular 'infrastructure/*' and 'tests/unit/infrastructure/*' alternatives added by TASK-15.2 and TASK-15.3 with just two lines:
+    | infrastructure
+    | tests/unit/infrastructure
+- app/Makefile RUFF_SCOPE: REMOVE the granular infrastructure/* and tests/unit/infrastructure/* tokens and replace them with:
+    infrastructure tests/unit/infrastructure
+  (This is a pure simplification; the migrated file set is unchanged. Verify with the AC diff check.)
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~59 files (note: reviewers may split resilience/idempotency/logging from audit/operations/events/storage into two PRs if <50 is required).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/infrastructure app/tests/unit/infrastructure is empty (entire infrastructure src + unit-test trees now migrated)
+- [ ] #2 force-exclude and RUFF_SCOPE consolidated to the single entries 'infrastructure' and 'tests/unit/infrastructure'; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.5 - Ruff-migration-05-integrations-aws-small-vendors.md
+++ b/backlog/tasks/task-15.5 - Ruff-migration-05-integrations-aws-small-vendors.md
@@ -1,0 +1,62 @@
+---
+id: TASK-15.5
+title: 'Ruff migration 05: integrations aws + small vendors'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:17'
+labels: []
+dependencies:
+  - TASK-15.4
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 62000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the aws integration plus the small vendor integrations (utils, maxmind, trello, notify, sentinel, opsgenie) and the tests/unit/integrations tree.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/integrations/aws app/integrations/utils app/integrations/maxmind app/integrations/trello app/integrations/notify app/integrations/sentinel app/integrations/opsgenie \
+    app/tests/integrations/aws app/tests/integrations/utils app/tests/integrations/maxmind app/tests/integrations/trello app/tests/integrations/notify app/tests/integrations/sentinel app/tests/integrations/opsgenie \
+    app/tests/unit/integrations
+
+Note: several of these files carry individually-reviewed S105/S106/S107 noqa markers (non-secret header/field names) that arrive via the checkout -- keep them verbatim; do not add or remove noqa.
+
+app/pyproject.toml -> add to [tool.black] force-exclude:
+    | integrations/aws
+    | integrations/utils
+    | integrations/maxmind
+    | integrations/trello
+    | integrations/notify
+    | integrations/sentinel
+    | integrations/opsgenie
+    | tests/integrations/aws
+    | tests/integrations/utils
+    | tests/integrations/maxmind
+    | tests/integrations/trello
+    | tests/integrations/notify
+    | tests/integrations/sentinel
+    | tests/integrations/opsgenie
+    | tests/unit/integrations
+
+app/Makefile -> append to RUFF_SCOPE:
+    integrations/aws integrations/utils integrations/maxmind integrations/trello integrations/notify integrations/sentinel integrations/opsgenie tests/integrations/aws tests/integrations/utils tests/integrations/maxmind tests/integrations/trello tests/integrations/notify tests/integrations/sentinel tests/integrations/opsgenie tests/unit/integrations
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~51 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/integrations/aws app/integrations/utils app/integrations/maxmind app/integrations/trello app/integrations/notify app/integrations/sentinel app/integrations/opsgenie app/tests/integrations/aws app/tests/integrations/utils app/tests/integrations/maxmind app/tests/integrations/trello app/tests/integrations/notify app/tests/integrations/sentinel app/tests/integrations/opsgenie app/tests/unit/integrations is empty
+- [ ] #2 force-exclude + RUFF_SCOPE include all listed integrations src/test dirs plus tests/unit/integrations; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.6 - Ruff-migration-06-integrations-google_workspace-slack-completes-integrations.md
+++ b/backlog/tasks/task-15.6 - Ruff-migration-06-integrations-google_workspace-slack-completes-integrations.md
@@ -1,0 +1,52 @@
+---
+id: TASK-15.6
+title: >-
+  Ruff migration 06: integrations google_workspace + slack (completes
+  integrations/)
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:18'
+labels: []
+dependencies:
+  - TASK-15.5
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 63000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the two largest integrations (google_workspace, slack) and their tests, COMPLETING integrations/.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/integrations/google_workspace app/integrations/slack \
+    app/tests/integrations/google_workspace app/tests/integrations/slack
+
+Note: slack + google_workspace files carry reviewed S105/S106/S107 noqa markers (non-secret token/field names) from the checkout -- keep verbatim.
+
+CONSOLIDATION (this PR completes integrations/ and tests/integrations/):
+- app/pyproject.toml [tool.black] force-exclude: REPLACE the granular 'integrations/*' and 'tests/integrations/*' alternatives from TASK-15.5 with:
+    | integrations
+    | tests/integrations
+  (Leave the 'tests/unit/integrations' line from TASK-15.5 as-is.)
+- app/Makefile RUFF_SCOPE: replace the granular integrations/* and tests/integrations/* tokens with:
+    integrations tests/integrations
+  (Keep tests/unit/integrations.)
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~39 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/integrations app/tests/integrations is empty (entire integrations src + legacy-test trees now migrated)
+- [ ] #2 force-exclude + RUFF_SCOPE consolidated to 'integrations' and 'tests/integrations' (tests/unit/integrations already migrated in TASK-15.5); make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.7 - Ruff-migration-07-modules-incident-small-atip-secret-role.md
+++ b/backlog/tasks/task-15.7 - Ruff-migration-07-modules-incident-small-atip-secret-role.md
@@ -1,0 +1,54 @@
+---
+id: TASK-15.7
+title: 'Ruff migration 07: modules incident + small (atip, secret, role)'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:18'
+labels: []
+dependencies:
+  - TASK-15.6
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 64000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates modules/incident plus the small modules (atip, secret, role) and their tests.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/modules/incident app/modules/atip app/modules/secret app/modules/role \
+    app/tests/modules/incident app/tests/modules/secret app/tests/modules/role app/tests/unit/modules/atip
+
+Note: modules/secret/secret.py is the actual secrets module and carries carefully-reviewed S-family noqa markers from the checkout -- keep them verbatim; do NOT reflexively add/remove noqa. modules/incident files carry reviewed B904/SIM/S fixes from the branch.
+
+app/pyproject.toml -> add to [tool.black] force-exclude:
+    | modules/incident
+    | modules/atip
+    | modules/secret
+    | modules/role
+    | tests/modules/incident
+    | tests/modules/secret
+    | tests/modules/role
+    | tests/unit/modules/atip
+
+app/Makefile -> append to RUFF_SCOPE:
+    modules/incident modules/atip modules/secret modules/role tests/modules/incident tests/modules/secret tests/modules/role tests/unit/modules/atip
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~38 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/modules/incident app/modules/atip app/modules/secret app/modules/role app/tests/modules/incident app/tests/modules/secret app/tests/modules/role app/tests/unit/modules/atip is empty
+- [ ] #2 force-exclude + RUFF_SCOPE include all listed module src/test dirs; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.8 - Ruff-migration-08-modules-webhooks-aws.md
+++ b/backlog/tasks/task-15.8 - Ruff-migration-08-modules-webhooks-aws.md
@@ -1,0 +1,50 @@
+---
+id: TASK-15.8
+title: 'Ruff migration 08: modules webhooks + aws'
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:18'
+labels: []
+dependencies:
+  - TASK-15.7
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 65000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates modules/webhooks and modules/aws and their tests.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/modules/webhooks app/modules/aws \
+    app/tests/modules/webhooks app/tests/unit/modules/aws
+
+Note: modules/webhooks and modules/aws files carry reviewed S105/S106/S107 noqa markers (non-secret names) from the branch -- keep verbatim.
+
+app/pyproject.toml -> add to [tool.black] force-exclude:
+    | modules/webhooks
+    | modules/aws
+    | tests/modules/webhooks
+    | tests/unit/modules/aws
+
+app/Makefile -> append to RUFF_SCOPE:
+    modules/webhooks modules/aws tests/modules/webhooks tests/unit/modules/aws
+
+Validate (from app/): make lint-ci && make fmt-ci && make test
+Expected size: ~44 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/modules/webhooks app/modules/aws app/tests/modules/webhooks app/tests/unit/modules/aws is empty
+- [ ] #2 force-exclude + RUFF_SCOPE include modules/webhooks, modules/aws, tests/modules/webhooks, tests/unit/modules/aws; make lint-ci && make fmt-ci pass
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->

--- a/backlog/tasks/task-15.9 - Ruff-migration-09-modules-tail-misc-utils-models-jobs-bin-server-completes-modules.md
+++ b/backlog/tasks/task-15.9 - Ruff-migration-09-modules-tail-misc-utils-models-jobs-bin-server-completes-modules.md
@@ -1,0 +1,62 @@
+---
+id: TASK-15.9
+title: >-
+  Ruff migration 09: modules tail + misc (utils, models, jobs, bin, server);
+  completes modules/
+status: To Do
+assignee: []
+created_date: '2026-07-23 14:18'
+labels: []
+dependencies:
+  - TASK-15.8
+references:
+  - decisions/toolchain.md
+parent_task_id: TASK-15
+ordinal: 66000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow the SHARED RECIPE in TASK-15.1. Migrates the remaining small modules (sre, slack, provisioning, dev, reports, modules/__init__.py) plus the miscellaneous top-level src trees (utils, models, jobs, bin, server) and their unit tests. COMPLETES modules/.
+
+Paths to pull:
+  git checkout feat/dev_env_setup_ruff -- \
+    app/modules/sre app/modules/slack app/modules/provisioning app/modules/dev app/modules/reports app/modules/__init__.py \
+    app/utils app/models app/jobs app/bin app/server \
+    app/tests/modules/slack app/tests/modules/provisioning app/tests/modules/permissions app/tests/modules/ops \
+    app/tests/unit/modules/sre app/tests/unit/jobs app/tests/unit/server app/tests/unit/models
+
+Note: bin/check_prefix_command_namespace.py carries the reviewed SIM102/SIM103 rewrites -- after checkout run 'make check-prefix-guardrail' to confirm the guardrail still passes.
+
+CONSOLIDATION (this PR completes modules/, tests/modules/, tests/unit/modules/):
+- app/pyproject.toml [tool.black] force-exclude: REPLACE the granular 'modules/*', 'tests/modules/*', 'tests/unit/modules/*' alternatives from TASK-15.7/08 with:
+    | modules
+    | tests/modules
+    | tests/unit/modules
+  and ADD the misc trees:
+    | utils
+    | models
+    | jobs
+    | bin
+    | server
+    | tests/unit/jobs
+    | tests/unit/server
+    | tests/unit/models
+- app/Makefile RUFF_SCOPE: replace granular modules tokens with 'modules tests/modules tests/unit/modules' and append 'utils models jobs bin server tests/unit/jobs tests/unit/server tests/unit/models'.
+
+Validate (from app/): make lint-ci && make fmt-ci && make check-prefix-guardrail && make test
+Expected size: ~39 files.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 git diff feat/dev_env_setup_ruff -- app/modules app/tests/modules app/tests/unit/modules app/utils app/models app/jobs app/bin app/server app/tests/unit/jobs app/tests/unit/server app/tests/unit/models is empty
+- [ ] #2 force-exclude + RUFF_SCOPE consolidated for modules (modules, tests/modules, tests/unit/modules) and include utils, models, jobs, bin, server + their unit tests; make lint-ci && make fmt-ci pass
+- [ ] #3 make check-prefix-guardrail passes after migrating bin/check_prefix_command_namespace.py
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+<!-- DOD:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request initiates the incremental migration to using Ruff as the sole Python formatter and linter, replacing Black and Bandit, by splitting the migration into a sequence of smaller, reviewable PRs. It updates the umbrella TASK-15 to "In Progress" and adds detailed implementation and decomposition notes, and introduces the first and tenth migration sub-tasks (TASK-15.1 and TASK-15.10), each specifying their scope, acceptance criteria, and step-by-step migration instructions.

**Migration Plan and Task Decomposition:**

* `backlog/tasks/task-15 - Adopt-ruff-as-sole-formatter-and-linter-remove-black-and-standalone-bandit.md`:
  * Updated status to "In Progress", assigned to self, and added a comprehensive implementation plan and notes. The plan details the stepwise migration strategy, commit structuring, and risk mitigation, and decomposes the migration into 12 sequential sub-tasks (TASK-15.1 to TASK-15.12), each migrating a manageable slice of the codebase. [[1]](diffhunk://#diff-0e94ead6d436c2b6e28ab8a5152cdcb31c902fce46592bf32c71d0276047e6dbL4-R8) [[2]](diffhunk://#diff-0e94ead6d436c2b6e28ab8a5152cdcb31c902fce46592bf32c71d0276047e6dbL36-R167)

**New Migration Sub-tasks:**

* `backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md`:
  * Introduces the first migration PR, which scaffolds parallel Black/Ruff CI and migrates `app/api` and `app/tests/api`. It details the shared migration recipe, acceptance criteria, and ensures both toolchains run in CI over their respective scopes.

* `backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md`:
  * Adds the tenth migration PR, covering the `packages/access` feature package and its unit tests. It follows the shared recipe, specifies the paths to migrate, and includes instructions for updating the formatter/linter scope in configuration files.

These changes collectively set up a safe, incremental migration path to Ruff, ensuring continuous integration remains stable and reviewable throughout the process.