### PR TITLE
Feat/dev env setup ruff 2

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev dev-setup fmt install lint test test-unit test-integration test-legacy test-all fmt-ci lint-ci install-dev run test-coverage test-coverage-unit backlog-board check-prefix-guardrail audit-client-usage-matrix
 
-RUFF_SCOPE := api tests/api
+RUFF_SCOPE := api tests/api infrastructure/clients tests/unit/infrastructure/clients
 
 dev:
 	PREFIX="dev-" SLACK__COMMAND_PREFIX="dev-" uv run uvicorn main:server_app --reload
@@ -25,7 +25,7 @@ install-dev:
 
 lint:
 	uv run ruff check .
-	uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
+	uv run ruff check --extend-select=I,B,UP,C4,SIM,S $(RUFF_SCOPE)
 
 lint-types:
 	@command -v uv >/dev/null 2>&1 && uv run mypy . --check-untyped-defs --explicit-package-bases || echo "⚠️  uv not installed. Run 'make install-dev' to enable type checking."
@@ -81,7 +81,7 @@ test-coverage-all:
 
 lint-ci:
 	uv run ruff check .
-	uv run ruff check --select=E,F,W,I,B,UP,C4,SIM,S $(RUFF_SCOPE)
+	uv run ruff check --extend-select=I,B,UP,C4,SIM,S $(RUFF_SCOPE)
 	@command -v uv >/dev/null 2>&1 && uv run mypy . --check-untyped-defs || true
 
 fmt-ci:

--- a/app/infrastructure/clients/aws/config.py
+++ b/app/infrastructure/clients/aws/config.py
@@ -3,7 +3,7 @@
 Provides operations to interact with AWS Config service, enabling retrieval of configuration compliance and resource details, with consistent error handling via OperationResult.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
 from infrastructure.clients.aws.session_provider import SessionProvider
@@ -20,7 +20,7 @@ class ConfigClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_role_arn: Optional[str] = None,
+        default_role_arn: str | None = None,
     ) -> None:
         self._session_provider = session_provider
         self._default_role_arn = default_role_arn
@@ -28,14 +28,14 @@ class ConfigClient:
 
     # TODO: Add support for role_arn parameters to override default_role_arn
     def describe_aggregate_compliance_by_config_rules(
-        self, config_aggregator_name: str, filters: Optional[Dict[str, Any]] = None
+        self, config_aggregator_name: str, filters: dict[str, Any] | None = None
     ) -> OperationResult:
         """Describe aggregate compliance by config rules.
 
         Returns an OperationResult whose `data` is a list of compliance objects
         when successful.
         """
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "ConfigurationAggregatorName": config_aggregator_name,
             "Filters": filters,
         }

--- a/app/infrastructure/clients/aws/cost_explorer.py
+++ b/app/infrastructure/clients/aws/cost_explorer.py
@@ -3,14 +3,13 @@
 Provides operations to interact with AWS Cost Explorer service, enabling retrieval of cost and usage data with consistent error handling via OperationResult.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import structlog
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
 from infrastructure.clients.aws.session_provider import SessionProvider
 from infrastructure.operations.result import OperationResult
-
 
 logger = structlog.get_logger()
 
@@ -25,21 +24,19 @@ class CostExplorerClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_role_arn: Optional[str] = None,
+        default_role_arn: str | None = None,
     ) -> None:
         self._session_provider = session_provider
         self._default_role_arn = default_role_arn
         self.service_name = "ce"
 
-    def get_cost_and_usage(
-        self, time_period: Dict[str, str], metrics: list, **kwargs
-    ) -> OperationResult:
+    def get_cost_and_usage(self, time_period: dict[str, str], metrics: list, **kwargs) -> OperationResult:
         """Get cost and usage data from AWS Cost Explorer.
 
         Returns an OperationResult whose `data` contains the cost and usage details
         when successful.
         """
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "TimePeriod": time_period,
             "Metrics": metrics,
             **kwargs,

--- a/app/infrastructure/clients/aws/dynamodb.py
+++ b/app/infrastructure/clients/aws/dynamodb.py
@@ -4,7 +4,7 @@ Provides type-safe access to DynamoDB operations (get_item, put_item, query, sca
 with consistent error handling and OperationResult return types.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import structlog
 
@@ -28,7 +28,7 @@ class DynamoDBClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_role_arn: Optional[str] = None,
+        default_role_arn: str | None = None,
     ) -> None:
         self._session_provider = session_provider
         self._default_role_arn = default_role_arn
