### PR TITLE
Feat/dev env setup ruff 1

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,5 +1,7 @@
 .PHONY: dev dev-setup fmt install lint test test-unit test-integration test-legacy test-all fmt-ci lint-ci install-dev run test-coverage test-coverage-unit backlog-board check-prefix-guardrail audit-client-usage-matrix
 
+RUFF_SCOPE := api tests/api
+
 dev:
 	PREFIX="dev-" SLACK__COMMAND_PREFIX="dev-" uv run uvicorn main:server_app --reload
 
@@ -13,6 +15,7 @@ debug:
 
 fmt:
 	uv run black . $(ARGS) --target-version py311
+	uv run ruff format $(RUFF_SCOPE) $(ARGS)
 
 install:
 	uv sync
@@ -22,6 +25,7 @@ install-dev:
 
 lint:
 	uv run ruff check .
+	uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
 
 lint-types:
 	@command -v uv >/dev/null 2>&1 && uv run mypy . --check-untyped-defs --explicit-package-bases || echo "⚠️  uv not installed. Run 'make install-dev' to enable type checking."
@@ -77,10 +81,12 @@ test-coverage-all:
 
 lint-ci:
 	uv run ruff check .
+	uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
 	@command -v uv >/dev/null 2>&1 && uv run mypy . --check-untyped-defs || true
 
 fmt-ci:
 	uv run black --check . --target-version py311
+	uv run ruff format --check $(RUFF_SCOPE)
 
 check-prefix-guardrail:
 	python bin/check_prefix_command_namespace.py

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,9 +1,10 @@
 import structlog
-from fastapi import APIRouter, Request, Depends
-from api.routes.system import router as system_router
-from api.routes.landing import router as landing_router
-from api.v1.router import router as v1_router, legacy_router
+from fastapi import APIRouter, Depends, Request
 
+from api.routes.landing import router as landing_router
+from api.routes.system import router as system_router
+from api.v1.router import legacy_router
+from api.v1.router import router as v1_router
 
 logger = structlog.get_logger()
 

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
+
 from api.v1.routes.geolocate import router as legacy_geolocate_router
 from api.v1.routes.webhooks import router as webhooks_router
-
 
 # Main v1 router (includes all endpoints)
 router = APIRouter()

--- a/app/api/v1/routes/geolocate.py
+++ b/app/api/v1/routes/geolocate.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
-from integrations import maxmind
+
 from infrastructure.security import get_limiter
+from integrations import maxmind
 from packages.geolocate.schemas import build_open_source_map_links
 
 router = APIRouter(tags=["Geolocation"])

--- a/app/api/v1/routes/webhooks.py
+++ b/app/api/v1/routes/webhooks.py
@@ -1,8 +1,8 @@
 import json
-from typing import Any, Dict, Optional, Union
-import structlog
+from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request, Body
+import structlog
+from fastapi import APIRouter, Body, HTTPException, Request
 from slack_sdk import WebClient
 
 from infrastructure.security import get_limiter
@@ -12,13 +12,12 @@ from modules.slack import webhooks
 from modules.webhooks.base import handle_webhook_payload
 from modules.webhooks.slack import hydrate_ip_addresses, map_emails_to_slack_users
 
-
 logger = structlog.get_logger()
 router = APIRouter(tags=["Webhooks"])
 limiter = get_limiter()
 
 
-def _get_bot_client(request: Request) -> Optional[WebClient]:
+def _get_bot_client(request: Request) -> WebClient | None:
     bot = getattr(request.app.state, "bot", None)
     if bot is None:
         return None