@@ -38,8 +38,8 @@ class DynamoDBClient:
     def get_item(
         self,
         table_name: str,
-        Key: Dict[str, Any],
-        role_arn: Optional[str] = None,
+        Key: dict[str, Any],
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Get an item from DynamoDB.
@@ -54,9 +54,7 @@ class DynamoDBClient:
             OperationResult with item data or error
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "get_item",
@@ -69,8 +67,8 @@ class DynamoDBClient:
     def put_item(
         self,
         table_name: str,
-        Item: Dict[str, Any],
-        role_arn: Optional[str] = None,
+        Item: dict[str, Any],
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Put an item into DynamoDB.
@@ -85,9 +83,7 @@ class DynamoDBClient:
             OperationResult with status
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "put_item",
@@ -100,8 +96,8 @@ class DynamoDBClient:
     def update_item(
         self,
         table_name: str,
-        Key: Dict[str, Any],
-        role_arn: Optional[str] = None,
+        Key: dict[str, Any],
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Update an item in DynamoDB.
@@ -116,9 +112,7 @@ class DynamoDBClient:
             OperationResult with updated item data or error
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "update_item",
@@ -131,8 +125,8 @@ class DynamoDBClient:
     def delete_item(
         self,
         table_name: str,
-        Key: Dict[str, Any],
-        role_arn: Optional[str] = None,
+        Key: dict[str, Any],
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Delete an item from DynamoDB.
@@ -147,9 +141,7 @@ class DynamoDBClient:
             OperationResult with status
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "delete_item",
@@ -163,7 +155,7 @@ class DynamoDBClient:
         self,
         table_name: str,
         KeyConditionExpression: Any,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Query items from DynamoDB using key condition.
@@ -178,9 +170,7 @@ class DynamoDBClient:
             OperationResult with items list or error
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "query",
@@ -193,7 +183,7 @@ class DynamoDBClient:
     def scan(
         self,
         table_name: str,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Scan all items from a DynamoDB table.
@@ -207,9 +197,7 @@ class DynamoDBClient:
             OperationResult with items list or error
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "dynamodb",
             "scan",
@@ -218,7 +206,7 @@ class DynamoDBClient:
             **kwargs,
         )
 
-    def healthcheck(self, role_arn: Optional[str] = None) -> OperationResult:
+    def healthcheck(self, role_arn: str | None = None) -> OperationResult:
         """Lightweight health check for DynamoDB.
 
         Performs a cheap `list_tables` call to verify the service is reachable.

--- a/app/infrastructure/clients/aws/executor.py
+++ b/app/infrastructure/clients/aws/executor.py
@@ -6,12 +6,13 @@ settings at import time and accepts configuration via parameters.
 """
 
 import time
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any
 
 import boto3  # type: ignore
+import structlog
 from botocore.client import BaseClient  # type: ignore
 from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
-import structlog
 
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
@@ -21,9 +22,9 @@ logger = structlog.get_logger()
 
 def get_boto3_client(
     service_name: str,
-    session_config: Optional[Dict[str, Any]] = None,
-    client_config: Optional[Dict[str, Any]] = None,
-    role_arn: Optional[str] = None,
+    session_config: dict[str, Any] | None = None,
+    client_config: dict[str, Any] | None = None,
+    role_arn: str | None = None,
     session_name: str = "InfraClientSession",
 ) -> BaseClient:
     """Create a boto3 client for the given service.
@@ -86,9 +87,9 @@ def _determine_pagination_strategy(
 
 
 def _aggregate_page_items(
-    page: Dict[str, Any],
-    keys: Optional[List[str]],
-) -> List[Any]:
+    page: dict[str, Any],
+    keys: list[str] | None,
+) -> list[Any]:
     """Extract and aggregate items from a paginated response page.
 
     Args:
@@ -98,7 +99,7 @@ def _aggregate_page_items(
     Returns:
         List of aggregated items from this page
     """
-    items: List[Any] = []
+    items: list[Any] = []
 
     if keys:
         # Extract only specified keys
@@ -135,9 +136,9 @@ def _aggregate_page_items(
 def _call_with_paginator(
     client: BaseClient,
     method: str,
-    keys: Optional[List[str]],
-    api_kwargs: Dict[str, Any],
-) -> Optional[List[Any]]:
+    keys: list[str] | None,
+    api_kwargs: dict[str, Any],
+) -> list[Any] | None:
     """Execute a paginated API call and aggregate results.
 
     Args:
@@ -155,7 +156,7 @@ def _call_with_paginator(
         # Paginator not available; caller should fallback to direct call
         return None
 
-    results: List[Any] = []
+    results: list[Any] = []
     for page in paginator.paginate(**api_kwargs):
         page_items = _aggregate_page_items(page, keys)
         results.extend(page_items)
@@ -166,12 +167,12 @@ def _call_with_paginator(
 def _call_api_once(
     service_name: str,
     method: str,
-    keys: Optional[List[str]],
-    role_arn: Optional[str],
-    session_config: Optional[Dict[str, Any]],
-    client_config: Optional[Dict[str, Any]],
+    keys: list[str] | None,
+    role_arn: str | None,
+    session_config: dict[str, Any] | None,
+    client_config: dict[str, Any] | None,
     force_paginate: bool,
-    kwargs: Dict[str, Any],
+    kwargs: dict[str, Any],
 ) -> Any:
     """Execute a single AWS API call with optional pagination.
 
@@ -214,7 +215,7 @@ def _map_client_error(
     service_name: str,
     method: str,
     treat_conflict_as_success: bool,
-    conflict_callback: Optional[Callable[[Exception], None]],
+    conflict_callback: Callable[[Exception], None] | None,
 ) -> OperationResult:
     error_code = e.response.get("Error", {}).get("Code")
     error_message = e.response.get("Error", {}).get("Message", str(e))
@@ -240,9 +241,7 @@ def _map_client_error(
         if treat_conflict_as_success:
             return OperationResult.success(data=None, message=error_message)
 
-        return OperationResult.permanent_error(
-            message=error_message, error_code=error_code
-        )
+        return OperationResult.permanent_error(message=error_message, error_code=error_code)
 
     if error_code in ("ThrottlingException", "RequestLimitExceeded"):
         retry_after = None
@@ -250,14 +249,10 @@ def _map_client_error(
             retry_after = int(e.response.get("RetryAfter", 0))
         except Exception:
             retry_after = None
-        return OperationResult.transient_error(
-            message=error_message, error_code=error_code, retry_after=retry_after
-        )
+        return OperationResult.transient_error(message=error_message, error_code=error_code, retry_after=retry_after)
 
     if error_code in ("AccessDeniedException", "UnauthorizedOperation"):
-        return OperationResult.error(
-            OperationStatus.UNAUTHORIZED, message=error_message
-        )
+        return OperationResult.error(OperationStatus.UNAUTHORIZED, message=error_message)
 
     return OperationResult.permanent_error(message=error_message, error_code=error_code)
 
@@ -265,15 +260,15 @@ def _map_client_error(
 def execute_aws_api_call(
     service_name: str,
     method: str,
-    keys: Optional[List[str]] = None,
-    role_arn: Optional[str] = None,
-    session_config: Optional[Dict[str, Any]] = None,
-    client_config: Optional[Dict[str, Any]] = None,
+    keys: list[str] | None = None,
+    role_arn: str | None = None,
+    session_config: dict[str, Any] | None = None,
+    client_config: dict[str, Any] | None = None,
     max_retries: int = 3,
     force_paginate: bool = False,
     backoff_factor: float = 0.5,
     treat_conflict_as_success: bool = False,
-    conflict_callback: Optional[Callable[[Exception], None]] = None,
+    conflict_callback: Callable[[Exception], None] | None = None,
     **kwargs,
 ) -> OperationResult:
     """Execute an AWS API call with retries and standardized results.
@@ -282,7 +277,7 @@ def execute_aws_api_call(
     `OperationResult` object for consistent downstream handling.
     """
 
-    last_exc: Optional[Exception] = None
+    last_exc: Exception | None = None
 
     for attempt in range(max_retries + 1):
         try:
@@ -296,25 +291,18 @@ def execute_aws_api_call(
                 force_paginate,
                 kwargs,
             )
-            return OperationResult.success(
-                data=result, message=f"{service_name}.{method} succeeded"
-            )
+            return OperationResult.success(data=result, message=f"{service_name}.{method} succeeded")
 
         except ClientError as e:
             last_exc = e
-            mapped = _map_client_error(
-                e, service_name, method, treat_conflict_as_success, conflict_callback
-            )
+            mapped = _map_client_error(e, service_name, method, treat_conflict_as_success, conflict_callback)
 
             # If conflict was treated as success, return success result immediately
             if mapped.is_success:
                 return mapped
 
             # Retry on transient errors if attempts remain
-            if (
-                mapped.status == OperationStatus.TRANSIENT_ERROR
-                and attempt < max_retries
-            ):
+            if mapped.status == OperationStatus.TRANSIENT_ERROR and attempt < max_retries:
                 delay = _calculate_retry_delay(attempt, backoff_factor)
                 logger.warning(
                     "aws_api_retry",
@@ -327,9 +315,7 @@ def execute_aws_api_call(
                 time.sleep(delay)
                 continue
 
-            logger.error(
-                "aws_api_error_final", service=service_name, method=method, error=str(e)
-            )
+            logger.error("aws_api_error_final", service=service_name, method=method, error=str(e))
             return mapped
 
         except (BotoCoreError, Exception) as e:  # pylint: disable=broad-except
@@ -342,6 +328,4 @@ def execute_aws_api_call(
             )
             return OperationResult.permanent_error(message=str(e))
 
-    return OperationResult.permanent_error(
-        message=str(last_exc) if last_exc else "unknown_error"
-    )
+    return OperationResult.permanent_error(message=str(last_exc) if last_exc else "unknown_error")

--- a/app/infrastructure/clients/aws/facade.py
+++ b/app/infrastructure/clients/aws/facade.py
@@ -60,9 +60,7 @@ class AWSClients:
 
         self.dynamodb: DynamoDBClient = DynamoDBClient(
             self._session_provider,
-            default_role_arn=self._session_provider.get_role_arn_for_service(
-                "dynamodb"
-            ),
+            default_role_arn=self._session_provider.get_role_arn_for_service("dynamodb"),
         )
         self.identitystore: IdentityStoreClient = IdentityStoreClient(
             self._session_provider,
@@ -70,9 +68,7 @@ class AWSClients:
         )
         self.organizations: OrganizationsClient = OrganizationsClient(
             self._session_provider,
-            default_role_arn=self._session_provider.get_role_arn_for_service(
-                "organizations"
-            ),
+            default_role_arn=self._session_provider.get_role_arn_for_service("organizations"),
         )
         self.sso_admin: SsoAdminClient = SsoAdminClient(
             self._session_provider,
@@ -84,9 +80,7 @@ class AWSClients:
         )
         self.guardduty: GuardDutyClient = GuardDutyClient(
             self._session_provider,
-            default_role_arn=self._session_provider.get_role_arn_for_service(
-                "guardduty"
-            ),
+            default_role_arn=self._session_provider.get_role_arn_for_service("guardduty"),
         )
         self.cost_explorer: CostExplorerClient = CostExplorerClient(
             self._session_provider,

--- a/app/infrastructure/clients/aws/guard_duty.py
+++ b/app/infrastructure/clients/aws/guard_duty.py
@@ -3,8 +3,6 @@
 Provides operations to interact with AWS GuardDuty service, enabling retrieval of detectors and findings statistics with consistent error handling via OperationResult.
 """
 
-from typing import Optional
-
 import structlog
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
@@ -24,7 +22,7 @@ class GuardDutyClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_role_arn: Optional[str] = None,
+        default_role_arn: str | None = None,
     ) -> None:
         self._session_provider = session_provider
         self._default_role_arn = default_role_arn

--- a/app/infrastructure/clients/aws/health.py
+++ b/app/infrastructure/clients/aws/health.py
@@ -3,7 +3,7 @@
 Provides aggregated health check operations for AWS services, enabling monitoring and alerting for service availability and performance issues.
 """
 
-from typing import Callable, Dict, Iterable, Optional
+from collections.abc import Callable, Iterable
 
 import structlog
 
@@ -31,9 +31,9 @@ class AWSIntegrationHealth:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_identity_store_id: Optional[str] = None,
-        default_sso_instance_arn: Optional[str] = None,
-        config_aggregator_name: Optional[str] = None,
+        default_identity_store_id: str | None = None,
+        default_sso_instance_arn: str | None = None,
+        config_aggregator_name: str | None = None,
         include_guardduty: bool = True,
         include_cost_explorer: bool = True,
     ) -> None:
@@ -43,9 +43,7 @@ class AWSIntegrationHealth:
         # Clients with defaults inherited from facade
         self.dynamodb: DynamoDBClient = DynamoDBClient(
             session_provider,
-            default_role_arn=self._session_provider.get_role_arn_for_service(
-                "dynamodb"
-            ),
+            default_role_arn=self._session_provider.get_role_arn_for_service("dynamodb"),
         )
         self.identitystore: IdentityStoreClient = IdentityStoreClient(
             session_provider,
@@ -53,9 +51,7 @@ class AWSIntegrationHealth:
         )
         self.organizations: OrganizationsClient = OrganizationsClient(
             session_provider,
-            default_role_arn=self._session_provider.get_role_arn_for_service(
-                "organizations"
-            ),
+            default_role_arn=self._session_provider.get_role_arn_for_service("organizations"),
         )
         self.sso_admin: SsoAdminClient = SsoAdminClient(
             session_provider,
@@ -65,15 +61,13 @@ class AWSIntegrationHealth:
             session_provider,
             default_role_arn=self._session_provider.get_role_arn_for_service("config"),
         )
-        self.guardduty: Optional[GuardDutyClient] = None
+        self.guardduty: GuardDutyClient | None = None
         if include_guardduty:
             self.guardduty = GuardDutyClient(
                 session_provider,
-                default_role_arn=self._session_provider.get_role_arn_for_service(
-                    "guardduty"
-                ),
+                default_role_arn=self._session_provider.get_role_arn_for_service("guardduty"),
             )
-        self.cost_explorer: Optional[CostExplorerClient]
+        self.cost_explorer: CostExplorerClient | None
         if include_cost_explorer:
             self.cost_explorer = CostExplorerClient(
                 session_provider,
@@ -85,7 +79,7 @@ class AWSIntegrationHealth:
         self._config_aggregator_name = config_aggregator_name
 
         # Registry of cheap health checks per service
-        self._checks: Dict[str, Callable[[], OperationResult]] = {
+        self._checks: dict[str, Callable[[], OperationResult]] = {
             "dynamodb": self._check_dynamodb,
             "identitystore": self._check_identity_store,
             "organizations": self._check_organizations,
@@ -112,8 +106,8 @@ class AWSIntegrationHealth:
 
     def check_all(
         self,
-        include: Optional[Iterable[str]] = None,
-        exclude: Optional[Iterable[str]] = None,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
     ) -> OperationResult:
         """Run health checks for all (or filtered) services.
 
@@ -124,7 +118,7 @@ class AWSIntegrationHealth:
         exclude_set = set(exclude) if exclude else set()
         services = [s for s in include_set if s not in exclude_set]
 
-        results: Dict[str, OperationResult] = {}
+        results: dict[str, OperationResult] = {}
         all_success = True
 
         for service in sorted(services):
@@ -134,15 +128,9 @@ class AWSIntegrationHealth:
                 all_success = False
 
         if all_success:
-            return OperationResult.success(
-                data={"services": results}, message="All services healthy"
-            )
+            return OperationResult.success(data={"services": results}, message="All services healthy")
         # Use first failed service's status, or TRANSIENT_ERROR if no results
-        first_status = (
-            results[next(iter(results))].status
-            if results
-            else OperationStatus.TRANSIENT_ERROR
-        )
+        first_status = results[next(iter(results))].status if results else OperationStatus.TRANSIENT_ERROR
         return OperationResult.error(
             status=first_status,
             message="One or more services unhealthy",

--- a/app/infrastructure/clients/aws/identity_store.py
+++ b/app/infrastructure/clients/aws/identity_store.py
@@ -4,8 +4,9 @@ Provides type-safe access to AWS Identity Store operations (list_users, describe
 with consistent error handling and OperationResult return types.
 """
 
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from typing import Any
 
 import structlog
 
@@ -31,7 +32,7 @@ class IdentityStoreClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_identity_store_id: Optional[str] = None,
+        default_identity_store_id: str | None = None,
     ) -> None:
         self._session_provider = session_provider
         self._service_name = "identitystore"
@@ -41,9 +42,9 @@ class IdentityStoreClient:
     def create_group_membership(
         self,
         GroupId: str,
-        MemberId: Dict[str, str],
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        MemberId: dict[str, str],
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Create a group membership in Identity Store.
@@ -64,9 +65,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "create_group_membership",
@@ -81,8 +80,8 @@ class IdentityStoreClient:
         self,
         UserName: str,
         DisplayName: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Create a new user in Identity Store.
@@ -104,9 +103,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "create_user",
@@ -120,8 +117,8 @@ class IdentityStoreClient:
     def delete_group_membership(
         self,
         membership_id: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Delete a group membership from Identity Store.
@@ -141,9 +138,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "delete_group_membership",
@@ -156,8 +151,8 @@ class IdentityStoreClient:
     def delete_user(
         self,
         user_id: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Delete a user from Identity Store.
@@ -178,9 +173,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "delete_user",
@@ -193,8 +186,8 @@ class IdentityStoreClient:
     def describe_group(
         self,
         group_id: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Describe a group from Identity Store.
@@ -214,9 +207,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "describe_group",
@@ -229,8 +220,8 @@ class IdentityStoreClient:
     def describe_group_by_name(
         self,
         group_name: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Describe a group from Identity Store by group name.
@@ -267,8 +258,8 @@ class IdentityStoreClient:
     def describe_user(
         self,
         user_id: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Describe a user from Identity Store.
@@ -289,9 +280,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "describe_user",
@@ -304,8 +293,8 @@ class IdentityStoreClient:
     def describe_user_by_username(
         self,
         username: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Describe a user from Identity Store by username.
@@ -342,7 +331,7 @@ class IdentityStoreClient:
 
     def get_batch_groups(
         self,
-        group_ids: List[str],
+        group_ids: list[str],
         **kwargs,
     ) -> OperationResult:
         """Fetch multiple groups by their IDs using individual API calls.
@@ -376,16 +365,12 @@ class IdentityStoreClient:
                     error=response.message,
                 )
 
-        log.info(
-            "batch_groups_fetched", successful=sum(1 for v in results.values() if v)
-        )
-        return OperationResult.success(
-            data=results, message=f"Fetched {len(results)} group(s)"
-        )
+        log.info("batch_groups_fetched", successful=sum(1 for v in results.values() if v))
+        return OperationResult.success(data=results, message=f"Fetched {len(results)} group(s)")
 
     def get_batch_users(
         self,
-        user_ids: List[str],
+        user_ids: list[str],
         **kwargs,
     ) -> OperationResult:
         """Fetch multiple users by their IDs using individual API calls.
@@ -419,18 +404,14 @@ class IdentityStoreClient:
                     error=response.message,
                 )
 
-        log.info(
-            "batch_users_fetched", successful=sum(1 for v in results.values() if v)
-        )
-        return OperationResult.success(
-            data=results, message=f"Fetched {len(results)} user(s)"
-        )
+        log.info("batch_users_fetched", successful=sum(1 for v in results.values() if v))
+        return OperationResult.success(data=results, message=f"Fetched {len(results)} user(s)")
 
     def get_group_id_by_group_name(
         self,
         group_name: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Get a group ID by its group name.
@@ -450,9 +431,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             service_name="identitystore",
             method="get_group_id",
@@ -470,9 +449,9 @@ class IdentityStoreClient:
     def get_group_membership_id(
         self,
         group_id: str,
-        member_id: Dict[str, str],
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        member_id: dict[str, str],
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Get a group membership ID by group ID and member ID.
@@ -493,9 +472,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         result = execute_aws_api_call(
             "identitystore",
             "get_group_membership_id",
@@ -516,8 +493,8 @@ class IdentityStoreClient:
     def get_user_id_by_username(
         self,
         username: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """
@@ -537,9 +514,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             service_name="identitystore",
             method="get_user_id",
@@ -554,9 +529,7 @@ class IdentityStoreClient:
             **kwargs,
         )
 
-    def healthcheck(
-        self, identity_store_id: Optional[str] = None, role_arn: Optional[str] = None
-    ) -> OperationResult:
+    def healthcheck(self, identity_store_id: str | None = None, role_arn: str | None = None) -> OperationResult:
         """Lightweight health check for Identity Store.
 
         Calls `list_users` with a small page to validate connectivity and permissions.
@@ -568,9 +541,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_users",
@@ -583,8 +554,8 @@ class IdentityStoreClient:
         self,
         user_id: str,
         group_ids: list[str],
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Check if a user is a member of a specific group.
@@ -605,9 +576,7 @@ class IdentityStoreClient:
                 message="identity_store_id is required",
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_group_memberships_for_member",
@@ -621,8 +590,8 @@ class IdentityStoreClient:
     def list_group_memberships(
         self,
         group_id: str,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List group memberships in Identity Store.
@@ -642,9 +611,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_group_memberships",
@@ -656,9 +623,9 @@ class IdentityStoreClient:
 
     def list_group_memberships_for_member(
         self,
-        member_id: Dict[str, str],
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        member_id: dict[str, str],
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List group memberships for a specific member in Identity Store.
@@ -678,9 +645,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_group_memberships_for_member",
@@ -692,8 +657,8 @@ class IdentityStoreClient:
 
     def list_groups(
         self,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List groups in Identity Store.
@@ -712,9 +677,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_groups",
@@ -725,13 +688,13 @@ class IdentityStoreClient:
 
     def list_groups_with_memberships(
         self,
-        identity_store_id: Optional[str] = None,
-        groups_filters: Optional[List[Callable]] = None,
-        groups_kwargs: Optional[Dict[str, Any]] = None,
-        memberships_kwargs: Optional[Dict[str, Any]] = None,
-        users_kwargs: Optional[Dict[str, Any]] = None,
+        identity_store_id: str | None = None,
+        groups_filters: list[Callable] | None = None,
+        groups_kwargs: dict[str, Any] | None = None,
+        memberships_kwargs: dict[str, Any] | None = None,
+        users_kwargs: dict[str, Any] | None = None,
         tolerate_errors: bool = False,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
     ) -> OperationResult:
         """List all groups in Identity Store with their members and member details.
 
@@ -783,7 +746,7 @@ class IdentityStoreClient:
                 error_code="list_groups_failed",
             )
 
-        groups: List[Dict[str, Any]] = groups_result.data
+        groups: list[dict[str, Any]] = groups_result.data
         log.info("groups_listed", count=len(groups))
 
         # 2. Apply filters if provided
@@ -793,15 +756,13 @@ class IdentityStoreClient:
             log.info("groups_filtered", count=len(groups), filters=len(groups_filters))
 
         # 3. Fetch group memberships in parallel
-        group_ids: List[str] = []
+        group_ids: list[str] = []
         for g in groups:
             gid = g.get("GroupId")
             if isinstance(gid, str):
                 group_ids.append(gid)
 
-        memberships_by_group = self._fetch_group_memberships_parallel(
-            group_ids, **(memberships_kwargs or {})
-        )
+        memberships_by_group = self._fetch_group_memberships_parallel(group_ids, **(memberships_kwargs or {}))
         log.info("memberships_fetched", groups_with_members=len(memberships_by_group))
 
         # 4. Fetch all user details
@@ -815,10 +776,8 @@ class IdentityStoreClient:
                 error_code="list_users_failed",
             )
 
-        users: List[Dict[str, Any]] = users_result.data
-        users_by_id: Mapping[str, Optional[Dict[str, Any]]] = {
-            str(u.get("UserId", "")): u for u in users if u.get("UserId")
-        }
+        users: list[dict[str, Any]] = users_result.data
+        users_by_id: Mapping[str, dict[str, Any] | None] = {str(u.get("UserId", "")): u for u in users if u.get("UserId")}
         log.info("users_fetched", count=len(users_by_id))
 
         # 5. Assemble final result
@@ -838,8 +797,8 @@ class IdentityStoreClient:
 
     def list_users(
         self,
-        identity_store_id: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        identity_store_id: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List users in Identity Store.
@@ -859,9 +818,7 @@ class IdentityStoreClient:
                 error_code="MISSING_IDENTITY_STORE_ID",
             )
 
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "identitystore",
             "list_users",
@@ -872,10 +829,10 @@ class IdentityStoreClient:
 
     def _fetch_group_memberships_parallel(
         self,
-        group_ids: List[str],
+        group_ids: list[str],
         max_workers: int = 10,
         **kwargs,
-    ) -> Dict[str, List[Dict[str, Any]]]:
+    ) -> dict[str, list[dict[str, Any]]]:
         """Fetch group memberships in parallel.
 
         Args:
@@ -895,7 +852,7 @@ class IdentityStoreClient:
             max_workers=max_workers,
         )
 
-        memberships_by_group: Dict[str, List[Dict[str, Any]]] = {}
+        memberships_by_group: dict[str, list[dict[str, Any]]] = {}
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Submit all tasks
@@ -919,20 +876,18 @@ class IdentityStoreClient:
                         memberships_by_group[gid] = []
                         log.warning("fetch_group_memberships_failed", group_id=gid)
                 except Exception as exc:  # pylint: disable=broad-except
-                    log.exception(
-                        "fetch_group_memberships_exception", group_id=gid, exc=exc
-                    )
+                    log.exception("fetch_group_memberships_exception", group_id=gid, exc=exc)
                     memberships_by_group[gid] = []
 
         return memberships_by_group
 
     def _assemble_groups_with_memberships(
         self,
-        groups: List[Dict],
-        memberships_by_group: Mapping[str, Optional[List[Dict[str, Any]]]],
-        users_by_id: Mapping[str, Optional[Dict[str, Any]]],
+        groups: list[dict],
+        memberships_by_group: Mapping[str, list[dict[str, Any]] | None],
+        users_by_id: Mapping[str, dict[str, Any] | None],
         tolerate_errors: bool,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Assemble final groups with memberships and user details.
 
         Args:
@@ -966,11 +921,7 @@ class IdentityStoreClient:
             error_info = None
 
             # Check for fetch errors
-            if (
-                not memberships
-                and memberships_by_group.get(group_id) is None
-                and tolerate_errors
-            ):
+            if not memberships and memberships_by_group.get(group_id) is None and tolerate_errors:
                 error_info = "Failed to fetch members"
 
             # Process memberships with user details

--- a/app/infrastructure/clients/aws/organizations.py
+++ b/app/infrastructure/clients/aws/organizations.py
@@ -4,8 +4,6 @@ Provides type-safe access to AWS Organizations operations (list_accounts, descri
 with consistent error handling and OperationResult return types.
 """
 
-from typing import Optional
-
 import structlog
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
@@ -28,7 +26,7 @@ class OrganizationsClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_role_arn: Optional[str] = None,
+        default_role_arn: str | None = None,
     ) -> None:
         self._service_name = "organizations"
         self._session_provider = session_provider
@@ -37,7 +35,7 @@ class OrganizationsClient:
 
     def list_accounts(
         self,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List all accounts in the AWS Organization.
@@ -51,9 +49,7 @@ class OrganizationsClient:
         """
 
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         self._logger.info("listing_accounts", client_kwargs=client_kwargs)
         return execute_aws_api_call(
             self._service_name,
@@ -65,7 +61,7 @@ class OrganizationsClient:
     def describe_account(
         self,
         account_id: str,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Get details for a specific AWS account.
@@ -79,9 +75,7 @@ class OrganizationsClient:
             OperationResult with account details or error
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "organizations",
             "describe_account",
@@ -93,7 +87,7 @@ class OrganizationsClient:
     def get_account_id_by_name(
         self,
         account_name: str,
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Find an account ID by account name.
@@ -106,15 +100,11 @@ class OrganizationsClient:
         Returns:
             OperationResult with account ID or error
         """
-        log = self._logger.bind(
-            method="get_account_id_by_name", account_name=account_name
-        )
+        log = self._logger.bind(method="get_account_id_by_name", account_name=account_name)
         log.info("fetching_accounts")
 
         # List all accounts and search by name
-        result = self.list_accounts(
-            role_arn=role_arn or self._default_role_arn, **kwargs
-        )
+        result = self.list_accounts(role_arn=role_arn or self._default_role_arn, **kwargs)
         if not result.is_success:
             return result
 
@@ -133,15 +123,13 @@ class OrganizationsClient:
             error_code="ACCOUNT_NOT_FOUND",
         )
 
-    def healthcheck(self, role_arn: Optional[str] = None) -> OperationResult:
+    def healthcheck(self, role_arn: str | None = None) -> OperationResult:
         """Lightweight health check for Organizations.
 
         Calls `list_accounts` with minimal retries to validate access to Organizations API.
         """
         effective_role = role_arn or self._default_role_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=effective_role
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=effective_role)
         return execute_aws_api_call(
             "organizations",
             "list_accounts",

--- a/app/infrastructure/clients/aws/session_provider.py
+++ b/app/infrastructure/clients/aws/session_provider.py
@@ -5,7 +5,7 @@ building for all AWS service clients. Handles role assumption and parameter
 propagation for cross-account access.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import structlog
 
@@ -27,16 +27,16 @@ class SessionProvider:
 
     def __init__(
         self,
-        region: Optional[str] = None,
-        service_role_map: Optional[dict[str, str]] = None,
-        endpoint_url: Optional[str] = None,
+        region: str | None = None,
+        service_role_map: dict[str, str] | None = None,
+        endpoint_url: str | None = None,
     ) -> None:
         self.region = region
         self.service_role_map = service_role_map
         self.endpoint_url = endpoint_url
 
     @staticmethod
-    def _should_apply_endpoint_override(service_name: Optional[str]) -> bool:
+    def _should_apply_endpoint_override(service_name: str | None) -> bool:
         """Return whether a custom endpoint override applies to the service.
 
         The shared AWS endpoint override is reserved for local DynamoDB testing.
@@ -45,7 +45,7 @@ class SessionProvider:
         """
         return service_name == "dynamodb"
 
-    def get_role_arn_for_service(self, service_name: str) -> Optional[str]:
+    def get_role_arn_for_service(self, service_name: str) -> str | None:
         """Get the role ARN to assume for the given AWS service.
 
         Args:
@@ -60,9 +60,9 @@ class SessionProvider:
 
     def build_client_kwargs(
         self,
-        service_name: Optional[str] = None,
-        role_arn: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        service_name: str | None = None,
+        role_arn: str | None = None,
+    ) -> dict[str, Any]:
         """Build session and client configuration kwargs for boto3.
 
         Automatically resolves the role ARN from the service_role_map if
@@ -108,9 +108,7 @@ class SessionProvider:
             "role_arn": role_arn,
         }
 
-    def get_boto3_client(
-        self, service_name: str, role_arn: Optional[str] = None
-    ) -> Any:
+    def get_boto3_client(self, service_name: str, role_arn: str | None = None) -> Any:
         """Get a fully-configured boto3 client for the given service.
 
         Args:

--- a/app/infrastructure/clients/aws/sso_admin.py
+++ b/app/infrastructure/clients/aws/sso_admin.py
@@ -4,8 +4,6 @@ Provides type-safe access to AWS SSO Admin operations (create_account_assignment
 with consistent error handling and OperationResult return types.
 """
 
-from typing import Optional
-
 import structlog
 
 from infrastructure.clients.aws.executor import execute_aws_api_call
@@ -28,7 +26,7 @@ class SsoAdminClient:
     def __init__(
         self,
         session_provider: SessionProvider,
-        default_sso_instance_arn: Optional[str] = None,
+        default_sso_instance_arn: str | None = None,
     ) -> None:
         self._service_name = "sso-admin"
         self._session_provider = session_provider
@@ -42,8 +40,8 @@ class SsoAdminClient:
         principal_type: str,
         target_id: str,
         target_type: str = "AWS_ACCOUNT",
-        instance_arn: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        instance_arn: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Create an account assignment in AWS SSO.
@@ -65,9 +63,7 @@ class SsoAdminClient:
             if not self._default_sso_instance_arn:
                 raise ValueError("instance_arn must be provided if no default is set")
             instance_arn = self._default_sso_instance_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "sso-admin",
             "create_account_assignment",
@@ -88,8 +84,8 @@ class SsoAdminClient:
         principal_type: str,
         target_id: str,
         target_type: str = "AWS_ACCOUNT",
-        instance_arn: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        instance_arn: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """Delete an account assignment from AWS SSO.
@@ -111,9 +107,7 @@ class SsoAdminClient:
             if not self._default_sso_instance_arn:
                 raise ValueError("instance_arn must be provided if no default is set")
             instance_arn = self._default_sso_instance_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "sso-admin",
             "delete_account_assignment",
@@ -131,8 +125,8 @@ class SsoAdminClient:
         self,
         principal_id: str,
         principal_type: str,
-        instance_arn: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        instance_arn: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List account assignments for a principal.
@@ -151,9 +145,7 @@ class SsoAdminClient:
             if not self._default_sso_instance_arn:
                 raise ValueError("instance_arn must be provided if no default is set")
             instance_arn = self._default_sso_instance_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "sso-admin",
             "list_account_assignments",
@@ -166,8 +158,8 @@ class SsoAdminClient:
 
     def list_permission_sets(
         self,
-        instance_arn: Optional[str] = None,
-        role_arn: Optional[str] = None,
+        instance_arn: str | None = None,
+        role_arn: str | None = None,
         **kwargs,
     ) -> OperationResult:
         """List permission sets in the SSO instance.
@@ -183,9 +175,7 @@ class SsoAdminClient:
             if not self._default_sso_instance_arn:
                 raise ValueError("instance_arn must be provided if no default is set")
             instance_arn = self._default_sso_instance_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "sso-admin",
             "list_permission_sets",
@@ -194,9 +184,7 @@ class SsoAdminClient:
             **kwargs,
         )
 
-    def healthcheck(
-        self, instance_arn: Optional[str] = None, role_arn: Optional[str] = None
-    ) -> OperationResult:
+    def healthcheck(self, instance_arn: str | None = None, role_arn: str | None = None) -> OperationResult:
         """Lightweight health check for SSO Admin.
 
         Calls `list_account_assignments` if an `instance_arn` is provided; otherwise
@@ -206,9 +194,7 @@ class SsoAdminClient:
             if not self._default_sso_instance_arn:
                 raise ValueError("instance_arn must be provided if no default is set")
             instance_arn = self._default_sso_instance_arn
-        client_kwargs = self._session_provider.build_client_kwargs(
-            service_name=self._service_name, role_arn=role_arn
-        )
+        client_kwargs = self._session_provider.build_client_kwargs(service_name=self._service_name, role_arn=role_arn)
         return execute_aws_api_call(
             "sso-admin",
             "list_permission_sets",

--- a/app/infrastructure/clients/google_workspace/batch_executor.py
+++ b/app/infrastructure/clients/google_workspace/batch_executor.py
@@ -1,7 +1,8 @@
 """Batch execution utilities for Google Workspace API operations."""
 
 import time
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import structlog
 from googleapiclient.discovery import Resource
@@ -14,7 +15,7 @@ logger = structlog.get_logger()
 def execute_batch_request(
     service: Resource,
     requests: list[tuple[str, Any]],
-    callback_fn: Optional[Callable] = None,
+    callback_fn: Callable | None = None,
 ) -> OperationResult:
     """Execute multiple Google API calls in a single batch request.
 
@@ -92,9 +93,7 @@ def execute_batch_request(
             "total": total_requests,
             "successful": successful_requests,
             "failed": failed_requests,
-            "success_rate": (
-                successful_requests / total_requests if total_requests > 0 else 0
-            ),
+            "success_rate": (successful_requests / total_requests if total_requests > 0 else 0),
         },
     }
 