@@ -32,7 +31,7 @@ def _get_bot_client(request: Request) -> Optional[WebClient]:
 def handle_webhook(
     webhook_id: str,
     request: Request,
-    payload: Union[Dict[Any, Any], str] = Body(...),
+    payload: dict[Any, Any] | str = Body(...),  # noqa: B008 -- FastAPI dependency injection requires a call in the default
 ):
     """Handle incoming webhook requests and post to Slack channel.
 
@@ -84,16 +83,12 @@ def handle_webhook(
             detail=webhook_result.message or "Invalid payload",
         )
 
-    if webhook_result.action == "post" and isinstance(
-        webhook_result.payload, WebhookPayload
-    ):
+    if webhook_result.action == "post" and isinstance(webhook_result.payload, WebhookPayload):
         webhook_payload = webhook_result.payload
         webhook_payload = map_emails_to_slack_users(webhook_payload)
         webhook_payload = hydrate_ip_addresses(webhook_payload)
         webhook_payload.channel = webhook["channel"]["S"]
-        hook_type = webhook.get("hook_type", {}).get(
-            "S", "alert"
-        )  # Default to "alert" if hook_type is missing
+        hook_type = webhook.get("hook_type", {}).get("S", "alert")  # Default to "alert" if hook_type is missing
         if hook_type == "alert":
             webhook_payload = append_incident_buttons(webhook_payload, webhook_id)
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -70,6 +70,19 @@ select = ["E", "F", "W"]
 ignore = ["E501"]
 mccabe.max-complexity = 16
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S105", "S106", "S107", "B007", "B008", "B011", "B017", "B018", "B905", "C408", "C416", "C418", "SIM116", "SIM117", "SIM118", "UP028"]
+"utils/tests.py" = ["S101"]
+
+[tool.black]
+target-version = ["py311"]
+force-exclude = '''
+/(
+    api
+  | tests/api
+)/
+'''
+
 [tool.mypy]
 python_version = "3.14"
 warn_return_any = true

--- a/app/tests/api/dependencies/test_rate_limits.py
+++ b/app/tests/api/dependencies/test_rate_limits.py
@@ -1,12 +1,13 @@
 from unittest.mock import Mock, patch
-import pytest
+
 import httpx
-from fastapi import Request, FastAPI
+import pytest
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 
-from infrastructure.security import rate_limiter as rate_limits
 from api.routes.system import router as system_router
+from infrastructure.security import rate_limiter as rate_limits
 
 
 def test_header_exists_and_not_empty():

--- a/app/tests/api/routes/test_landing.py
+++ b/app/tests/api/routes/test_landing.py
@@ -20,9 +20,7 @@ def test_app():
 def landing_content():
     """Load the landing content JSON."""
 
-    content_path = (
-        Path(__file__).parent.parent.parent / "api" / "routes" / "landing_content.json"
-    )
+    content_path = Path(__file__).parent.parent.parent / "api" / "routes" / "landing_content.json"
     with open(content_path) as f:
         return json.load(f)
 
@@ -67,9 +65,7 @@ class TestLandingPage:
 
         # Check for French content strings (may be JSON-encoded in the response)
         # Check for French heading and other French markers
-        assert (
-            "Ingénierie de fiabilité de site" in html_content or "Ing" in html_content
-        )
+        assert "Ingénierie de fiabilité de site" in html_content or "Ing" in html_content
         assert "Backstage" in html_content  # Present in both EN and FR
         assert '"fr":' in html_content  # Check that FR language data is present
 
@@ -104,10 +100,7 @@ class TestLandingPage:
 
         # Check for API documentation link (may be JSON-encoded)
         assert "/docs" in html_content
-        assert (
-            "View API Documentation" in html_content
-            or "Afficher la documentation" in html_content
-        )
+        assert "View API Documentation" in html_content or "Afficher la documentation" in html_content
 
     def test_landing_page_responsive_design(self, test_app):
         """Test that the landing page includes responsive design styles."""

--- a/app/tests/api/v1/test_geolocate.py
+++ b/app/tests/api/v1/test_geolocate.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
+
 from fastapi.testclient import TestClient
+
 from api.v1.routes import geolocate
 from utils.tests import create_test_app
 

--- a/app/tests/api/v1/test_webhooks.py
+++ b/app/tests/api/v1/test_webhooks.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch, MagicMock, PropertyMock, call, ANY
+from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
-import pytest
 import httpx
+import pytest
 from fastapi.testclient import TestClient
+
 from api.v1.routes import webhooks
 from models.webhooks import (
     WebhookPayload,
@@ -74,9 +75,7 @@ def test_handle_webhook_malformed_json_string(test_client):
     payload = '{"invalid_json": "missing_end_quote}'
     response = test_client.post("/hook/id", json=payload)
     assert response.status_code == 400
-    assert response.json() == {
-        "detail": "Unterminated string starting at: line 1 column 18 (char 17)"
-    }
+    assert response.json() == {"detail": "Unterminated string starting at: line 1 column 18 (char 17)"}
 
 
 @patch("api.v1.routes.webhooks.webhooks.get_webhook")
@@ -220,9 +219,7 @@ def test_handle_webhook_with_none_payload_none(
         "hook_type": {"S": "standard"},
         "active": {"BOOL": True},
     }
-    handle_webhook_payload_mock.return_value = WebhookResult(
-        status="error", action=None, payload=None
-    )
+    handle_webhook_payload_mock.return_value = WebhookResult(status="error", action=None, payload=None)
 
     response = test_client.post("/hook/id", json=payload)
 
@@ -429,9 +426,7 @@ async def test_webhooks_rate_limiting(
         payload = '{"Type": "Notification"}'
         # Return a proper WebhookPayload instance
         mock_webhook_payload = WebhookPayload(text="Test message")
-        handle_webhook_payload_mock.return_value = WebhookResult(
-            status="success", action="post", payload=mock_webhook_payload
-        )
+        handle_webhook_payload_mock.return_value = WebhookResult(status="success", action="post", payload=mock_webhook_payload)
         # Make 30 requests to the handle_webhook endpoint
         for _ in range(30):
             response = await client.post("/hook/test-id", json=payload)

--- a/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
+++ b/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-15.1
 title: 'Ruff migration 01: scaffold parallel black/ruff CI + migrate app/api'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-23 14:11'
-updated_date: '2026-07-23 14:16'
+updated_date: '2026-07-23 15:41'
 labels: []
 dependencies:
   - TASK-15
@@ -92,3 +93,57 @@ Notes:
 <!-- DOD:BEGIN -->
 - [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Branch: git checkout main && git pull && git checkout -b <branch-name> (human/PR step, not run by agent).
+2. Pull migrated content for this slice from the reference branch (never hand-edit migrated source):
+   git checkout feat/dev_env_setup_ruff -- app/api app/tests/api
+   Verified against current main: 8 of 12 tracked files under these paths actually change content (app/api/router.py, app/api/v1/router.py, app/api/v1/routes/geolocate.py, app/api/v1/routes/webhooks.py, app/tests/api/dependencies/test_rate_limits.py, app/tests/api/routes/test_landing.py, app/tests/api/v1/test_geolocate.py, app/tests/api/v1/test_webhooks.py); 4 are byte-identical already (app/api/__init__.py, app/api/routes/landing.py, app/api/routes/system.py, app/tests/api/routes/test_system.py) -- confirmed via git diff main feat/dev_env_setup_ruff -- <path> (empty for all 4). Non-py tracked assets (app/api/routes/favicon.ico, app/api/routes/landing_content.json) are untouched by ruff/black, no action needed.
+3. Edit app/pyproject.toml (insert after line 71 "mccabe.max-complexity = 16", before line 73 "[tool.mypy]"):
+   [tool.ruff.lint.per-file-ignores]
+   "tests/**" = ["S101", "S105", "S106", "S107", "B007", "B008", "B011", "B017", "B018", "B905", "C408", "C416", "C418", "SIM116", "SIM117", "SIM118", "UP028"]
+   "utils/tests.py" = ["S101"]
+
+   [tool.black]
+   target-version = ["py311"]
+   force-exclude = '''
+   /(
+       api
+     | tests/api
+   )/
+   '''
+   Leave [tool.ruff.lint] select = ["E","F","W"] (line 69) and ignore/mccabe (lines 70-71) unchanged. Leave black in [project.optional-dependencies].dev (line 43) unchanged.
+4. Edit app/Makefile:
+   a. After line 1 (.PHONY ...), add: RUFF_SCOPE := api tests/api
+   b. fmt target (line 14-15): append a second recipe line "uv run ruff format $(RUFF_SCOPE) $(ARGS)" after the existing black line.
+   c. lint target (line 23-24): append a second recipe line "uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)" after the existing "uv run ruff check ." line.
+   d. lint-ci target (line 78-80): insert "uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)" between the existing "uv run ruff check ." line and the mypy "|| true" line.
+   e. fmt-ci target (line 82-83): append a second recipe line "uv run ruff format --check $(RUFF_SCOPE)" after the existing black --check line.
+   Do not touch test/test-unit/test-integration/lint-types targets.
+5. cd app && uv sync --extra dev (refresh lock only if pyproject changed structurally; dependency list itself is unchanged here so this is a no-op safety check).
+6. Validate from app/: make lint-ci && make fmt-ci && make test. All three simulated in an isolated worktree during planning (git worktree, content pulled from feat/dev_env_setup_ruff, config edits applied, discarded after): uv run ruff check . -> All checks passed; uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S api tests/api -> All checks passed; uv run black --check . --target-version py311 -> 649 files unchanged (api/tests/api correctly force-excluded); uv run ruff format --check api tests/api -> 12 files already formatted; make test -> 1812 passed/37 skipped + 1049 passed (test-unit + legacy), 0 failures. mypy remains soft-failing via existing "|| true" with 126 pre-existing errors in unrelated legacy modules (modules/incident, integrations/aws, etc.) -- unchanged by this PR, not a regression, out of scope (tracked separately per decisions/toolchain.md migration debt).
+7. Do not touch .github/workflows/bandit_security_scan.yml or any CI workflow file -- .github/workflows/ci_code.yml already calls "make lint-ci" / "make fmt-ci" / "make test" generically, so no workflow edits are needed for this slice.
+8. Ship one mechanical PR; reference decisions/toolchain.md and TASK-15.
+
+AC-to-step traceability:
+- AC#1 (parallel CI green) <- steps 3, 4, 6 (validated by dry-run above).
+- AC#2 (app/api, app/tests/api byte-identical to feat/dev_env_setup_ruff) <- step 2; verify with "git diff feat/dev_env_setup_ruff -- app/api app/tests/api" (must be empty after checkout).
+- AC#3 (pyproject force-exclude + per-file-ignores added, global select stays E,F,W, black stays in dev deps, Makefile has RUFF_SCOPE + dual targets) <- steps 3, 4; verify by reading the edited sections.
+- DoD#1 (make test passes; PR references decisions/toolchain.md + TASK-15) <- step 6 (test run) + PR description (human/PR action).
+
+Test matrix:
+- Happy path: make lint-ci (both ruff invocations pass, mypy soft-fails as today) and make fmt-ci (black --check whole tree minus api/tests/api, ruff format --check on RUFF_SCOPE) both exit 0.
+- Regression: make test unchanged pass count vs current main baseline (1812+1049 passed in the dry run); any new failure is a real regression in the migrated api/tests/api content, not expected from a mechanical pull.
+- Config-only check: grep -n "RUFF_SCOPE" app/Makefile and grep -n "force-exclude" app/pyproject.toml both hit exactly once.
+
+Assumptions / doubts (verified during planning, not guessed):
+- Reference branch feat/dev_env_setup_ruff has already fully cut over (no black anywhere, global ruff select already E,F,W,I,B,UP,C4,SIM,S, per-file-ignores already present) -- confirmed via git show feat/dev_env_setup_ruff:app/pyproject.toml. This PR's [tool.black] section is authored fresh for the transitional state and does not come from the reference branch.
+- No import-linter / lint-imports config exists yet in app/ (grep found none) -- reordered imports in api/router.py and api/v1/router.py from the reference branch cannot trip a contract that does not exist; not a concern for this slice.
+- __pycache__ artifacts under app/api and app/tests/api are gitignored (confirmed via git check-ignore) and not tracked; only favicon.ico and landing_content.json are tracked non-.py files and are unaffected by black/ruff.
+
+Blast radius and rollback:
+- Blast radius: app/pyproject.toml, app/Makefile, and 8 content files under app/api + app/tests/api. No route behavior, schema, or business logic changes -- purely import ordering/formatting/typing-syntax churn plus one added noqa comment (api/v1/routes/webhooks.py, B008, already justified inline). No changes to CI workflow files, other app/ paths, or dependencies.
+- Rollback: revert the single PR commit; both toolchains remain independently invertible (removing RUFF_SCOPE/[tool.black] restores prior single-toolchain Makefile/pyproject; re-checking out api/tests/api from main restores pre-migration source).
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request migrates the `app/api` and `app/tests/api` source trees to use Ruff for linting and formatting, running in parallel with Black as a transitional step. It updates configuration and Makefile targets to support both tools, applies per-file Ruff lint ignores, and ensures that all affected files match the formatting and import order from the reference migration branch. No route, schema, or business logic changes are included—only mechanical formatting, import ordering, and type hint syntax updates.

**Build and Lint Toolchain Updates:**

* [`app/Makefile`](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451R3-R4): Adds `RUFF_SCOPE` for targeting `api` and `tests/api`, and updates `fmt`, `lint`, `lint-ci`, and `fmt-ci` targets to run Ruff (check and format) alongside Black, with the correct select flags for Ruff. [[1]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451R3-R4) [[2]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451R18) [[3]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451R28) [[4]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451R84-R89)
* [`app/pyproject.toml`](diffhunk://#diff-f79644217c104a26d0814d8faf2afc24c0239350806e80ff239b93271888e465R73-R85): Adds Ruff per-file ignore rules for tests, configures Black to force-exclude `api` and `tests/api` (so only Ruff formats these), and documents the target Python version for Black.

**Source Code Formatting and Import Order:**

* `app/api/router.py`, `app/api/v1/router.py`, `app/api/v1/routes/geolocate.py`, `app/api/v1/routes/webhooks.py`, `app/tests/api/dependencies/test_rate_limits.py`, `app/tests/api/v1/test_geolocate.py`, `app/tests/api/v1/test_webhooks.py`: Update import order and formatting to match Ruff/Black output; update type hints to use modern syntax (e.g., `WebClient | None` instead of `Optional[WebClient]`). [[1]](diffhunk://#diff-a584b4dbaf5b09f2f4d0f56fed890b7a1fc811e02e8cb64326bcb204d9979aafL2-R7) [[2]](diffhunk://#diff-c518708effbb394ceab21f1e217fbd8b4bc39f6da81364e1af2e0c6b92d28b16R2-L5) [[3]](diffhunk://#diff-1d17bc77e80dc91aac882d0a8e87defb0ff8ec08e4594f6595d5bde630df0c18L2-R4) [[4]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46L2-R5) [[5]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46L15-R20) [[6]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46L35-R34) [[7]](diffhunk://#diff-0797b0f5d0f94ef6a17d884524560c09666fe4277e9ee43a5380060f562c2a46L87-R91) [[8]](diffhunk://#diff-1705f15d3a5339981d4dbdd47ea3d7f209055758d3119074398a7b5de87ced40L2-R10) [[9]](diffhunk://#diff-5e4e48547d1a1908d12a5ddc2057d5d6857bf5c291eed147868f8a913e4f5434R2-R4) [[10]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757L1-R6) [[11]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757L77-R78) [[12]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757L223-R222) [[13]](diffhunk://#diff-3487c8d32b4e30fde7dd1c1a9cd383e6539167dd0ec95c1eaaf7276af5b21757L432-R429)

**Test Code Formatting:**

* [`app/tests/api/routes/test_landing.py`](diffhunk://#diff-e9cdc100ed406c2647d73d6a5d6f08bc34d7b18ee79158b9ba5682f986d2d05cL23-R23): Reformats multi-line expressions for consistency and clarity, in line with Ruff/Black output. [[1]](diffhunk://#diff-e9cdc100ed406c2647d73d6a5d6f08bc34d7b18ee79158b9ba5682f986d2d05cL23-R23) [[2]](diffhunk://#diff-e9cdc100ed406c2647d73d6a5d6f08bc34d7b18ee79158b9ba5682f986d2d05cL70-R68) [[3]](diffhunk://#diff-e9cdc100ed406c2647d73d6a5d6f08bc34d7b18ee79158b9ba5682f986d2d05cL107-R103)

**Documentation and Planning:**

* [`backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md`](diffhunk://#diff-a65eb87d965a66362363ba1b72db3858a66a8629fe68a74df41a94b7a9e780a8L4-R8): Updates task status, assignee, and adds a detailed implementation plan documenting the migration steps, config changes, validation, and rollback strategy. [[1]](diffhunk://#diff-a65eb87d965a66362363ba1b72db3858a66a8629fe68a74df41a94b7a9e780a8L4-R8) [[2]](diffhunk://#diff-a65eb87d965a66362363ba1b72db3858a66a8629fe68a74df41a94b7a9e780a8R96-R149)

This PR is mechanical and ensures that all lint, format, and test targets pass with the new dual-toolchain setup, as required by the migration plan. (TASK-15, decisions/toolchain.md)