--- a/app/infrastructure/clients/google_workspace/directory.py
+++ b/app/infrastructure/clients/google_workspace/directory.py
@@ -4,8 +4,9 @@ Provides type-safe access to Google Workspace Directory API (users, groups, memb
 with consistent error handling and OperationResult return types.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, cast
+from typing import Any, cast
 
 import structlog
 
@@ -33,11 +34,11 @@ class ListGroupsWithMembersRequest:
         exclude_empty_groups: Whether to exclude groups with no members
     """
 
-    groups_filters: Optional[list[Callable]] = None
-    member_filters: Optional[list[Callable]] = None
-    groups_kwargs: Optional[dict] = field(default_factory=dict)
-    members_kwargs: Optional[dict] = field(default_factory=dict)
-    users_kwargs: Optional[dict] = field(default_factory=dict)
+    groups_filters: list[Callable] | None = None
+    member_filters: list[Callable] | None = None
+    groups_kwargs: dict | None = field(default_factory=dict)
+    members_kwargs: dict | None = field(default_factory=dict)
+    users_kwargs: dict | None = field(default_factory=dict)
     include_users_details: bool = True
     exclude_empty_groups: bool = False
 
@@ -65,7 +66,7 @@ class DirectoryClient:
     def get_user(
         self,
         user_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get a user by key (email or user ID).
 
@@ -82,9 +83,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.user.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
                 delegated_user_email=delegated_email,
             )
             request = service.users().get(userKey=user_key)
@@ -94,8 +93,8 @@ class DirectoryClient:
 
     def list_users(
         self,
-        customer: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        customer: str | None = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """List all users in domain with automatic pagination.
@@ -115,9 +114,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.user.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -138,7 +135,7 @@ class DirectoryClient:
     def create_user(
         self,
         body: dict[str, Any],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new user in domain.
 
@@ -167,7 +164,7 @@ class DirectoryClient:
         self,
         user_key: str,
         body: dict[str, Any],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Update an existing user.
 
@@ -196,7 +193,7 @@ class DirectoryClient:
     def delete_user(
         self,
         user_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Delete a user from domain.
 
@@ -225,7 +222,7 @@ class DirectoryClient:
     def get_group(
         self,
         group_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get a group by key (email or group ID).
 
@@ -242,9 +239,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
                 delegated_user_email=delegated_email,
             )
             request = service.groups().get(groupKey=group_key)
@@ -254,8 +249,8 @@ class DirectoryClient:
 
     def list_groups(
         self,
-        customer: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        customer: str | None = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """List all groups in domain with automatic pagination.
@@ -275,9 +270,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -297,8 +290,8 @@ class DirectoryClient:
 
     def health_check(
         self,
-        customer: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        customer: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Perform a lightweight remote health probe against the customer.
 
@@ -323,9 +316,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.customer.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.customer.readonly"],
                 delegated_user_email=delegated_email,
             )
             request = service.customers().get(customerKey=customer_id)
@@ -336,7 +327,7 @@ class DirectoryClient:
     def create_group(
         self,
         body: dict[str, Any],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new group in domain.
 
@@ -365,7 +356,7 @@ class DirectoryClient:
         self,
         group_key: str,
         body: dict[str, Any],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Update an existing group.
 
@@ -394,7 +385,7 @@ class DirectoryClient:
     def delete_group(
         self,
         group_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Delete a group from domain.
 
@@ -423,7 +414,7 @@ class DirectoryClient:
     def list_members(
         self,
         group_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """List all members of a group with automatic pagination.
@@ -442,9 +433,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.member.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.member.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -466,7 +455,7 @@ class DirectoryClient:
         self,
         group_key: str,
         body: dict[str, Any],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Add a member to a group.
 
@@ -478,9 +467,7 @@ class DirectoryClient:
         Returns:
             OperationResult with member data in data field
         """
-        self._logger.info(
-            "adding_member", group_key=group_key, member_email=body.get("email")
-        )
+        self._logger.info("adding_member", group_key=group_key, member_email=body.get("email"))
 
         def api_call() -> dict[str, Any]:
             service = self._session_provider.get_service(
@@ -498,7 +485,7 @@ class DirectoryClient:
         self,
         group_key: str,
         member_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Remove a member from a group.
 
@@ -529,7 +516,7 @@ class DirectoryClient:
         self,
         group_key: str,
         member_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get a specific member from a group.
 
@@ -547,9 +534,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.member.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.member.readonly"],
                 delegated_user_email=delegated_email,
             )
             request = service.members().get(groupKey=group_key, memberKey=member_key)
@@ -561,7 +546,7 @@ class DirectoryClient:
         self,
         group_key: str,
         member_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Check if a member exists in a group.
 
@@ -573,22 +558,16 @@ class DirectoryClient:
         Returns:
             OperationResult with boolean data indicating membership
         """
-        self._logger.debug(
-            "checking_member", group_key=group_key, member_key=member_key
-        )
+        self._logger.debug("checking_member", group_key=group_key, member_key=member_key)
 
         def api_call() -> dict[str, Any]:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.member.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.member.readonly"],
                 delegated_user_email=delegated_email,
             )
-            request = service.members().hasMember(
-                groupKey=group_key, memberKey=member_key
-            )
+            request = service.members().hasMember(groupKey=group_key, memberKey=member_key)
             return request.execute()
 
         return execute_google_api_call("has_member", api_call)
@@ -596,7 +575,7 @@ class DirectoryClient:
     def get_batch_users(
         self,
         user_keys: list[str],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """Get multiple users using batch requests.
@@ -611,13 +590,11 @@ class DirectoryClient:
         """
         self._logger.debug("getting_batch_users", user_keys=user_keys, kwargs=kwargs)
 
-        def api_call() -> dict[str, Optional[dict]]:
+        def api_call() -> dict[str, dict | None]:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.user.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -631,25 +608,19 @@ class DirectoryClient:
                 # Propagate batch error instead of returning empty dict
                 raise RuntimeError(resp.message or "Batch request failed")
 
-            results = (
-                resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
-            )
-            users_by_key: dict[str, Optional[dict]] = {
-                k: results.get(k) for k in user_keys
-            }
+            results = resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
+            users_by_key: dict[str, dict | None] = {k: results.get(k) for k in user_keys}
             return users_by_key
 
         result = execute_google_api_call("get_batch_users", api_call)
         if result.is_success:
-            return OperationResult.success(
-                data=result.data, message="Batch users retrieved successfully"
-            )
+            return OperationResult.success(data=result.data, message="Batch users retrieved successfully")
         return result
 
     def get_batch_groups(
         self,
         group_keys: list[str],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """Get multiple groups using batch requests.
@@ -664,13 +635,11 @@ class DirectoryClient:
         """
         self._logger.debug("getting_batch_groups", group_keys=group_keys, kwargs=kwargs)
 
-        def api_call() -> dict[str, Optional[dict]]:
+        def api_call() -> dict[str, dict | None]:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -684,25 +653,19 @@ class DirectoryClient:
                 # Propagate batch error instead of returning empty dict
                 raise RuntimeError(resp.message or "Batch request failed")
 
-            results = (
-                resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
-            )
-            groups_by_key: dict[str, Optional[dict]] = {
-                k: results.get(k) for k in group_keys
-            }
+            results = resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
+            groups_by_key: dict[str, dict | None] = {k: results.get(k) for k in group_keys}
             return groups_by_key
 
         result = execute_google_api_call("get_batch_groups", api_call)
         if result.is_success:
-            return OperationResult.success(
-                data=result.data, message="Batch groups retrieved successfully"
-            )
+            return OperationResult.success(data=result.data, message="Batch groups retrieved successfully")
         return result
 
     def list_user_groups(
         self,
         user_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """List all groups a user is a direct member of.
 
@@ -729,9 +692,7 @@ class DirectoryClient:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -751,7 +712,7 @@ class DirectoryClient:
         self,
         group_keys: list[str],
         user_key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """Get member objects for a user across multiple groups using batch requests.
@@ -772,21 +733,17 @@ class DirectoryClient:
             kwargs=kwargs,
         )
 
-        def api_call() -> dict[str, Optional[dict]]:
+        def api_call() -> dict[str, dict | None]:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.member.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.member.readonly"],
                 delegated_user_email=delegated_email,
             )
 
             requests = []
             for group_key in group_keys:
-                req = service.members().get(
-                    groupKey=group_key, memberKey=user_key, **kwargs
-                )
+                req = service.members().get(groupKey=group_key, memberKey=user_key, **kwargs)
                 requests.append((group_key, req))
 
             resp = execute_batch_request(service, requests)
@@ -794,12 +751,8 @@ class DirectoryClient:
                 # Propagate batch error instead of returning empty dict
                 raise RuntimeError(resp.message or "Batch request failed")
 
-            results = (
-                resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
-            )
-            members_by_group: dict[str, Optional[dict]] = {
-                k: results.get(k) for k in group_keys
-            }
+            results = resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
+            members_by_group: dict[str, dict | None] = {k: results.get(k) for k in group_keys}
             return members_by_group
 
         result = execute_google_api_call("get_batch_members_for_user", api_call)
@@ -813,7 +766,7 @@ class DirectoryClient:
     def get_batch_group_members(
         self,
         group_keys: list[str],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
         **kwargs: Any,
     ) -> OperationResult:
         """Get members for multiple groups using batch requests.
@@ -826,17 +779,13 @@ class DirectoryClient:
         Returns:
             OperationResult with dict mapping group_key to list of members
         """
-        self._logger.debug(
-            "getting_batch_group_members", group_keys=group_keys, kwargs=kwargs
-        )
+        self._logger.debug("getting_batch_group_members", group_keys=group_keys, kwargs=kwargs)
 
         def api_call() -> dict[str, list[dict]]:
             service = self._session_provider.get_service(
                 "admin",
                 "directory_v1",
-                scopes=[
-                    "https://www.googleapis.com/auth/admin.directory.group.readonly"
-                ],
+                scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
                 delegated_user_email=delegated_email,
             )
 
@@ -850,9 +799,7 @@ class DirectoryClient:
                 # Propagate batch error instead of returning empty dict
                 raise RuntimeError(resp.message or "Batch request failed")
 
-            results = (
-                resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
-            )
+            results = resp.data.get("results", {}) if isinstance(resp.data, dict) else {}
             members_by_group: dict[str, list[dict]] = {}
 
             for group_key in group_keys:
@@ -868,15 +815,13 @@ class DirectoryClient:
 
         result = execute_google_api_call("get_batch_group_members", api_call)
         if result.is_success:
-            return OperationResult.success(
-                data=result.data, message="Batch group members retrieved successfully"
-            )
+            return OperationResult.success(data=result.data, message="Batch group members retrieved successfully")
         return result
 
     def list_groups_with_members(
         self,
-        request: Optional[ListGroupsWithMembersRequest] = None,
-        delegated_email: Optional[str] = None,
+        request: ListGroupsWithMembersRequest | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """List groups with members, optionally filtered at group and member levels.
 
@@ -906,9 +851,7 @@ class DirectoryClient:
         self._logger.info("listing_groups_with_members", request=request)
 
         # Get groups
-        groups_resp = self.list_groups(
-            delegated_email=delegated_email, **(request.groups_kwargs or {})
-        )
+        groups_resp = self.list_groups(delegated_email=delegated_email, **(request.groups_kwargs or {}))
         self._logger.debug("fetched_groups", groups_count=len(groups_resp.data or []))
         if not groups_resp.is_success:
             return groups_resp
@@ -916,16 +859,10 @@ class DirectoryClient:
         # Apply group filters
         groups_list = groups_resp.data or []
         if request.groups_filters:
-            groups_list = [
-                g
-                for g in groups_list
-                if all(filter_fn(g) for filter_fn in request.groups_filters)
-            ]
+            groups_list = [g for g in groups_list if all(filter_fn(g) for filter_fn in request.groups_filters)]
 
         if not groups_list:
-            return OperationResult.success(
-                data=[], message="No groups found matching filters"
-            )
+            return OperationResult.success(data=[], message="No groups found matching filters")
 
         # Get members for all groups
         group_keys = [g.get("email") for g in groups_list]
@@ -938,15 +875,11 @@ class DirectoryClient:
             return members_resp
 
         members_by_group: dict[str, list[dict]] = (
-            members_resp.data
-            if isinstance(members_resp.data, dict)
-            else {k: [] for k in group_keys}
+            members_resp.data if isinstance(members_resp.data, dict) else {k: [] for k in group_keys}
         )
 
         # Assemble groups with members
-        results = self._assemble_groups_with_members(
-            groups_list, members_by_group, request.exclude_empty_groups
-        )
+        results = self._assemble_groups_with_members(groups_list, members_by_group, request.exclude_empty_groups)
 
         # Filter groups based on member criteria
         if request.member_filters:
@@ -971,9 +904,7 @@ class DirectoryClient:
                     users_by_email = users_resp.data or {}
                     results = self._enrich_members_with_users(results, users_by_email)
 
-        return OperationResult.success(
-            data=results, message="Groups with members retrieved successfully"
-        )
+        return OperationResult.success(data=results, message="Groups with members retrieved successfully")
 
     def _assemble_groups_with_members(
         self,
@@ -1025,10 +956,7 @@ class DirectoryClient:
                 email = cast(str, member.get("email"))
                 user_details = users_by_email.get(email) if email else None
 
-                if user_details:
-                    enriched_member = {**member, "user": user_details}
-                else:
-                    enriched_member = member
+                enriched_member = {**member, "user": user_details} if user_details else member
 
                 enriched_members.append(enriched_member)
 
@@ -1040,7 +968,7 @@ class DirectoryClient:
     def _filter_groups_by_members(
         self,
         groups_with_members: list[dict],
-        member_filters: Optional[list] = None,
+        member_filters: list | None = None,
     ) -> list[dict]:
         """Filter groups based on member criteria.
 
@@ -1060,10 +988,7 @@ class DirectoryClient:
         filtered_groups = []
         for group in groups_with_members:
             members = group.get("members", [])
-            has_matching_member = any(
-                all(filter_fn(member) for filter_fn in member_filters)
-                for member in members
-            )
+            has_matching_member = any(all(filter_fn(member) for filter_fn in member_filters) for member in members)
 
             if has_matching_member:
                 filtered_groups.append(group)

--- a/app/infrastructure/clients/google_workspace/docs.py
+++ b/app/infrastructure/clients/google_workspace/docs.py
@@ -5,7 +5,7 @@ including document creation, updates, and retrieval operations.
 """
 
 import re
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -46,7 +46,7 @@ class DocsClient:
     def get_document(
         self,
         document_id: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get a document from Google Docs.
 
@@ -84,7 +84,7 @@ class DocsClient:
     def create(
         self,
         title: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new document in Google Docs.
 
@@ -123,7 +123,7 @@ class DocsClient:
         self,
         document_id: str,
         requests: list[dict[str, Any]],
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Apply a list of updates to a document in Google Docs.
 
@@ -164,11 +164,7 @@ class DocsClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.documents()
-                .batchUpdate(documentId=document_id, body={"requests": requests})
-                .execute()
-            )
+            return service.documents().batchUpdate(documentId=document_id, body={"requests": requests}).execute()
 
         return execute_google_api_call(
             operation_name="docs.documents.batchUpdate",
@@ -180,7 +176,7 @@ class DocsClient:
     # ========================================================================
 
     @staticmethod
-    def extract_google_doc_id(url: str) -> Optional[str]:
+    def extract_google_doc_id(url: str) -> str | None:
         """Extract the Google Docs ID from a Google Docs URL.
 
         Args:

--- a/app/infrastructure/clients/google_workspace/drive.py
+++ b/app/infrastructure/clients/google_workspace/drive.py
@@ -4,7 +4,7 @@ Provides type-safe access to Google Drive API (files, folders, permissions, meta
 All methods return OperationResult for consistent error handling.
 """
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -58,7 +58,7 @@ class DriveClient:
         )
     """
 
-    def __init__(self, session_provider: "SessionProvider") -> None:
+    def __init__(self, session_provider: SessionProvider) -> None:
         """Initialize Drive client.
 
         Args:
@@ -76,7 +76,7 @@ class DriveClient:
         file_id: str,
         key: str,
         value: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Add custom metadata to a file using appProperties.
 
@@ -124,7 +124,7 @@ class DriveClient:
         self,
         file_id: str,
         key: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Delete custom metadata from a file by setting key to None.
 
@@ -170,7 +170,7 @@ class DriveClient:
     def list_metadata(
         self,
         file_id: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get all custom metadata for a file.
 
@@ -181,9 +181,7 @@ class DriveClient:
         Returns:
             OperationResult with file metadata including appProperties
         """
-        self._logger.debug(
-            "listing_metadata", file_id=file_id, delegated_user_email=delegated_email
-        )
+        self._logger.debug("listing_metadata", file_id=file_id, delegated_user_email=delegated_email)
 
         service = self._session_provider.get_service(
             service_name="drive",
@@ -216,8 +214,8 @@ class DriveClient:
         self,
         name: str,
         parent_folder_id: str,
-        fields: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        fields: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new folder in Google Drive.
 
@@ -267,8 +265,8 @@ class DriveClient:
     def list_folders_in_folder(
         self,
         folder_id: str,
-        query: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        query: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """List all folders within a parent folder.
 
@@ -333,7 +331,7 @@ class DriveClient:
     def list_files_in_folder(
         self,
         folder_id: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """List all non-folder files within a parent folder.
 
@@ -344,9 +342,7 @@ class DriveClient:
         Returns:
             OperationResult with list of files (id, name)
         """
-        self._logger.debug(
-            "listing_files", folder_id=folder_id, delegated_user_email=delegated_email
-        )
+        self._logger.debug("listing_files", folder_id=folder_id, delegated_user_email=delegated_email)
 
         service = self._session_provider.get_service(
             service_name="drive",
@@ -396,8 +392,8 @@ class DriveClient:
     def get_file(
         self,
         file_id: str,
-        fields: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        fields: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get file metadata by ID.
 
@@ -409,9 +405,7 @@ class DriveClient:
         Returns:
             OperationResult with file metadata
         """
-        self._logger.debug(
-            "getting_file", file_id=file_id, delegated_user_email=delegated_email
-        )
+        self._logger.debug("getting_file", file_id=file_id, delegated_user_email=delegated_email)
 
         service = self._session_provider.get_service(
             service_name="drive",
@@ -439,8 +433,8 @@ class DriveClient:
     def find_files_by_name(
         self,
         name: str,
-        folder_id: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        folder_id: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Find files by name, optionally within a specific folder.
 
@@ -507,8 +501,8 @@ class DriveClient:
         name: str,
         file_type: str,
         parent_folder_id: str,
-        fields: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        fields: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new Google Workspace file (Doc, Sheet, Slide, Form, Site).
 
@@ -571,8 +565,8 @@ class DriveClient:
         name: str,
         template_id: str,
         parent_folder_id: str,
-        fields: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        fields: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new file by copying a template.
 
@@ -626,7 +620,7 @@ class DriveClient:
         name: str,
         source_parent_id: str,
         destination_folder_id: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Copy a file and move the copy to a destination folder.
 

--- a/app/infrastructure/clients/google_workspace/executor.py
+++ b/app/infrastructure/clients/google_workspace/executor.py
@@ -1,7 +1,8 @@
 """Low-level Google API execution utilities with retry and error handling."""
 
 import time
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import structlog
 from googleapiclient.errors import HttpError
@@ -41,7 +42,7 @@ def _calculate_retry_delay(attempt: int, status_code: int) -> float:
 def execute_google_api_call(
     operation_name: str,
     api_callable: Callable[[], Any],
-    max_retries: Optional[int] = None,
+    max_retries: int | None = None,
 ) -> OperationResult:
     """Execute a Google API call with retry logic and error handling.
 
@@ -64,7 +65,7 @@ def execute_google_api_call(
     retry_errors_list: list[int] = ERROR_CONFIG["retry_errors"]  # type: ignore
     retry_codes = set(retry_errors_list)
 
-    last_exception: Optional[Exception] = None
+    last_exception: Exception | None = None
 
     for attempt in range(max_attempts + 1):
         try:

--- a/app/infrastructure/clients/google_workspace/facade.py
+++ b/app/infrastructure/clients/google_workspace/facade.py
@@ -54,7 +54,7 @@ class GoogleWorkspaceClients:
     sheets: SheetsClient
     gmail: GmailClient
 
-    def __init__(self, google_settings: "GoogleWorkspaceSettings") -> None:
+    def __init__(self, google_settings: GoogleWorkspaceSettings) -> None:
         """Initialize Google Workspace clients facade.
 
         Args:

--- a/app/infrastructure/clients/google_workspace/gmail.py
+++ b/app/infrastructure/clients/google_workspace/gmail.py
@@ -6,7 +6,7 @@ including email sending, draft creation, and message retrieval operations.
 
 import base64
 from email.message import EmailMessage
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -55,7 +55,7 @@ class GmailClient:
         recipient: str,
         content_type: str = "plain",
         user_id: str = "me",
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Send an email via Gmail API.
 
@@ -117,12 +117,7 @@ class GmailClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.users()
-                .messages()
-                .send(userId=user_id, body={"raw": raw_message})
-                .execute()
-            )
+            return service.users().messages().send(userId=user_id, body={"raw": raw_message}).execute()
 
         return execute_google_api_call(
             operation_name="gmail.users.messages.send",
@@ -137,7 +132,7 @@ class GmailClient:
         recipient: str,
         content_type: str = "plain",
         user_id: str = "me",
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a draft email via Gmail API.
 
@@ -199,12 +194,7 @@ class GmailClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.users()
-                .drafts()
-                .create(userId=user_id, body={"message": {"raw": raw_message}})
-                .execute()
-            )
+            return service.users().drafts().create(userId=user_id, body={"message": {"raw": raw_message}}).execute()
 
         return execute_google_api_call(
             operation_name="gmail.users.drafts.create",
@@ -220,7 +210,7 @@ class GmailClient:
         message_id: str,
         user_id: str = "me",
         format: str = "full",
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get a specific email message by ID.
 
@@ -256,12 +246,7 @@ class GmailClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.users()
-                .messages()
-                .get(userId=user_id, id=message_id, format=format)
-                .execute()
-            )
+            return service.users().messages().get(userId=user_id, id=message_id, format=format).execute()
 
         return execute_google_api_call(
             operation_name="gmail.users.messages.get",
@@ -270,11 +255,11 @@ class GmailClient:
 
     def list_messages(
         self,
-        query: Optional[str] = None,
+        query: str | None = None,
         max_results: int = 100,
         user_id: str = "me",
-        label_ids: Optional[list[str]] = None,
-        delegated_email: Optional[str] = None,
+        label_ids: list[str] | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """List messages in the user's mailbox.
 

--- a/app/infrastructure/clients/google_workspace/session_provider.py
+++ b/app/infrastructure/clients/google_workspace/session_provider.py
@@ -1,7 +1,6 @@
 """Google Workspace session provider for authentication and service creation."""
 
 import json
-from typing import List, Optional
 
 import structlog
 from google.oauth2 import service_account
@@ -34,20 +33,20 @@ class SessionProvider:
     def __init__(
         self,
         credentials_json: str,
-        default_delegated_email: Optional[str] = None,
-        default_scopes: Optional[List[str]] = None,
+        default_delegated_email: str | None = None,
+        default_scopes: list[str] | None = None,
     ) -> None:
         self._credentials_json: str = credentials_json
-        self._default_delegated_email: Optional[str] = default_delegated_email
-        self._default_scopes: List[str] = default_scopes or []
+        self._default_delegated_email: str | None = default_delegated_email
+        self._default_scopes: list[str] = default_scopes or []
         self._logger = logger.bind(component="google_session_provider")
 
     def get_service(
         self,
         service_name: str,
         version: str,
-        scopes: Optional[List[str]] = None,
-        delegated_user_email: Optional[str] = None,
+        scopes: list[str] | None = None,
+        delegated_user_email: str | None = None,
     ) -> Resource:
         """Create an authenticated Google API service resource.
 

--- a/app/infrastructure/clients/google_workspace/sheets.py
+++ b/app/infrastructure/clients/google_workspace/sheets.py
@@ -4,7 +4,7 @@ Provides type-safe access to Google Sheets API (spreadsheets, values, formatting
 All methods return OperationResult for consistent error handling.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -57,7 +57,7 @@ class SheetsClient:
         )
     """
 
-    def __init__(self, session_provider: "SessionProvider") -> None:
+    def __init__(self, session_provider: SessionProvider) -> None:
         """Initialize Sheets client.
 
         Args:
@@ -73,10 +73,10 @@ class SheetsClient:
     def get_spreadsheet(
         self,
         spreadsheet_id: str,
-        ranges: Optional[List[str]] = None,
+        ranges: list[str] | None = None,
         include_grid_data: bool = False,
-        fields: Optional[str] = None,
-        delegated_email: Optional[str] = None,
+        fields: str | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get spreadsheet metadata and optionally data.
 
@@ -130,8 +130,8 @@ class SheetsClient:
     def create_spreadsheet(
         self,
         title: str,
-        sheet_titles: Optional[List[str]] = None,
-        delegated_email: Optional[str] = None,
+        sheet_titles: list[str] | None = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Create a new spreadsheet.
 
@@ -160,21 +160,13 @@ class SheetsClient:
             delegated_user_email=delegated_email,
         )
 
-        body: Dict[str, Any] = {"properties": {"title": title}}
+        body: dict[str, Any] = {"properties": {"title": title}}
 
         if sheet_titles:
-            body["sheets"] = [
-                {"properties": {"title": sheet_title}} for sheet_title in sheet_titles
-            ]
+            body["sheets"] = [{"properties": {"title": sheet_title}} for sheet_title in sheet_titles]
 
         def api_call() -> Any:
-            return (
-                service.spreadsheets()
-                .create(
-                    body=body, fields="spreadsheetId,spreadsheetUrl,sheets.properties"
-                )
-                .execute()
-            )
+            return service.spreadsheets().create(body=body, fields="spreadsheetId,spreadsheetUrl,sheets.properties").execute()
 
         return execute_google_api_call(
             operation_name="sheets.spreadsheets.create",
@@ -184,8 +176,8 @@ class SheetsClient:
     def batch_update_spreadsheet(
         self,
         spreadsheet_id: str,
-        requests: List[Dict[str, Any]],
-        delegated_email: Optional[str] = None,
+        requests: list[dict[str, Any]],
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Apply batch updates to a spreadsheet (formatting, sheet operations).
 
@@ -215,11 +207,7 @@ class SheetsClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.spreadsheets()
-                .batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests})
-                .execute()
-            )
+            return service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
 
         return execute_google_api_call(
             operation_name="sheets.spreadsheets.batchUpdate",
@@ -237,7 +225,7 @@ class SheetsClient:
         major_dimension: str = "ROWS",
         value_render_option: str = "FORMATTED_VALUE",
         date_time_render_option: str = "SERIAL_NUMBER",
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Get values from a range in a spreadsheet.
 
@@ -292,9 +280,9 @@ class SheetsClient:
         self,
         spreadsheet_id: str,
         cell_range: str,
-        values: List[List[Any]],
+        values: list[list[Any]],
         value_input_option: str = VALUE_INPUT_OPTION_USER_ENTERED,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Update values in a range.
 
@@ -347,9 +335,9 @@ class SheetsClient:
     def batch_update_values(
         self,
         spreadsheet_id: str,
-        data: List[Dict[str, Any]],
+        data: list[dict[str, Any]],
         value_input_option: str = VALUE_INPUT_OPTION_USER_ENTERED,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Update multiple ranges in a single request.
 
@@ -399,10 +387,10 @@ class SheetsClient:
         self,
         spreadsheet_id: str,
         cell_range: str,
-        values: List[List[Any]],
+        values: list[list[Any]],
         value_input_option: str = VALUE_INPUT_OPTION_USER_ENTERED,
         insert_data_option: str = INSERT_DATA_OPTION_INSERT_ROWS,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Append values to the end of a range.
 
@@ -458,7 +446,7 @@ class SheetsClient:
         self,
         spreadsheet_id: str,
         cell_range: str,
-        delegated_email: Optional[str] = None,
+        delegated_email: str | None = None,
     ) -> OperationResult:
         """Clear values from a range.
 
@@ -488,12 +476,7 @@ class SheetsClient:
         )
 
         def api_call() -> Any:
-            return (
-                service.spreadsheets()
-                .values()
-                .clear(spreadsheetId=spreadsheet_id, range=cell_range, body={})
-                .execute()
-            )
+            return service.spreadsheets().values().clear(spreadsheetId=spreadsheet_id, range=cell_range, body={}).execute()
 
         return execute_google_api_call(
             operation_name="sheets.values.clear",

--- a/app/infrastructure/clients/maxmind/client.py
+++ b/app/infrastructure/clients/maxmind/client.py
@@ -6,7 +6,7 @@ and OperationResult return types.
 
 from dataclasses import dataclass
 from functools import cache
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import geoip2.database
 import structlog
@@ -25,12 +25,12 @@ logger = structlog.get_logger()
 class GeoLocationData:
     """Geolocation data for an IP address."""
 
-    country_code: Optional[str] = None
-    city: Optional[str] = None
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    postal_code: Optional[str] = None
-    time_zone: Optional[str] = None
+    country_code: str | None = None
+    city: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    postal_code: str | None = None
+    time_zone: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary format."""
@@ -53,7 +53,7 @@ class MaxMindClient:
         settings: Settings instance with maxmind.MAXMIND_DB_PATH
     """
 
-    def __init__(self, maxmind_settings: "MaxMindSettings") -> None:
+    def __init__(self, maxmind_settings: MaxMindSettings) -> None:
         self._db_path = maxmind_settings.MAXMIND_DB_PATH
         self._logger = logger.bind(component="maxmind_client")
 
@@ -88,9 +88,7 @@ class MaxMindClient:
                     country=location.country_code,
                     city=location.city,
                 )
-                return OperationResult.success(
-                    data=location.to_dict(), message="IP geolocated successfully"
-                )
+                return OperationResult.success(data=location.to_dict(), message="IP geolocated successfully")
 
             except AddressNotFoundError:
                 log.warning("ip_not_found")
@@ -117,7 +115,7 @@ class MaxMindClient:
             finally:
                 reader.close()
 
-        except (FileNotFoundError, IOError) as e:
+        except (OSError, FileNotFoundError) as e:
             log.error("database_file_error", error=str(e), db_path=self._db_path)
             return OperationResult.transient_error(
                 message=f"MaxMind database file error: {str(e)}",

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -80,6 +80,8 @@ force-exclude = '''
 /(
     api
   | tests/api
+  | infrastructure/clients
+  | tests/unit/infrastructure/clients
 )/
 '''
 

--- a/app/tests/unit/infrastructure/clients/aws/conftest.py
+++ b/app/tests/unit/infrastructure/clients/aws/conftest.py
@@ -4,7 +4,7 @@ Provides factory-as-fixture pattern for creating configurable fake boto3 clients
 used across AWS client unit tests, following the testing strategy.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -44,9 +44,9 @@ class FakeClient:
 
     def __init__(
         self,
-        paginated_pages: Optional[List[Dict[str, Any]]] = None,
-        api_responses: Optional[Dict[str, Any]] = None,
-        can_paginate: Optional[Any] = None,
+        paginated_pages: list[dict[str, Any]] | None = None,
+        api_responses: dict[str, Any] | None = None,
+        can_paginate: Any | None = None,
     ):
         self._paginated_pages = paginated_pages or []
         self._api_responses = api_responses or {}
@@ -127,9 +127,9 @@ def make_fake_client():
     """
 
     def _factory(
-        paginated_pages: Optional[List[Dict[str, Any]]] = None,
-        api_responses: Optional[Dict[str, Any]] = None,
-        can_paginate: Optional[Any] = None,
+        paginated_pages: list[dict[str, Any]] | None = None,
+        api_responses: dict[str, Any] | None = None,
+        can_paginate: Any | None = None,
     ) -> FakeClient:
         """Create a FakeClient with the given configuration."""
         return FakeClient(

--- a/app/tests/unit/infrastructure/clients/aws/test_aws_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_aws_client.py
@@ -11,9 +11,7 @@ class TestClient:
     def test_calculate_retry_delay(self):
         assert aws_client._calculate_retry_delay(0) == pytest.approx(0.5)
         assert aws_client._calculate_retry_delay(1) == pytest.approx(1.0)
-        assert aws_client._calculate_retry_delay(
-            3, backoff_factor=1.0
-        ) == pytest.approx(8.0)
+        assert aws_client._calculate_retry_delay(3, backoff_factor=1.0) == pytest.approx(8.0)
 
     @staticmethod
     def make_client_with_method(result=None, raise_exc=None):
@@ -30,9 +28,7 @@ class TestClient:
 
     def test_map_client_error_conflict_treated_as_success(self, monkeypatch):
         # Build a fake ClientError with ResourceAlreadyExistsException
-        response = {
-            "Error": {"Code": "ResourceAlreadyExistsException", "Message": "exists"}
-        }
+        response = {"Error": {"Code": "ResourceAlreadyExistsException", "Message": "exists"}}
         e = ClientError(response, operation_name="Create")
 
         res = aws_client._map_client_error(e, "s3", "create_bucket", True, None)
@@ -63,53 +59,37 @@ class TestClient:
 
     def test_execute_aws_api_call_success(self, monkeypatch, make_fake_client):
         # Use the fixture to create a fake client with desired method response
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={"describe_something": {"ok": True, "args": {}}}
-            )
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"describe_something": {"ok": True, "args": {}}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", get_boto3_client)
 
-        res = aws_client.execute_aws_api_call(
-            "service", "describe_something", max_retries=0
-        )
+        res = aws_client.execute_aws_api_call("service", "describe_something", max_retries=0)
         assert res.is_success
         assert res.data == {"ok": True, "args": {}}
 
-    def test_execute_aws_api_call_clienterror_retry(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_execute_aws_api_call_clienterror_retry(self, monkeypatch, make_fake_client):
         calls = {"count": 0}
 
         def flaky_raises(*args, **kwargs):
             calls["count"] += 1
             if calls["count"] < 2:
-                response = {
-                    "Error": {"Code": "ThrottlingException", "Message": "throttle"}
-                }
+                response = {"Error": {"Code": "ThrottlingException", "Message": "throttle"}}
                 raise ClientError(response, operation_name="Flaky")
             return {"ok": True}
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"flaky": flaky_raises})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", get_boto3_client)
-        res = aws_client.execute_aws_api_call(
-            "svc", "flaky", max_retries=2, backoff_factor=0
-        )
+        res = aws_client.execute_aws_api_call("svc", "flaky", max_retries=2, backoff_factor=0)
         assert res.is_success
         assert calls["count"] >= 2
 
     def test_force_paginate_with_keys(self, monkeypatch, make_fake_client):
         pages = [{"Items": [1, 2]}, {"Items": [3]}]
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(paginated_pages=pages, api_responses={})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", get_boto3_client)
@@ -133,9 +113,7 @@ class TestClient:
             {"Items": [{"id": 2}], "Count": 1},
         ]
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(paginated_pages=pages, api_responses={})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", get_boto3_client)
@@ -153,18 +131,14 @@ class TestClient:
 
         assert result == [{"id": 1}, 1, {"id": 2}, 1]
 
-    def test_conflict_callback_invoked_treat_as_success(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_conflict_callback_invoked_treat_as_success(self, monkeypatch, make_fake_client):
         called = {"flag": False}
 
         def create_raises(*args, **kwargs):
             response = {"Error": {"Code": "EntityAlreadyExists", "Message": "exists"}}
             raise ClientError(response, operation_name="Create")
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"create": create_raises})
 
         def conflict_cb(exc):
@@ -189,9 +163,7 @@ class TestClient:
             response = {"Error": {"Code": "ConflictException", "Message": "conflict"}}
             raise ClientError(response, operation_name="Create")
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"create": create_raises})
 
         def conflict_cb(exc):
@@ -209,18 +181,14 @@ class TestClient:
 
         assert res.is_success
 
-    def test_conflict_callback_invoked_permanent_error(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_conflict_callback_invoked_permanent_error(self, monkeypatch, make_fake_client):
         called = {"flag": False}
 
         def create_raises(*args, **kwargs):
             response = {"Error": {"Code": "EntityAlreadyExists", "Message": "exists"}}
             raise ClientError(response, operation_name="Create")
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"create": create_raises})
 
         def conflict_cb(exc):
@@ -249,15 +217,11 @@ class TestClient:
         def flaky_raises(*args, **kwargs):
             calls["count"] += 1
             if calls["count"] < 3:
-                response = {
-                    "Error": {"Code": "ThrottlingException", "Message": "throttle"}
-                }
+                response = {"Error": {"Code": "ThrottlingException", "Message": "throttle"}}
                 raise ClientError(response, operation_name="Flaky")
             return {"ok": True}
 
-        def get_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def get_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"flaky": flaky_raises})
 
         def fake_sleep(delay):
@@ -266,9 +230,7 @@ class TestClient:
         monkeypatch.setattr(aws_client, "get_boto3_client", get_boto3_client)
         monkeypatch.setattr(aws_client.time, "sleep", fake_sleep)
 
-        res = aws_client.execute_aws_api_call(
-            "svc", "flaky", max_retries=2, backoff_factor=0.5
-        )
+        res = aws_client.execute_aws_api_call("svc", "flaky", max_retries=2, backoff_factor=0.5)
         assert res.is_success
         assert len(sleep_calls) == 2
         assert sleep_calls[0] == pytest.approx(0.5)

--- a/app/tests/unit/infrastructure/clients/aws/test_aws_clients_facade.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_aws_clients_facade.py
@@ -7,13 +7,13 @@ import pytest
 
 from infrastructure.clients.aws import (
     AWSClients,
+    ConfigClient,
+    CostExplorerClient,
     DynamoDBClient,
+    GuardDutyClient,
     IdentityStoreClient,
     OrganizationsClient,
     SsoAdminClient,
-    ConfigClient,
-    GuardDutyClient,
-    CostExplorerClient,
 )
 
 
@@ -48,14 +48,9 @@ class TestAWSClientsFacade:
 
         clients = AWSClients(aws_settings=mock_aws_settings)
 
-        assert (
-            clients.dynamodb._default_role_arn
-            == "arn:aws:iam::123456789012:role/DynamoDBRole"
-        )
+        assert clients.dynamodb._default_role_arn == "arn:aws:iam::123456789012:role/DynamoDBRole"
 
-    def test_facade_passes_default_role_arn_to_organizations_client(
-        self, mock_aws_settings
-    ):
+    def test_facade_passes_default_role_arn_to_organizations_client(self, mock_aws_settings):
         """Test AWSClients passes correct default_role_arn to OrganizationsClient."""
         mock_aws_settings.SERVICE_ROLE_MAP = {
             "organizations": "arn:aws:iam::123456789012:role/OrganizationsRole",
@@ -63,23 +58,15 @@ class TestAWSClientsFacade:
 
         clients = AWSClients(aws_settings=mock_aws_settings)
 
-        assert (
-            clients.organizations._default_role_arn
-            == "arn:aws:iam::123456789012:role/OrganizationsRole"
-        )
+        assert clients.organizations._default_role_arn == "arn:aws:iam::123456789012:role/OrganizationsRole"
 
-    def test_facade_passes_default_sso_instance_arn_to_sso_admin(
-        self, mock_aws_settings
-    ):
+    def test_facade_passes_default_sso_instance_arn_to_sso_admin(self, mock_aws_settings):
         """Test AWSClients passes INSTANCE_ARN to SsoAdminClient."""
         mock_aws_settings.INSTANCE_ARN = "arn:aws:sso:::instance/sso-1234567890"
 
         clients = AWSClients(aws_settings=mock_aws_settings)
 
-        assert (
-            clients.sso_admin._default_sso_instance_arn
-            == "arn:aws:sso:::instance/sso-1234567890"
-        )
+        assert clients.sso_admin._default_sso_instance_arn == "arn:aws:sso:::instance/sso-1234567890"
 
     def test_facade_passes_identity_store_id_to_identity_store(self, mock_aws_settings):
         """Test AWSClients passes INSTANCE_ID to IdentityStoreClient."""
@@ -131,12 +118,8 @@ class TestAWSClientsFacade:
 
         clients = AWSClients(aws_settings=mock_aws_settings)
 
-        dynamodb_kwargs = clients._session_provider.build_client_kwargs(
-            service_name="dynamodb"
-        )
-        identitystore_kwargs = clients._session_provider.build_client_kwargs(
-            service_name="identitystore"
-        )
+        dynamodb_kwargs = clients._session_provider.build_client_kwargs(service_name="dynamodb")
+        identitystore_kwargs = clients._session_provider.build_client_kwargs(service_name="identitystore")
 
         assert clients._session_provider.endpoint_url == "https://dynamodb.example.com"
         assert dynamodb_kwargs["client_config"] == {

--- a/app/tests/unit/infrastructure/clients/aws/test_aws_config.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_aws_config.py
@@ -21,9 +21,7 @@ def test_describe_aggregate_compliance_calls_execute(monkeypatch, session_provid
         called["method"] = method
         return []
 
-    monkeypatch.setattr(
-        "infrastructure.clients.aws.executor.execute_aws_api_call", fake_execute
-    )
+    monkeypatch.setattr("infrastructure.clients.aws.executor.execute_aws_api_call", fake_execute)
 
     result = client.describe_aggregate_compliance_by_config_rules("agg", {})
     assert result is not None

--- a/app/tests/unit/infrastructure/clients/aws/test_config_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_config_client.py
@@ -30,17 +30,13 @@ class TestConfigClient:
         client = ConfigClient(session_provider=session_provider)
         assert client._default_role_arn is None
 
-    def test_describe_aggregate_compliance_by_config_rules_success(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_describe_aggregate_compliance_by_config_rules_success(self, monkeypatch, make_fake_client):
         """Test describe_aggregate_compliance_by_config_rules returns compliance data."""
 
         session_provider = SessionProvider(region="us-east-1")
         client = ConfigClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
                 api_responses={
                     "describe_aggregate_compliance_by_config_rules": {
@@ -56,14 +52,10 @@ class TestConfigClient:
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
-        result = client.describe_aggregate_compliance_by_config_rules(
-            config_aggregator_name="org-aggregator"
-        )
+        result = client.describe_aggregate_compliance_by_config_rules(config_aggregator_name="org-aggregator")
         assert result.is_success
 
-    def test_describe_aggregate_compliance_by_config_rules_with_filters(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_describe_aggregate_compliance_by_config_rules_with_filters(self, monkeypatch, make_fake_client):
         """Test describe_aggregate_compliance_by_config_rules with filters."""
 
         session_provider = SessionProvider(region="us-east-1")
@@ -72,16 +64,10 @@ class TestConfigClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
             return make_fake_client(
-                api_responses={
-                    "describe_aggregate_compliance_by_config_rules": {
-                        "AggregateComplianceByConfigRules": []
-                    }
-                }
+                api_responses={"describe_aggregate_compliance_by_config_rules": {"AggregateComplianceByConfigRules": []}}
             )
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -92,9 +78,7 @@ class TestConfigClient:
         )
         assert result.is_success
 
-    def test_describe_aggregate_compliance_by_config_rules_uses_default_role(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_describe_aggregate_compliance_by_config_rules_uses_default_role(self, monkeypatch, make_fake_client):
         """Test describe_aggregate_compliance_by_config_rules uses default_role_arn."""
 
         session_provider = SessionProvider(region="us-east-1")
@@ -103,21 +87,13 @@ class TestConfigClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
             return make_fake_client(
-                api_responses={
-                    "describe_aggregate_compliance_by_config_rules": {
-                        "AggregateComplianceByConfigRules": []
-                    }
-                }
+                api_responses={"describe_aggregate_compliance_by_config_rules": {"AggregateComplianceByConfigRules": []}}
             )
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
-        result = client.describe_aggregate_compliance_by_config_rules(
-            config_aggregator_name="org-aggregator"
-        )
+        result = client.describe_aggregate_compliance_by_config_rules(config_aggregator_name="org-aggregator")
         assert result.is_success

--- a/app/tests/unit/infrastructure/clients/aws/test_cost_explorer_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_cost_explorer_client.py
@@ -21,10 +21,7 @@ class TestCostExplorerClient:
             session_provider=session_provider,
             default_role_arn="arn:aws:iam::123456789012:role/CostExplorerRole",
         )
-        assert (
-            client._default_role_arn
-            == "arn:aws:iam::123456789012:role/CostExplorerRole"
-        )
+        assert client._default_role_arn == "arn:aws:iam::123456789012:role/CostExplorerRole"
         assert client.service_name == "ce"
 
     def test_init_without_default_role_arn(self):
@@ -42,9 +39,7 @@ class TestCostExplorerClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
             return make_fake_client(
                 api_responses={
@@ -55,9 +50,7 @@ class TestCostExplorerClient:
                                     "Start": "2024-01-01",
                                     "End": "2024-01-02",
                                 },
-                                "Total": {
-                                    "BlendedCost": {"Amount": "100", "Unit": "USD"}
-                                },
+                                "Total": {"BlendedCost": {"Amount": "100", "Unit": "USD"}},
                             }
                         ]
                     }
@@ -82,13 +75,9 @@ class TestCostExplorerClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
-            return make_fake_client(
-                api_responses={"get_cost_and_usage": {"ResultsByTime": []}}
-            )
+            return make_fake_client(api_responses={"get_cost_and_usage": {"ResultsByTime": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -106,9 +95,7 @@ class TestCostExplorerClient:
         session_provider = SessionProvider(region="us-east-1")
         client = CostExplorerClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
                 api_responses={
                     "get_cost_and_usage": {
@@ -118,9 +105,7 @@ class TestCostExplorerClient:
                                     "Start": "2024-01-01",
                                     "End": "2024-01-02",
                                 },
-                                "Total": {
-                                    "BlendedCost": {"Amount": "100", "Unit": "USD"}
-                                },
+                                "Total": {"BlendedCost": {"Amount": "100", "Unit": "USD"}},
                             }
                         ]
                     }

--- a/app/tests/unit/infrastructure/clients/aws/test_dynamodb.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_dynamodb.py
@@ -1,4 +1,5 @@
 import importlib
+
 import pytest
 
 from infrastructure.operations.result import OperationResult

--- a/app/tests/unit/infrastructure/clients/aws/test_dynamodb_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_dynamodb_client.py
@@ -4,6 +4,7 @@ Validates DynamoDB operations with default role fallback and service_name resolu
 """
 
 import pytest
+
 from infrastructure.clients.aws import executor as aws_client
 from infrastructure.clients.aws.dynamodb import DynamoDBClient
 from infrastructure.clients.aws.session_provider import SessionProvider
@@ -39,13 +40,9 @@ class TestDynamoDBClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
-            return make_fake_client(
-                api_responses={"get_item": {"Item": {"id": {"S": "123"}}}}
-            )
+            return make_fake_client(api_responses={"get_item": {"Item": {"id": {"S": "123"}}}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -53,9 +50,7 @@ class TestDynamoDBClient:
         assert result.is_success
         assert result.data == {"Item": {"id": {"S": "123"}}}
 
-    def test_get_item_explicit_role_overrides_default(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_get_item_explicit_role_overrides_default(self, monkeypatch, make_fake_client):
         """Test get_item explicit role_arn overrides default."""
 
         session_provider = SessionProvider(region="us-east-1")
@@ -64,9 +59,7 @@ class TestDynamoDBClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::999999999999:role/OverrideRole"
             return make_fake_client(api_responses={"get_item": {"Item": {}}})
 
@@ -85,16 +78,12 @@ class TestDynamoDBClient:
         session_provider = SessionProvider(region="us-east-1")
         client = DynamoDBClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"put_item": {}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
-        result = client.put_item(
-            "my_table", {"id": {"S": "123"}, "data": {"S": "test"}}
-        )
+        result = client.put_item("my_table", {"id": {"S": "123"}, "data": {"S": "test"}})
         assert result.is_success
 
     def test_scan_with_pagination(self, monkeypatch, make_fake_client):
@@ -108,9 +97,7 @@ class TestDynamoDBClient:
             {"Items": [{"id": {"S": "2"}}], "Count": 1},
         ]
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(paginated_pages=pages)
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -124,9 +111,7 @@ class TestDynamoDBClient:
         session_provider = SessionProvider(region="us-east-1")
         client = DynamoDBClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"list_tables": {"TableNames": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)

--- a/app/tests/unit/infrastructure/clients/aws/test_guard_duty_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_guard_duty_client.py
@@ -21,9 +21,7 @@ class TestGuardDutyClient:
             session_provider=session_provider,
             default_role_arn="arn:aws:iam::123456789012:role/GuardDutyRole",
         )
-        assert (
-            client._default_role_arn == "arn:aws:iam::123456789012:role/GuardDutyRole"
-        )
+        assert client._default_role_arn == "arn:aws:iam::123456789012:role/GuardDutyRole"
         assert client.service_name == "guardduty"
 
     def test_init_without_default_role_arn(self):
@@ -41,13 +39,9 @@ class TestGuardDutyClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
-            return make_fake_client(
-                api_responses={"list_detectors": {"DetectorIds": ["detector-123"]}}
-            )
+            return make_fake_client(api_responses={"list_detectors": {"DetectorIds": ["detector-123"]}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -63,15 +57,9 @@ class TestGuardDutyClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
-            return make_fake_client(
-                api_responses={
-                    "list_detectors": {"DetectorIds": ["detector-1", "detector-2"]}
-                }
-            )
+            return make_fake_client(api_responses={"list_detectors": {"DetectorIds": ["detector-1", "detector-2"]}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -84,12 +72,8 @@ class TestGuardDutyClient:
         session_provider = SessionProvider(region="us-east-1")
         client = GuardDutyClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={"list_detectors": {"DetectorIds": []}}
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"list_detectors": {"DetectorIds": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 

--- a/app/tests/unit/infrastructure/clients/aws/test_health_aggregator.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_health_aggregator.py
@@ -49,9 +49,7 @@ class TestAWSIntegrationHealth:
     def test_check_service_health_dynamodb(self, monkeypatch, make_fake_client):
         """Test check_service_health for dynamodb."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"list_tables": {"TableNames": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -65,9 +63,7 @@ class TestAWSIntegrationHealth:
     def test_check_service_health_organizations(self, monkeypatch, make_fake_client):
         """Test check_service_health for organizations."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"list_accounts": {"Accounts": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -90,9 +86,7 @@ class TestAWSIntegrationHealth:
     def test_check_all_returns_aggregated_results(self, monkeypatch, make_fake_client):
         """Test check_all returns aggregated health for all services."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             responses = {
                 "dynamodb": {"list_tables": {"TableNames": []}},
                 "organizations": {"list_accounts": {"Accounts": []}},
@@ -112,17 +106,11 @@ class TestAWSIntegrationHealth:
     def test_check_all_with_include_filter(self, monkeypatch, make_fake_client):
         """Test check_all with include filter only checks specified services."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             if service_name == "dynamodb":
-                return make_fake_client(
-                    api_responses={"list_tables": {"TableNames": []}}
-                )
+                return make_fake_client(api_responses={"list_tables": {"TableNames": []}})
             elif service_name == "organizations":
-                return make_fake_client(
-                    api_responses={"list_accounts": {"Accounts": []}}
-                )
+                return make_fake_client(api_responses={"list_accounts": {"Accounts": []}})
             return make_fake_client(api_responses={})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -139,17 +127,11 @@ class TestAWSIntegrationHealth:
     def test_check_all_with_exclude_filter(self, monkeypatch, make_fake_client):
         """Test check_all with exclude filter skips specified services."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             if service_name == "dynamodb":
-                return make_fake_client(
-                    api_responses={"list_tables": {"TableNames": []}}
-                )
+                return make_fake_client(api_responses={"list_tables": {"TableNames": []}})
             elif service_name == "organizations":
-                return make_fake_client(
-                    api_responses={"list_accounts": {"Accounts": []}}
-                )
+                return make_fake_client(api_responses={"list_accounts": {"Accounts": []}})
             return make_fake_client(api_responses={})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -202,9 +184,7 @@ class TestAWSIntegrationHealth:
     def test_check_all_aggregates_results(self, monkeypatch, make_fake_client):
         """Test check_all aggregates all service check results."""
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             responses = {
                 "dynamodb": {"list_tables": {"TableNames": []}},
                 "organizations": {"list_accounts": {"Accounts": []}},

--- a/app/tests/unit/infrastructure/clients/aws/test_identity_store_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_identity_store_client.py
@@ -3,13 +3,13 @@
 Validates AWS Identity Store operations with default identity_store_id fallback.
 """
 
-from botocore.exceptions import ClientError
 import pytest
+from botocore.exceptions import ClientError
 
 from infrastructure.clients.aws import executor as aws_client
 from infrastructure.clients.aws.identity_store import IdentityStoreClient
-from infrastructure.operations import OperationStatus
 from infrastructure.clients.aws.session_provider import SessionProvider
+from infrastructure.operations import OperationStatus
 
 
 @pytest.mark.unit
@@ -40,16 +40,8 @@ class TestIdentityStoreClient:
             default_identity_store_id="store-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={
-                    "list_users": {
-                        "Users": [{"UserId": "user-123", "UserName": "testuser"}]
-                    }
-                }
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"list_users": {"Users": [{"UserId": "user-123", "UserName": "testuser"}]}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -74,12 +66,8 @@ class TestIdentityStoreClient:
             default_identity_store_id="store-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={"create_user": {"UserId": "user-new-123"}}
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"create_user": {"UserId": "user-new-123"}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -98,9 +86,7 @@ class TestIdentityStoreClient:
             default_identity_store_id="store-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
                 api_responses={
                     "describe_user": {
@@ -125,9 +111,7 @@ class TestIdentityStoreClient:
             default_identity_store_id="store-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"delete_user": {}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -135,9 +119,7 @@ class TestIdentityStoreClient:
         result = client.delete_user(user_id="user-123")
         assert result.is_success
 
-    def test_get_group_membership_id_maps_resource_not_found_to_not_found(
-        self, monkeypatch
-    ):
+    def test_get_group_membership_id_maps_resource_not_found_to_not_found(self, monkeypatch):
         """Membership lookup misses should normalize to NOT_FOUND for adapter idempotency."""
 
         session_provider = SessionProvider(region="us-east-1")
@@ -146,9 +128,7 @@ class TestIdentityStoreClient:
             default_identity_store_id="store-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             class FakeClient:
                 def get_group_membership_id(self, **kwargs):
                     raise ClientError(

--- a/app/tests/unit/infrastructure/clients/aws/test_identity_store_unit.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_identity_store_unit.py
@@ -1,4 +1,5 @@
 import importlib
+
 import pytest
 
 from infrastructure.operations.result import OperationResult
@@ -16,9 +17,7 @@ class TestIdentityStore:
             captured.update(kwargs)
             return OperationResult.success(data={})
 
-        identity_mod = importlib.import_module(
-            "infrastructure.clients.aws.identity_store"
-        )
+        identity_mod = importlib.import_module("infrastructure.clients.aws.identity_store")
         monkeypatch.setattr(identity_mod, "execute_aws_api_call", fake_execute)
 
         # list_users - uses facade's configured identity_store_id
@@ -39,9 +38,7 @@ class TestIdentityStore:
 
         # create_user - uses facade's configured identity_store_id
         captured.clear()
-        res = aws_factory.identitystore.create_user(
-            UserName="jsmith", DisplayName="J Smith"
-        )
+        res = aws_factory.identitystore.create_user(UserName="jsmith", DisplayName="J Smith")
         assert res.is_success
         assert captured["service"] == "identitystore"
         assert captured["method"] == "create_user"

--- a/app/tests/unit/infrastructure/clients/aws/test_organizations_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_organizations_client.py
@@ -39,17 +39,9 @@ class TestOrganizationsClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
-            return make_fake_client(
-                api_responses={
-                    "list_accounts": {
-                        "Accounts": [{"Id": "123456789012", "Name": "Production"}]
-                    }
-                }
-            )
+            return make_fake_client(api_responses={"list_accounts": {"Accounts": [{"Id": "123456789012", "Name": "Production"}]}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -65,9 +57,7 @@ class TestOrganizationsClient:
             default_role_arn="arn:aws:iam::123456789012:role/DefaultRole",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             assert role_arn == "arn:aws:iam::123456789012:role/DefaultRole"
             return make_fake_client(
                 api_responses={
@@ -91,16 +81,8 @@ class TestOrganizationsClient:
         session_provider = SessionProvider(region="us-east-1")
         client = OrganizationsClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={
-                    "describe_account": {
-                        "Account": {"Id": "123456789012", "Name": "Production"}
-                    }
-                }
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"describe_account": {"Account": {"Id": "123456789012", "Name": "Production"}}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -113,9 +95,7 @@ class TestOrganizationsClient:
         session_provider = SessionProvider(region="us-east-1")
         client = OrganizationsClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
                 api_responses={
                     "list_accounts": {
@@ -139,16 +119,8 @@ class TestOrganizationsClient:
         session_provider = SessionProvider(region="us-east-1")
         client = OrganizationsClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={
-                    "list_accounts": {
-                        "Accounts": [{"Id": "123456789012", "Name": "Production"}]
-                    }
-                }
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"list_accounts": {"Accounts": [{"Id": "123456789012", "Name": "Production"}]}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
@@ -162,9 +134,7 @@ class TestOrganizationsClient:
         session_provider = SessionProvider(region="us-east-1")
         client = OrganizationsClient(session_provider=session_provider)
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(api_responses={"list_accounts": {"Accounts": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)

--- a/app/tests/unit/infrastructure/clients/aws/test_organizations_unit.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_organizations_unit.py
@@ -8,18 +8,14 @@ from infrastructure.operations.result import OperationResult, OperationStatus
 @pytest.mark.unit
 @pytest.mark.skip(reason="Deprecated tests, marked for deletion")
 class TestOrganizations:
-    def test_organizations_methods_and_get_account_id_by_name(
-        self, monkeypatch, aws_factory
-    ):
+    def test_organizations_methods_and_get_account_id_by_name(self, monkeypatch, aws_factory):
         captured = {}
 
         def fake_execute(service_name, method, **kwargs):
             captured["service"] = service_name
             captured["method"] = method
             captured.update(kwargs)
-            return OperationResult.success(
-                data={"Accounts": [{"Id": "111", "Name": "alpha"}]}
-            )
+            return OperationResult.success(data={"Accounts": [{"Id": "111", "Name": "alpha"}]})
 
         orgs_mod = importlib.import_module("infrastructure.clients.aws.organizations")
         monkeypatch.setattr(orgs_mod, "execute_aws_api_call", fake_execute)
@@ -44,9 +40,7 @@ class TestOrganizations:
 
         # get_account_id_by_name - not found
         def fake_execute_no_accounts(service_name, method, **kwargs):
-            return OperationResult.success(
-                data={"Accounts": [{"Id": "222", "Name": "beta"}]}
-            )
+            return OperationResult.success(data={"Accounts": [{"Id": "222", "Name": "beta"}]})
 
         monkeypatch.setattr(orgs_mod, "execute_aws_api_call", fake_execute_no_accounts)
         res = aws_factory.organizations.get_account_id_by_name("nope")

--- a/app/tests/unit/infrastructure/clients/aws/test_session_provider.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_session_provider.py
@@ -45,9 +45,7 @@ class TestSessionProvider:
         assert captured["role_arn"] == "arn:aws:iam::123456789012:role/Explicit"
         assert captured["session_config"] == {"region_name": "ca-central-1"}
 
-    def test_get_boto3_client_uses_service_role_map_when_role_missing(
-        self, monkeypatch
-    ):
+    def test_get_boto3_client_uses_service_role_map_when_role_missing(self, monkeypatch):
         """Mapped service role should be used when role_arn is not provided."""
         captured = {}
 
@@ -84,9 +82,7 @@ class TestSessionProvider:
         )
 
         dynamodb_kwargs = provider.build_client_kwargs(service_name="dynamodb")
-        identitystore_kwargs = provider.build_client_kwargs(
-            service_name="identitystore"
-        )
+        identitystore_kwargs = provider.build_client_kwargs(service_name="identitystore")
 
         assert dynamodb_kwargs["client_config"] == {
             "region_name": "ca-central-1",

--- a/app/tests/unit/infrastructure/clients/aws/test_sso_admin_client.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_sso_admin_client.py
@@ -6,8 +6,8 @@ Validates AWS SSO Admin operations with default SSO instance ARN and service_nam
 import pytest
 
 from infrastructure.clients.aws import executor as aws_client
-from infrastructure.clients.aws.sso_admin import SsoAdminClient
 from infrastructure.clients.aws.session_provider import SessionProvider
+from infrastructure.clients.aws.sso_admin import SsoAdminClient
 
 
 @pytest.mark.unit
@@ -21,9 +21,7 @@ class TestSsoAdminClient:
             session_provider=session_provider,
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
-        assert (
-            client._default_sso_instance_arn == "arn:aws:sso:::instance/sso-1234567890"
-        )
+        assert client._default_sso_instance_arn == "arn:aws:sso:::instance/sso-1234567890"
         assert client._service_name == "sso-admin"
 
     def test_init_without_default_sso_instance_arn(self):
@@ -41,15 +39,9 @@ class TestSsoAdminClient:
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
-                api_responses={
-                    "create_account_assignment": {
-                        "AccountAssignmentCreationStatus": {"RequestId": "req-12345"}
-                    }
-                }
+                api_responses={"create_account_assignment": {"AccountAssignmentCreationStatus": {"RequestId": "req-12345"}}}
             )
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -64,9 +56,7 @@ class TestSsoAdminClient:
         )
         assert result.is_success
 
-    def test_create_account_assignment_uses_default_instance_arn(
-        self, monkeypatch, make_fake_client
-    ):
+    def test_create_account_assignment_uses_default_instance_arn(self, monkeypatch, make_fake_client):
         """Test create_account_assignment uses default_sso_instance_arn when not provided."""
 
         session_provider = SessionProvider(region="us-east-1")
@@ -77,17 +67,11 @@ class TestSsoAdminClient:
 
         call_count = 0
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             nonlocal call_count
             call_count += 1
             fake_client = make_fake_client(
-                api_responses={
-                    "create_account_assignment": {
-                        "AccountAssignmentCreationStatus": {"RequestId": "req-12345"}
-                    }
-                }
+                api_responses={"create_account_assignment": {"AccountAssignmentCreationStatus": {"RequestId": "req-12345"}}}
             )
             # Store the first call's instance_arn for validation
             return fake_client
@@ -113,15 +97,9 @@ class TestSsoAdminClient:
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
-                api_responses={
-                    "delete_account_assignment": {
-                        "AccountAssignmentDeletionStatus": {"RequestId": "req-12345"}
-                    }
-                }
+                api_responses={"delete_account_assignment": {"AccountAssignmentDeletionStatus": {"RequestId": "req-12345"}}}
             )
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
@@ -145,9 +123,7 @@ class TestSsoAdminClient:
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
                 api_responses={
                     "list_account_assignments": {
@@ -181,22 +157,14 @@ class TestSsoAdminClient:
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
             return make_fake_client(
-                api_responses={
-                    "list_permission_sets": {
-                        "PermissionSets": ["arn:aws:sso:::permissionSet/ps-1234567890"]
-                    }
-                }
+                api_responses={"list_permission_sets": {"PermissionSets": ["arn:aws:sso:::permissionSet/ps-1234567890"]}}
             )
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 
-        result = client.list_permission_sets(
-            instance_arn="arn:aws:sso:::instance/sso-1234567890"
-        )
+        result = client.list_permission_sets(instance_arn="arn:aws:sso:::instance/sso-1234567890")
         assert result.is_success
 
     def test_healthcheck_with_default_instance_arn(self, monkeypatch, make_fake_client):
@@ -208,12 +176,8 @@ class TestSsoAdminClient:
             default_sso_instance_arn="arn:aws:sso:::instance/sso-1234567890",
         )
 
-        def mock_boto3_client(
-            service_name, session_config=None, client_config=None, role_arn=None
-        ):
-            return make_fake_client(
-                api_responses={"list_permission_sets": {"PermissionSets": []}}
-            )
+        def mock_boto3_client(service_name, session_config=None, client_config=None, role_arn=None):
+            return make_fake_client(api_responses={"list_permission_sets": {"PermissionSets": []}})
 
         monkeypatch.setattr(aws_client, "get_boto3_client", mock_boto3_client)
 

--- a/app/tests/unit/infrastructure/clients/aws/test_sso_admin_unit.py
+++ b/app/tests/unit/infrastructure/clients/aws/test_sso_admin_unit.py
@@ -1,5 +1,6 @@
-import pytest
 import importlib
+
+import pytest
 
 from infrastructure.operations.result import OperationResult
 

--- a/app/tests/unit/infrastructure/clients/google_workspace/conftest.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/conftest.py
@@ -1,7 +1,8 @@
 """Shared fixtures for Google Workspace client tests."""
 
 import json
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -189,9 +190,7 @@ def mock_google_api_error():
                 "error": {
                     "code": status,
                     "message": reason,
-                    "errors": [
-                        {"message": reason, "reason": reason.lower().replace(" ", "_")}
-                    ],
+                    "errors": [{"message": reason, "reason": reason.lower().replace(" ", "_")}],
                 }
             }
         ).encode()

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_batch_executor.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_batch_executor.py
@@ -104,9 +104,7 @@ class TestExecuteBatchRequest:
         assert result.data["summary"]["failed"] == 1
         assert result.data["summary"]["success_rate"] == pytest.approx(2 / 3)
 
-    def test_batch_request_with_operation_result_response_success(
-        self, mock_google_service
-    ):
+    def test_batch_request_with_operation_result_response_success(self, mock_google_service):
         """Test batch request when callback receives OperationResult responses (success)."""
         # Arrange
         requests = [
@@ -149,9 +147,7 @@ class TestExecuteBatchRequest:
         assert result.data["results"]["req2"] == {"user": "user2@example.com"}
         assert len(result.data["errors"]) == 0
 
-    def test_batch_request_with_operation_result_response_failure(
-        self, mock_google_service
-    ):
+    def test_batch_request_with_operation_result_response_failure(self, mock_google_service):
         """Test batch request when callback receives OperationResult responses (failure)."""
         # Arrange
         requests = [
@@ -176,9 +172,7 @@ class TestExecuteBatchRequest:
             # Second fails (OperationResult with error)
             cb(
                 "req2",
-                OperationResult.permanent_error(
-                    message="User not found", error_code="NOT_FOUND"
-                ),
+                OperationResult.permanent_error(message="User not found", error_code="NOT_FOUND"),
                 None,
             )
 
@@ -200,9 +194,7 @@ class TestExecuteBatchRequest:
         assert result.data["errors"]["req2"]["message"] == "User not found"
         assert result.data["errors"]["req2"]["error_code"] == "NOT_FOUND"
 
-    def test_batch_request_with_exception_without_code_attribute(
-        self, mock_google_service
-    ):
+    def test_batch_request_with_exception_without_code_attribute(self, mock_google_service):
         """Test batch request when exception doesn't have a code attribute."""
         # Arrange
         requests = [("req1", Mock())]
@@ -262,9 +254,7 @@ class TestExecuteBatchRequest:
         custom_callback_calls = []
 
         def custom_callback(request_id, response, exception):
-            custom_callback_calls.append(
-                {"request_id": request_id, "response": response, "exception": exception}
-            )
+            custom_callback_calls.append({"request_id": request_id, "response": response, "exception": exception})
 
         callback_holder = {}
 

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_directory.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_directory.py
@@ -28,9 +28,7 @@ class TestDirectoryClientUsers:
         mock_session_provider.get_service.return_value = mock_service
 
         # Execute
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_user("user@example.com")
 
         # Verify
@@ -48,12 +46,8 @@ class TestDirectoryClientUsers:
         mock_service.users().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_user(
-            "user@example.com", delegated_email="admin@example.com"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_user("user@example.com", delegated_email="admin@example.com")
 
         assert result.is_success
         mock_session_provider.get_service.assert_called_once()
@@ -74,9 +68,7 @@ class TestDirectoryClientUsers:
         mock_service.users().list_next.return_value = None
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_users()
 
         assert result.is_success
@@ -98,17 +90,13 @@ class TestDirectoryClientUsers:
 
         # Page 2
         mock_request2 = Mock()
-        mock_request2.execute.return_value = {
-            "users": [{"primaryEmail": "user2@example.com", "id": "2"}]
-        }
+        mock_request2.execute.return_value = {"users": [{"primaryEmail": "user2@example.com", "id": "2"}]}
 
         mock_service.users().list.return_value = mock_request1
         mock_service.users().list_next.side_effect = [mock_request2, None]
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_users()
 
         assert result.is_success
@@ -126,9 +114,7 @@ class TestDirectoryClientUsers:
         mock_service.users().list_next.return_value = None
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_users(customer="custom_customer")
 
         assert result.is_success
@@ -143,15 +129,11 @@ class TestDirectoryClientUsers:
         mock_service.users().list_next.return_value = None
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_users(maxResults=10, query="name:John")
 
         assert result.is_success
-        mock_service.users().list.assert_called_once_with(
-            customer="my_customer", maxResults=10, query="name:John"
-        )
+        mock_service.users().list.assert_called_once_with(customer="my_customer", maxResults=10, query="name:John")
 
     def test_create_user_success(self, mock_session_provider: Mock):
         """Test successful user creation."""
@@ -172,9 +154,7 @@ class TestDirectoryClientUsers:
             "password": "SecurePass123!",
         }
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.create_user(user_body)
 
         assert result.is_success
@@ -196,17 +176,13 @@ class TestDirectoryClientUsers:
 
         update_body = {"suspended": True}
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.update_user("user@example.com", update_body)
 
         assert result.is_success
         assert result.data is not None
         assert result.data["suspended"] is True
-        mock_service.users().update.assert_called_once_with(
-            userKey="user@example.com", body=update_body
-        )
+        mock_service.users().update.assert_called_once_with(userKey="user@example.com", body=update_body)
 
     def test_delete_user_success(self, mock_session_provider: Mock):
         """Test successful user deletion."""
@@ -216,9 +192,7 @@ class TestDirectoryClientUsers:
         mock_service.users().delete.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.delete_user("user@example.com")
 
         assert result.is_success
@@ -240,9 +214,7 @@ class TestDirectoryClientGroups:
         mock_service.groups().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_group("group@example.com")
 
         assert result.is_success
@@ -265,9 +237,7 @@ class TestDirectoryClientGroups:
         mock_service.groups().list_next.return_value = None
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_groups()
 
         assert result.is_success
@@ -288,17 +258,13 @@ class TestDirectoryClientGroups:
 
         # Page 2
         mock_request2 = Mock()
-        mock_request2.execute.return_value = {
-            "groups": [{"email": "group2@example.com", "id": "2"}]
-        }
+        mock_request2.execute.return_value = {"groups": [{"email": "group2@example.com", "id": "2"}]}
 
         mock_service.groups().list.return_value = mock_request1
         mock_service.groups().list_next.side_effect = [mock_request2, None]
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_groups()
 
         assert result.is_success
@@ -316,9 +282,7 @@ class TestDirectoryClientGroups:
         mock_service.customers().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.health_check()
 
         assert result.is_success
@@ -326,9 +290,7 @@ class TestDirectoryClientGroups:
         assert result.data["id"] == "C123abc"
         mock_service.customers().get.assert_called_once_with(customerKey="my_customer")
 
-    def test_health_check_falls_back_to_my_customer_when_default_is_empty(
-        self, mock_session_provider: Mock
-    ):
+    def test_health_check_falls_back_to_my_customer_when_default_is_empty(self, mock_session_provider: Mock):
         """Test blank configured customer IDs still probe the stable default."""
         mock_service = Mock()
         mock_request = Mock()
@@ -336,9 +298,7 @@ class TestDirectoryClientGroups:
         mock_service.customers().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id=""
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="")
 
         result = client.health_check()
 
@@ -363,9 +323,7 @@ class TestDirectoryClientGroups:
             "name": "New Group",
         }
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.create_group(group_body)
 
         assert result.is_success
@@ -387,17 +345,13 @@ class TestDirectoryClientGroups:
 
         update_body = {"name": "Updated Name"}
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.update_group("group@example.com", update_body)
 
         assert result.is_success
         assert result.data is not None
         assert result.data["name"] == "Updated Name"
-        mock_service.groups().update.assert_called_once_with(
-            groupKey="group@example.com", body=update_body
-        )
+        mock_service.groups().update.assert_called_once_with(groupKey="group@example.com", body=update_body)
 
     def test_delete_group_success(self, mock_session_provider: Mock):
         """Test successful group deletion."""
@@ -407,15 +361,11 @@ class TestDirectoryClientGroups:
         mock_service.groups().delete.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.delete_group("group@example.com")
 
         assert result.is_success
-        mock_service.groups().delete.assert_called_once_with(
-            groupKey="group@example.com"
-        )
+        mock_service.groups().delete.assert_called_once_with(groupKey="group@example.com")
 
 
 class TestDirectoryClientMembers:
@@ -435,9 +385,7 @@ class TestDirectoryClientMembers:
         mock_service.members().list_next.return_value = None
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_members("group@example.com")
 
         assert result.is_success
@@ -445,9 +393,7 @@ class TestDirectoryClientMembers:
         assert len(result.data) == 2
         assert result.data[0]["email"] == "user1@example.com"
         assert result.data[1]["role"] == "OWNER"
-        mock_service.members().list.assert_called_once_with(
-            groupKey="group@example.com"
-        )
+        mock_service.members().list.assert_called_once_with(groupKey="group@example.com")
 
     def test_list_members_pagination(self, mock_session_provider: Mock):
         """Test listing members with automatic pagination."""
@@ -462,17 +408,13 @@ class TestDirectoryClientMembers:
 
         # Page 2
         mock_request2 = Mock()
-        mock_request2.execute.return_value = {
-            "members": [{"email": "user2@example.com", "role": "OWNER"}]
-        }
+        mock_request2.execute.return_value = {"members": [{"email": "user2@example.com", "role": "OWNER"}]}
 
         mock_service.members().list.return_value = mock_request1
         mock_service.members().list_next.side_effect = [mock_request2, None]
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_members("group@example.com")
 
         assert result.is_success
@@ -496,17 +438,13 @@ class TestDirectoryClientMembers:
             "role": "MEMBER",
         }
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.add_member("group@example.com", member_body)
 
         assert result.is_success
         assert result.data is not None
         assert result.data["email"] == "newmember@example.com"
-        mock_service.members().insert.assert_called_once_with(
-            groupKey="group@example.com", body=member_body
-        )
+        mock_service.members().insert.assert_called_once_with(groupKey="group@example.com", body=member_body)
 
     def test_remove_member_success(self, mock_session_provider: Mock):
         """Test successful member removal."""
@@ -516,15 +454,11 @@ class TestDirectoryClientMembers:
         mock_service.members().delete.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.remove_member("group@example.com", "user@example.com")
 
         assert result.is_success
-        mock_service.members().delete.assert_called_once_with(
-            groupKey="group@example.com", memberKey="user@example.com"
-        )
+        mock_service.members().delete.assert_called_once_with(groupKey="group@example.com", memberKey="user@example.com")
 
 
 class TestDirectoryClientErrorHandling:
@@ -536,16 +470,12 @@ class TestDirectoryClientErrorHandling:
         mock_service = Mock()
         mock_request = Mock()
         # Simulate 404 Not Found
-        http_error = HttpError(
-            resp=Mock(status=404), content=b'{"error": "User not found"}'
-        )
+        http_error = HttpError(resp=Mock(status=404), content=b'{"error": "User not found"}')
         mock_request.execute.side_effect = http_error
         mock_service.users().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_user("nonexistent@example.com")
 
         assert not result.is_success
@@ -557,16 +487,12 @@ class TestDirectoryClientErrorHandling:
         mock_service = Mock()
         mock_request = Mock()
         # Simulate 403 Forbidden
-        http_error = HttpError(
-            resp=Mock(status=403), content=b'{"error": "Permission denied"}'
-        )
+        http_error = HttpError(resp=Mock(status=403), content=b'{"error": "Permission denied"}')
         mock_request.execute.side_effect = http_error
         mock_service.users().list.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.list_users()
 
         assert not result.is_success
@@ -588,18 +514,14 @@ class TestDirectoryClientMembershipChecks:
         mock_service.members().get.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_member("group@example.com", "member@example.com")
 
         assert result.is_success
         assert result.data is not None
         assert result.data["email"] == "member@example.com"
         assert result.data["role"] == "MEMBER"
-        mock_service.members().get.assert_called_once_with(
-            groupKey="group@example.com", memberKey="member@example.com"
-        )
+        mock_service.members().get.assert_called_once_with(groupKey="group@example.com", memberKey="member@example.com")
 
     def test_has_member_success(self, mock_session_provider: Mock):
         """Test successful membership check."""
@@ -609,17 +531,13 @@ class TestDirectoryClientMembershipChecks:
         mock_service.members().hasMember.return_value = mock_request
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.has_member("group@example.com", "member@example.com")
 
         assert result.is_success
         assert result.data is not None
         assert result.data["isMember"] is True
-        mock_service.members().hasMember.assert_called_once_with(
-            groupKey="group@example.com", memberKey="member@example.com"
-        )
+        mock_service.members().hasMember.assert_called_once_with(groupKey="group@example.com", memberKey="member@example.com")
 
 
 class TestDirectoryClientBatchOperations:
@@ -659,9 +577,7 @@ class TestDirectoryClientBatchOperations:
         mock_service.users().get.return_value = Mock()  # API request objects
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_batch_users(["user1@example.com", "user2@example.com"])
 
         assert result.is_success
@@ -700,9 +616,7 @@ class TestDirectoryClientBatchOperations:
         mock_service.groups().get.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_batch_groups(["group1@example.com", "group2@example.com"])
 
         assert result.is_success
@@ -741,12 +655,8 @@ class TestDirectoryClientBatchOperations:
         mock_service.members().get.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_batch_members_for_user(
-            ["group1@example.com", "group2@example.com"], "user@example.com"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_batch_members_for_user(["group1@example.com", "group2@example.com"], "user@example.com")
 
         assert result.is_success
         assert result.data is not None
@@ -789,12 +699,8 @@ class TestDirectoryClientBatchOperations:
         mock_service.members().list.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_batch_group_members(
-            ["group1@example.com", "group2@example.com"]
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_batch_group_members(["group1@example.com", "group2@example.com"])
 
         assert result.is_success
         assert result.data is not None
@@ -850,9 +756,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         request = ListGroupsWithMembersRequest(include_users_details=False)
         result = client.list_groups_with_members(request)
 
@@ -864,9 +768,7 @@ class TestDirectoryClientAdvancedFeatures:
         assert result.data[1]["email"] == "group2@example.com"
         assert len(result.data[1]["members"]) == 1
 
-    def test_list_groups_with_members_with_group_filters(
-        self, mock_session_provider: Mock
-    ):
+    def test_list_groups_with_members_with_group_filters(self, mock_session_provider: Mock):
         """Test list_groups_with_members with group filters."""
 
         mock_service = Mock()
@@ -910,9 +812,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         request = ListGroupsWithMembersRequest(
             groups_filters=[lambda g: g.get("email", "").startswith("team-")],
             include_users_details=False,
@@ -924,9 +824,7 @@ class TestDirectoryClientAdvancedFeatures:
         assert len(result.data) == 2
         assert all(g["email"].startswith("team-") for g in result.data)
 
-    def test_list_groups_with_members_with_member_filters(
-        self, mock_session_provider: Mock
-    ):
+    def test_list_groups_with_members_with_member_filters(self, mock_session_provider: Mock):
         """Test list_groups_with_members with member filters."""
 
         mock_service = Mock()
@@ -974,9 +872,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         # Filter for groups that have at least one OWNER
         request = ListGroupsWithMembersRequest(
             member_filters=[lambda m: m.get("role") == "OWNER"],
@@ -1028,12 +924,8 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        request = ListGroupsWithMembersRequest(
-            exclude_empty_groups=True, include_users_details=False
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        request = ListGroupsWithMembersRequest(exclude_empty_groups=True, include_users_details=False)
         result = client.list_groups_with_members(request)
 
         assert result.is_success
@@ -1041,9 +933,7 @@ class TestDirectoryClientAdvancedFeatures:
         assert len(result.data) == 1
         assert result.data[0]["email"] == "group1@example.com"
 
-    def test_list_groups_with_members_with_user_details(
-        self, mock_session_provider: Mock
-    ):
+    def test_list_groups_with_members_with_user_details(self, mock_session_provider: Mock):
         """Test list_groups_with_members with user details enrichment."""
 
         mock_service = Mock()
@@ -1112,9 +1002,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         request = ListGroupsWithMembersRequest(include_users_details=True)
         result = client.list_groups_with_members(request)
 
@@ -1129,9 +1017,7 @@ class TestDirectoryClientAdvancedFeatures:
         assert "user" in group["members"][1]
         assert group["members"][1]["user"]["name"]["fullName"] == "User Two"
 
-    def test_list_groups_with_members_no_matching_groups(
-        self, mock_session_provider: Mock
-    ):
+    def test_list_groups_with_members_no_matching_groups(self, mock_session_provider: Mock):
         """Test list_groups_with_members when filters return no groups."""
 
         mock_service = Mock()
@@ -1147,9 +1033,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
 
         # Filter that excludes all groups
         request = ListGroupsWithMembersRequest(
@@ -1186,9 +1070,7 @@ class TestDirectoryClientAdvancedFeatures:
 
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         request = ListGroupsWithMembersRequest(include_users_details=False)
         result = client.list_groups_with_members(request)
 
@@ -1210,9 +1092,7 @@ class TestDirectoryClientBatchOperationEdgeCases:
         mock_service.users().get.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_batch_users(["user1@example.com", "user2@example.com"])
 
         # Batch failure should propagate as error
@@ -1229,18 +1109,14 @@ class TestDirectoryClientBatchOperationEdgeCases:
         mock_service.groups().get.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
         result = client.get_batch_groups(["group1@example.com", "group2@example.com"])
 
         # Batch failure should propagate as error
         assert not result.is_success
         assert result.error_code == "GOOGLE_API_ERROR"
 
-    def test_get_batch_members_for_user_with_batch_failure(
-        self, mock_session_provider: Mock
-    ):
+    def test_get_batch_members_for_user_with_batch_failure(self, mock_session_provider: Mock):
         """Test get_batch_members_for_user propagates batch execution failure as error."""
         mock_service = Mock()
         mock_batch = Mock()
@@ -1250,20 +1126,14 @@ class TestDirectoryClientBatchOperationEdgeCases:
         mock_service.members().get.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_batch_members_for_user(
-            ["group1@example.com", "group2@example.com"], "user@example.com"
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_batch_members_for_user(["group1@example.com", "group2@example.com"], "user@example.com")
 
         # Batch failure should propagate as error
         assert not result.is_success
         assert result.error_code == "GOOGLE_API_ERROR"
 
-    def test_get_batch_group_members_with_batch_failure(
-        self, mock_session_provider: Mock
-    ):
+    def test_get_batch_group_members_with_batch_failure(self, mock_session_provider: Mock):
         """Test get_batch_group_members propagates batch execution failure as error."""
         mock_service = Mock()
         mock_batch = Mock()
@@ -1273,20 +1143,14 @@ class TestDirectoryClientBatchOperationEdgeCases:
         mock_service.members().list.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_batch_group_members(
-            ["group1@example.com", "group2@example.com"]
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_batch_group_members(["group1@example.com", "group2@example.com"])
 
         # Batch failure should propagate as error
         assert not result.is_success
         assert result.error_code == "GOOGLE_API_ERROR"
 
-    def test_get_batch_group_members_handles_various_result_types(
-        self, mock_session_provider: Mock
-    ):
+    def test_get_batch_group_members_handles_various_result_types(self, mock_session_provider: Mock):
         """Test get_batch_group_members handles dict, None, and other result types."""
         mock_service = Mock()
         mock_batch = Mock()
@@ -1317,12 +1181,8 @@ class TestDirectoryClientBatchOperationEdgeCases:
         mock_service.members().list.return_value = Mock()
         mock_session_provider.get_service.return_value = mock_service
 
-        client = DirectoryClient(
-            session_provider=mock_session_provider, default_customer_id="my_customer"
-        )
-        result = client.get_batch_group_members(
-            ["group1@example.com", "group2@example.com", "group3@example.com"]
-        )
+        client = DirectoryClient(session_provider=mock_session_provider, default_customer_id="my_customer")
+        result = client.get_batch_group_members(["group1@example.com", "group2@example.com", "group3@example.com"])
 
         assert result.is_success
         assert result.data is not None

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_docs.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_docs.py
@@ -149,9 +149,7 @@ class TestDocumentOperations:
         requests = [{"insertText": {"location": {"index": 1}, "text": "Test"}}]
 
         # Execute
-        result = client.batch_update(
-            "doc789", requests, delegated_email="service@example.com"
-        )
+        result = client.batch_update("doc789", requests, delegated_email="service@example.com")
 
         # Assert
         assert result.is_success
@@ -219,9 +217,7 @@ class TestErrorHandling:
 
         # Simulate API error by having execute() raise an exception
 
-        mock_service.documents().get().execute.side_effect = HttpError(
-            resp=MagicMock(status=404), content=b"Not found"
-        )
+        mock_service.documents().get().execute.side_effect = HttpError(resp=MagicMock(status=404), content=b"Not found")
 
         # Execute
         result = client.get_document("nonexistent_doc")

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_drive.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_drive.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from infrastructure.clients.google_workspace.drive import DriveClient, MIME_TYPES
+from infrastructure.clients.google_workspace.drive import MIME_TYPES, DriveClient
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
 
@@ -35,9 +35,7 @@ class TestMetadataOperations:
         }
 
         # Act
-        result = drive_client.add_metadata(
-            file_id="file123", key="incident_id", value="INC-001"
-        )
+        result = drive_client.add_metadata(file_id="file123", key="incident_id", value="INC-001")
 
         # Assert
         assert result.is_success
@@ -46,9 +44,7 @@ class TestMetadataOperations:
         # Verify update was called with correct parameters
         assert mock_service.files().update.called
 
-    def test_add_metadata_with_delegation(
-        self, drive_client, mock_session_provider, mock_service
-    ):
+    def test_add_metadata_with_delegation(self, drive_client, mock_session_provider, mock_service):
         """Test adding metadata with delegated authentication."""
         # Arrange
         mock_service.files().update().execute.return_value = {"id": "file123"}
@@ -114,9 +110,7 @@ class TestFolderOperations:
         }
 
         # Act
-        result = drive_client.create_folder(
-            name="Incidents 2026", parent_folder_id="parent123"
-        )
+        result = drive_client.create_folder(name="Incidents 2026", parent_folder_id="parent123")
 
         # Assert
         assert result.is_success
@@ -148,14 +142,10 @@ class TestFolderOperations:
     def test_list_folders_with_query(self, drive_client, mock_service):
         """Test listing folders with additional query filter."""
         # Arrange
-        mock_service.files().list().execute.return_value = {
-            "files": [{"id": "folder1", "name": "Active Folder"}]
-        }
+        mock_service.files().list().execute.return_value = {"files": [{"id": "folder1", "name": "Active Folder"}]}
 
         # Act
-        result = drive_client.list_folders_in_folder(
-            folder_id="parent123", query="name contains 'Active'"
-        )
+        result = drive_client.list_folders_in_folder(folder_id="parent123", query="name contains 'Active'")
 
         # Assert
         assert result.is_success
@@ -257,14 +247,10 @@ class TestFileOperations:
     def test_find_files_by_name_in_folder(self, drive_client, mock_service):
         """Test finding files by name within a specific folder."""
         # Arrange
-        mock_service.files().list().execute.return_value = {
-            "files": [{"id": "file1", "name": "incident.doc"}]
-        }
+        mock_service.files().list().execute.return_value = {"files": [{"id": "file1", "name": "incident.doc"}]}
 
         # Act
-        result = drive_client.find_files_by_name(
-            name="incident.doc", folder_id="folder123"
-        )
+        result = drive_client.find_files_by_name(name="incident.doc", folder_id="folder123")
 
         # Assert
         assert result.is_success
@@ -315,9 +301,7 @@ class TestFileOperations:
             ("form", MIME_TYPES["form"]),
         ],
     )
-    def test_create_file_types(
-        self, drive_client, mock_service, file_type, expected_mime
-    ):
+    def test_create_file_types(self, drive_client, mock_service, file_type, expected_mime):
         """Test creating different file types."""
         # Arrange
         mock_service.files().create().execute.return_value = {"id": "file123"}

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_executor.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_executor.py
@@ -64,9 +64,7 @@ class TestExecuteGoogleApiCall:
 
     def test_successful_call_with_operation_result(self, make_mock_request):
         """Test API call that returns OperationResult is propagated."""
-        inner_result = OperationResult.success(
-            data={"id": "456"}, message="Inner success"
-        )
+        inner_result = OperationResult.success(data={"id": "456"}, message="Inner success")
         api_callable = make_mock_request(return_value=inner_result).execute
 
         result = execute_google_api_call("test_operation", api_callable)
@@ -75,9 +73,7 @@ class TestExecuteGoogleApiCall:
         assert result.data == {"id": "456"}
         assert result.message == "Inner success"
 
-    def test_retryable_error_succeeds_on_retry(
-        self, make_mock_request, mock_google_api_error
-    ):
+    def test_retryable_error_succeeds_on_retry(self, make_mock_request, mock_google_api_error):
         """Test that retryable errors are retried and eventually succeed."""
         error = mock_google_api_error(status=500, reason="Internal Server Error")
         success_data = {"id": "789"}
@@ -91,26 +87,20 @@ class TestExecuteGoogleApiCall:
         assert result.is_success
         assert result.data == success_data
 
-    def test_rate_limit_error_uses_correct_delay(
-        self, make_mock_request, mock_google_api_error
-    ):
+    def test_rate_limit_error_uses_correct_delay(self, make_mock_request, mock_google_api_error):
         """Test that rate limit errors use the configured delay."""
         error = mock_google_api_error(status=429, reason="Rate Limit Exceeded")
         success_data = {"id": "101"}
 
         api_callable = make_mock_request(side_effect=[error, success_data]).execute
 
-        with patch(
-            "infrastructure.clients.google_workspace.executor.time.sleep"
-        ) as mock_sleep:
+        with patch("infrastructure.clients.google_workspace.executor.time.sleep") as mock_sleep:
             result = execute_google_api_call("test_operation", api_callable)
 
         assert result.is_success
         mock_sleep.assert_called_once_with(60.0)
 
-    def test_non_retryable_error_fails_immediately(
-        self, make_mock_request, mock_google_api_error
-    ):
+    def test_non_retryable_error_fails_immediately(self, make_mock_request, mock_google_api_error):
         """Test that non-retryable errors fail without retry."""
         error = mock_google_api_error(status=404, reason="Not Found")
         api_callable = make_mock_request(raise_error=error).execute
@@ -127,9 +117,7 @@ class TestExecuteGoogleApiCall:
         api_callable = make_mock_request(raise_error=error).execute
 
         with patch("infrastructure.clients.google_workspace.executor.time.sleep"):
-            result = execute_google_api_call(
-                "test_operation", api_callable, max_retries=2
-            )
+            result = execute_google_api_call("test_operation", api_callable, max_retries=2)
 
         assert not result.is_success
         assert result.error_code == "GOOGLE_API_ERROR_500"
@@ -141,14 +129,10 @@ class TestExecuteGoogleApiCall:
         success_data = {"id": "202"}
 
         # Fail 4 times, succeed on 5th (max_retries=4 means 5 total attempts)
-        api_callable = make_mock_request(
-            side_effect=[error, error, error, error, success_data]
-        ).execute
+        api_callable = make_mock_request(side_effect=[error, error, error, error, success_data]).execute
 
         with patch("infrastructure.clients.google_workspace.executor.time.sleep"):
-            result = execute_google_api_call(
-                "test_operation", api_callable, max_retries=4
-            )
+            result = execute_google_api_call("test_operation", api_callable, max_retries=4)
 
         assert result.is_success
         assert result.data == success_data
@@ -159,15 +143,11 @@ class TestExecuteGoogleApiCall:
         success_data = {"id": "303"}
 
         for status_code in retryable_codes:
-            error = mock_google_api_error(
-                status=status_code, reason=f"Error {status_code}"
-            )
+            error = mock_google_api_error(status=status_code, reason=f"Error {status_code}")
             api_callable = make_mock_request(side_effect=[error, success_data]).execute
 
             with patch("infrastructure.clients.google_workspace.executor.time.sleep"):
-                result = execute_google_api_call(
-                    f"test_operation_{status_code}", api_callable
-                )
+                result = execute_google_api_call(f"test_operation_{status_code}", api_callable)
 
             assert result.is_success, f"Status code {status_code} should be retryable"
 
@@ -182,21 +162,15 @@ class TestExecuteGoogleApiCall:
         assert result.error_code == "GOOGLE_API_ERROR"
         assert "Invalid parameter" in result.message
 
-    def test_exponential_backoff_progression(
-        self, make_mock_request, mock_google_api_error
-    ):
+    def test_exponential_backoff_progression(self, make_mock_request, mock_google_api_error):
         """Test that exponential backoff increases correctly across retries."""
         error = mock_google_api_error(status=502, reason="Bad Gateway")
         success_data = {"id": "404"}
 
         # Fail 3 times, succeed on 4th
-        api_callable = make_mock_request(
-            side_effect=[error, error, error, success_data]
-        ).execute
+        api_callable = make_mock_request(side_effect=[error, error, error, success_data]).execute
 
-        with patch(
-            "infrastructure.clients.google_workspace.executor.time.sleep"
-        ) as mock_sleep:
+        with patch("infrastructure.clients.google_workspace.executor.time.sleep") as mock_sleep:
             result = execute_google_api_call("test_operation", api_callable)
 
         assert result.is_success

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_facade.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_facade.py
@@ -13,9 +13,7 @@ class TestGoogleWorkspaceClients:
     """Test suite for GoogleWorkspaceClients facade."""
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_initialization(
-        self, mock_session_provider_class, mock_google_workspace_settings
-    ):
+    def test_initialization(self, mock_session_provider_class, mock_google_workspace_settings):
         """Test facade initialization with settings."""
         mock_provider_instance = Mock(spec=SessionProvider)
         mock_session_provider_class.return_value = mock_provider_instance
@@ -33,9 +31,7 @@ class TestGoogleWorkspaceClients:
         assert facade._session_provider == mock_provider_instance
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_session_provider_attribute(
-        self, mock_session_provider_class, mock_google_workspace_settings
-    ):
+    def test_session_provider_attribute(self, mock_session_provider_class, mock_google_workspace_settings):
         """Test that session provider is accessible."""
         mock_provider_instance = Mock(spec=SessionProvider)
         mock_session_provider_class.return_value = mock_provider_instance
@@ -46,9 +42,7 @@ class TestGoogleWorkspaceClients:
         assert isinstance(facade._session_provider, (SessionProvider, Mock))
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_multiple_instances_get_own_session_provider(
-        self, mock_session_provider_class, mock_google_workspace_settings
-    ):
+    def test_multiple_instances_get_own_session_provider(self, mock_session_provider_class, mock_google_workspace_settings):
         """Test that each facade instance gets its own session provider."""
         mock_provider_instance_1 = Mock(spec=SessionProvider)
         mock_provider_instance_2 = Mock(spec=SessionProvider)
@@ -86,9 +80,7 @@ class TestGoogleWorkspaceClients:
         )
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_blank_customer_id_falls_back_to_my_customer(
-        self, mock_session_provider_class, google_credentials_json
-    ):
+    def test_blank_customer_id_falls_back_to_my_customer(self, mock_session_provider_class, google_credentials_json):
         """Test blank customer settings still produce a stable default on the client."""
         mock_provider_instance = Mock(spec=SessionProvider)
         mock_session_provider_class.return_value = mock_provider_instance
@@ -103,9 +95,7 @@ class TestGoogleWorkspaceClients:
         assert facade.directory._default_customer_id == "my_customer"
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_logger_binding(
-        self, mock_session_provider_class, mock_google_workspace_settings
-    ):
+    def test_logger_binding(self, mock_session_provider_class, mock_google_workspace_settings):
         """Test that logger is properly bound with component name."""
         mock_provider_instance = Mock(spec=SessionProvider)
         mock_session_provider_class.return_value = mock_provider_instance
@@ -117,9 +107,7 @@ class TestGoogleWorkspaceClients:
         assert facade._logger is not None
 
     @patch("infrastructure.clients.google_workspace.facade.SessionProvider")
-    def test_client_attributes_exist(
-        self, mock_session_provider_class, mock_google_workspace_settings
-    ):
+    def test_client_attributes_exist(self, mock_session_provider_class, mock_google_workspace_settings):
         """Test that all client attributes are properly initialized."""
         mock_provider_instance = Mock(spec=SessionProvider)
         mock_session_provider_class.return_value = mock_provider_instance

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_gmail.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_gmail.py
@@ -354,10 +354,7 @@ class TestUtilityFunctions:
         assert isinstance(encoded, str)
         assert len(encoded) > 0
         # Base64 encoded strings should only contain these characters
-        assert all(
-            c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="
-            for c in encoded
-        )
+        assert all(c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=" for c in encoded)
 
     def test_create_mime_message_html(self):
         """Test creating HTML MIME message."""
@@ -383,9 +380,7 @@ class TestErrorHandling:
         mock_service = mock_session_provider.get_service.return_value
 
         # Simulate API error
-        mock_service.users().messages().get().execute.side_effect = HttpError(
-            resp=MagicMock(status=404), content=b"Not found"
-        )
+        mock_service.users().messages().get().execute.side_effect = HttpError(resp=MagicMock(status=404), content=b"Not found")
 
         # Execute
         result = client.get_message("nonexistent_msg")

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_session_provider.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_session_provider.py
@@ -44,9 +44,7 @@ class TestSessionProvider:
     ):
         """Test basic service creation without delegation or scopes."""
         mock_creds = Mock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         provider = SessionProvider(credentials_json=google_credentials_json)
@@ -54,9 +52,7 @@ class TestSessionProvider:
 
         # Verify credentials were loaded
         mock_service_account.Credentials.from_service_account_info.assert_called_once()
-        creds_dict = (
-            mock_service_account.Credentials.from_service_account_info.call_args[0][0]
-        )
+        creds_dict = mock_service_account.Credentials.from_service_account_info.call_args[0][0]
         assert creds_dict["client_email"] == "test@test-project.iam.gserviceaccount.com"
 
         # Verify service was built
@@ -82,16 +78,12 @@ class TestSessionProvider:
         mock_creds = Mock()
         mock_delegated_creds = Mock()
         mock_creds.with_subject.return_value = mock_delegated_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         delegated_email = "admin@example.com"
         provider = SessionProvider(credentials_json=google_credentials_json)
-        provider.get_service(
-            "admin", "directory_v1", delegated_user_email=delegated_email
-        )
+        provider.get_service("admin", "directory_v1", delegated_user_email=delegated_email)
 
         # Verify delegation was applied
         mock_creds.with_subject.assert_called_once_with(delegated_email)
@@ -116,9 +108,7 @@ class TestSessionProvider:
         mock_creds = Mock()
         mock_delegated_creds = Mock()
         mock_creds.with_subject.return_value = mock_delegated_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         default_email = "sre-bot@example.com"
@@ -144,9 +134,7 @@ class TestSessionProvider:
         mock_creds = Mock()
         mock_scoped_creds = Mock()
         mock_creds.with_scopes.return_value = mock_scoped_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         scopes = ["https://www.googleapis.com/auth/admin.directory.user"]
@@ -176,15 +164,11 @@ class TestSessionProvider:
         mock_creds = Mock()
         mock_scoped_creds = Mock()
         mock_creds.with_scopes.return_value = mock_scoped_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         default_scopes = ["https://www.googleapis.com/auth/admin.directory.user"]
-        provider = SessionProvider(
-            credentials_json=google_credentials_json, default_scopes=default_scopes
-        )
+        provider = SessionProvider(credentials_json=google_credentials_json, default_scopes=default_scopes)
         provider.get_service("admin", "directory_v1")
 
         # Verify default scopes were used
@@ -203,17 +187,13 @@ class TestSessionProvider:
         mock_creds = Mock()
         mock_scoped_creds = Mock()
         mock_creds.with_scopes.return_value = mock_scoped_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         default_scopes = ["https://www.googleapis.com/auth/admin.directory.user"]
         override_scopes = ["https://www.googleapis.com/auth/admin.directory.group"]
 
-        provider = SessionProvider(
-            credentials_json=google_credentials_json, default_scopes=default_scopes
-        )
+        provider = SessionProvider(credentials_json=google_credentials_json, default_scopes=default_scopes)
         provider.get_service("admin", "directory_v1", scopes=override_scopes)
 
         # Verify override scopes were used, not defaults
@@ -241,18 +221,14 @@ class TestSessionProvider:
         mock_scoped_creds = Mock()
         mock_creds.with_subject.return_value = mock_delegated_creds
         mock_delegated_creds.with_scopes.return_value = mock_scoped_creds
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_creds
-        )
+        mock_service_account.Credentials.from_service_account_info.return_value = mock_creds
         mock_build.return_value = mock_google_service
 
         delegated_email = "admin@example.com"
         scopes = ["https://www.googleapis.com/auth/admin.directory.user"]
 
         provider = SessionProvider(credentials_json=google_credentials_json)
-        provider.get_service(
-            "admin", "directory_v1", scopes=scopes, delegated_user_email=delegated_email
-        )
+        provider.get_service("admin", "directory_v1", scopes=scopes, delegated_user_email=delegated_email)
 
         # Verify both delegation and scopes were applied in correct order
         mock_creds.with_subject.assert_called_once_with(delegated_email)

--- a/app/tests/unit/infrastructure/clients/google_workspace/test_sheets.py
+++ b/app/tests/unit/infrastructure/clients/google_workspace/test_sheets.py
@@ -55,9 +55,7 @@ class TestSpreadsheetOperations:
         }
 
         # Act
-        result = sheets_client.get_spreadsheet(
-            spreadsheet_id="sheet123", ranges=["Sheet1!A1:B10", "Sheet2!C1:D5"]
-        )
+        result = sheets_client.get_spreadsheet(spreadsheet_id="sheet123", ranges=["Sheet1!A1:B10", "Sheet2!C1:D5"])
 
         # Assert
         assert result.is_success
@@ -67,15 +65,11 @@ class TestSpreadsheetOperations:
         # Arrange
         mock_service.spreadsheets().get().execute.return_value = {
             "spreadsheetId": "sheet123",
-            "sheets": [
-                {"data": [{"rowData": [{"values": [{"formattedValue": "Test"}]}]}]}
-            ],
+            "sheets": [{"data": [{"rowData": [{"values": [{"formattedValue": "Test"}]}]}]}],
         }
 
         # Act
-        result = sheets_client.get_spreadsheet(
-            spreadsheet_id="sheet123", include_grid_data=True
-        )
+        result = sheets_client.get_spreadsheet(spreadsheet_id="sheet123", include_grid_data=True)
 
         # Assert
         assert result.is_success
@@ -134,9 +128,7 @@ class TestSpreadsheetOperations:
         ]
 
         # Act
-        result = sheets_client.batch_update_spreadsheet(
-            spreadsheet_id="sheet123", requests=requests
-        )
+        result = sheets_client.batch_update_spreadsheet(spreadsheet_id="sheet123", requests=requests)
 
         # Assert
         assert result.is_success
@@ -155,9 +147,7 @@ class TestValuesOperations:
         }
 
         # Act
-        result = sheets_client.get_values(
-            spreadsheet_id="sheet123", cell_range="Sheet1!A1:B2"
-        )
+        result = sheets_client.get_values(spreadsheet_id="sheet123", cell_range="Sheet1!A1:B2")
 
         # Assert
         assert result.is_success
@@ -173,9 +163,7 @@ class TestValuesOperations:
         }
 
         # Act
-        result = sheets_client.get_values(
-            spreadsheet_id="sheet123", cell_range="Sheet1!A1:B2"
-        )
+        result = sheets_client.get_values(spreadsheet_id="sheet123", cell_range="Sheet1!A1:B2")
 
         # Assert
         assert result.is_success
@@ -294,9 +282,7 @@ class TestValuesOperations:
         }
 
         # Act
-        result = sheets_client.clear_values(
-            spreadsheet_id="sheet123", cell_range="Sheet1!A1:B10"
-        )
+        result = sheets_client.clear_values(spreadsheet_id="sheet123", cell_range="Sheet1!A1:B10")
 
         # Assert
         assert result.is_success
@@ -306,14 +292,10 @@ class TestValuesOperations:
 class TestDelegation:
     """Test delegated authentication."""
 
-    def test_get_values_with_delegation(
-        self, sheets_client, mock_session_provider, mock_service
-    ):
+    def test_get_values_with_delegation(self, sheets_client, mock_session_provider, mock_service):
         """Test getting values with delegated authentication."""
         # Arrange
-        mock_service.spreadsheets().values().get().execute.return_value = {
-            "values": [[]]
-        }
+        mock_service.spreadsheets().values().get().execute.return_value = {"values": [[]]}
 
         # Act
         result = sheets_client.get_values(

--- a/app/tests/unit/infrastructure/clients/test_maxmind.py
+++ b/app/tests/unit/infrastructure/clients/test_maxmind.py
@@ -1,10 +1,11 @@
 """Unit tests for MaxMind infrastructure client."""
 
+from unittest.mock import MagicMock, Mock
+
 import pytest
-from unittest.mock import Mock, MagicMock
 from geoip2.errors import AddressNotFoundError, GeoIP2Error
 
-from infrastructure.clients.maxmind import MaxMindClient, GeoLocationData
+from infrastructure.clients.maxmind import GeoLocationData, MaxMindClient
 from infrastructure.operations import OperationStatus
 
 

--- a/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
+++ b/backlog/tasks/task-15.1 - Ruff-migration-01-scaffold-parallel-black-ruff-CI-migrate-app-api.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-15.1
 title: 'Ruff migration 01: scaffold parallel black/ruff CI + migrate app/api'
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-23 14:11'
-updated_date: '2026-07-23 15:41'
+updated_date: '2026-07-23 16:34'
 labels: []
 dependencies:
   - TASK-15
@@ -84,14 +84,14 @@ Notes:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Parallel CI is green: black --check . (legacy scope, migrated paths force-excluded) passes AND ruff format --check plus ruff check --select=E,F,W,I,B,UP,C4,SIM,S over RUFF_SCOPE (api tests/api) pass
-- [ ] #2 app/api and app/tests/api are byte-identical to feat/dev_env_setup_ruff: git diff feat/dev_env_setup_ruff -- app/api app/tests/api is empty
-- [ ] #3 pyproject gains [tool.black] force-exclude + tests per-file-ignores; global ruff select stays [E,F,W]; black still present in dev deps; Makefile has RUFF_SCOPE and dual black+ruff fmt-ci/lint-ci
+- [x] #1 Parallel CI is green: black --check . (legacy scope, migrated paths force-excluded) passes AND ruff format --check plus ruff check --select=E,F,W,I,B,UP,C4,SIM,S over RUFF_SCOPE (api tests/api) pass
+- [x] #2 app/api and app/tests/api are byte-identical to feat/dev_env_setup_ruff: git diff feat/dev_env_setup_ruff -- app/api app/tests/api is empty
+- [x] #3 pyproject gains [tool.black] force-exclude + tests per-file-ignores; global ruff select stays [E,F,W]; black still present in dev deps; Makefile has RUFF_SCOPE and dual black+ruff fmt-ci/lint-ci
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+- [x] #1 make test passes; PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
+++ b/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
@@ -71,3 +71,15 @@ AC-to-step traceability:
 - AC#2 (RUFF_SCOPE + force-exclude updated; make lint-ci && make fmt-ci pass) <- steps 2, 3, verified by step 4.
 - DoD#1 (make test passes; PR references decisions/toolchain.md + TASK-15) <- step 4 (test run) + PR description (human/PR action).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented per plan (mirrors TASK-15.1 recipe):
+1. git checkout feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients (49 files, no adds/deletes). git diff feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients is empty (AC#1 verified).
+2. app/pyproject.toml [tool.black] force-exclude: added "infrastructure/clients" and "tests/unit/infrastructure/clients" alternatives.
+3. app/Makefile: RUFF_SCOPE extended to "api tests/api infrastructure/clients tests/unit/infrastructure/clients".
+4. Root-cause fix (not in original recipe, required for AC#2): the scoped ruff invocations in `lint` and `lint-ci` used `--select=E,F,W,I,B,UP,C4,SIM,S`, which caused CLI --select to override pyproject's `ignore = ["E501"]`, producing 5 false-positive E501 (line too long) failures on migrated docstrings that are otherwise correctly ruff-formatted. Switched both occurrences to `--extend-select=I,B,UP,C4,SIM,S` (base select E,F,W + ignore E501 come from pyproject config as intended, CLI only extends with the additional migration categories). Verified equivalent rule coverage; no other files affected.
+5. Validation: make lint-ci -> both ruff checks "All checks passed!" (mypy remains soft-failing via existing "|| true", same pre-existing unrelated errors as TASK-15.1, not a regression). make fmt-ci -> black 596 files unchanged, ruff format 66 files already formatted. uv run pytest tests/unit/infrastructure/clients -> 226 passed, 37 skipped. make test -> run by user directly, confirmed green (exit 0).
+DoD#1 (make test) verified by user directly, as requested. PR should reference decisions/toolchain.md and TASK-15.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
+++ b/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
@@ -44,5 +44,5 @@ Expected size: ~49 files. No hand-edits to migrated source -- content must equal
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+- [ ] #1 make test passes (prompt user to perform the tests); PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->

--- a/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
+++ b/backlog/tasks/task-15.2 - Ruff-migration-02-infrastructure-clients.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15.2
 title: 'Ruff migration 02: infrastructure/clients'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-23 14:16'
+updated_date: '2026-07-23 16:46'
 labels: []
 dependencies:
   - TASK-15.1
@@ -38,11 +40,34 @@ Expected size: ~49 files. No hand-edits to migrated source -- content must equal
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 git diff feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients is empty
-- [ ] #2 RUFF_SCOPE and [tool.black] force-exclude both include infrastructure/clients and tests/unit/infrastructure/clients; make lint-ci && make fmt-ci pass
+- [x] #1 git diff feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients is empty
+- [x] #2 RUFF_SCOPE and [tool.black] force-exclude both include infrastructure/clients and tests/unit/infrastructure/clients; make lint-ci && make fmt-ci pass
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 make test passes (prompt user to perform the tests); PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pull migrated content from reference branch (never hand-edit migrated source):
+   git checkout feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients
+   Verified against current main: 49 tracked files under these paths change content (git diff --stat main feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients -> 49 files changed, 612 insertions(+), 1359 deletions(-)); no files added or deleted (git diff --diff-filter=A/D empty).
+2. Edit app/pyproject.toml [tool.black] force-exclude block: add two alternatives inside the /( ... )/ group:
+     | infrastructure/clients
+     | tests/unit/infrastructure/clients
+   Leave [tool.ruff.lint] select = ["E","F","W"] and everything else unchanged (same as TASK-15.1).
+3. Edit app/Makefile: append to RUFF_SCOPE:
+     RUFF_SCOPE := api tests/api infrastructure/clients tests/unit/infrastructure/clients
+   Do not touch fmt/lint/fmt-ci/lint-ci target bodies (they already reference $(RUFF_SCOPE) generically per TASK-15.1 scaffolding).
+4. Validate from app/: make lint-ci && make fmt-ci && uv run pytest tests/unit/infrastructure/clients && make test.
+5. Confirm git diff feat/dev_env_setup_ruff -- app/infrastructure/clients app/tests/unit/infrastructure/clients is empty (AC#1).
+6. Ship one mechanical PR; reference decisions/toolchain.md and TASK-15.
+
+AC-to-step traceability:
+- AC#1 (byte-identical to reference branch) <- step 1, verified by step 5.
+- AC#2 (RUFF_SCOPE + force-exclude updated; make lint-ci && make fmt-ci pass) <- steps 2, 3, verified by step 4.
+- DoD#1 (make test passes; PR references decisions/toolchain.md + TASK-15) <- step 4 (test run) + PR description (human/PR action).
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request modernizes and standardizes type annotations across several AWS client modules, replacing legacy `typing` types with Python 3.9+ built-in generics, and cleans up related imports. It also updates the `Makefile` to expand the linting scope and refines linting options for better code quality enforcement.

**Type Annotations Modernization:**

* Replaced `Optional`, `Dict`, and `List` from `typing` with built-in generics like `dict`, `list`, and the `| None` syntax throughout AWS client modules (`dynamodb.py`, `config.py`, `cost_explorer.py`, `executor.py`) for improved readability and consistency. [[1]](diffhunk://#diff-87a2a07ea57ca453273c6c407bda053c8e9ef815f1337572594e6268655b06a1L6-R6) [[2]](diffhunk://#diff-87a2a07ea57ca453273c6c407bda053c8e9ef815f1337572594e6268655b06a1L23-R38) [[3]](diffhunk://#diff-4dd05da864a374329e1cbb1a377887dd6efc10c5ff4b41efcf0648eea3f2d305L6-L14) [[4]](diffhunk://#diff-4dd05da864a374329e1cbb1a377887dd6efc10c5ff4b41efcf0648eea3f2d305L28-R39) [[5]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL7-R7) [[6]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL31-R31) [[7]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL41-R42) [[8]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL72-R71) [[9]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL103-R100) [[10]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL134-R129) [[11]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL166-R158) [[12]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL196-R186) [[13]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL221-R209) [[14]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL9-L14) [[15]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL24-R27) [[16]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL89-R92) [[17]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL101-R102) [[18]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL138-R141) [[19]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL158-R159) [[20]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL169-R175) [[21]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL217-R218)

* Cleaned up unused or redundant imports related to type annotations in the affected files. [[1]](diffhunk://#diff-87a2a07ea57ca453273c6c407bda053c8e9ef815f1337572594e6268655b06a1L6-R6) [[2]](diffhunk://#diff-4dd05da864a374329e1cbb1a377887dd6efc10c5ff4b41efcf0648eea3f2d305L6-L14) [[3]](diffhunk://#diff-2d5ee2fd437736d9b85119d14de1582627ca5eaa5c118e05e0d3c3988722b6eaL7-R7) [[4]](diffhunk://#diff-d5e4079bb40346b93dac61d450d447f9affa0eddde40e5aaa05770cc596545ddL9-L14)

**Makefile Linting Improvements:**

* Expanded the `RUFF_SCOPE` variable in the `Makefile` to include `infrastructure/clients` and related test directories, ensuring more comprehensive linting coverage.

* Updated `lint` and `lint-ci` targets to use `--extend-select` instead of `--select` for Ruff, refining which linting rules are enforced. [[1]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451L28-R28) [[2]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451L84-R84)

These changes improve code consistency, modernize the codebase for newer Python versions, and strengthen code quality checks.