### PR TITLE
Feat/dev env setup ruff 10

### DIFF
--- a/.github/workflows/scripts/run_bandit_scan.sh
+++ b/.github/workflows/scripts/run_bandit_scan.sh
@@ -20,7 +20,7 @@ docker pull cytopia/bandit:latest
 # avoid false AST-parse failures without losing security coverage. Keep this
 # list in sync with RUFF_SCOPE as later TASK-15.x slices land; the whole
 # workflow is deleted once the migration completes (TASK-15.12).
-RUFF_MIGRATED_PATHS="/data/app/api,/data/app/tests/api,/data/app/infrastructure,/data/app/tests/unit/infrastructure,/data/app/integrations,/data/app/tests/integrations,/data/app/tests/unit/integrations,/data/app/modules,/data/app/tests/modules,/data/app/tests/unit/modules,/data/app/utils,/data/app/models,/data/app/jobs,/data/app/bin,/data/app/server,/data/app/tests/unit/jobs,/data/app/tests/unit/server,/data/app/tests/unit/models"
+RUFF_MIGRATED_PATHS="/data/app/api,/data/app/tests/api,/data/app/infrastructure,/data/app/tests/unit/infrastructure,/data/app/integrations,/data/app/tests/integrations,/data/app/tests/unit/integrations,/data/app/modules,/data/app/tests/modules,/data/app/tests/unit/modules,/data/app/utils,/data/app/models,/data/app/jobs,/data/app/bin,/data/app/server,/data/app/tests/unit/jobs,/data/app/tests/unit/server,/data/app/tests/unit/models,/data/app/packages/access,/data/app/tests/unit/packages/access"
 
 # Scan source code and only report on high severity issues
 docker run --rm -v "${REPO_ROOT}":/data cytopia/bandit \

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev dev-setup fmt install lint test test-unit test-integration test-legacy test-all fmt-ci lint-ci install-dev run test-coverage test-coverage-unit backlog-board check-prefix-guardrail audit-client-usage-matrix
 
-RUFF_SCOPE := api tests/api infrastructure tests/unit/infrastructure integrations tests/integrations tests/unit/integrations modules tests/modules tests/unit/modules utils models jobs bin server tests/unit/jobs tests/unit/server tests/unit/models
+RUFF_SCOPE := api tests/api infrastructure tests/unit/infrastructure integrations tests/integrations tests/unit/integrations modules tests/modules tests/unit/modules utils models jobs bin server tests/unit/jobs tests/unit/server tests/unit/models packages/access tests/unit/packages/access
 
 dev:
 	PREFIX="dev-" SLACK__COMMAND_PREFIX="dev-" uv run uvicorn main:server_app --reload

--- a/app/packages/access/catalog/__init__.py
+++ b/app/packages/access/catalog/__init__.py
@@ -6,12 +6,12 @@ interaction support is deferred to the next iteration.
 """
 
 from infrastructure.plugins import hookimpl
-from packages.access.common.providers import get_access_runtime_config
+from packages.access.catalog.interactions.http import router as access_catalog_router
 from packages.access.catalog.providers import (
     get_catalog_service,
     get_catalog_settings,
 )
-from packages.access.catalog.interactions.http import router as access_catalog_router
+from packages.access.common.providers import get_access_runtime_config
 
 
 @hookimpl

--- a/app/packages/access/catalog/domain.py
+++ b/app/packages/access/catalog/domain.py
@@ -6,7 +6,7 @@ owns the HTTP-boundary Pydantic models.
 """
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -23,10 +23,10 @@ class ParsedEntitlementToken:
 
     raw: str
     product: str = ""
-    env: Optional[str] = None
+    env: str | None = None
     role: str = ""
-    service: Optional[str] = None
-    resource: Optional[str] = None
+    service: str | None = None
+    resource: str | None = None
     parsed: bool = False
 
 
@@ -37,7 +37,7 @@ class PlatformSummary:
     key: str
     display_name: str
     authn_group_slug: str
-    entitlement_count: Optional[int] = None
+    entitlement_count: int | None = None
 
 
 @dataclass(frozen=True)
@@ -49,7 +49,5 @@ class EntitlementEntry:
     group_email: str
     mode: Literal["sync_managed", "ephemeral", "deactivated"]
     requestable: bool
-    already_provisioned: Optional[bool]
-    parsed_token: ParsedEntitlementToken = field(
-        default_factory=lambda: ParsedEntitlementToken(raw="")
-    )
+    already_provisioned: bool | None
+    parsed_token: ParsedEntitlementToken = field(default_factory=lambda: ParsedEntitlementToken(raw=""))

--- a/app/packages/access/catalog/interactions/http.py
+++ b/app/packages/access/catalog/interactions/http.py
@@ -9,14 +9,14 @@ Handlers validate, delegate to the service, and map OperationResult to HTTP.
 No business logic lives here.
 """
 
-from typing import Annotated, List, Protocol
+from typing import Annotated, Protocol
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Security
 
-from infrastructure.security.models import User
 from infrastructure.operations import OperationResult, OperationStatus
 from infrastructure.security import get_current_user
+from infrastructure.security.models import User
 from packages.access.catalog.domain import EntitlementEntry, PlatformSummary
 from packages.access.catalog.providers import get_catalog_service, get_catalog_settings
 from packages.access.catalog.schemas import (
@@ -40,13 +40,13 @@ class _CatalogSettingsPort(Protocol):
 class _CatalogServicePort(Protocol):
     """Structural contract for catalog service consumed by route handlers."""
 
-    def list_platforms(self) -> OperationResult[List[PlatformSummary]]: ...
+    def list_platforms(self) -> OperationResult[list[PlatformSummary]]: ...
 
     def list_entitlements(
         self,
         platform: str,
         user_email: str,
-    ) -> OperationResult[List[EntitlementEntry]]: ...
+    ) -> OperationResult[list[EntitlementEntry]]: ...
 
 
 def _map_status(status: OperationStatus) -> int:
@@ -86,12 +86,8 @@ def _noop_catalog_service() -> _CatalogServicePort | None:
 )
 def list_platforms(
     settings: Annotated[_CatalogSettingsPort, Depends(get_catalog_settings)],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-catalog"])
-    ],
-    service: Annotated[
-        _CatalogServicePort | None, Depends(_noop_catalog_service)
-    ] = None,
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-catalog"])],
+    service: Annotated[_CatalogServicePort | None, Depends(_noop_catalog_service)] = None,
 ) -> PlatformListResponse:
     """List all configured platforms."""
     log = logger.bind(
@@ -113,9 +109,7 @@ def list_platforms(
     if result.data is None:
         raise HTTPException(status_code=500, detail="Failed to retrieve platforms")
 
-    return PlatformListResponse(
-        platforms=[_platform_to_response(p) for p in result.data]
-    )
+    return PlatformListResponse(platforms=[_platform_to_response(p) for p in result.data])
 
 
 @router.get(
@@ -123,8 +117,7 @@ def list_platforms(
     response_model=EntitlementListResponse,
     summary="List entitlements for a platform",
     description=(
-        "Return all entitlements available on the platform, annotated with "
-        "the authenticated user's current membership status."
+        "Return all entitlements available on the platform, annotated with the authenticated user's current membership status."
     ),
     status_code=200,
     responses={
@@ -135,12 +128,8 @@ def list_platforms(
 def list_entitlements(
     platform: str,
     settings: Annotated[_CatalogSettingsPort, Depends(get_catalog_settings)],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-catalog"])
-    ],
-    service: Annotated[
-        _CatalogServicePort | None, Depends(_noop_catalog_service)
-    ] = None,
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-catalog"])],
+    service: Annotated[_CatalogServicePort | None, Depends(_noop_catalog_service)] = None,
 ) -> EntitlementListResponse:
     """List entitlements for a platform with membership annotation."""
     log = logger.bind(
@@ -165,7 +154,7 @@ def list_entitlements(
             detail=result.message or "Failed to retrieve entitlements",
         )
 
-    entries: List[EntitlementEntry] = result.data or []
+    entries: list[EntitlementEntry] = result.data or []
     return EntitlementListResponse(
         platform=platform.strip().lower(),
         entitlements=[_entry_to_response(e) for e in entries],

--- a/app/packages/access/catalog/parsers.py
+++ b/app/packages/access/catalog/parsers.py
@@ -10,7 +10,7 @@ is assembled.  Adding a parser for a new platform is a ``providers.py``-only cha
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Protocol, Set
+from typing import Protocol
 
 from packages.access.catalog.domain import ParsedEntitlementToken
 
@@ -48,7 +48,7 @@ class AwsCatalogSlugParser:
                     (e.g. {"dev", "staging", "prod"}).
     """
 
-    known_envs: Set[str] = field(default_factory=set)
+    known_envs: set[str] = field(default_factory=set)
 
     def parse(self, token: str) -> ParsedEntitlementToken:
         """Parse an AWS entitlement token into structured fields."""
@@ -57,7 +57,7 @@ class AwsCatalogSlugParser:
             return ParsedEntitlementToken(raw=token, parsed=False)
 
         normalized_envs = {e.lower() for e in self.known_envs}
-        env_index: Optional[int] = None
+        env_index: int | None = None
         for i, seg in enumerate(segments):
             if seg in normalized_envs:
                 env_index = i
@@ -65,7 +65,7 @@ class AwsCatalogSlugParser:
 
         if env_index is not None and env_index >= 1:
             product = "-".join(segments[:env_index])
-            env: Optional[str] = segments[env_index]
+            env: str | None = segments[env_index]
             remainder = segments[env_index + 1 :]
         else:
             # No env segment found; first segment is product, rest is role+
@@ -77,8 +77,8 @@ class AwsCatalogSlugParser:
             return ParsedEntitlementToken(raw=token, parsed=False)
 
         role = remainder[0]
-        service: Optional[str] = remainder[1] if len(remainder) > 1 else None
-        resource: Optional[str] = remainder[2] if len(remainder) > 2 else None
+        service: str | None = remainder[1] if len(remainder) > 1 else None
+        resource: str | None = remainder[2] if len(remainder) > 2 else None
 
         return ParsedEntitlementToken(
             raw=token,

--- a/app/packages/access/catalog/providers.py
+++ b/app/packages/access/catalog/providers.py
@@ -8,7 +8,6 @@ module scope — never bypass providers.
 """
 
 from functools import lru_cache
-from typing import Dict
 
 from infrastructure.directory import get_directory_provider
 from packages.access.catalog.parsers import (
@@ -27,7 +26,7 @@ def get_catalog_settings() -> AccessCatalogSettings:
 
 
 @lru_cache(maxsize=1)
-def _build_parser_map() -> Dict[str, CatalogSlugParser]:
+def _build_parser_map() -> dict[str, CatalogSlugParser]:
     """Build the platform key → parser mapping from runtime config.
 
     Parser config (``known_envs``) is read from the typed ``catalog_extensions``
@@ -35,7 +34,7 @@ def _build_parser_map() -> Dict[str, CatalogSlugParser]:
     fall back to ``FallbackCatalogSlugParser``.
     """
     runtime_config = get_access_runtime_config()
-    parsers: Dict[str, CatalogSlugParser] = {}
+    parsers: dict[str, CatalogSlugParser] = {}
 
     for platform_key in runtime_config.platforms:
         known_envs = set()
@@ -66,7 +65,7 @@ def get_catalog_service() -> CatalogService:
     directory = get_directory_provider()
     parser_map = _build_parser_map()
 
-    display_names: Dict[str, str] = {}
+    display_names: dict[str, str] = {}
     if runtime_config.catalog_extensions:
         display_names = dict(runtime_config.catalog_extensions.platform_display_names)
 

--- a/app/packages/access/catalog/schemas.py
+++ b/app/packages/access/catalog/schemas.py
@@ -4,7 +4,7 @@ These models are the only types that cross the HTTP boundary.
 They are never used inside the service layer.
 """
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -14,10 +14,10 @@ class ParsedTokenResponse(BaseModel):
 
     raw: str
     product: str = ""
-    env: Optional[str] = None
+    env: str | None = None
     role: str = ""
-    service: Optional[str] = None
-    resource: Optional[str] = None
+    service: str | None = None
+    resource: str | None = None
     parsed: bool = False
 
 
@@ -27,13 +27,13 @@ class PlatformSummaryResponse(BaseModel):
     key: str
     display_name: str
     authn_group_slug: str
-    entitlement_count: Optional[int] = None
+    entitlement_count: int | None = None
 
 
 class PlatformListResponse(BaseModel):
     """Response for GET /api/v1/access/catalog."""
 
-    platforms: List[PlatformSummaryResponse]
+    platforms: list[PlatformSummaryResponse]
 
 
 class EntitlementEntryResponse(BaseModel):
@@ -44,7 +44,7 @@ class EntitlementEntryResponse(BaseModel):
     group_email: str
     mode: Literal["sync_managed", "ephemeral", "deactivated"]
     requestable: bool
-    already_provisioned: Optional[bool] = None
+    already_provisioned: bool | None = None
     parsed: ParsedTokenResponse
 
 
@@ -52,4 +52,4 @@ class EntitlementListResponse(BaseModel):
     """Response for GET /api/v1/access/catalog/{platform}."""
 
     platform: str
-    entitlements: List[EntitlementEntryResponse]
+    entitlements: list[EntitlementEntryResponse]

--- a/app/packages/access/catalog/service.py
+++ b/app/packages/access/catalog/service.py
@@ -9,7 +9,7 @@ All I/O is read-only: runtime config reads and directory membership checks.
 No state is modified here.
 """
 
-from typing import Dict, List, Optional, Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import structlog
 
@@ -30,13 +30,13 @@ logger = structlog.get_logger()
 class CatalogServicePort(Protocol):
     """Structural contract for the catalog service consumed by route handlers."""
 
-    def list_platforms(self) -> OperationResult[List[PlatformSummary]]: ...
+    def list_platforms(self) -> OperationResult[list[PlatformSummary]]: ...
 
     def list_entitlements(
         self,
         platform: str,
         user_email: str,
-    ) -> OperationResult[List[EntitlementEntry]]: ...
+    ) -> OperationResult[list[EntitlementEntry]]: ...
 
 
 class CatalogService:
@@ -55,10 +55,10 @@ class CatalogService:
 
     def __init__(
         self,
-        runtime_config: "AccessRuntimeConfig",
-        directory: "DirectoryProvider",
-        parsers: Dict[str, CatalogSlugParser],
-        display_names: Optional[Dict[str, str]] = None,
+        runtime_config: AccessRuntimeConfig,
+        directory: DirectoryProvider,
+        parsers: dict[str, CatalogSlugParser],
+        display_names: dict[str, str] | None = None,
     ) -> None:
         self._config = runtime_config
         self._directory = directory
@@ -71,7 +71,7 @@ class CatalogService:
     # Public API
     # ------------------------------------------------------------------
 
-    def list_platforms(self) -> OperationResult[List[PlatformSummary]]:
+    def list_platforms(self) -> OperationResult[list[PlatformSummary]]:
         """Return a summary for every configured platform.
 
         No IDP calls are made — this is a pure config read.
@@ -82,7 +82,7 @@ class CatalogService:
         log = self.logger.bind(operation="list_platforms")
         log.info("catalog_list_platforms_started")
 
-        summaries: List[PlatformSummary] = []
+        summaries: list[PlatformSummary] = []
         for key in sorted(self._config.platforms.keys()):
             authn_slug = self._config.authn_group_slug(key)
             display_name = self._display_names.get(key, key)
@@ -101,7 +101,7 @@ class CatalogService:
         self,
         platform: str,
         user_email: str,
-    ) -> OperationResult[List[EntitlementEntry]]:
+    ) -> OperationResult[list[EntitlementEntry]]:
         """Enumerate all entitlements for a platform with membership annotation.
 
         Steps:
@@ -156,7 +156,7 @@ class CatalogService:
         groups = discovery_result.data  # List[DirectoryGroup]
         authn_slug = self._config.authn_group_slug(normalized)
 
-        entries: List[EntitlementEntry] = []
+        entries: list[EntitlementEntry] = []
         requestable_count = 0
         provisioned_count = 0
 
@@ -176,11 +176,7 @@ class CatalogService:
 
             # Resolve effective mode from config-time overrides.
             raw_mode = policy.mode_overrides.get(token, "sync_managed")
-            mode: str = (
-                raw_mode
-                if raw_mode in ("sync_managed", "ephemeral", "deactivated")
-                else "sync_managed"
-            )
+            mode: str = raw_mode if raw_mode in ("sync_managed", "ephemeral", "deactivated") else "sync_managed"
             requestable = mode == "sync_managed"
 
             parsed_token = parser.parse(token)
@@ -226,11 +222,11 @@ class CatalogService:
         user_email: str,
         log: object,
         token: str,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         """Return membership status; None on IDP error (non-fatal)."""
         result = self._directory.check_membership(group_email, user_email)
         if not result.is_success:
-            getattr(log, "warning")(
+            log.warning(
                 "catalog_membership_check_failed",
                 token=token,
                 group_email=group_email,

--- a/app/packages/access/common/config/loaders.py
+++ b/app/packages/access/common/config/loaders.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Protocol
+from typing import Any, Protocol
 
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -28,7 +28,6 @@ from packages.access.common.config.settings import (
     EntitlementMode,
     PlatformPolicy,
 )
-
 
 # ---------------------------------------------------------------------------
 # Key Normalization
@@ -65,10 +64,10 @@ class AccessConfigLoader(Protocol):
 class PlatformPolicyConfigModel(BaseModel):
     """Typed schema for one platform policy in runtime config JSON."""
 
-    authn_token: str = "authn"
+    authn_token: str = "authn"  # noqa: S105 -- default group-slug token, not a credential
     authn_removal_mode: str = "delete"
     adapter_type: str = "fake"
-    mode_overrides: Dict[str, EntitlementMode] = Field(default_factory=dict)
+    mode_overrides: dict[str, EntitlementMode] = Field(default_factory=dict)
 
 
 class CatalogParserConfigModel(BaseModel):
@@ -80,8 +79,8 @@ class CatalogParserConfigModel(BaseModel):
 class CatalogExtensionsConfigModel(BaseModel):
     """Typed schema for catalog extensions block in runtime config."""
 
-    parsers: Dict[str, CatalogParserConfigModel] = Field(default_factory=dict)
-    platform_display_names: Dict[str, str] = Field(default_factory=dict)
+    parsers: dict[str, CatalogParserConfigModel] = Field(default_factory=dict)
+    platform_display_names: dict[str, str] = Field(default_factory=dict)
 
 
 class RuntimeConfigJsonModel(BaseModel):
@@ -112,8 +111,8 @@ class RuntimeConfigJsonModel(BaseModel):
 
     dir_prefix: str
     dir_separator: str = "-"
-    platforms: Dict[str, PlatformPolicyConfigModel] = Field(default_factory=dict)
-    extensions: Dict[str, Any] = Field(default_factory=dict)
+    platforms: dict[str, PlatformPolicyConfigModel] = Field(default_factory=dict)
+    extensions: dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -124,11 +123,11 @@ class RuntimeConfigJsonModel(BaseModel):
 def _build_runtime_config(
     dir_prefix: str,
     dir_separator: str,
-    platforms_model: Dict[str, PlatformPolicyConfigModel],
-    extensions: Dict[str, Any] | None = None,
+    platforms_model: dict[str, PlatformPolicyConfigModel],
+    extensions: dict[str, Any] | None = None,
 ) -> AccessRuntimeConfig:
     """Convert validated JSON platform models into ``AccessRuntimeConfig``."""
-    platforms: Dict[str, PlatformPolicy] = {}
+    platforms: dict[str, PlatformPolicy] = {}
     for key, raw_policy in platforms_model.items():
         platforms[normalize_target_key(key)] = PlatformPolicy(
             authn_token=raw_policy.authn_token,
@@ -142,9 +141,7 @@ def _build_runtime_config(
         cat_model = CatalogExtensionsConfigModel.model_validate(extensions["catalog"])
         parsers = {}
         for platform_key, parser_cfg in cat_model.parsers.items():
-            parsers[platform_key] = CatalogParserConfig(
-                known_envs=list(parser_cfg.known_envs)
-            )
+            parsers[platform_key] = CatalogParserConfig(known_envs=list(parser_cfg.known_envs))
         catalog_ext = CatalogExtensions(
             parsers=parsers,
             platform_display_names=dict(cat_model.platform_display_names),
@@ -241,9 +238,7 @@ class EnvConfigLoader:
     class _EnvModel(BaseSettings):
         dir_prefix: str = Field(default="", alias="ACCESS_CONFIG_ENV_DIR_PREFIX")
         dir_separator: str = Field(default="-", alias="ACCESS_CONFIG_ENV_DIR_SEPARATOR")
-        platforms_json: str = Field(
-            default="{}", alias="ACCESS_CONFIG_ENV_PLATFORMS_JSON"
-        )
+        platforms_json: str = Field(default="{}", alias="ACCESS_CONFIG_ENV_PLATFORMS_JSON")
 
         model_config = SettingsConfigDict(
             env_file=".env",
@@ -316,10 +311,7 @@ class FileJsonConfigLoader:
             return result
         return OperationResult.success(
             data=result.data,
-            message=(
-                f"file_json_config_loaded path={path} "
-                f"platforms={len(result.data.platforms) if result.data else 0}"
-            ),
+            message=(f"file_json_config_loaded path={path} platforms={len(result.data.platforms) if result.data else 0}"),
         )
 
 
@@ -348,7 +340,4 @@ def get_access_config_loader(source: str) -> AccessConfigLoader:
         return FileJsonConfigLoader()
     if source == "env":
         return EnvConfigLoader()
-    raise ValueError(
-        f"Unsupported ACCESS_CONFIG_SOURCE '{source}'. "
-        "Use bundle, inline_json, file_json, or env."
-    )
+    raise ValueError(f"Unsupported ACCESS_CONFIG_SOURCE '{source}'. Use bundle, inline_json, file_json, or env.")

--- a/app/packages/access/common/config/settings.py
+++ b/app/packages/access/common/config/settings.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
 from packages.access.common.naming import AccessGroupNaming
-
 
 EntitlementMode = Literal["sync_managed", "ephemeral", "deactivated"]
 
@@ -26,25 +25,25 @@ class EntitlementRule:
 class PlatformPolicy:
     """Per-platform policy loaded from runtime configuration."""
 
-    authn_token: str = "authn"
+    authn_token: str = "authn"  # noqa: S105 -- default group-slug token, not a credential
     authn_removal_mode: str = "delete"  # disable | delete | entitlement_only
     adapter_type: str = "fake"  # aws_identity_center | fake
-    mode_overrides: Dict[str, EntitlementMode] = field(default_factory=dict)
+    mode_overrides: dict[str, EntitlementMode] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class CatalogParserConfig:
     """Runtime configuration for a platform's catalog token parser."""
 
-    known_envs: List[str] = field(default_factory=list)
+    known_envs: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class CatalogExtensions:
     """Typed runtime extensions for the catalog sub-feature."""
 
-    parsers: Dict[str, CatalogParserConfig] = field(default_factory=dict)
-    platform_display_names: Dict[str, str] = field(default_factory=dict)
+    parsers: dict[str, CatalogParserConfig] = field(default_factory=dict)
+    platform_display_names: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -54,9 +53,9 @@ class EntitlementModeOverride:
     platform: str
     group_slug: str
     mode: EntitlementMode
-    reason: Optional[str] = None
-    requested_by: Optional[str] = None
-    expires_at: Optional[datetime] = None
+    reason: str | None = None
+    requested_by: str | None = None
+    expires_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -65,13 +64,11 @@ class AccessRuntimeConfig:
 
     dir_prefix: str
     dir_separator: str = "-"
-    platforms: Dict[str, PlatformPolicy] = field(default_factory=dict)
-    entitlement_mode_overrides: List[EntitlementModeOverride] = field(
-        default_factory=list
-    )
+    platforms: dict[str, PlatformPolicy] = field(default_factory=dict)
+    entitlement_mode_overrides: list[EntitlementModeOverride] = field(default_factory=list)
     # Typed extensions for catalog feature; empty dict when not present.
-    extensions: Dict[str, Any] = field(default_factory=dict)
-    catalog_extensions: Optional[CatalogExtensions] = None
+    extensions: dict[str, Any] = field(default_factory=dict)
+    catalog_extensions: CatalogExtensions | None = None
 
     def group_prefix(self, platform: str) -> str:
         """Return the IDP group slug prefix for a given platform."""
@@ -91,7 +88,7 @@ class AccessRuntimeConfig:
         )
 
     @property
-    def catalog(self) -> Optional[CatalogExtensions]:
+    def catalog(self) -> CatalogExtensions | None:
         """Return typed catalog extension configuration."""
         return self.catalog_extensions
 

--- a/app/packages/access/common/naming.py
+++ b/app/packages/access/common/naming.py
@@ -22,7 +22,7 @@ class AccessGroupNaming:
         """
         return f"{self.dir_prefix}{self.dir_separator}{platform}{self.dir_separator}"
 
-    def authn_group_slug(self, platform: str, authn_token: str = "authn") -> str:
+    def authn_group_slug(self, platform: str, authn_token: str = "authn") -> str:  # noqa: S107 -- default group-slug token, not a credential
         """Return the authn lifecycle group slug for a platform.
 
         Example: ``sg-aws-authn``.

--- a/app/packages/access/common/providers.py
+++ b/app/packages/access/common/providers.py
@@ -11,7 +11,6 @@ sub-features.  Bootstrap config (which loader source/ref) lives there under
 """
 
 from functools import lru_cache
-from typing import Optional
 
 from infrastructure.operations import OperationResult
 from packages.access.common.config import (
@@ -37,7 +36,7 @@ def get_access_runtime_config() -> AccessRuntimeConfig:
     settings = get_access_settings()
     loader = get_access_config_loader(source=settings.config.source)
     result: OperationResult[AccessRuntimeConfig] = loader.load(ref=settings.config.ref)
-    config: Optional[AccessRuntimeConfig] = result.data
+    config: AccessRuntimeConfig | None = result.data
     if not result.is_success or config is None:
         raise RuntimeError(f"access_config_load_failed: {result.message}")
     return config

--- a/app/packages/access/common/settings.py
+++ b/app/packages/access/common/settings.py
@@ -46,9 +46,7 @@ class AccessConfigSettings(BaseModel):
     def _validate_source(cls, value: object) -> object:
         allowed = {"bundle", "inline_json", "file_json", "env"}
         if isinstance(value, str) and value not in allowed:
-            raise ValueError(
-                "ACCESS_CONFIG_SOURCE must be one of: bundle, inline_json, file_json, env"
-            )
+            raise ValueError("ACCESS_CONFIG_SOURCE must be one of: bundle, inline_json, file_json, env")
         return value
 
 

--- a/app/packages/access/request/domain.py
+++ b/app/packages/access/request/domain.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import Literal
 
 ActorType = Literal["self", "delegated"]
 
@@ -76,10 +76,10 @@ class AccessRequest:
     entitlement_id: str
     status: RequestStatus
     justification: str
-    resolved_approvers: List[str] = field(default_factory=list)
-    ticket_id: Optional[str] = None
-    requested_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None
+    resolved_approvers: list[str] = field(default_factory=list)
+    ticket_id: str | None = None
+    requested_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/app/packages/access/request/interactions/http.py
+++ b/app/packages/access/request/interactions/http.py
@@ -12,14 +12,14 @@ Handlers validate the incoming body, delegate to the service via
 No business logic lives here.
 """
 
-from typing import Annotated, List, Protocol
+from typing import Annotated, Protocol
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Security
 
-from infrastructure.security.models import User
 from infrastructure.operations import OperationResult, OperationStatus
 from infrastructure.security import get_current_user
+from infrastructure.security.models import User
 from packages.access.request.domain import AccessRequest, ApprovalDecision
 from packages.access.request.providers import (
     get_access_request_service,
@@ -67,33 +67,33 @@ class _AccessRequestServicePort(Protocol):
         request_id: str,
         approver_email: str,
         comment: str = "",
-    ) -> OperationResult[tuple[AccessRequest, List[ApprovalDecision]]]: ...
+    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
     def reject_request(
         self,
         request_id: str,
         approver_email: str,
         comment: str,
-    ) -> OperationResult[tuple[AccessRequest, List[ApprovalDecision]]]: ...
+    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
     def cancel_request(
         self,
         request_id: str,
         actor_email: str,
         comment: str = "",
-    ) -> OperationResult[tuple[AccessRequest, List[ApprovalDecision]]]: ...
+    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
     def retry_request(
         self,
         request_id: str,
         actor_email: str,
         comment: str = "",
-    ) -> OperationResult[tuple[AccessRequest, List[ApprovalDecision]]]: ...
+    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
     def get_request_status(
         self,
         request_id: str,
-    ) -> OperationResult[tuple[AccessRequest, List[ApprovalDecision]]]: ...
+    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +126,7 @@ def _build_decision_response(decision: ApprovalDecision) -> ApprovalDecisionResp
 
 def _build_request_response(
     request: AccessRequest,
-    decisions: List[ApprovalDecision],
+    decisions: list[ApprovalDecision],
 ) -> AccessRequestStatusResponse:
     return AccessRequestStatusResponse(
         request_id=request.request_id,
@@ -171,10 +171,7 @@ def _noop_request_service() -> _AccessRequestServicePort | None:
     "",
     response_model=SubmitAccessRequestResponse,
     summary="Submit an access request",
-    description=(
-        "Submit a new access request for the authenticated user or, "
-        "for delegated requests, on behalf of another user."
-    ),
+    description=("Submit a new access request for the authenticated user or, for delegated requests, on behalf of another user."),
     status_code=202,
     responses={
         400: {"description": "Invalid request payload or policy violation."},
@@ -184,21 +181,13 @@ def _noop_request_service() -> _AccessRequestServicePort | None:
 )
 def submit_request(
     body: SubmitAccessRequestBody,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> SubmitAccessRequestResponse:
     """Submit a new access request."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     user_email = body.user_email or current_user.email
@@ -257,21 +246,13 @@ def submit_request(
 def approve_request(
     request_id: str,
     body: ApproveRequestBody,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> AccessRequestStatusResponse:
     """Submit an approval decision for a pending access request."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     log = logger.bind(
@@ -315,21 +296,13 @@ def approve_request(
 def reject_request(
     request_id: str,
     body: RejectRequestBody,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> AccessRequestStatusResponse:
     """Submit a rejection decision for a pending access request."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     log = logger.bind(
@@ -373,21 +346,13 @@ def reject_request(
 def cancel_request(
     request_id: str,
     body: CancelRequestBody,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> AccessRequestStatusResponse:
     """Cancel a pending access request (requester only)."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     log = logger.bind(
@@ -436,21 +401,13 @@ def cancel_request(
 def retry_request(
     request_id: str,
     body: RetryRequestBody,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> AccessRequestStatusResponse:
     """Retry IDP provisioning for a failed access request."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     log = logger.bind(
@@ -491,21 +448,13 @@ def retry_request(
 )
 def get_request_status(
     request_id: str,
-    settings: Annotated[
-        _AccessRequestSettingsPort, Depends(get_access_request_settings)
-    ],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-requests"])
-    ],
-    service: Annotated[
-        _AccessRequestServicePort | None, Depends(_noop_request_service)
-    ] = None,
+    settings: Annotated[_AccessRequestSettingsPort, Depends(get_access_request_settings)],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-requests"])],
+    service: Annotated[_AccessRequestServicePort | None, Depends(_noop_request_service)] = None,
 ) -> AccessRequestStatusResponse:
     """Fetch request status, resolved approvers, and decision history."""
     if not settings.enabled:
-        raise HTTPException(
-            status_code=503, detail="Access Requests feature is disabled."
-        )
+        raise HTTPException(status_code=503, detail="Access Requests feature is disabled.")
     service_dep = _resolve_service(service)
 
     log = logger.bind(

--- a/app/packages/access/request/policies.py
+++ b/app/packages/access/request/policies.py
@@ -13,7 +13,7 @@ Pattern mirrors PolicyEngine in packages/access/sync/policies.py.
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from packages.access.common.config import EntitlementMode
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 def check_entitlement_mode(
-    runtime_config: "AccessRuntimeConfig",
+    runtime_config: AccessRuntimeConfig,
     platform: str,
     group_slug: str,
 ) -> EntitlementMode:
@@ -68,10 +68,10 @@ def check_entitlement_mode(
 
 
 def resolve_approver_candidates(
-    directory_group: "DirectoryGroup",
+    directory_group: DirectoryGroup,
     fallback_slug: str,
-    directory: "DirectoryProvider",
-) -> List[str]:
+    directory: DirectoryProvider,
+) -> list[str]:
     """Resolve an ordered list of eligible approver emails for a target group.
 
     Resolution order:
@@ -95,11 +95,7 @@ def resolve_approver_candidates(
         include_member_types={"USER"},
     )
     if members_result.is_success and members_result.data:
-        owners = [
-            m.email
-            for m in members_result.data
-            if m.role is not None and m.role.upper() in ("OWNER", "MANAGER")
-        ]
+        owners = [m.email for m in members_result.data if m.role is not None and m.role.upper() in ("OWNER", "MANAGER")]
         if owners:
             return owners
 
@@ -115,7 +111,7 @@ def resolve_approver_candidates(
 
 def is_auto_approvable(
     actor_type: str,
-    sensitive_entitlement_types: "frozenset[str] | None" = None,
+    sensitive_entitlement_types: frozenset[str] | None = None,
     entitlement_type: str = "group",
 ) -> bool:
     """Return True if the request qualifies for auto-approval.
@@ -135,13 +131,11 @@ def is_auto_approvable(
     """
     if actor_type != "delegated":
         return False
-    if sensitive_entitlement_types and entitlement_type in sensitive_entitlement_types:
-        return False
-    return True
+    return not (sensitive_entitlement_types and entitlement_type in sensitive_entitlement_types)
 
 
 def is_self_approval(
-    request: "AccessRequest",
+    request: AccessRequest,
     approver_email: str,
 ) -> bool:
     """Return True if the approver is the same person as the actor.
@@ -161,7 +155,7 @@ def is_self_approval(
 
 
 def meets_minimum_approver_count(
-    decisions: "List[ApprovalDecision]",
+    decisions: list[ApprovalDecision],
     required_count: int,
 ) -> bool:
     """Return True if the approved-decision count meets the required minimum.

--- a/app/packages/access/request/schemas.py
+++ b/app/packages/access/request/schemas.py
@@ -7,10 +7,7 @@ service layer works exclusively with domain.py dataclasses.
 Route handlers translate between these schemas and internal domain models.
 """
 
-from typing import List, Optional
-
 from pydantic import BaseModel, Field
-
 
 # ---------------------------------------------------------------------------
 # Request bodies
@@ -29,9 +26,7 @@ class SubmitAccessRequestBody(BaseModel):
             "server-side from this slug."
         ),
     )
-    entitlement_type: str = Field(
-        default="group", description="Entitlement classification. Defaults to 'group'."
-    )
+    entitlement_type: str = Field(default="group", description="Entitlement classification. Defaults to 'group'.")
     actor_type: str = Field(
         default="self",
         description="'self' for self-service; 'delegated' for manager-submitted.",
@@ -40,17 +35,14 @@ class SubmitAccessRequestBody(BaseModel):
         default="grant",
         description="'grant' to add access; 'revoke' to remove access.",
     )
-    user_email: Optional[str] = Field(
+    user_email: str | None = Field(
         default=None,
         description=(
-            "Target user email. Required for delegated requests; defaults to the "
-            "authenticated actor for self-service requests."
+            "Target user email. Required for delegated requests; defaults to the authenticated actor for self-service requests."
         ),
     )
     justification: str = Field(..., min_length=1, description="Reason for the request.")
-    ticket_id: Optional[str] = Field(
-        default=None, description="Optional external ticket reference."
-    )
+    ticket_id: str | None = Field(default=None, description="Optional external ticket reference.")
 
 
 class ApproveRequestBody(BaseModel):
@@ -62,9 +54,7 @@ class ApproveRequestBody(BaseModel):
 class RejectRequestBody(BaseModel):
     """Body for POST /api/v1/access/requests/{request_id}/reject."""
 
-    comment: str = Field(
-        ..., min_length=1, description="Required reason for rejection."
-    )
+    comment: str = Field(..., min_length=1, description="Required reason for rejection.")
 
 
 class CancelRequestBody(BaseModel):
@@ -110,11 +100,11 @@ class AccessRequestStatusResponse(BaseModel):
     request_type: str
     status: str
     justification: str
-    resolved_approvers: List[str]
-    ticket_id: Optional[str] = None
-    requested_at: Optional[str] = None
-    updated_at: Optional[str] = None
-    decisions: List[ApprovalDecisionResponse] = Field(
+    resolved_approvers: list[str]
+    ticket_id: str | None = None
+    requested_at: str | None = None
+    updated_at: str | None = None
+    decisions: list[ApprovalDecisionResponse] = Field(
         default_factory=list,
         description=(
             "Approval decision history. This list is empty for cancel and retry "

--- a/app/packages/access/request/service.py
+++ b/app/packages/access/request/service.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import replace
-from datetime import datetime, timezone
-from typing import Optional, Protocol, TYPE_CHECKING, Union
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol
 
 import structlog
 
@@ -70,7 +70,7 @@ class AccessRequestServicePort(Protocol):
         group_slug: str,
         entitlement_type: str,
         justification: str,
-        ticket_id: Optional[str] = None,
+        ticket_id: str | None = None,
     ) -> OperationResult[AccessRequest]: ...
 
     def approve_request(
@@ -101,9 +101,7 @@ class AccessRequestServicePort(Protocol):
         comment: str = "",
     ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
-    def get_request_status(
-        self, request_id: str
-    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
+    def get_request_status(self, request_id: str) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]: ...
 
     def advance_from_sync_result(self, event: Event) -> None: ...
 
@@ -127,7 +125,7 @@ class AccessRequestService:
     def __init__(
         self,
         repository: AccessRequestRepository,
-        directory: "DirectoryProvider",
+        directory: DirectoryProvider,
         runtime_config: AccessRuntimeConfig,
         dispatcher: EventDispatcher,
         fallback_approver_slug: str = "sg-org-admins",
@@ -155,7 +153,7 @@ class AccessRequestService:
         group_slug: str,
         entitlement_type: str,
         justification: str,
-        ticket_id: Optional[str] = None,
+        ticket_id: str | None = None,
     ) -> OperationResult[AccessRequest]:
         """Accept and process a new access request through intake.
 
@@ -214,11 +212,7 @@ class AccessRequestService:
         # Derive entitlement_id from the group slug by stripping the platform prefix.
         # For sg-aws-scratch with platform=aws and prefix sg-aws-, token is "scratch".
         group_prefix = self._config.group_prefix(platform)
-        entitlement_id = (
-            group_slug[len(group_prefix) :]
-            if group_slug.startswith(group_prefix)
-            else group_slug
-        )
+        entitlement_id = group_slug[len(group_prefix) :] if group_slug.startswith(group_prefix) else group_slug
 
         # Step 2: entitlement mode pre-check
         mode = check_entitlement_mode(self._config, platform, group_slug)
@@ -230,9 +224,7 @@ class AccessRequestService:
             )
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    "Automation is suspended for this group. Contact an administrator."
-                ),
+                message=("Automation is suspended for this group. Contact an administrator."),
                 error_code="ENTITLEMENT_MODE_DEACTIVATED",
             )
         if mode == "ephemeral":
@@ -243,17 +235,12 @@ class AccessRequestService:
             )
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    "This group uses ephemeral access. "
-                    "Use the elevated-access workflow instead."
-                ),
+                message=("This group uses ephemeral access. Use the elevated-access workflow instead."),
                 error_code="ENTITLEMENT_MODE_EPHEMERAL",
             )
 
         # Step 3: eligibility — direction-aware membership check
-        membership_result = self._directory.check_membership(
-            directory_group.group_email, user_email
-        )
+        membership_result = self._directory.check_membership(directory_group.group_email, user_email)
         if membership_result.is_success and membership_result.data is not None:
             is_member = membership_result.data.is_member
             if request_type == "grant" and is_member:
@@ -296,9 +283,7 @@ class AccessRequestService:
                 )
             members = members_result.data or []
             actor_is_owner_or_manager = any(
-                m.email.lower() == actor_email.lower()
-                and m.role is not None
-                and m.role.upper() in ("OWNER", "MANAGER")
+                m.email.lower() == actor_email.lower() and m.role is not None and m.role.upper() in ("OWNER", "MANAGER")
                 for m in members
             )
             if not actor_is_owner_or_manager:
@@ -346,7 +331,7 @@ class AccessRequestService:
             entitlement_type=entitlement_type,
         )
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         initial_status = "approved" if auto_approved else "pending_approval"
 
         request = AccessRequest(
@@ -384,17 +369,13 @@ class AccessRequestService:
         # Step 8: for auto-approved requests, write the membership change to the
         # IDP immediately. Direction is determined by request_type.
         if auto_approved:
-            idp_result: Union[OperationResult[DirectoryMember], OperationResult[None]]
+            idp_result: OperationResult[DirectoryMember] | OperationResult[None]
             if request_type == "grant":
-                idp_result = self._directory.add_group_member(
-                    directory_group.group_email, user_email
-                )
+                idp_result = self._directory.add_group_member(directory_group.group_email, user_email)
             else:
-                idp_result = self._directory.remove_group_member(
-                    directory_group.group_email, user_email
-                )
+                idp_result = self._directory.remove_group_member(directory_group.group_email, user_email)
             if not idp_result.is_success:
-                fail_now = datetime.now(tz=timezone.utc)
+                fail_now = datetime.now(tz=UTC)
                 failed = replace(request, status="failed", updated_at=fail_now)
                 self._repo.save_request(failed)
                 self._repo.save_audit_event(
@@ -518,16 +499,11 @@ class AccessRequestService:
         if request.status != "pending_approval":
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    f"Request is in '{request.status}' state; "
-                    "only 'pending_approval' requests can be approved."
-                ),
+                message=(f"Request is in '{request.status}' state; only 'pending_approval' requests can be approved."),
                 error_code="INVALID_STATE_TRANSITION",
             )
 
-        if approver_email.lower() not in [
-            a.lower() for a in request.resolved_approvers
-        ]:
+        if approver_email.lower() not in [a.lower() for a in request.resolved_approvers]:
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
                 message="Actor is not in the resolved approver list.",
@@ -541,7 +517,7 @@ class AccessRequestService:
                 error_code="SELF_APPROVAL_DENIED",
             )
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         decision = ApprovalDecision(
             request_id=request_id,
             actor_email=approver_email,
@@ -564,15 +540,11 @@ class AccessRequestService:
         if meets_minimum_approver_count(all_decisions, self._min_approver_count):
             # Write the membership change to the IDP — source of truth — before
             # publishing the event. Direction is determined by request_type.
-            idp_result: Union[OperationResult[DirectoryMember], OperationResult[None]]
+            idp_result: OperationResult[DirectoryMember] | OperationResult[None]
             if request.request_type == "grant":
-                idp_result = self._directory.add_group_member(
-                    request.group_email, request.user_email
-                )
+                idp_result = self._directory.add_group_member(request.group_email, request.user_email)
             else:
-                idp_result = self._directory.remove_group_member(
-                    request.group_email, request.user_email
-                )
+                idp_result = self._directory.remove_group_member(request.group_email, request.user_email)
             if not idp_result.is_success:
                 failed = replace(request, status="failed", updated_at=now)
                 self._repo.save_request(failed)
@@ -656,23 +628,18 @@ class AccessRequestService:
         if request.status != "pending_approval":
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    f"Request is in '{request.status}' state; "
-                    "only 'pending_approval' requests can be rejected."
-                ),
+                message=(f"Request is in '{request.status}' state; only 'pending_approval' requests can be rejected."),
                 error_code="INVALID_STATE_TRANSITION",
             )
 
-        if approver_email.lower() not in [
-            a.lower() for a in request.resolved_approvers
-        ]:
+        if approver_email.lower() not in [a.lower() for a in request.resolved_approvers]:
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
                 message="Actor is not in the resolved approver list.",
                 error_code="APPROVER_NOT_AUTHORIZED",
             )
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         decision = ApprovalDecision(
             request_id=request_id,
             actor_email=approver_email,
@@ -744,9 +711,7 @@ class AccessRequestService:
         if request.status not in ("submitted", "pending_approval"):
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    f"Request is in '{request.status}' state and cannot be cancelled."
-                ),
+                message=(f"Request is in '{request.status}' state and cannot be cancelled."),
                 error_code="INVALID_STATE_TRANSITION",
             )
 
@@ -757,7 +722,7 @@ class AccessRequestService:
                 error_code="CANCELLATION_NOT_AUTHORIZED",
             )
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         updated = replace(request, status="cancelled", updated_at=now)
         self._repo.save_request(updated)
         self._repo.save_audit_event(
@@ -825,10 +790,7 @@ class AccessRequestService:
         if request.status != "failed":
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    f"Request is in '{request.status}' state; "
-                    "only 'failed' requests can be retried."
-                ),
+                message=(f"Request is in '{request.status}' state; only 'failed' requests can be retried."),
                 error_code="INVALID_STATE_TRANSITION",
             )
 
@@ -839,17 +801,13 @@ class AccessRequestService:
                 error_code="APPROVER_NOT_AUTHORIZED",
             )
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
 
-        idp_result: Union[OperationResult[DirectoryMember], OperationResult[None]]
+        idp_result: OperationResult[DirectoryMember] | OperationResult[None]
         if request.request_type == "grant":
-            idp_result = self._directory.add_group_member(
-                request.group_email, request.user_email
-            )
+            idp_result = self._directory.add_group_member(request.group_email, request.user_email)
         else:
-            idp_result = self._directory.remove_group_member(
-                request.group_email, request.user_email
-            )
+            idp_result = self._directory.remove_group_member(request.group_email, request.user_email)
         if not idp_result.is_success:
             self._repo.save_audit_event(
                 RequestAuditEvent(
@@ -905,9 +863,7 @@ class AccessRequestService:
             message="Retry succeeded. Access provisioning re-triggered.",
         )
 
-    def get_request_status(
-        self, request_id: str
-    ) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]:
+    def get_request_status(self, request_id: str) -> OperationResult[tuple[AccessRequest, list[ApprovalDecision]]]:
         """Return the access request and all recorded decisions.
 
         Returns:
@@ -940,9 +896,7 @@ class AccessRequestService:
             event: Domain event with ``event_type`` SYNC_COMPLETED or SYNC_FAILED.
         """
         metadata = event.metadata or {}
-        request_id = (
-            metadata.get("request_id", "") if isinstance(metadata, dict) else ""
-        )
+        request_id = metadata.get("request_id", "") if isinstance(metadata, dict) else ""
         if not request_id:
             return
 
@@ -967,7 +921,7 @@ class AccessRequestService:
             )
             return
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
 
         if event.event_type == SYNC_COMPLETED:
             updated = replace(request, status="completed", updated_at=now)

--- a/app/packages/access/request/store.py
+++ b/app/packages/access/request/store.py
@@ -23,8 +23,7 @@ trail with a single DynamoDB ``query`` against the request's PK, without table
 scans or GSIs.
 """
 
-from datetime import datetime, timezone
-from typing import List, Optional
+from datetime import UTC, datetime
 
 import structlog
 
@@ -81,12 +80,8 @@ class AccessRequestRepository:
             "justification": request.justification,
             "resolved_approvers": request.resolved_approvers,
             "ticket_id": request.ticket_id,
-            "requested_at": (
-                request.requested_at.isoformat() if request.requested_at else None
-            ),
-            "updated_at": (
-                request.updated_at.isoformat() if request.updated_at else None
-            ),
+            "requested_at": (request.requested_at.isoformat() if request.requested_at else None),
+            "updated_at": (request.updated_at.isoformat() if request.updated_at else None),
         }
         result = self._storage.put(self.TABLE, item)
         if not result.is_success:
@@ -96,7 +91,7 @@ class AccessRequestRepository:
                 error=result.message,
             )
 
-    def get_request(self, request_id: str) -> Optional[AccessRequest]:
+    def get_request(self, request_id: str) -> AccessRequest | None:
         """Return the AccessRequest for the given request ID, or None."""
         result = self._storage.get(
             self.TABLE,
@@ -133,7 +128,7 @@ class AccessRequestRepository:
                 error=result.message,
             )
 
-    def get_decisions(self, request_id: str) -> List[ApprovalDecision]:
+    def get_decisions(self, request_id: str) -> list[ApprovalDecision]:
         """Return all decisions for the given request, ordered by SK."""
         result = self._storage.query(
             self.TABLE,
@@ -176,9 +171,7 @@ class AccessRequestRepository:
     # Full request context
     # ------------------------------------------------------------------
 
-    def get_request_with_decisions(
-        self, request_id: str
-    ) -> tuple[Optional[AccessRequest], List[ApprovalDecision]]:
+    def get_request_with_decisions(self, request_id: str) -> tuple[AccessRequest | None, list[ApprovalDecision]]:
         """Return the access request and all its recorded decisions.
 
         Uses a single DynamoDB query on the PK prefix to retrieve both
@@ -195,8 +188,8 @@ class AccessRequestRepository:
         if not result.is_success or result.data is None:
             return None, []
 
-        request: Optional[AccessRequest] = None
-        decisions: List[ApprovalDecision] = []
+        request: AccessRequest | None = None
+        decisions: list[ApprovalDecision] = []
 
         for item in result.data:
             sk = item.get("SK", "")
@@ -229,16 +222,8 @@ class AccessRequestRepository:
             justification=item["justification"],
             resolved_approvers=item.get("resolved_approvers") or [],
             ticket_id=item.get("ticket_id"),
-            requested_at=(
-                datetime.fromisoformat(item["requested_at"])
-                if item.get("requested_at")
-                else None
-            ),
-            updated_at=(
-                datetime.fromisoformat(item["updated_at"])
-                if item.get("updated_at")
-                else None
-            ),
+            requested_at=(datetime.fromisoformat(item["requested_at"]) if item.get("requested_at") else None),
+            updated_at=(datetime.fromisoformat(item["updated_at"]) if item.get("updated_at") else None),
         )
 
     @staticmethod
@@ -254,4 +239,4 @@ class AccessRequestRepository:
     @staticmethod
     def _now() -> datetime:
         """Return current UTC time."""
-        return datetime.now(tz=timezone.utc)
+        return datetime.now(tz=UTC)

--- a/app/packages/access/sync/adapters/__init__.py
+++ b/app/packages/access/sync/adapters/__init__.py
@@ -7,7 +7,7 @@ All methods are idempotent and return OperationResult.
 Adapters must never raise exceptions across this boundary.
 """
 
-from typing import Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from infrastructure.operations import OperationResult
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class AccessSyncAdapter(Protocol):
     """Contract for all platform sync adapters."""
 
-    def capabilities(self) -> "AdapterCapabilities":
+    def capabilities(self) -> AdapterCapabilities:
         """Return the execution capabilities declared by this adapter."""
         ...
 
@@ -56,8 +56,8 @@ class AccessSyncAdapter(Protocol):
     def reconcile_user(
         self,
         user_email: str,
-        desired_state: "DesiredUserState",
-        context: "PlanningContext",
+        desired_state: DesiredUserState,
+        context: PlanningContext,
         dry_run: bool = False,
     ) -> OperationResult:
         """Assess current platform state, plan delta, execute changes for one user.
@@ -74,8 +74,8 @@ class AccessSyncAdapter(Protocol):
 
     def reconcile_platform(
         self,
-        desired_state: "DesiredPlatformState",
-        context: "PlanningContext",
+        desired_state: DesiredPlatformState,
+        context: PlanningContext,
         dry_run: bool = False,
     ) -> OperationResult:
         """Batch reconcile a full platform using entitlement-shaped desired state.

--- a/app/packages/access/sync/adapters/aws_identity_center.py
+++ b/app/packages/access/sync/adapters/aws_identity_center.py
@@ -11,8 +11,10 @@ AWS IC has no native "disable" state; disable_user signals manual_action_require
 """
 
 import re
-from dataclasses import dataclass, field, replace as dc_replace
-from typing import Any, Dict, List, Mapping, Optional, Set
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from dataclasses import replace as dc_replace
+from typing import Any
 
 import structlog
 
@@ -57,9 +59,9 @@ def _looks_like_group_id(value: str) -> bool:
 class _AwsGroupIndex:
     """Immutable index of AWS Identity Center groups built from a single list call."""
 
-    by_id: Dict[str, str] = field(default_factory=dict)
-    by_display_name_exact: Dict[str, str] = field(default_factory=dict)
-    by_display_name_norm: Dict[str, Set[str]] = field(default_factory=dict)
+    by_id: dict[str, str] = field(default_factory=dict)
+    by_display_name_exact: dict[str, str] = field(default_factory=dict)
+    by_display_name_norm: dict[str, set[str]] = field(default_factory=dict)
 
 
 class AwsIdentityCenterAdapter:
@@ -79,11 +81,11 @@ class AwsIdentityCenterAdapter:
 
     def __init__(self, aws_clients: AWSClients) -> None:
         self._aws = aws_clients
-        self._group_id_cache: Dict[str, str] = {}
-        self._group_index: Optional[_AwsGroupIndex] = None
+        self._group_id_cache: dict[str, str] = {}
+        self._group_index: _AwsGroupIndex | None = None
 
     @staticmethod
-    def _build_identitystore_name(user_email: str) -> Dict[str, str]:
+    def _build_identitystore_name(user_email: str) -> dict[str, str]:
         """Build a minimal AWS Identity Store Name payload from an email address."""
         local_part = user_email.split("@", 1)[0].strip()
         normalized = re.sub(r"[._-]+", " ", local_part)
@@ -99,7 +101,7 @@ class AwsIdentityCenterAdapter:
             "FamilyName": " ".join(token.title() for token in tokens[1:]),
         }
 
-    def _extract_primary_email(self, user: Mapping[str, Any]) -> Optional[str]:
+    def _extract_primary_email(self, user: Mapping[str, Any]) -> str | None:
         """Return the primary email from an Identity Store user payload."""
         emails = user.get("Emails", [])
         if not isinstance(emails, list):
@@ -124,9 +126,7 @@ class AwsIdentityCenterAdapter:
                 message="Unexpected Identity Store list_users payload",
                 error_code="INVALID_AWS_RESPONSE",
             )
-        users: List[Mapping[str, Any]] = [
-            item for item in result.data if isinstance(item, dict)
-        ]
+        users: list[Mapping[str, Any]] = [item for item in result.data if isinstance(item, dict)]
         return OperationResult.success(data=users)
 
     def capabilities(self) -> AdapterCapabilities:
@@ -169,15 +169,13 @@ class AwsIdentityCenterAdapter:
             log.error("build_group_index_failed", error=result.message)
             return result
 
-        groups: List[Mapping[str, Any]] = (
-            [item for item in result.data if isinstance(item, dict)]
-            if isinstance(result.data, list)
-            else []
+        groups: list[Mapping[str, Any]] = (
+            [item for item in result.data if isinstance(item, dict)] if isinstance(result.data, list) else []
         )
 
-        by_id: Dict[str, str] = {}
-        by_display_name_exact: Dict[str, str] = {}
-        by_display_name_norm: Dict[str, Set[str]] = {}
+        by_id: dict[str, str] = {}
+        by_display_name_exact: dict[str, str] = {}
+        by_display_name_norm: dict[str, set[str]] = {}
 
         for group in groups:
             group_id = group.get("GroupId")
@@ -259,9 +257,7 @@ class AwsIdentityCenterAdapter:
         exact_group_id = index.by_display_name_exact.get(token)
         if exact_group_id is not None:
             self._group_id_cache[candidate] = exact_group_id
-            log.info(
-                "resolve_group_id_exact_name", group_id=exact_group_id, token=token
-            )
+            log.info("resolve_group_id_exact_name", group_id=exact_group_id, token=token)
             return OperationResult.success(data=exact_group_id)
 
         # Step 3 & 4: normalized display-name match.
@@ -288,10 +284,7 @@ class AwsIdentityCenterAdapter:
             )
             return OperationResult.error(
                 OperationStatus.PERMANENT_ERROR,
-                message=(
-                    f"Ambiguous group name '{token}': {len(matching_ids)} AWS IC groups "
-                    f"normalize to the same token."
-                ),
+                message=(f"Ambiguous group name '{token}': {len(matching_ids)} AWS IC groups normalize to the same token."),
                 error_code="AMBIGUOUS_GROUP_NAME",
             )
 
@@ -376,15 +369,10 @@ class AwsIdentityCenterAdapter:
         Returns PERMANENT_ERROR with error_code="UNSUPPORTED_OPERATION" so the
         service can flag the run as requiring manual action.
         """
-        logger.bind(user_email=user_email, adapter="aws_identity_center").warning(
-            "disable_user_not_supported"
-        )
+        logger.bind(user_email=user_email, adapter="aws_identity_center").warning("disable_user_not_supported")
         return OperationResult.error(
             OperationStatus.PERMANENT_ERROR,
-            message=(
-                f"AWS Identity Center does not support native disable. "
-                f"Manual action required for user: {user_email}"
-            ),
+            message=(f"AWS Identity Center does not support native disable. Manual action required for user: {user_email}"),
             error_code="UNSUPPORTED_OPERATION",
         )
 
@@ -498,9 +486,7 @@ class AwsIdentityCenterAdapter:
         if not id_result.is_success:
             if id_result.status == OperationStatus.NOT_FOUND:
                 log.info("remove_entitlement_user_absent")
-                return OperationResult.success(
-                    message="user_absent_entitlement_skipped"
-                )
+                return OperationResult.success(message="user_absent_entitlement_skipped")
             return id_result
         user_id: str = (id_result.data or {}).get("user_id", "")
 
@@ -516,9 +502,7 @@ class AwsIdentityCenterAdapter:
         if not membership_result.is_success:
             if membership_result.status == OperationStatus.NOT_FOUND:
                 log.info("remove_entitlement_not_member", group_id=group_id)
-                return OperationResult.success(
-                    message="group_membership_already_absent"
-                )
+                return OperationResult.success(message="group_membership_already_absent")
             return membership_result
 
         membership_id: str = (membership_result.data or {}).get("MembershipId", "")
@@ -551,10 +535,8 @@ class AwsIdentityCenterAdapter:
             log.error("fetch_current_state_failed", error=result.message)
             return result
 
-        memberships: List[Mapping[str, Any]] = (
-            [item for item in result.data if isinstance(item, dict)]
-            if isinstance(result.data, list)
-            else []
+        memberships: list[Mapping[str, Any]] = (
+            [item for item in result.data if isinstance(item, dict)] if isinstance(result.data, list) else []
         )
         group_ids = [
             group_id
@@ -563,9 +545,7 @@ class AwsIdentityCenterAdapter:
             if isinstance(group_id, str) and group_id
         ]
         log.info("fetch_current_state_ok", group_count=len(group_ids))
-        return OperationResult.success(
-            data={"user_id": user_id, "group_ids": group_ids}
-        )
+        return OperationResult.success(data={"user_id": user_id, "group_ids": group_ids})
 
     def list_all_provisioned_users(self) -> OperationResult:
         """Return the set of all user emails provisioned in AWS Identity Store.
@@ -581,7 +561,7 @@ class AwsIdentityCenterAdapter:
             log.error("list_all_provisioned_users_failed", error=result.message)
             return result
 
-        emails: Set[str] = set()
+        emails: set[str] = set()
         users = result.data if isinstance(result.data, list) else []
         for user in users:
             email = self._extract_primary_email(user)
@@ -611,19 +591,17 @@ class AwsIdentityCenterAdapter:
         log = logger.bind(group_id=resolved_group_id, adapter="aws_identity_center")
         log.info("list_group_members_started")
 
-        memberships_result = self._aws.identitystore.list_group_memberships(
-            group_id=resolved_group_id
-        )
+        memberships_result = self._aws.identitystore.list_group_memberships(group_id=resolved_group_id)
         if not memberships_result.is_success:
             log.error("list_group_memberships_failed", error=memberships_result.message)
             return memberships_result
 
-        memberships: List[Mapping[str, Any]] = (
+        memberships: list[Mapping[str, Any]] = (
             [item for item in memberships_result.data if isinstance(item, dict)]
             if isinstance(memberships_result.data, list)
             else []
         )
-        member_user_ids: Set[str] = {
+        member_user_ids: set[str] = {
             user_id
             for membership in memberships
             for member_id in [membership.get("MemberId")]
@@ -638,17 +616,13 @@ class AwsIdentityCenterAdapter:
         map_result = self._build_user_id_email_map()
         if not map_result.is_success:
             return map_result
-        user_id_to_email: Dict[str, str] = (
-            map_result.data if isinstance(map_result.data, dict) else {}
-        )
+        user_id_to_email: dict[str, str] = map_result.data if isinstance(map_result.data, dict) else {}
 
-        member_emails: Set[str] = {
-            user_id_to_email[uid] for uid in member_user_ids if uid in user_id_to_email
-        }
+        member_emails: set[str] = {user_id_to_email[uid] for uid in member_user_ids if uid in user_id_to_email}
         log.info("list_group_members_ok", count=len(member_emails))
         return OperationResult.success(data=member_emails)
 
-    def list_members_for_groups(self, group_ids: Set[str]) -> OperationResult:
+    def list_members_for_groups(self, group_ids: set[str]) -> OperationResult:
         """Return group_id -> member email set using a bulk read path.
 
         Prefers the infrastructure client's list_groups_with_memberships orchestration
@@ -658,9 +632,7 @@ class AwsIdentityCenterAdapter:
             return OperationResult.success(data={})
 
         resolved_group_ids_result = self._resolve_group_ids(group_ids)
-        if not resolved_group_ids_result.is_success or not isinstance(
-            resolved_group_ids_result.data, set
-        ):
+        if not resolved_group_ids_result.is_success or not isinstance(resolved_group_ids_result.data, set):
             return resolved_group_ids_result
         resolved_group_ids = resolved_group_ids_result.data
 
@@ -669,9 +641,7 @@ class AwsIdentityCenterAdapter:
             group_count=len(resolved_group_ids),
         )
         bulk_mapping_result = self._list_members_for_groups_bulk(resolved_group_ids)
-        if bulk_mapping_result.is_success and isinstance(
-            bulk_mapping_result.data, dict
-        ):
+        if bulk_mapping_result.is_success and isinstance(bulk_mapping_result.data, dict):
             log.info("list_members_for_groups_ok", groups=len(bulk_mapping_result.data))
             return bulk_mapping_result
         if not bulk_mapping_result.is_success:
@@ -680,33 +650,29 @@ class AwsIdentityCenterAdapter:
                 error=bulk_mapping_result.message,
             )
 
-        fallback_mapping: Dict[str, Set[str]] = {}
+        fallback_mapping: dict[str, set[str]] = {}
         for group_id in resolved_group_ids:
             result = self.list_group_members(group_id)
             if not result.is_success:
                 return result
             members = result.data if isinstance(result.data, set) else set()
-            fallback_mapping[group_id] = {
-                email for email in members if isinstance(email, str)
-            }
+            fallback_mapping[group_id] = {email for email in members if isinstance(email, str)}
 
         log.info("list_members_for_groups_ok_fallback", groups=len(fallback_mapping))
         return OperationResult.success(data=fallback_mapping)
 
-    def _resolve_group_ids(self, group_ids: Set[str]) -> OperationResult:
+    def _resolve_group_ids(self, group_ids: set[str]) -> OperationResult:
         """Resolve many group identifiers to canonical GroupIds."""
-        resolved_group_ids: Set[str] = set()
+        resolved_group_ids: set[str] = set()
         for group_identifier in group_ids:
             resolved_result = self._resolve_group_id(group_identifier)
-            if not resolved_result.is_success or not isinstance(
-                resolved_result.data, str
-            ):
+            if not resolved_result.is_success or not isinstance(resolved_result.data, str):
                 return resolved_result
             resolved_group_ids.add(resolved_result.data)
         return OperationResult.success(data=resolved_group_ids)
 
     def _list_members_for_groups_bulk(  # noqa: C901
-        self, group_ids: Set[str]
+        self, group_ids: set[str]
     ) -> OperationResult:
         """Attempt one bulk list path for many groups."""
         identitystore = self._aws.identitystore
@@ -719,28 +685,22 @@ class AwsIdentityCenterAdapter:
 
         target_ids = set(group_ids)
         bulk_result = identitystore.list_groups_with_memberships(
-            groups_filters=[
-                lambda group: isinstance(group, dict)
-                and group.get("GroupId") in target_ids
-            ]
+            groups_filters=[lambda group: isinstance(group, dict) and group.get("GroupId") in target_ids]
         )
         if not bulk_result.is_success or not isinstance(bulk_result.data, list):
             return bulk_result
 
-        mapping: Dict[str, Set[str]] = {}
-        user_ids_by_group: Dict[str, Set[str]] = {}
+        mapping: dict[str, set[str]] = {}
+        user_ids_by_group: dict[str, set[str]] = {}
         for group in bulk_result.data:
             if not isinstance(group, dict):
                 continue
             group_identifier = group.get("GroupId")
-            if (
-                not isinstance(group_identifier, str)
-                or group_identifier not in target_ids
-            ):
+            if not isinstance(group_identifier, str) or group_identifier not in target_ids:
                 continue
             members = group.get("GroupMemberships", [])
-            emails: Set[str] = set()
-            pending_user_ids: Set[str] = set()
+            emails: set[str] = set()
+            pending_user_ids: set[str] = set()
             if isinstance(members, list):
                 for membership in members:
                     if not isinstance(membership, dict):
@@ -760,22 +720,16 @@ class AwsIdentityCenterAdapter:
             mapping[group_identifier] = emails
             user_ids_by_group[group_identifier] = pending_user_ids
 
-        unresolved_user_ids = {
-            user_id for user_ids in user_ids_by_group.values() for user_id in user_ids
-        }
+        unresolved_user_ids = {user_id for user_ids in user_ids_by_group.values() for user_id in user_ids}
         if unresolved_user_ids:
             user_map_result = self._build_user_id_email_map()
-            if not user_map_result.is_success or not isinstance(
-                user_map_result.data, dict
-            ):
+            if not user_map_result.is_success or not isinstance(user_map_result.data, dict):
                 return user_map_result
-            user_id_to_email: Dict[str, str] = user_map_result.data
+            user_id_to_email: dict[str, str] = user_map_result.data
 
             for group_identifier, pending_user_ids in user_ids_by_group.items():
                 mapping.setdefault(group_identifier, set()).update(
-                    user_id_to_email[user_id]
-                    for user_id in pending_user_ids
-                    if user_id in user_id_to_email
+                    user_id_to_email[user_id] for user_id in pending_user_ids if user_id in user_id_to_email
                 )
 
         for group_identifier in target_ids:
@@ -793,7 +747,7 @@ class AwsIdentityCenterAdapter:
         if not result.is_success:
             return result
 
-        mapping: Dict[str, str] = {}
+        mapping: dict[str, str] = {}
         users = result.data if isinstance(result.data, list) else []
         for user in users:
             user_id = user.get("UserId", "")
@@ -810,7 +764,7 @@ class AwsIdentityCenterAdapter:
 
     def _canonicalize_rules(
         self,
-        rules: List[EntitlementRule],
+        rules: list[EntitlementRule],
     ) -> OperationResult:
         """Resolve entitlement tokens to canonical AWS IC GroupIds.
 
@@ -820,7 +774,7 @@ class AwsIdentityCenterAdapter:
         """
         _SKIP_CODES = frozenset({"GROUP_ID_NOT_FOUND", "AMBIGUOUS_GROUP_NAME"})
         log = logger.bind(adapter="aws_identity_center")
-        canonical: List[EntitlementRule] = []
+        canonical: list[EntitlementRule] = []
         for rule in rules:
             if rule.entitlement_type != "group":
                 canonical.append(rule)
@@ -852,10 +806,10 @@ class AwsIdentityCenterAdapter:
     def _execute_planned_actions(
         self,
         user_email: str,
-        planned: List[PlannedAction],
+        planned: list[PlannedAction],
     ) -> OperationResult:
         """Execute a list of planned actions; return SyncOutcome or error."""
-        applied: List[str] = []
+        applied: list[str] = []
         requires_manual_action = False
         for action in planned:
             if action.action == "provision_user":
@@ -872,13 +826,9 @@ class AwsIdentityCenterAdapter:
                         error_code="INVALID_PLANNED_ACTION",
                     )
                 if action.action == "apply_entitlement":
-                    result = self.apply_entitlement(
-                        user_email, action.entitlement_type, action.entitlement_id
-                    )
+                    result = self.apply_entitlement(user_email, action.entitlement_type, action.entitlement_id)
                 else:
-                    result = self.remove_entitlement(
-                        user_email, action.entitlement_type, action.entitlement_id
-                    )
+                    result = self.remove_entitlement(user_email, action.entitlement_type, action.entitlement_id)
             else:
                 return OperationResult.error(
                     OperationStatus.PERMANENT_ERROR,
@@ -910,15 +860,11 @@ class AwsIdentityCenterAdapter:
         log: Any,
         dry_run: bool,
         plan: PlatformActionPlan,
-        entitlement_slug_by_id: Dict[str, str],
+        entitlement_slug_by_id: dict[str, str],
         unchanged_user_count: int,
     ) -> None:
         """Emit a concise slug-first summary for full-platform reconciliation."""
-        changed_users: Set[str] = (
-            set(plan.users_to_provision)
-            | set(plan.users_to_disable)
-            | set(plan.users_to_remove)
-        )
+        changed_users: set[str] = set(plan.users_to_provision) | set(plan.users_to_disable) | set(plan.users_to_remove)
         for members in plan.entitlement_adds_by_id.values():
             changed_users.update(members)
         for members in plan.entitlement_removes_by_id.values():
@@ -930,14 +876,10 @@ class AwsIdentityCenterAdapter:
             changed_user_count=len(changed_users),
             unchanged_user_count=unchanged_user_count,
             action_counts={
-                "apply_entitlement": sum(
-                    len(members) for members in plan.entitlement_adds_by_id.values()
-                ),
+                "apply_entitlement": sum(len(members) for members in plan.entitlement_adds_by_id.values()),
                 "disable_user": len(plan.users_to_disable),
                 "provision_user": len(plan.users_to_provision),
-                "remove_entitlement": sum(
-                    len(members) for members in plan.entitlement_removes_by_id.values()
-                ),
+                "remove_entitlement": sum(len(members) for members in plan.entitlement_removes_by_id.values()),
                 "remove_user": len(plan.users_to_remove),
             },
             lifecycle_actions={
@@ -947,20 +889,12 @@ class AwsIdentityCenterAdapter:
             },
             entitlements_by_action={
                 "apply_entitlement": {
-                    entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(
-                        members
-                    )
-                    for entitlement_id, members in sorted(
-                        plan.entitlement_adds_by_id.items()
-                    )
+                    entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(members)
+                    for entitlement_id, members in sorted(plan.entitlement_adds_by_id.items())
                 },
                 "remove_entitlement": {
-                    entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(
-                        members
-                    )
-                    for entitlement_id, members in sorted(
-                        plan.entitlement_removes_by_id.items()
-                    )
+                    entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(members)
+                    for entitlement_id, members in sorted(plan.entitlement_removes_by_id.items())
                 },
             },
         )
@@ -968,20 +902,16 @@ class AwsIdentityCenterAdapter:
     def _build_canonical_platform_state(
         self,
         desired_state: DesiredPlatformState,
-        canonical_rules: List[EntitlementRule],
+        canonical_rules: list[EntitlementRule],
     ) -> DesiredPlatformState:
         """Translate desired platform state to canonical AWS group IDs."""
-        canonical_id_by_slug: Dict[str, str] = {
-            rule.group_slug: rule.entitlement_id
-            for rule in canonical_rules
-            if rule.entitlement_type == "group"
+        canonical_id_by_slug: dict[str, str] = {
+            rule.group_slug: rule.entitlement_id for rule in canonical_rules if rule.entitlement_type == "group"
         }
-        desired_members_by_entitlement: Dict[str, Set[str]] = {
+        desired_members_by_entitlement: dict[str, set[str]] = {
             canonical_id: set() for canonical_id in canonical_id_by_slug.values()
         }
-        entitlement_slug_by_id: Dict[str, str] = {
-            canonical_id: slug for slug, canonical_id in canonical_id_by_slug.items()
-        }
+        entitlement_slug_by_id: dict[str, str] = {canonical_id: slug for slug, canonical_id in canonical_id_by_slug.items()}
 
         for (
             entitlement_id,
@@ -993,9 +923,7 @@ class AwsIdentityCenterAdapter:
             canonical_id = canonical_id_by_slug.get(slug)
             if canonical_id is None:
                 continue
-            desired_members_by_entitlement.setdefault(canonical_id, set()).update(
-                member.lower() for member in members
-            )
+            desired_members_by_entitlement.setdefault(canonical_id, set()).update(member.lower() for member in members)
 
         return DesiredPlatformState(
             desired_users={email.lower() for email in desired_state.desired_users},
@@ -1005,36 +933,26 @@ class AwsIdentityCenterAdapter:
 
     def _build_current_platform_state(
         self,
-        managed_entitlement_ids: Set[str],
+        managed_entitlement_ids: set[str],
     ) -> OperationResult:
         """Read current AWS users and entitlement memberships once per run."""
         provisioned_result = self.list_all_provisioned_users()
-        if not provisioned_result.is_success or not isinstance(
-            provisioned_result.data, set
-        ):
+        if not provisioned_result.is_success or not isinstance(provisioned_result.data, set):
             return provisioned_result
 
-        current_members_by_entitlement: Dict[str, Set[str]] = {}
+        current_members_by_entitlement: dict[str, set[str]] = {}
         if managed_entitlement_ids:
             memberships_result = self.list_members_for_groups(managed_entitlement_ids)
-            if not memberships_result.is_success or not isinstance(
-                memberships_result.data, dict
-            ):
+            if not memberships_result.is_success or not isinstance(memberships_result.data, dict):
                 return memberships_result
             current_members_by_entitlement = {
-                entitlement_id: {
-                    email.lower() for email in members if isinstance(email, str)
-                }
+                entitlement_id: {email.lower() for email in members if isinstance(email, str)}
                 for entitlement_id, members in memberships_result.data.items()
             }
 
         return OperationResult.success(
             data=CurrentPlatformState(
-                current_users={
-                    email.lower()
-                    for email in provisioned_result.data
-                    if isinstance(email, str)
-                },
+                current_users={email.lower() for email in provisioned_result.data if isinstance(email, str)},
                 current_members_by_entitlement=current_members_by_entitlement,
             )
         )
@@ -1042,14 +960,12 @@ class AwsIdentityCenterAdapter:
     def _build_user_action_map(
         self,
         plan: PlatformActionPlan,
-    ) -> Dict[str, List[PlannedAction]]:
+    ) -> dict[str, list[PlannedAction]]:
         """Translate grouped platform deltas into targeted per-user actions."""
-        actions_by_user: Dict[str, List[PlannedAction]] = {}
+        actions_by_user: dict[str, list[PlannedAction]] = {}
 
         for user_email in sorted(plan.users_to_provision):
-            actions_by_user.setdefault(user_email, []).append(
-                PlannedAction(action="provision_user")
-            )
+            actions_by_user.setdefault(user_email, []).append(PlannedAction(action="provision_user"))
         for entitlement_id, members in sorted(plan.entitlement_adds_by_id.items()):
             for user_email in sorted(members):
                 actions_by_user.setdefault(user_email, []).append(
@@ -1069,13 +985,9 @@ class AwsIdentityCenterAdapter:
                     )
                 )
         for user_email in sorted(plan.users_to_disable):
-            actions_by_user.setdefault(user_email, []).append(
-                PlannedAction(action="disable_user")
-            )
+            actions_by_user.setdefault(user_email, []).append(PlannedAction(action="disable_user"))
         for user_email in sorted(plan.users_to_remove):
-            actions_by_user.setdefault(user_email, []).append(
-                PlannedAction(action="remove_user")
-            )
+            actions_by_user.setdefault(user_email, []).append(PlannedAction(action="remove_user"))
 
         return actions_by_user
 
@@ -1104,12 +1016,12 @@ class AwsIdentityCenterAdapter:
         canon_result = self._canonicalize_rules(context.entitlement_rules)
         if not canon_result.is_success or not isinstance(canon_result.data, list):
             return canon_result
-        canonical_rules: List[EntitlementRule] = canon_result.data
+        canonical_rules: list[EntitlementRule] = canon_result.data
 
         required_result = self._canonicalize_rules(desired_state.required_entitlements)
         if not required_result.is_success or not isinstance(required_result.data, list):
             return required_result
-        canonical_required: List[EntitlementRule] = required_result.data
+        canonical_required: list[EntitlementRule] = required_result.data
 
         assessment = self._assess_live(user_email)
         if not assessment.is_success or assessment.data is None:
@@ -1126,15 +1038,13 @@ class AwsIdentityCenterAdapter:
             current_entitlement_ids=current.current_entitlement_ids,
             platform_user_exists=current.platform_user_exists,
         )
-        planned_names: List[str] = [a.action for a in planned]
+        planned_names: list[str] = [a.action for a in planned]
         log.debug(
             "reconcile_user_plan_summary",
             dry_run=dry_run,
             user_should_exist=desired_state.user_should_exist,
             platform_user_exists=current.platform_user_exists,
-            desired_entitlement_ids=sorted(
-                rule.entitlement_id for rule in canonical_required
-            ),
+            desired_entitlement_ids=sorted(rule.entitlement_id for rule in canonical_required),
             current_entitlement_ids=sorted(current.current_entitlement_ids),
             planned_actions=planned_names,
         )
@@ -1168,7 +1078,7 @@ class AwsIdentityCenterAdapter:
         canon_result = self._canonicalize_rules(context.entitlement_rules)
         if not canon_result.is_success or not isinstance(canon_result.data, list):
             return canon_result
-        canonical_rules: List[EntitlementRule] = canon_result.data
+        canonical_rules: list[EntitlementRule] = canon_result.data
         canonical_context = dc_replace(context, entitlement_rules=canonical_rules)
         canonical_desired = self._build_canonical_platform_state(
             desired_state=desired_state,
@@ -1176,13 +1086,9 @@ class AwsIdentityCenterAdapter:
         )
 
         current_state_result = self._build_current_platform_state(
-            managed_entitlement_ids=set(
-                canonical_desired.desired_members_by_entitlement.keys()
-            )
+            managed_entitlement_ids=set(canonical_desired.desired_members_by_entitlement.keys())
         )
-        if not current_state_result.is_success or not isinstance(
-            current_state_result.data, CurrentPlatformState
-        ):
+        if not current_state_result.is_success or not isinstance(current_state_result.data, CurrentPlatformState):
             return current_state_result
         current_state: CurrentPlatformState = current_state_result.data
 
@@ -1197,8 +1103,7 @@ class AwsIdentityCenterAdapter:
         actions_by_user = self._build_user_action_map(plan)
 
         failed_group_slugs = sorted(
-            set(desired_state.entitlement_slug_by_id.values())
-            - set(canonical_desired.entitlement_slug_by_id.values())
+            set(desired_state.entitlement_slug_by_id.values()) - set(canonical_desired.entitlement_slug_by_id.values())
         )
         log.info(
             "reconcile_platform_groups_matched",
@@ -1212,13 +1117,10 @@ class AwsIdentityCenterAdapter:
             dry_run=dry_run,
             plan=plan,
             entitlement_slug_by_id=canonical_desired.entitlement_slug_by_id,
-            unchanged_user_count=len(
-                canonical_desired.desired_users | current_state.current_users
-            )
-            - len(actions_by_user),
+            unchanged_user_count=len(canonical_desired.desired_users | current_state.current_users) - len(actions_by_user),
         )
 
-        per_user: Dict[str, SyncOutcome] = {}
+        per_user: dict[str, SyncOutcome] = {}
         users_converged = 0
         requires_manual_action_count = 0
         for user_email in sorted(actions_by_user):
@@ -1230,9 +1132,7 @@ class AwsIdentityCenterAdapter:
                 )
             else:
                 exec_result = self._execute_planned_actions(user_email, planned_actions)
-                if not exec_result.is_success or not isinstance(
-                    exec_result.data, SyncOutcome
-                ):
+                if not exec_result.is_success or not isinstance(exec_result.data, SyncOutcome):
                     return exec_result
                 outcome = exec_result.data
             per_user[user_email] = outcome
@@ -1241,12 +1141,8 @@ class AwsIdentityCenterAdapter:
             if outcome.requires_manual_action:
                 requires_manual_action_count += 1
 
-        users_synced = len(
-            canonical_desired.desired_users | current_state.current_users
-        )
-        orphans_found = len(
-            current_state.current_users - canonical_desired.desired_users
-        )
+        users_synced = len(canonical_desired.desired_users | current_state.current_users)
+        orphans_found = len(current_state.current_users - canonical_desired.desired_users)
         log.info(
             "reconcile_platform_completed",
             users_synced=users_synced,
@@ -1264,20 +1160,12 @@ class AwsIdentityCenterAdapter:
                 dry_run=dry_run,
                 per_user=per_user,
                 changed_user_count=len(actions_by_user),
-                unchanged_user_count=len(
-                    canonical_desired.desired_users | current_state.current_users
-                )
-                - len(actions_by_user),
+                unchanged_user_count=len(canonical_desired.desired_users | current_state.current_users) - len(actions_by_user),
                 action_counts={
-                    "apply_entitlement": sum(
-                        len(members) for members in plan.entitlement_adds_by_id.values()
-                    ),
+                    "apply_entitlement": sum(len(members) for members in plan.entitlement_adds_by_id.values()),
                     "disable_user": len(plan.users_to_disable),
                     "provision_user": len(plan.users_to_provision),
-                    "remove_entitlement": sum(
-                        len(members)
-                        for members in plan.entitlement_removes_by_id.values()
-                    ),
+                    "remove_entitlement": sum(len(members) for members in plan.entitlement_removes_by_id.values()),
                     "remove_user": len(plan.users_to_remove),
                 },
                 lifecycle_actions={
@@ -1287,20 +1175,12 @@ class AwsIdentityCenterAdapter:
                 },
                 entitlements_by_action={
                     "apply_entitlement": {
-                        canonical_desired.entitlement_slug_by_id.get(
-                            entitlement_id, entitlement_id
-                        ): sorted(members)
-                        for entitlement_id, members in sorted(
-                            plan.entitlement_adds_by_id.items()
-                        )
+                        canonical_desired.entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(members)
+                        for entitlement_id, members in sorted(plan.entitlement_adds_by_id.items())
                     },
                     "remove_entitlement": {
-                        canonical_desired.entitlement_slug_by_id.get(
-                            entitlement_id, entitlement_id
-                        ): sorted(members)
-                        for entitlement_id, members in sorted(
-                            plan.entitlement_removes_by_id.items()
-                        )
+                        canonical_desired.entitlement_slug_by_id.get(entitlement_id, entitlement_id): sorted(members)
+                        for entitlement_id, members in sorted(plan.entitlement_removes_by_id.items())
                     },
                 },
             )
@@ -1318,7 +1198,7 @@ class AwsIdentityCenterAdapter:
                     )
                 )
             return state_result
-        group_ids: Set[str] = set((state_result.data or {}).get("group_ids", []))
+        group_ids: set[str] = set((state_result.data or {}).get("group_ids", []))
         return OperationResult.success(
             data=AdapterAssessment(
                 platform_user_exists=True,

--- a/app/packages/access/sync/adapters/fake_platform.py
+++ b/app/packages/access/sync/adapters/fake_platform.py
@@ -4,8 +4,6 @@ Provides deterministic responses for a non-AWS platform to validate
 orchestration paths without external API dependencies.
 """
 
-from typing import Dict, List, Set
-
 import structlog
 
 from infrastructure.operations import OperationResult, OperationStatus
@@ -32,13 +30,13 @@ class FakePlatformAdapter:
     """In-memory fake platform adapter with sample users and group memberships."""
 
     def __init__(self) -> None:
-        self._users: Set[str] = {
+        self._users: set[str] = {
             "alice@example.com",
             "bob@example.com",
             "carol@example.com",
         }
-        self._disabled: Set[str] = set()
-        self._members_by_group: Dict[str, Set[str]] = {
+        self._disabled: set[str] = set()
+        self._members_by_group: dict[str, set[str]] = {
             "fake-group-admin": {"alice@example.com", "carol@example.com"},
             "fake-group-read": {"bob@example.com"},
         }
@@ -120,11 +118,7 @@ class FakePlatformAdapter:
                 platform_user_exists=False,
                 current_entitlement_ids=set(),
             )
-        group_ids: Set[str] = {
-            gid
-            for gid, members in self._members_by_group.items()
-            if normalized in members
-        }
+        group_ids: set[str] = {gid for gid, members in self._members_by_group.items() if normalized in members}
         return AdapterAssessment(
             platform_user_exists=True,
             current_entitlement_ids=group_ids,
@@ -133,9 +127,9 @@ class FakePlatformAdapter:
     def _execute_planned_actions(
         self,
         user_email: str,
-        planned: List[PlannedAction],
+        planned: list[PlannedAction],
     ) -> OperationResult:
-        applied: List[str] = []
+        applied: list[str] = []
         requires_manual_action = False
         for action in planned:
             if action.action == "provision_user":
@@ -152,13 +146,9 @@ class FakePlatformAdapter:
                         error_code="INVALID_PLANNED_ACTION",
                     )
                 if action.action == "apply_entitlement":
-                    result = self.apply_entitlement(
-                        user_email, action.entitlement_type, action.entitlement_id
-                    )
+                    result = self.apply_entitlement(user_email, action.entitlement_type, action.entitlement_id)
                 else:
-                    result = self.remove_entitlement(
-                        user_email, action.entitlement_type, action.entitlement_id
-                    )
+                    result = self.remove_entitlement(user_email, action.entitlement_type, action.entitlement_id)
             else:
                 return OperationResult.error(
                     OperationStatus.PERMANENT_ERROR,
@@ -170,9 +160,7 @@ class FakePlatformAdapter:
             elif result.error_code == "UNSUPPORTED_OPERATION":
                 requires_manual_action = True
             else:
-                return OperationResult.error(
-                    result.status, message=result.message, error_code=result.error_code
-                )
+                return OperationResult.error(result.status, message=result.message, error_code=result.error_code)
         return OperationResult.success(
             data=SyncOutcome(
                 planned_actions=[a.action for a in planned],
@@ -223,8 +211,7 @@ class FakePlatformAdapter:
         current_state = CurrentPlatformState(
             current_users=set(self._users),
             current_members_by_entitlement={
-                entitlement_id: set(members)
-                for entitlement_id, members in self._members_by_group.items()
+                entitlement_id: set(members) for entitlement_id, members in self._members_by_group.items()
             },
         )
         plan = planner.plan_platform_actions(
@@ -234,12 +221,10 @@ class FakePlatformAdapter:
             current_members_by_entitlement=current_state.current_members_by_entitlement,
             authn_removal_mode=context.authn_removal_mode,
         )
-        actions_by_user: Dict[str, List[PlannedAction]] = {}
+        actions_by_user: dict[str, list[PlannedAction]] = {}
 
         for email in sorted(plan.users_to_provision):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="provision_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="provision_user"))
         for entitlement_id, members in sorted(plan.entitlement_adds_by_id.items()):
             for email in sorted(members):
                 actions_by_user.setdefault(email, []).append(
@@ -259,18 +244,14 @@ class FakePlatformAdapter:
                     )
                 )
         for email in sorted(plan.users_to_disable):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="disable_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="disable_user"))
         for email in sorted(plan.users_to_remove):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="remove_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="remove_user"))
 
         users_synced = len(desired_state.desired_users | current_state.current_users)
         users_converged = 0
         requires_manual_action_count = 0
-        per_user: Dict[str, SyncOutcome] = {}
+        per_user: dict[str, SyncOutcome] = {}
         for email in sorted(actions_by_user):
             planned = actions_by_user[email]
             if dry_run:
@@ -280,9 +261,7 @@ class FakePlatformAdapter:
                 )
             else:
                 exec_result = self._execute_planned_actions(email, planned)
-                if not exec_result.is_success or not isinstance(
-                    exec_result.data, SyncOutcome
-                ):
+                if not exec_result.is_success or not isinstance(exec_result.data, SyncOutcome):
                     return exec_result
                 outcome = exec_result.data
             per_user[email] = outcome
@@ -296,9 +275,7 @@ class FakePlatformAdapter:
                 platform=context.platform,
                 users_synced=users_synced,
                 users_converged=users_converged,
-                orphans_found=len(
-                    current_state.current_users - desired_state.desired_users
-                ),
+                orphans_found=len(current_state.current_users - desired_state.desired_users),
                 requires_manual_action_count=requires_manual_action_count,
                 dry_run=dry_run,
                 per_user=per_user,

--- a/app/packages/access/sync/application.py
+++ b/app/packages/access/sync/application.py
@@ -10,7 +10,8 @@ All platform state assessment, planning, and execution is owned by adapters.
 """
 
 import uuid
-from typing import TYPE_CHECKING, Mapping, Optional, Protocol, Tuple
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Protocol
 
 import structlog
 
@@ -70,8 +71,8 @@ class AccessSyncApplicationService:
         adapters: Mapping[str, AccessSyncAdapter],
         config: AccessRuntimeConfig,
         membership_builder: DirectoryMembershipBuilder,
-        repository: "Optional[SyncRunRepository]" = None,
-        dispatcher: Optional[EventDispatcher] = None,
+        repository: SyncRunRepository | None = None,
+        dispatcher: EventDispatcher | None = None,
     ) -> None:
         self._adapters = adapters
         self._config = config
@@ -79,10 +80,12 @@ class AccessSyncApplicationService:
         self._repository = repository
         self._dispatcher = dispatcher
 
-    def _resolve(self, platform: str) -> Tuple[
-        Optional[AccessSyncAdapter],
-        Optional[EffectivePlatformPolicy],
-        Optional[OperationResult],
+    def _resolve(
+        self, platform: str
+    ) -> tuple[
+        AccessSyncAdapter | None,
+        EffectivePlatformPolicy | None,
+        OperationResult | None,
     ]:
         """Return (adapter, effective_policy, None) or (None, None, error)."""
         if platform not in self._config.platforms:
@@ -106,9 +109,7 @@ class AccessSyncApplicationService:
                     error_code="ADAPTER_NOT_FOUND",
                 ),
             )
-        discovered = self._membership_builder.discover_group_slugs(
-            self._config, platform
-        )
+        discovered = self._membership_builder.discover_group_slugs(self._config, platform)
         effective = resolve_effective_policy(self._config, platform, discovered)
         return adapter, effective, None
 
@@ -123,9 +124,7 @@ class AccessSyncApplicationService:
     ) -> None:
         if self._repository is None:
             return
-        status = (
-            "manual_action_required" if outcome.requires_manual_action else "success"
-        )
+        status = "manual_action_required" if outcome.requires_manual_action else "success"
         self._repository.save(
             SyncRunRecord(
                 run_id=run_id,
@@ -156,8 +155,8 @@ class AccessSyncApplicationService:
         adapter, effective, error = self._resolve(platform)
         if error is not None:
             return error
-        assert adapter is not None
-        assert effective is not None
+        assert adapter is not None  # noqa: S101 -- adapter/effective are guaranteed after _resolve() returns no error
+        assert effective is not None  # noqa: S101 -- adapter/effective are guaranteed after _resolve() returns no error
 
         desired_result = self._membership_builder.build_user_state_from_effective(
             user_email=user_email,
@@ -174,9 +173,7 @@ class AccessSyncApplicationService:
         )
 
         if result.is_success and isinstance(result.data, SyncOutcome):
-            self._persist(
-                run_id, user_email, platform, result.data, dry_run, request_id
-            )
+            self._persist(run_id, user_email, platform, result.data, dry_run, request_id)
             if self._dispatcher:
                 self._dispatcher.dispatch_background(
                     Event(
@@ -234,8 +231,8 @@ class AccessSyncApplicationService:
         adapter, effective, error = self._resolve(platform)
         if error is not None:
             return error
-        assert adapter is not None
-        assert effective is not None
+        assert adapter is not None  # noqa: S101 -- adapter/effective are guaranteed after _resolve() returns no error
+        assert effective is not None  # noqa: S101 -- adapter/effective are guaranteed after _resolve() returns no error
 
         desired_result = self._membership_builder.build_platform_state_from_effective(
             effective=effective,

--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -12,7 +12,7 @@ of IDP groups is handled by ``discover_group_slugs`` which queries the
 directory with the platform prefix and returns matching slugs.
 """
 
-from typing import Dict, List, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import structlog
 
@@ -38,7 +38,7 @@ class DirectoryMembershipBuilder:
     failures through the standard result contract without catching exceptions.
     """
 
-    def __init__(self, directory: "DirectoryProvider") -> None:
+    def __init__(self, directory: DirectoryProvider) -> None:
         self._directory = directory
 
     def build_user_state_from_effective(
@@ -64,9 +64,7 @@ class DirectoryMembershipBuilder:
         before calling this method.
         """
         log = logger.bind(user_email=user_email, platform=effective.platform)
-        authn_result = self._check_group_membership(
-            effective.authn_group_slug, user_email
-        )
+        authn_result = self._check_group_membership(effective.authn_group_slug, user_email)
         log.debug(
             "check_authn_group_membership_completed",
             authn_group_slug=effective.authn_group_slug,
@@ -82,7 +80,7 @@ class DirectoryMembershipBuilder:
 
         user_should_exist: bool = authn_result.data or False
 
-        required_entitlements: List[EntitlementRule] = []
+        required_entitlements: list[EntitlementRule] = []
         if user_should_exist:
             user_groups_result = self._directory.get_user_groups(user_email)
             if not user_groups_result.is_success:
@@ -92,28 +90,20 @@ class DirectoryMembershipBuilder:
                     error_code=user_groups_result.error_code,
                 )
 
-            user_group_slugs: Set[str] = {
-                group.group_slug.lower()
-                for group in (user_groups_result.data or [])
-                if group.group_slug
+            user_group_slugs: set[str] = {
+                group.group_slug.lower() for group in (user_groups_result.data or []) if group.group_slug
             }
 
             required_entitlements = [
-                rule
-                for rule in effective.sync_managed_rules()
-                if rule.group_slug.lower() in user_group_slugs
+                rule for rule in effective.sync_managed_rules() if rule.group_slug.lower() in user_group_slugs
             ]
 
         logger.bind(user_email=user_email, platform=effective.platform).info(
             "build_user_state_completed",
             user_should_exist=user_should_exist,
             required_entitlement_count=len(required_entitlements),
-            required_entitlement_group_slugs=[
-                rule.group_slug for rule in required_entitlements
-            ],
-            required_entitlement_ids=[
-                rule.entitlement_id for rule in required_entitlements
-            ],
+            required_entitlement_group_slugs=[rule.group_slug for rule in required_entitlements],
+            required_entitlement_ids=[rule.entitlement_id for rule in required_entitlements],
         )
         return OperationResult.success(
             data=DesiredUserState(
@@ -149,12 +139,10 @@ class DirectoryMembershipBuilder:
                 error_code=authn_members_result.error_code,
             )
 
-        desired_users: Set[str] = {
-            member.email.lower() for member in (authn_members_result.data or [])
-        }
+        desired_users: set[str] = {member.email.lower() for member in (authn_members_result.data or [])}
         log.info("build_desired_state_authn_members", count=len(desired_users))
 
-        email_to_rule: Dict[str, EntitlementRule] = {}
+        email_to_rule: dict[str, EntitlementRule] = {}
         for rule in effective.sync_managed_rules():
             group_result = self._directory.get_group(rule.group_slug)
             if not group_result.is_success or not group_result.data:
@@ -165,11 +153,8 @@ class DirectoryMembershipBuilder:
                 continue
             email_to_rule[group_result.data.group_email] = rule
 
-        desired_members_by_entitlement: Dict[str, Set[str]] = {}
-        entitlement_slug_by_id: Dict[str, str] = {
-            rule.entitlement_id: rule.group_slug
-            for rule in effective.sync_managed_rules()
-        }
+        desired_members_by_entitlement: dict[str, set[str]] = {}
+        entitlement_slug_by_id: dict[str, str] = {rule.entitlement_id: rule.group_slug for rule in effective.sync_managed_rules()}
 
         if email_to_rule:
             batch_result = self._directory.get_group_members_batch(
@@ -186,12 +171,8 @@ class DirectoryMembershipBuilder:
                     matched_rule = email_to_rule.get(group_email)
                     if matched_rule is None:
                         continue
-                    desired_members_by_entitlement.setdefault(
-                        matched_rule.entitlement_id, set()
-                    ).update(
-                        member.email.lower()
-                        for member in members
-                        if member.email.lower() in desired_users
+                    desired_members_by_entitlement.setdefault(matched_rule.entitlement_id, set()).update(
+                        member.email.lower() for member in members if member.email.lower() in desired_users
                     )
 
         return OperationResult.success(
@@ -204,9 +185,9 @@ class DirectoryMembershipBuilder:
 
     def discover_group_slugs(
         self,
-        config: "AccessRuntimeConfig",
+        config: AccessRuntimeConfig,
         platform: str,
-    ) -> Set[str]:
+    ) -> set[str]:
         """Discover IDP group slugs for a platform by querying with the platform prefix.
 
         Uses ``config.group_prefix(platform)`` as the query and filters results

--- a/app/packages/access/sync/domain.py
+++ b/app/packages/access/sync/domain.py
@@ -10,8 +10,8 @@ and never produce a ``SyncOutcome``.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Dict, List, Literal, Optional, Set
+from datetime import UTC, datetime
+from typing import Literal
 
 from packages.access.sync.policies import EntitlementRule
 
@@ -35,7 +35,7 @@ class AdapterAssessment:
     """
 
     platform_user_exists: bool
-    current_entitlement_ids: Set[str] = field(default_factory=set)
+    current_entitlement_ids: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -48,24 +48,24 @@ class DesiredUserState:
     """
 
     user_should_exist: bool
-    required_entitlements: List[EntitlementRule] = field(default_factory=list)
+    required_entitlements: list[EntitlementRule] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class DesiredPlatformState:
     """Resolved desired state for a full platform reconciliation run."""
 
-    desired_users: Set[str] = field(default_factory=set)
-    desired_members_by_entitlement: Dict[str, Set[str]] = field(default_factory=dict)
-    entitlement_slug_by_id: Dict[str, str] = field(default_factory=dict)
+    desired_users: set[str] = field(default_factory=set)
+    desired_members_by_entitlement: dict[str, set[str]] = field(default_factory=dict)
+    entitlement_slug_by_id: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class CurrentPlatformState:
     """Current platform state for a full platform reconciliation run."""
 
-    current_users: Set[str] = field(default_factory=set)
-    current_members_by_entitlement: Dict[str, Set[str]] = field(default_factory=dict)
+    current_users: set[str] = field(default_factory=set)
+    current_members_by_entitlement: dict[str, set[str]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -82,8 +82,8 @@ class SyncOutcome:
             sync still succeeded for the actions that were automatable.
     """
 
-    planned_actions: List[str] = field(default_factory=list)
-    applied_actions: List[str] = field(default_factory=list)
+    planned_actions: list[str] = field(default_factory=list)
+    applied_actions: list[str] = field(default_factory=list)
     requires_manual_action: bool = False
 
 
@@ -94,12 +94,12 @@ class SyncRunRecord:
     run_id: str
     user_email: str
     platform: str
-    actions_applied: List[str]
+    actions_applied: list[str]
     status: Literal["success", "partial", "failed", "manual_action_required"]
     dry_run: bool = False
-    request_id: Optional[str] = None
-    error_message: Optional[str] = None
-    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    request_id: str | None = None
+    error_message: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 @dataclass(frozen=True)
@@ -122,11 +122,9 @@ class ReconciliationOutcome:
     orphans_found: int
     requires_manual_action_count: int
     dry_run: bool = False
-    per_user: Dict[str, SyncOutcome] = field(default_factory=dict)
+    per_user: dict[str, SyncOutcome] = field(default_factory=dict)
     changed_user_count: int = 0
     unchanged_user_count: int = 0
-    action_counts: Dict[str, int] = field(default_factory=dict)
-    lifecycle_actions: Dict[str, List[str]] = field(default_factory=dict)
-    entitlements_by_action: Dict[str, Dict[str, List[str]]] = field(
-        default_factory=dict
-    )
+    action_counts: dict[str, int] = field(default_factory=dict)
+    lifecycle_actions: dict[str, list[str]] = field(default_factory=dict)
+    entitlements_by_action: dict[str, dict[str, list[str]]] = field(default_factory=dict)

--- a/app/packages/access/sync/events.py
+++ b/app/packages/access/sync/events.py
@@ -9,6 +9,8 @@ This module contains event name constants only.
 
 from packages.access.common.events import (
     SYNC_COMPLETED as COMMON_SYNC_COMPLETED,
+)
+from packages.access.common.events import (
     SYNC_FAILED as COMMON_SYNC_FAILED,
 )
 

--- a/app/packages/access/sync/interactions/http.py
+++ b/app/packages/access/sync/interactions/http.py
@@ -10,15 +10,21 @@ FastAPI ``Depends`` factories for the coordinator and settings are declared in
 so they are test-substitutable without monkey-patching FastAPI.
 """
 
-from typing import Annotated, Protocol, Union
+from typing import Annotated, Protocol
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Response, Security
 
-from infrastructure.security.models import User
+from infrastructure.idempotency import get_idempotency_service
 from infrastructure.operations import OperationResult
 from infrastructure.security import get_current_user
-from infrastructure.idempotency import get_idempotency_service
+from infrastructure.security.models import User
+from packages.access.sync.interactions.ingress import (
+    EnqueuedJob,
+    enqueue_platform_sync,
+    enqueue_user_sync,
+)
+from packages.access.sync.presenters import to_http_status_response
 from packages.access.sync.providers import (
     get_access_sync_coordinator,
     get_access_sync_settings,
@@ -30,12 +36,6 @@ from packages.access.sync.schemas import (
     UserSyncJobAcceptedResponse,
     UserSyncRequest,
 )
-from packages.access.sync.interactions.ingress import (
-    EnqueuedJob,
-    enqueue_platform_sync,
-    enqueue_user_sync,
-)
-from packages.access.sync.presenters import to_http_status_response
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/access", tags=["Access Sync"])
@@ -104,7 +104,7 @@ def _noop_coordinator() -> _AccessSyncApplicationServicePort | None:
 
 @router.post(
     "/sync-runs",
-    response_model=Union[UserSyncJobAcceptedResponse, PlatformSyncJobAcceptedResponse],
+    response_model=UserSyncJobAcceptedResponse | PlatformSyncJobAcceptedResponse,
     summary="Sync access",
     description=(
         "Converge user or platform access state to match IDP group membership policy. "
@@ -123,13 +123,9 @@ def sync_endpoint(
     request: AccessSyncRequest,
     response: Response,
     settings: Annotated[_AccessSyncSettingsPort, Depends(get_access_sync_settings)],
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-sync"])
-    ],
-    coordinator: Annotated[
-        _AccessSyncApplicationServicePort | None, Depends(_noop_coordinator)
-    ] = None,
-) -> Union[UserSyncJobAcceptedResponse, PlatformSyncJobAcceptedResponse]:
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-sync"])],
+    coordinator: Annotated[_AccessSyncApplicationServicePort | None, Depends(_noop_coordinator)] = None,
+) -> UserSyncJobAcceptedResponse | PlatformSyncJobAcceptedResponse:
     """Enqueue an on-demand user sync or a full platform sync job."""
     log = logger.bind(
         sync_type=request.sync_type,
@@ -158,9 +154,7 @@ def sync_endpoint(
             request_id=request.request_id or "",
         )
         if not result.is_success or result.data is None:
-            raise _http_error_from_enqueue(
-                result.error_code or "", result.message or ""
-            )
+            raise _http_error_from_enqueue(result.error_code or "", result.message or "")
         job: EnqueuedJob = result.data
         response.status_code = 202
         return UserSyncJobAcceptedResponse(
@@ -213,9 +207,7 @@ def sync_endpoint(
 )
 def get_sync_job_status(
     job_id: str,
-    current_user: Annotated[
-        User, Security(get_current_user, scopes=["sre-bot:access-sync"])
-    ],
+    current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-sync"])],
 ) -> SyncJobStatusResponse:
     """Return the current status and outcome of a sync job."""
     idempotency = get_idempotency_service()

--- a/app/packages/access/sync/interactions/ingress.py
+++ b/app/packages/access/sync/interactions/ingress.py
@@ -9,7 +9,7 @@ Transports are responsible only for request parsing and response formatting.
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Protocol
 
 import structlog
@@ -53,7 +53,7 @@ class EnqueuedJob:
 def enqueue_user_sync(
     coordinator: AccessSyncApplicationServicePort,
     idempotency: IdempotencyService,
-    settings: "_IngressSettings",
+    settings: _IngressSettings,
     user_email: str,
     platform: str,
     dry_run: bool = False,
@@ -78,9 +78,7 @@ def enqueue_user_sync(
     running = check_lock(lock_key, idempotency, settings.lock_stale_seconds)
     if running is not None:
         existing_job_id = running.get("job_id", "")
-        logger.bind(platform=platform, user_email=user_email).info(
-            "user_sync_already_running", existing_job_id=existing_job_id
-        )
+        logger.bind(platform=platform, user_email=user_email).info("user_sync_already_running", existing_job_id=existing_job_id)
         return OperationResult.success(
             data=EnqueuedJob(
                 job_id=existing_job_id,
@@ -93,7 +91,7 @@ def enqueue_user_sync(
         )
 
     job_id = str(uuid.uuid4())
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
     spawn_user_sync_thread(
         coordinator=coordinator,
         idempotency=idempotency,
@@ -120,7 +118,7 @@ def enqueue_user_sync(
 def enqueue_platform_sync(
     coordinator: AccessSyncApplicationServicePort,
     idempotency: IdempotencyService,
-    settings: "_IngressSettings",
+    settings: _IngressSettings,
     platform: str,
     dry_run: bool = False,
     request_id: str = "",
@@ -144,9 +142,7 @@ def enqueue_platform_sync(
     running = check_lock(lock_key, idempotency, settings.lock_stale_seconds)
     if running is not None:
         existing_job_id = running.get("job_id", "")
-        logger.bind(platform=platform).info(
-            "platform_sync_already_running", existing_job_id=existing_job_id
-        )
+        logger.bind(platform=platform).info("platform_sync_already_running", existing_job_id=existing_job_id)
         return OperationResult.success(
             data=EnqueuedJob(
                 job_id=existing_job_id,
@@ -159,7 +155,7 @@ def enqueue_platform_sync(
         )
 
     job_id = str(uuid.uuid4())
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
     spawn_platform_sync_thread(
         coordinator=coordinator,
         idempotency=idempotency,

--- a/app/packages/access/sync/interactions/slack.py
+++ b/app/packages/access/sync/interactions/slack.py
@@ -9,7 +9,7 @@ Command hierarchy under /sre:
             └── status  <job_id>
 """
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
-def register_commands(provider: "SlackPlatformProvider") -> None:
+def register_commands(provider: SlackPlatformProvider) -> None:
     """Register access sync Slack commands.
 
     Registers the ``access`` parent (shared by all access subpackages), the
@@ -154,7 +154,7 @@ def register_commands(provider: "SlackPlatformProvider") -> None:
 
 def handle_sync_user_command(
     payload: CommandPayload,
-    parsed_args: Dict[str, Any],
+    parsed_args: dict[str, Any],
 ) -> CommandResponse:
     """Handle /sre access sync user <user_email> <platform> [--dry-run].
 
@@ -247,7 +247,7 @@ def handle_sync_user_command(
 
 def handle_sync_platform_command(
     payload: CommandPayload,
-    parsed_args: Dict[str, Any],
+    parsed_args: dict[str, Any],
 ) -> CommandResponse:
     """Handle /sre access sync platform <platform> [--dry-run].
 
@@ -336,7 +336,7 @@ def handle_sync_platform_command(
 
 def handle_sync_status_command(
     payload: CommandPayload,
-    parsed_args: Dict[str, Any],
+    parsed_args: dict[str, Any],
 ) -> CommandResponse:
     """Handle /sre access sync status <job_id>.
 

--- a/app/packages/access/sync/job_models.py
+++ b/app/packages/access/sync/job_models.py
@@ -11,8 +11,6 @@ converts to the wire representation expected by ``IdempotencyService``.
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, List
-
 
 # ---------------------------------------------------------------------------
 # Status and error constants
@@ -95,8 +93,8 @@ class CompletedUserRecord:
     dry_run: bool
     started_at: str
     completed_at: str
-    actions_planned: List[str]
-    actions_applied: List[str]
+    actions_planned: list[str]
+    actions_applied: list[str]
     requires_manual_action: bool
     sync_type: str = "user"
     status: str = JobStatus.COMPLETED
@@ -120,11 +118,9 @@ class CompletedPlatformRecord:
     requires_manual_action_count: int
     changed_user_count: int = 0
     unchanged_user_count: int = 0
-    action_counts: Dict[str, int] = dataclasses.field(default_factory=dict)
-    lifecycle_actions: Dict[str, List[str]] = dataclasses.field(default_factory=dict)
-    entitlements_by_action: Dict[str, Dict[str, List[str]]] = dataclasses.field(
-        default_factory=dict
-    )
+    action_counts: dict[str, int] = dataclasses.field(default_factory=dict)
+    lifecycle_actions: dict[str, list[str]] = dataclasses.field(default_factory=dict)
+    entitlements_by_action: dict[str, dict[str, list[str]]] = dataclasses.field(default_factory=dict)
     sync_type: str = "platform"
     status: str = JobStatus.COMPLETED
 

--- a/app/packages/access/sync/job_runner.py
+++ b/app/packages/access/sync/job_runner.py
@@ -18,19 +18,13 @@ exact same locking, job record shape, and error sanitization semantics.
 """
 
 import threading
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import structlog
 
 from infrastructure.idempotency import IdempotencyService
 from packages.access.sync.application import AccessSyncApplicationServicePort
 from packages.access.sync.domain import ReconciliationOutcome, SyncOutcome
-from packages.access.sync.platform_lock import (
-    acquire_lock,
-    platform_lock_key,
-    release_lock,
-    user_lock_key,
-)
 from packages.access.sync.job_models import (
     CompletedPlatformRecord,
     CompletedUserRecord,
@@ -40,6 +34,12 @@ from packages.access.sync.job_models import (
     PlatformRunningRecord,
     SyncJobError,
     UserRunningRecord,
+)
+from packages.access.sync.platform_lock import (
+    acquire_lock,
+    platform_lock_key,
+    release_lock,
+    user_lock_key,
 )
 
 logger = structlog.get_logger()
@@ -68,9 +68,7 @@ def run_user_sync_job(
     external error payload always uses ``SyncJobError.SYNC_FAILED`` so
     implementation details do not leak through the job store.
     """
-    log = logger.bind(
-        job_id=job_id, user_email=user_email, platform=platform, dry_run=dry_run
-    )
+    log = logger.bind(job_id=job_id, user_email=user_email, platform=platform, dry_run=dry_run)
     log.info("user_sync_job_started", correlation_id=request_id)
     record: FailedUserRecord | CompletedUserRecord
     try:
@@ -80,10 +78,8 @@ def run_user_sync_job(
             dry_run=dry_run,
             request_id=request_id,
         )
-        log.info(
-            "user_sync_job_finished", success=result.is_success, error=result.message
-        )
-        completed_at = datetime.now(timezone.utc).isoformat()
+        log.info("user_sync_job_finished", success=result.is_success, error=result.message)
+        completed_at = datetime.now(UTC).isoformat()
         if result.is_success and result.data is not None:
             outcome: SyncOutcome = result.data
             record = CompletedUserRecord(
@@ -118,7 +114,7 @@ def run_user_sync_job(
                 error_code=result.error_code,
             )
     except Exception as exc:
-        completed_at = datetime.now(timezone.utc).isoformat()
+        completed_at = datetime.now(UTC).isoformat()
         record = FailedUserRecord(
             job_id=job_id,
             user_email=user_email,
@@ -132,9 +128,7 @@ def run_user_sync_job(
 
     payload = record.to_dict()
     idempotency.set(job_id, payload, ttl_seconds=job_ttl_seconds)
-    release_lock(
-        user_lock_key(platform, user_email), payload, idempotency, job_ttl_seconds
-    )
+    release_lock(user_lock_key(platform, user_email), payload, idempotency, job_ttl_seconds)
 
 
 def run_platform_sync_job(
@@ -176,7 +170,7 @@ def run_platform_sync_job(
             dry_run=dry_run,
             request_id=request_id,
         )
-        completed_at = datetime.now(timezone.utc).isoformat()
+        completed_at = datetime.now(UTC).isoformat()
         if result.is_success and result.data is not None:
             recon: ReconciliationOutcome = result.data
             record = CompletedPlatformRecord(
@@ -192,10 +186,7 @@ def run_platform_sync_job(
                 changed_user_count=recon.changed_user_count,
                 unchanged_user_count=recon.unchanged_user_count,
                 action_counts=dict(recon.action_counts),
-                lifecycle_actions={
-                    action: list(users)
-                    for action, users in recon.lifecycle_actions.items()
-                },
+                lifecycle_actions={action: list(users) for action, users in recon.lifecycle_actions.items()},
                 entitlements_by_action={
                     action: {slug: list(users) for slug, users in by_slug.items()}
                     for action, by_slug in recon.entitlements_by_action.items()
@@ -224,7 +215,7 @@ def run_platform_sync_job(
                 error_code=result.error_code,
             )
     except Exception as exc:
-        completed_at = datetime.now(timezone.utc).isoformat()
+        completed_at = datetime.now(UTC).isoformat()
         record = FailedPlatformRecord(
             job_id=job_id,
             platform=platform,

--- a/app/packages/access/sync/platform_lock.py
+++ b/app/packages/access/sync/platform_lock.py
@@ -9,8 +9,8 @@ from ``AccessSyncSettings``) is treated as stale so a crashed background
 thread cannot block future syncs indefinitely.
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from datetime import UTC, datetime
+from typing import Any
 
 from infrastructure.idempotency import IdempotencyService
 
@@ -27,7 +27,7 @@ def check_lock(
     key: str,
     idempotency: IdempotencyService,
     lock_stale_after_seconds: int,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Return the running job record if an active lock exists, else None.
 
     Returns None when no record exists, status is not "running", or the lock
@@ -39,9 +39,7 @@ def check_lock(
     started_at_raw: str = record.get("started_at", "")
     if started_at_raw:
         try:
-            elapsed = (
-                datetime.now(timezone.utc) - datetime.fromisoformat(started_at_raw)
-            ).total_seconds()
+            elapsed = (datetime.now(UTC) - datetime.fromisoformat(started_at_raw)).total_seconds()
             if elapsed > lock_stale_after_seconds:
                 return None
         except ValueError:
@@ -51,7 +49,7 @@ def check_lock(
 
 def acquire_lock(
     key: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     idempotency: IdempotencyService,
     ttl_seconds: int,
 ) -> None:
@@ -61,7 +59,7 @@ def acquire_lock(
 
 def release_lock(
     key: str,
-    final_payload: Dict[str, Any],
+    final_payload: dict[str, Any],
     idempotency: IdempotencyService,
     ttl_seconds: int,
 ) -> None:

--- a/app/packages/access/sync/policies.py
+++ b/app/packages/access/sync/policies.py
@@ -27,7 +27,7 @@ Adapters must not duplicate any logic from this module.
 """
 
 from dataclasses import dataclass
-from typing import Dict, List, Literal, Optional, Set, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from packages.access.common.config import EntitlementRule
 
@@ -52,9 +52,9 @@ class EffectivePlatformPolicy:
     platform: str
     authn_group_slug: str
     authn_removal_mode: str
-    entitlement_rules: List[EntitlementRule]
+    entitlement_rules: list[EntitlementRule]
 
-    def sync_managed_rules(self) -> List[EntitlementRule]:
+    def sync_managed_rules(self) -> list[EntitlementRule]:
         """All rules (every rule in effective policy is already sync_managed)."""
         return list(self.entitlement_rules)
 
@@ -72,14 +72,14 @@ class PlanningContext:
 
     platform: str
     authn_removal_mode: str
-    entitlement_rules: List[EntitlementRule]
+    entitlement_rules: list[EntitlementRule]
 
-    def sync_managed_rules(self) -> List[EntitlementRule]:
+    def sync_managed_rules(self) -> list[EntitlementRule]:
         """All rules (every rule in planning context is already sync_managed)."""
         return list(self.entitlement_rules)
 
     @classmethod
-    def from_effective(cls, effective: "EffectivePlatformPolicy") -> "PlanningContext":
+    def from_effective(cls, effective: EffectivePlatformPolicy) -> PlanningContext:
         """Derive a PlanningContext from an EffectivePlatformPolicy."""
         return cls(
             platform=effective.platform,
@@ -89,9 +89,9 @@ class PlanningContext:
 
 
 def resolve_effective_policy(
-    config: "AccessRuntimeConfig",
+    config: AccessRuntimeConfig,
     platform: str,
-    discovered_slugs: Set[str],
+    discovered_slugs: set[str],
 ) -> EffectivePlatformPolicy:
     """Build the run-scoped effective policy from IDP-discovered group slugs.
 
@@ -113,7 +113,7 @@ def resolve_effective_policy(
     prefix = config.group_prefix(platform)
     authn_slug = config.authn_group_slug(platform)
 
-    rules: List[EntitlementRule] = []
+    rules: list[EntitlementRule] = []
     for slug in sorted(discovered_slugs):
         normalized = slug.strip().lower()
         if normalized == authn_slug.lower():
@@ -159,7 +159,7 @@ class AdapterCapabilities:
 
     supports_disable: bool
     supports_delete: bool
-    supported_entitlement_types: Set[str]
+    supported_entitlement_types: set[str]
     supports_bulk_user_delta: bool = False
 
 
@@ -180,19 +180,19 @@ class PlannedAction:
         "apply_entitlement",
         "remove_entitlement",
     ]
-    entitlement_type: Optional[str] = None
-    entitlement_id: Optional[str] = None
+    entitlement_type: str | None = None
+    entitlement_id: str | None = None
 
 
 @dataclass(frozen=True)
 class PlatformActionPlan:
     """Lifecycle and entitlement deltas for a full platform reconciliation run."""
 
-    users_to_provision: Set[str]
-    users_to_disable: Set[str]
-    users_to_remove: Set[str]
-    entitlement_adds_by_id: Dict[str, Set[str]]
-    entitlement_removes_by_id: Dict[str, Set[str]]
+    users_to_provision: set[str]
+    users_to_disable: set[str]
+    users_to_remove: set[str]
+    entitlement_adds_by_id: dict[str, set[str]]
+    entitlement_removes_by_id: dict[str, set[str]]
 
 
 class PolicyEngine:
@@ -211,10 +211,10 @@ class PolicyEngine:
         policy: PlanningContext,
         capabilities: AdapterCapabilities,
         user_should_exist: bool,
-        required_entitlements: List[EntitlementRule],
-        current_entitlement_ids: Optional[Set[str]] = None,
+        required_entitlements: list[EntitlementRule],
+        current_entitlement_ids: set[str] | None = None,
         platform_user_exists: bool = False,
-    ) -> List[PlannedAction]:
+    ) -> list[PlannedAction]:
         """Produce the minimal ordered action list to converge one user.
 
         Args:
@@ -232,18 +232,16 @@ class PolicyEngine:
             Ordered list of PlannedActions.  Entitlement removals precede
             user-lifecycle actions so records are clean before deactivation.
         """
-        planned: List[PlannedAction] = []
-        current_ids: Set[str] = current_entitlement_ids or set()
+        planned: list[PlannedAction] = []
+        current_ids: set[str] = current_entitlement_ids or set()
 
-        sync_managed_by_id: Dict[str, EntitlementRule] = {
-            r.entitlement_id: r for r in policy.sync_managed_rules()
-        }
+        sync_managed_by_id: dict[str, EntitlementRule] = {r.entitlement_id: r for r in policy.sync_managed_rules()}
 
         if user_should_exist:
             if not platform_user_exists:
                 planned.append(PlannedAction(action="provision_user"))
 
-            desired_ids: Set[str] = set()
+            desired_ids: set[str] = set()
             for rule in required_entitlements:
                 if rule.entitlement_type in capabilities.supported_entitlement_types:
                     planned.append(
@@ -258,10 +256,7 @@ class PolicyEngine:
             for ent_id in sorted(current_ids):
                 if ent_id in sync_managed_by_id and ent_id not in desired_ids:
                     rule = sync_managed_by_id[ent_id]
-                    if (
-                        rule.entitlement_type
-                        in capabilities.supported_entitlement_types
-                    ):
+                    if rule.entitlement_type in capabilities.supported_entitlement_types:
                         planned.append(
                             PlannedAction(
                                 action="remove_entitlement",
@@ -298,34 +293,24 @@ class PlatformReconciliationPlanner:
 
     def plan_platform_actions(
         self,
-        desired_users: Set[str],
-        desired_members_by_entitlement: Dict[str, Set[str]],
-        current_users: Set[str],
-        current_members_by_entitlement: Dict[str, Set[str]],
+        desired_users: set[str],
+        desired_members_by_entitlement: dict[str, set[str]],
+        current_users: set[str],
+        current_members_by_entitlement: dict[str, set[str]],
         authn_removal_mode: str,
     ) -> PlatformActionPlan:
         """Return direct set-based deltas for platform reconciliation."""
         users_to_provision = desired_users - current_users
-        users_to_disable = (
-            current_users - desired_users if authn_removal_mode == "disable" else set()
-        )
-        users_to_remove = (
-            current_users - desired_users if authn_removal_mode == "delete" else set()
-        )
+        users_to_disable = current_users - desired_users if authn_removal_mode == "disable" else set()
+        users_to_remove = current_users - desired_users if authn_removal_mode == "delete" else set()
 
-        entitlement_adds_by_id: Dict[str, Set[str]] = {}
-        entitlement_removes_by_id: Dict[str, Set[str]] = {}
-        entitlement_ids = set(desired_members_by_entitlement.keys()) | set(
-            current_members_by_entitlement.keys()
-        )
+        entitlement_adds_by_id: dict[str, set[str]] = {}
+        entitlement_removes_by_id: dict[str, set[str]] = {}
+        entitlement_ids = set(desired_members_by_entitlement.keys()) | set(current_members_by_entitlement.keys())
 
         for entitlement_id in sorted(entitlement_ids):
-            desired_members = set(
-                desired_members_by_entitlement.get(entitlement_id, set())
-            )
-            current_members = set(
-                current_members_by_entitlement.get(entitlement_id, set())
-            )
+            desired_members = set(desired_members_by_entitlement.get(entitlement_id, set()))
+            current_members = set(current_members_by_entitlement.get(entitlement_id, set()))
             members_to_add = desired_members - current_members
             members_to_remove = current_members - desired_members
 

--- a/app/packages/access/sync/presenters.py
+++ b/app/packages/access/sync/presenters.py
@@ -5,7 +5,7 @@ transport-appropriate response shapes. All status formatting logic lives
 here so HTTP routes and Slack handlers share a single source of truth.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from infrastructure.i18n import t
 from packages.access.sync.job_models import JobStatus
@@ -17,7 +17,7 @@ _MAX_USERS_PER_ENTITLEMENT = 3
 _MAX_USER_ACTIONS = 6
 
 
-def to_http_status_response(record: Dict[str, Any]) -> SyncJobStatusResponse:
+def to_http_status_response(record: dict[str, Any]) -> SyncJobStatusResponse:
     """Convert a stored job record dict to an HTTP polling response model."""
     return SyncJobStatusResponse(**record)
 
@@ -65,10 +65,7 @@ def to_slack_status_message(record: SyncJobStatusResponse, locale: str) -> str:
                     t(
                         "access_sync.status.result.completed_user_counts",
                         locale,
-                        (
-                            f"Actions planned: {len(actions_planned)} | "
-                            f"Applied: {len(actions_applied)}"
-                        ),
+                        (f"Actions planned: {len(actions_planned)} | Applied: {len(actions_applied)}"),
                         actions_planned_count=len(actions_planned),
                         actions_applied_count=len(actions_applied),
                     )
@@ -81,10 +78,7 @@ def to_slack_status_message(record: SyncJobStatusResponse, locale: str) -> str:
                         t(
                             "access_sync.status.result.completed_user_planned_actions",
                             locale,
-                            (
-                                "Planned actions: "
-                                f"{_truncate_list(actions_planned, _MAX_USER_ACTIONS)}"
-                            ),
+                            (f"Planned actions: {_truncate_list(actions_planned, _MAX_USER_ACTIONS)}"),
                             actions=_truncate_list(actions_planned, _MAX_USER_ACTIONS),
                         )
                     )
@@ -95,10 +89,7 @@ def to_slack_status_message(record: SyncJobStatusResponse, locale: str) -> str:
                         t(
                             "access_sync.status.result.completed_user_applied_actions",
                             locale,
-                            (
-                                "Applied actions: "
-                                f"{_truncate_list(actions_applied, _MAX_USER_ACTIONS)}"
-                            ),
+                            (f"Applied actions: {_truncate_list(actions_applied, _MAX_USER_ACTIONS)}"),
                             actions=_truncate_list(actions_applied, _MAX_USER_ACTIONS),
                         )
                     )
@@ -234,19 +225,13 @@ def to_slack_status_message(record: SyncJobStatusResponse, locale: str) -> str:
 
 
 def _format_lifecycle_details(
-    lifecycle_actions: Dict[str, Any],
+    lifecycle_actions: dict[str, Any],
     locale: str,
 ) -> list[str]:
     """Return a concise lifecycle preview block for Slack status messages."""
-    provision_users = [
-        str(user) for user in lifecycle_actions.get("provision_user", []) if user
-    ]
-    remove_users = [
-        str(user) for user in lifecycle_actions.get("remove_user", []) if user
-    ]
-    disable_users = [
-        str(user) for user in lifecycle_actions.get("disable_user", []) if user
-    ]
+    provision_users = [str(user) for user in lifecycle_actions.get("provision_user", []) if user]
+    remove_users = [str(user) for user in lifecycle_actions.get("remove_user", []) if user]
+    disable_users = [str(user) for user in lifecycle_actions.get("disable_user", []) if user]
 
     details: list[str] = []
     if provision_users:
@@ -255,10 +240,7 @@ def _format_lifecycle_details(
                 t(
                     "access_sync.status.result.completed_lifecycle_provision",
                     locale,
-                    (
-                        f"• Users to provision ({len(provision_users)}): "
-                        f"{_truncate_list(provision_users, _MAX_LIFECYCLE_USERS)}"
-                    ),
+                    (f"• Users to provision ({len(provision_users)}): {_truncate_list(provision_users, _MAX_LIFECYCLE_USERS)}"),
                     count=len(provision_users),
                     users=_truncate_list(provision_users, _MAX_LIFECYCLE_USERS),
                 )
@@ -270,10 +252,7 @@ def _format_lifecycle_details(
                 t(
                     "access_sync.status.result.completed_lifecycle_remove",
                     locale,
-                    (
-                        f"• Users to remove ({len(remove_users)}): "
-                        f"{_truncate_list(remove_users, _MAX_LIFECYCLE_USERS)}"
-                    ),
+                    (f"• Users to remove ({len(remove_users)}): {_truncate_list(remove_users, _MAX_LIFECYCLE_USERS)}"),
                     count=len(remove_users),
                     users=_truncate_list(remove_users, _MAX_LIFECYCLE_USERS),
                 )
@@ -285,10 +264,7 @@ def _format_lifecycle_details(
                 t(
                     "access_sync.status.result.completed_lifecycle_disable",
                     locale,
-                    (
-                        f"• Users to disable ({len(disable_users)}): "
-                        f"{_truncate_list(disable_users, _MAX_LIFECYCLE_USERS)}"
-                    ),
+                    (f"• Users to disable ({len(disable_users)}): {_truncate_list(disable_users, _MAX_LIFECYCLE_USERS)}"),
                     count=len(disable_users),
                     users=_truncate_list(disable_users, _MAX_LIFECYCLE_USERS),
                 )
@@ -298,7 +274,7 @@ def _format_lifecycle_details(
 
 
 def _format_entitlement_details(
-    entitlements_by_action: Dict[str, Any],
+    entitlements_by_action: dict[str, Any],
     locale: str,
 ) -> list[str]:
     """Return a concise entitlement preview block for Slack status messages."""
@@ -336,9 +312,7 @@ def _format_entitlement_action_details(
     for slug, users in sorted(mapping.items()):
         if not isinstance(slug, str):
             continue
-        normalized_users = (
-            [str(user) for user in users] if isinstance(users, list) else []
-        )
+        normalized_users = [str(user) for user in users] if isinstance(users, list) else []
         entries.append((slug, normalized_users))
 
     lines: list[str] = []
@@ -348,10 +322,7 @@ def _format_entitlement_action_details(
                 t(
                     action_key,
                     locale,
-                    (
-                        f"{fallback_prefix} — *{slug}* ({len(users)}): "
-                        f"{_truncate_list(users, _MAX_USERS_PER_ENTITLEMENT)}"
-                    ),
+                    (f"{fallback_prefix} — *{slug}* ({len(users)}): {_truncate_list(users, _MAX_USERS_PER_ENTITLEMENT)}"),
                     slug=slug,
                     count=len(users),
                     users=_truncate_list(users, _MAX_USERS_PER_ENTITLEMENT),

--- a/app/packages/access/sync/providers.py
+++ b/app/packages/access/sync/providers.py
@@ -1,5 +1,4 @@
 import functools
-from typing import Dict
 
 from infrastructure.clients.aws import get_aws_clients
 from infrastructure.directory import get_directory_provider
@@ -21,10 +20,10 @@ def get_access_sync_settings() -> AccessSyncSettings:
 
 
 @functools.lru_cache(maxsize=1)
-def get_access_sync_adapters() -> Dict[str, AccessSyncAdapter]:
+def get_access_sync_adapters() -> dict[str, AccessSyncAdapter]:
     """Provide a map of available platform adapters."""
     config = get_access_runtime_config()
-    adapters: Dict[str, AccessSyncAdapter] = {}
+    adapters: dict[str, AccessSyncAdapter] = {}
 
     for platform_name, policy in config.platforms.items():
         if policy.adapter_type == "aws_identity_center":
@@ -32,9 +31,7 @@ def get_access_sync_adapters() -> Dict[str, AccessSyncAdapter]:
         elif policy.adapter_type == "fake":
             adapters[platform_name] = FakePlatformAdapter()
         else:
-            raise ValueError(
-                f"unknown adapter_type '{policy.adapter_type}' for platform '{platform_name}'"
-            )
+            raise ValueError(f"unknown adapter_type '{policy.adapter_type}' for platform '{platform_name}'")
 
     return adapters
 
@@ -51,9 +48,7 @@ def get_access_sync_coordinator() -> AccessSyncApplicationService:
     return AccessSyncApplicationService(
         adapters=get_access_sync_adapters(),
         config=get_access_runtime_config(),
-        membership_builder=DirectoryMembershipBuilder(
-            directory=get_directory_provider()
-        ),
+        membership_builder=DirectoryMembershipBuilder(directory=get_directory_provider()),
         repository=get_sync_run_repository(),
         dispatcher=get_event_dispatcher(),
     )

--- a/app/packages/access/sync/schemas.py
+++ b/app/packages/access/sync/schemas.py
@@ -8,7 +8,7 @@ The `sync_type` Literal field acts as a Pydantic discriminator so the
 correct schema is validated before the request reaches the service layer.
 """
 
-from typing import Annotated, Dict, List, Literal, Optional, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, EmailStr, Field
 
@@ -18,14 +18,12 @@ class UserSyncRequest(BaseModel):
 
     sync_type: Literal["user"] = "user"
     user_email: EmailStr = Field(..., description="Email of the user to sync.")
-    platform: str = Field(
-        ..., min_length=2, description="Target platform key, e.g. 'aws'."
-    )
+    platform: str = Field(..., min_length=2, description="Target platform key, e.g. 'aws'.")
     dry_run: bool = Field(
         default=False,
         description="If true, return planned actions without executing them.",
     )
-    request_id: Optional[str] = Field(
+    request_id: str | None = Field(
         default=None,
         description="Optional correlation ID for tracing.",
     )
@@ -35,21 +33,19 @@ class PlatformSyncRequest(BaseModel):
     """Batch platform-wide sync: converge all users on a platform."""
 
     sync_type: Literal["platform"] = "platform"
-    platform: str = Field(
-        ..., min_length=2, description="Platform key to sync, e.g. 'aws'."
-    )
+    platform: str = Field(..., min_length=2, description="Platform key to sync, e.g. 'aws'.")
     dry_run: bool = Field(
         default=False,
         description="If true, return planned actions without executing them.",
     )
-    request_id: Optional[str] = Field(
+    request_id: str | None = Field(
         default=None,
         description="Optional correlation ID for tracing.",
     )
 
 
 AccessSyncRequest = Annotated[
-    Union[UserSyncRequest, PlatformSyncRequest],
+    UserSyncRequest | PlatformSyncRequest,
     Field(discriminator="sync_type"),
 ]
 
@@ -87,25 +83,25 @@ class SyncJobStatusResponse(BaseModel):
     """
 
     job_id: str
-    sync_type: Optional[str] = None
+    sync_type: str | None = None
     platform: str
     dry_run: bool
     status: str
-    started_at: Optional[str] = None
-    completed_at: Optional[str] = None
-    error: Optional[str] = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    error: str | None = None
     # Platform sync outcome fields
-    users_synced: Optional[int] = None
-    users_converged: Optional[int] = None
-    orphans_found: Optional[int] = None
-    requires_manual_action_count: Optional[int] = None
-    changed_user_count: Optional[int] = None
-    unchanged_user_count: Optional[int] = None
-    action_counts: Optional[Dict[str, int]] = None
-    lifecycle_actions: Optional[Dict[str, List[str]]] = None
-    entitlements_by_action: Optional[Dict[str, Dict[str, List[str]]]] = None
+    users_synced: int | None = None
+    users_converged: int | None = None
+    orphans_found: int | None = None
+    requires_manual_action_count: int | None = None
+    changed_user_count: int | None = None
+    unchanged_user_count: int | None = None
+    action_counts: dict[str, int] | None = None
+    lifecycle_actions: dict[str, list[str]] | None = None
+    entitlements_by_action: dict[str, dict[str, list[str]]] | None = None
     # User sync outcome fields
-    user_email: Optional[str] = None
-    actions_planned: Optional[List[str]] = None
-    actions_applied: Optional[List[str]] = None
-    requires_manual_action: Optional[bool] = None
+    user_email: str | None = None
+    actions_planned: list[str] | None = None
+    actions_applied: list[str] | None = None
+    requires_manual_action: bool | None = None

--- a/app/packages/access/sync/store.py
+++ b/app/packages/access/sync/store.py
@@ -12,8 +12,7 @@ This allows efficient per-user, per-platform pagination (newest first via
 ``ScanIndexForward=False``).
 """
 
-from datetime import datetime, timezone
-from typing import List, Optional
+from datetime import UTC, datetime
 
 import structlog
 
@@ -67,7 +66,7 @@ class SyncRunRepository:
         platform: str,
         user_email: str,
         limit: int = 10,
-    ) -> List[SyncRunRecord]:
+    ) -> list[SyncRunRecord]:
         """Return recent runs for the given platform + user, newest first."""
         pk = f"SYNC_RUN#{platform}#{user_email}"
         result = self._storage.query(
@@ -89,12 +88,8 @@ class SyncRunRepository:
 
     @staticmethod
     def _deserialize(item: dict) -> SyncRunRecord:
-        created_raw: Optional[str] = item.get("created_at")
-        created_at = (
-            datetime.fromisoformat(created_raw)
-            if created_raw
-            else datetime.now(timezone.utc)
-        )
+        created_raw: str | None = item.get("created_at")
+        created_at = datetime.fromisoformat(created_raw) if created_raw else datetime.now(UTC)
         return SyncRunRecord(
             run_id=item.get("run_id", ""),
             user_email=item.get("user_email", ""),

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -96,6 +96,8 @@ force-exclude = '''
     | tests/unit/jobs
     | tests/unit/server
     | tests/unit/models
+  | packages/access
+  | tests/unit/packages/access
 )/
 '''
 

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_package_init.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_package_init.py
@@ -30,9 +30,7 @@ def test_catalog_startup_warmup_validates_runtime_config(monkeypatch):
         provider_warm_called = True
         return object()
 
-    monkeypatch.setattr(
-        catalog_pkg, "get_access_runtime_config", _runtime_config, raising=False
-    )
+    monkeypatch.setattr(catalog_pkg, "get_access_runtime_config", _runtime_config, raising=False)
     monkeypatch.setattr(catalog_pkg, "get_catalog_settings", lambda: _Settings())
     monkeypatch.setattr(catalog_pkg, "get_catalog_service", _warm_provider)
 

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_parsers.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_parsers.py
@@ -5,7 +5,6 @@ from packages.access.catalog.parsers import (
     FallbackCatalogSlugParser,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers / Factories
 # ---------------------------------------------------------------------------
@@ -13,9 +12,7 @@ from packages.access.catalog.parsers import (
 
 def make_aws_parser(known_envs=None):
     """Factory for AwsCatalogSlugParser with optional known_envs."""
-    return AwsCatalogSlugParser(
-        known_envs=set(known_envs or ["dev", "staging", "prod"])
-    )
+    return AwsCatalogSlugParser(known_envs=set(known_envs or ["dev", "staging", "prod"]))
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_routes.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_routes.py
@@ -5,18 +5,14 @@ stub service and settings objects via the FastAPI dependency-injection
 protocol used in test_routes patterns across this codebase.
 """
 
-from typing import Optional
-
 import pytest
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
-from infrastructure.security.models import AuthPrincipalSource, User
 from infrastructure.operations import OperationResult, OperationStatus
 from infrastructure.security import get_current_user
-from packages.access.catalog.providers import get_catalog_service, get_catalog_settings
+from infrastructure.security.models import AuthPrincipalSource, User
 from packages.access.catalog.domain import (
     EntitlementEntry,
     ParsedEntitlementToken,
@@ -27,15 +23,12 @@ from packages.access.catalog.interactions.http import (
     list_platforms,
     router,
 )
+from packages.access.catalog.providers import get_catalog_service, get_catalog_settings
 
 
 def _get_route(path: str, method: str) -> APIRoute:
     for route in router.routes:
-        if (
-            isinstance(route, APIRoute)
-            and route.path == path
-            and method in route.methods
-        ):
+        if isinstance(route, APIRoute) and route.path == path and method in route.methods:
             return route
     raise AssertionError(f"Route {method} {path} not found")
 
@@ -53,13 +46,11 @@ class _FakeSettings:
 class _FakeCatalogService:
     def __init__(
         self,
-        platforms_result: Optional[OperationResult] = None,
-        entitlements_result: Optional[OperationResult] = None,
+        platforms_result: OperationResult | None = None,
+        entitlements_result: OperationResult | None = None,
     ) -> None:
         self._platforms_result = platforms_result or OperationResult.success(data=[])
-        self._entitlements_result = entitlements_result or OperationResult.success(
-            data=[]
-        )
+        self._entitlements_result = entitlements_result or OperationResult.success(data=[])
 
     def list_platforms(self) -> OperationResult:
         return self._platforms_result
@@ -91,7 +82,7 @@ def _make_entry(
     token: str = "admin",
     mode: str = "sync_managed",
     requestable: bool = True,
-    already_provisioned: Optional[bool] = False,
+    already_provisioned: bool | None = False,
 ) -> EntitlementEntry:
     return EntitlementEntry(
         token=token,
@@ -133,9 +124,7 @@ def test_list_platforms_should_return_503_when_feature_disabled():
 def test_list_platforms_should_return_platform_list_on_success():
     # Arrange
     summaries = [_make_platform_summary("aws"), _make_platform_summary("gcp")]
-    service = _FakeCatalogService(
-        platforms_result=OperationResult.success(data=summaries)
-    )
+    service = _FakeCatalogService(platforms_result=OperationResult.success(data=summaries))
 
     # Act
     response = list_platforms(
@@ -157,9 +146,7 @@ def test_list_platforms_should_return_platform_list_on_success():
 def test_list_platforms_should_return_500_when_service_fails():
     # Arrange
     service = _FakeCatalogService(
-        platforms_result=OperationResult.error(
-            OperationStatus.PERMANENT_ERROR, message="unexpected failure"
-        )
+        platforms_result=OperationResult.error(OperationStatus.PERMANENT_ERROR, message="unexpected failure")
     )
 
     # Act / Assert
@@ -226,9 +213,7 @@ def test_list_platforms_returns_503_without_service_dependency_assembly():
         service_provider_called = True
         raise AssertionError("catalog service dependency should not be assembled")
 
-    app.dependency_overrides[get_catalog_settings] = lambda: _FakeSettings(
-        enabled=False
-    )
+    app.dependency_overrides[get_catalog_settings] = lambda: _FakeSettings(enabled=False)
     app.dependency_overrides[get_catalog_service] = _service_provider
     app.dependency_overrides[get_current_user] = _make_user
 
@@ -248,9 +233,7 @@ def test_list_platforms_returns_503_without_service_dependency_assembly():
 def test_list_entitlements_should_return_entitlement_list_on_success():
     # Arrange
     entries = [_make_entry("admin"), _make_entry("readonly")]
-    service = _FakeCatalogService(
-        entitlements_result=OperationResult.success(data=entries)
-    )
+    service = _FakeCatalogService(entitlements_result=OperationResult.success(data=entries))
 
     # Act
     response = list_entitlements(
@@ -268,9 +251,7 @@ def test_list_entitlements_should_return_entitlement_list_on_success():
 def test_list_entitlements_should_normalize_platform_in_response():
     # Arrange — caller submits mixed-case platform; route normalises it
     entries = [_make_entry("admin")]
-    service = _FakeCatalogService(
-        entitlements_result=OperationResult.success(data=entries)
-    )
+    service = _FakeCatalogService(entitlements_result=OperationResult.success(data=entries))
 
     # Act
     response = list_entitlements(
@@ -340,9 +321,7 @@ def test_list_entitlements_should_return_500_when_service_fails():
 def test_list_entitlements_should_propagate_membership_status():
     # Arrange
     entries = [_make_entry("admin", already_provisioned=True)]
-    service = _FakeCatalogService(
-        entitlements_result=OperationResult.success(data=entries)
-    )
+    service = _FakeCatalogService(entitlements_result=OperationResult.success(data=entries))
 
     # Act
     response = list_entitlements(
@@ -359,9 +338,7 @@ def test_list_entitlements_should_propagate_membership_status():
 def test_list_entitlements_should_propagate_requestable_flag():
     # Arrange
     entries = [_make_entry("legacy-role", mode="deactivated", requestable=False)]
-    service = _FakeCatalogService(
-        entitlements_result=OperationResult.success(data=entries)
-    )
+    service = _FakeCatalogService(entitlements_result=OperationResult.success(data=entries))
 
     # Act
     response = list_entitlements(

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
@@ -2,7 +2,6 @@
 
 import json
 from dataclasses import dataclass, field
-from typing import Dict, Optional
 
 from infrastructure.directory.models import DirectoryGroup, MembershipCheckResult
 from infrastructure.operations import OperationResult, OperationStatus
@@ -11,10 +10,11 @@ from packages.access.catalog.domain import ParsedEntitlementToken
 from packages.access.catalog.service import CatalogService
 from packages.access.common.config import (
     AccessRuntimeConfig as AccessSyncRuntimeConfig,
+)
+from packages.access.common.config import (
     InlineJsonConfigLoader,
     PlatformPolicy,
 )
-
 
 # ---------------------------------------------------------------------------
 # Stub helpers
@@ -25,8 +25,8 @@ from packages.access.common.config import (
 class _FakeDirectory:
     """Stub that lets each test declare its own IDP responses."""
 
-    groups_by_prefix: Dict[str, OperationResult] = field(default_factory=dict)
-    memberships: Dict[str, OperationResult] = field(default_factory=dict)
+    groups_by_prefix: dict[str, OperationResult] = field(default_factory=dict)
+    memberships: dict[str, OperationResult] = field(default_factory=dict)
 
     def list_groups(self, query: str) -> OperationResult:
         return self.groups_by_prefix.get(
@@ -53,15 +53,13 @@ class _AlwaysParsedParser:
     """Stub that returns a fixed ParsedEntitlementToken with parsed=True."""
 
     def parse(self, token: str) -> ParsedEntitlementToken:
-        return ParsedEntitlementToken(
-            raw=token, product=token, role="role", parsed=True
-        )
+        return ParsedEntitlementToken(raw=token, product=token, role="role", parsed=True)
 
 
 def make_runtime_config(
     platform: str = "aws",
     authn_token: str = "authn",
-    mode_overrides: Optional[Dict] = None,
+    mode_overrides: dict | None = None,
     dir_prefix: str = "sg",
     dir_separator: str = "-",
 ) -> AccessSyncRuntimeConfig:
@@ -171,9 +169,7 @@ def test_list_platforms_should_use_display_name_from_runtime_extensions_via_prov
                 "mode_overrides": {},
             }
         },
-        "extensions": {
-            "catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}
-        },
+        "extensions": {"catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}},
     }
     result = InlineJsonConfigLoader().load(json.dumps(payload))
     assert result.is_success
@@ -245,9 +241,7 @@ def test_list_entitlements_should_return_not_found_for_unknown_platform():
 
 def test_list_entitlements_should_normalize_platform_key_to_lowercase():
     # Arrange
-    directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=[])}
-    )
+    directory = _FakeDirectory(groups_by_prefix={"sg-aws-": OperationResult.success(data=[])})
     service = make_service(directory=directory)
 
     # Act — mixed case
@@ -379,11 +373,7 @@ def test_list_entitlements_should_set_membership_to_none_when_check_fails():
     groups = [make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com")]
     directory = _FakeDirectory(
         groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
-        memberships={
-            "sg-aws-admin@example.com": OperationResult.error(
-                OperationStatus.PERMANENT_ERROR, message="IDP hiccup"
-            )
-        },
+        memberships={"sg-aws-admin@example.com": OperationResult.error(OperationStatus.PERMANENT_ERROR, message="IDP hiccup")},
     )
     service = make_service(directory=directory)
 

--- a/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
+++ b/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
@@ -143,15 +143,9 @@ def test_mode_override_contract_multiple_tokens_isolated():
         }
     )
 
-    admins_mode = check_entitlement_mode(
-        config, platform="aws", group_slug="sg-aws-admins"
-    )
-    devs_mode = check_entitlement_mode(
-        config, platform="aws", group_slug="sg-aws-developers"
-    )
-    guests_mode = check_entitlement_mode(
-        config, platform="aws", group_slug="sg-aws-guests"
-    )
+    admins_mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-admins")
+    devs_mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-developers")
+    guests_mode = check_entitlement_mode(config, platform="aws", group_slug="sg-aws-guests")
 
     assert admins_mode == "deactivated"
     assert devs_mode == "ephemeral"

--- a/app/tests/unit/packages/access/common/test_settings.py
+++ b/app/tests/unit/packages/access/common/test_settings.py
@@ -16,7 +16,6 @@ from packages.access.common.settings import (
     AccessSyncSettings,
 )
 
-
 # ---------------------------------------------------------------------------
 # Sub-model plain BaseModel defaults (no env reads needed)
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/packages/access/request/test_access_request_package_init.py
+++ b/app/tests/unit/packages/access/request/test_access_request_package_init.py
@@ -5,8 +5,8 @@ from typing import get_args, get_origin, get_type_hints
 
 import pytest
 
-from infrastructure.operations import OperationResult
 from infrastructure.events import get_event_dispatcher
+from infrastructure.operations import OperationResult
 from packages.access.common.events import SYNC_COMPLETED, SYNC_FAILED
 from packages.access.request.domain import AccessRequest, ApprovalDecision
 from packages.access.request.service import AccessRequestServicePort
@@ -55,9 +55,7 @@ def test_request_startup_warmup_registers_handlers_and_warms_runtime_config(
         provider_warm_called = True
         return object()
 
-    monkeypatch.setattr(
-        request_pkg, "get_access_runtime_config", _runtime_config, raising=False
-    )
+    monkeypatch.setattr(request_pkg, "get_access_runtime_config", _runtime_config, raising=False)
     monkeypatch.setattr(request_pkg, "get_access_request_settings", lambda: _Settings())
     monkeypatch.setattr(request_pkg, "get_access_request_service", _warm_provider)
 
@@ -112,17 +110,13 @@ def test_request_startup_warmup_registers_handlers_via_event_dispatcher(monkeypa
     monkeypatch.setattr(
         request_pkg,
         "register_event_handler",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("direct register_event_handler usage is forbidden")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("direct register_event_handler usage is forbidden")),
         raising=False,
     )
     monkeypatch.setattr(
         request_pkg,
         "get_handlers_for_event",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("direct get_handlers_for_event usage is forbidden")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("direct get_handlers_for_event usage is forbidden")),
         raising=False,
     )
 
@@ -146,15 +140,11 @@ def test_request_startup_warmup_registers_handlers_via_event_dispatcher(monkeypa
 def test_access_request_service_port_uses_parameterized_operation_result_returns():
     expected_returns = {
         "submit_request": OperationResult[AccessRequest],
-        "approve_request": OperationResult[
-            tuple[AccessRequest, list[ApprovalDecision]]
-        ],
+        "approve_request": OperationResult[tuple[AccessRequest, list[ApprovalDecision]]],
         "reject_request": OperationResult[tuple[AccessRequest, list[ApprovalDecision]]],
         "cancel_request": OperationResult[tuple[AccessRequest, list[ApprovalDecision]]],
         "retry_request": OperationResult[tuple[AccessRequest, list[ApprovalDecision]]],
-        "get_request_status": OperationResult[
-            tuple[AccessRequest, list[ApprovalDecision]]
-        ],
+        "get_request_status": OperationResult[tuple[AccessRequest, list[ApprovalDecision]]],
     }
 
     for method_name, expected in expected_returns.items():

--- a/app/tests/unit/packages/access/request/test_access_request_routes.py
+++ b/app/tests/unit/packages/access/request/test_access_request_routes.py
@@ -4,38 +4,32 @@ Tests invoke route handlers directly with fakes to validate HTTP mapping and
 response-shape behavior at the transport boundary.
 """
 
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
 import pytest
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
-from infrastructure.security.models import AuthPrincipalSource, User
-from infrastructure.security import get_current_user
 from infrastructure.operations import OperationResult, OperationStatus
+from infrastructure.security import get_current_user
+from infrastructure.security.models import AuthPrincipalSource, User
 from packages.access.request.domain import AccessRequest, ApprovalDecision
-from packages.access.request.providers import (
-    get_access_request_service,
-    get_access_request_settings,
-)
-from packages.access.request.schemas import ApproveRequestBody, SubmitAccessRequestBody
 from packages.access.request.interactions.http import (
     approve_request,
     router,
     submit_request,
 )
+from packages.access.request.providers import (
+    get_access_request_service,
+    get_access_request_settings,
+)
+from packages.access.request.schemas import ApproveRequestBody, SubmitAccessRequestBody
 
 
 def _get_route(path: str, method: str) -> APIRoute:
     for route in router.routes:
-        if (
-            isinstance(route, APIRoute)
-            and route.path == path
-            and method in route.methods
-        ):
+        if isinstance(route, APIRoute) and route.path == path and method in route.methods:
             return route
     raise AssertionError(f"Route {method} {path} not found")
 
@@ -48,8 +42,8 @@ class _FakeSettings:
 class _FakeAccessRequestService:
     def __init__(
         self,
-        submit_result: Optional[OperationResult] = None,
-        approve_result: Optional[OperationResult] = None,
+        submit_result: OperationResult | None = None,
+        approve_result: OperationResult | None = None,
     ) -> None:
         self._submit_result = submit_result
         self._approve_result = approve_result
@@ -64,7 +58,7 @@ class _FakeAccessRequestService:
         group_slug: str,
         entitlement_type: str,
         justification: str,
-        ticket_id: Optional[str] = None,
+        ticket_id: str | None = None,
     ) -> OperationResult:
         return self._submit_result or OperationResult.success(data=_make_request())
 
@@ -76,9 +70,7 @@ class _FakeAccessRequestService:
     ) -> OperationResult:
         if self._approve_result is not None:
             return self._approve_result
-        return OperationResult.success(
-            data=(_make_request(), [_make_decision(request_id)])
-        )
+        return OperationResult.success(data=(_make_request(), [_make_decision(request_id)]))
 
 
 def _make_user(email: str = "approver@example.com") -> User:
@@ -92,7 +84,7 @@ def _make_user(email: str = "approver@example.com") -> User:
 
 
 def _make_request(request_id: str = "req-1") -> AccessRequest:
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     return AccessRequest(
         request_id=request_id,
         user_email="user@example.com",
@@ -119,7 +111,7 @@ def _make_decision(request_id: str = "req-1") -> ApprovalDecision:
         actor_email="approver@example.com",
         decision="approved",
         comment="approved",
-        decided_at=datetime.now(tz=timezone.utc),
+        decided_at=datetime.now(tz=UTC),
     )
 
 
@@ -179,13 +171,9 @@ def test_submit_request_returns_503_without_service_dependency_assembly() -> Non
         service_provider_called = True
         raise AssertionError("service dependency should not be assembled")
 
-    app.dependency_overrides[get_access_request_settings] = lambda: _FakeSettings(
-        enabled=False
-    )
+    app.dependency_overrides[get_access_request_settings] = lambda: _FakeSettings(enabled=False)
     app.dependency_overrides[get_access_request_service] = _service_provider
-    app.dependency_overrides[get_current_user] = lambda: _make_user(
-        "caller@example.com"
-    )
+    app.dependency_overrides[get_current_user] = lambda: _make_user("caller@example.com")
 
     client = TestClient(app)
     response = client.post(

--- a/app/tests/unit/packages/access/request/test_access_request_schemas.py
+++ b/app/tests/unit/packages/access/request/test_access_request_schemas.py
@@ -6,9 +6,7 @@ from packages.access.request.schemas import AccessRequestStatusResponse
 
 
 @pytest.mark.unit
-def test_access_request_status_response_decisions_description_documents_invariant() -> (
-    None
-):
+def test_access_request_status_response_decisions_description_documents_invariant() -> None:
     schema = AccessRequestStatusResponse.model_json_schema()
     decisions_schema = schema["properties"]["decisions"]
 

--- a/app/tests/unit/packages/access/request/test_policies.py
+++ b/app/tests/unit/packages/access/request/test_policies.py
@@ -4,8 +4,7 @@ All functions are pure — no mocks required for entitlement-mode and
 approval-count tests.  DirectoryProvider tests use simple in-memory stubs.
 """
 
-from datetime import datetime, timezone
-from typing import List
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -66,7 +65,7 @@ def make_request(
     actor_email: str = "actor@example.com",
     actor_type: str = "self",
     status: str = "pending_approval",
-    resolved_approvers: List[str] | None = None,
+    resolved_approvers: list[str] | None = None,
 ) -> AccessRequest:
     return AccessRequest(
         request_id=request_id,
@@ -95,7 +94,7 @@ def make_decision(
         actor_email=actor_email,
         decision=decision,  # type: ignore[arg-type]
         comment="",
-        decided_at=datetime.now(tz=timezone.utc),
+        decided_at=datetime.now(tz=UTC),
     )
 
 
@@ -174,12 +173,8 @@ def test_resolve_approver_candidates_falls_back_to_org_admins():
 
     def get_group_members(group_key, include_member_types=None):
         if "sg-aws-admins" in group_key:
-            return OperationResult.success(
-                data=[make_member("member@example.com", role="MEMBER")]
-            )
-        return OperationResult.success(
-            data=[make_member("admin@example.com", role="OWNER")]
-        )
+            return OperationResult.success(data=[make_member("member@example.com", role="MEMBER")])
+        return OperationResult.success(data=[make_member("admin@example.com", role="OWNER")])
 
     directory.get_group_members.side_effect = get_group_members
     group = make_directory_group()

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -5,8 +5,7 @@ Tests cover the main orchestration paths and error branches.
 """
 
 from dataclasses import replace
-from datetime import datetime, timezone
-from typing import List, Optional
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -57,9 +56,7 @@ def make_directory_group(
     )
 
 
-def make_membership(
-    is_member: bool, group_email: str = "sg-aws-admins@example.com"
-) -> MembershipCheckResult:
+def make_membership(is_member: bool, group_email: str = "sg-aws-admins@example.com") -> MembershipCheckResult:
     return MembershipCheckResult(
         group_email=group_email,
         group_slug="sg-aws-admins",
@@ -74,27 +71,25 @@ class FakeRepository:
 
     def __init__(self) -> None:
         self._store: dict[str, AccessRequest] = {}
-        self._decisions: dict[str, List[ApprovalDecision]] = {}
+        self._decisions: dict[str, list[ApprovalDecision]] = {}
         self._audit: list = []
 
     def save_request(self, request: AccessRequest) -> None:
         self._store[request.request_id] = request
 
-    def get_request(self, request_id: str) -> Optional[AccessRequest]:
+    def get_request(self, request_id: str) -> AccessRequest | None:
         return self._store.get(request_id)
 
     def save_decision(self, decision: ApprovalDecision) -> None:
         self._decisions.setdefault(decision.request_id, []).append(decision)
 
-    def get_decisions(self, request_id: str) -> List[ApprovalDecision]:
+    def get_decisions(self, request_id: str) -> list[ApprovalDecision]:
         return self._decisions.get(request_id, [])
 
     def save_audit_event(self, event) -> None:
         self._audit.append(event)
 
-    def get_request_with_decisions(
-        self, request_id: str
-    ) -> tuple[Optional[AccessRequest], List[ApprovalDecision]]:
+    def get_request_with_decisions(self, request_id: str) -> tuple[AccessRequest | None, list[ApprovalDecision]]:
         return (
             self._store.get(request_id),
             self._decisions.get(request_id, []),
@@ -105,21 +100,21 @@ class FakeDispatcher:
     """Records dispatched events."""
 
     def __init__(self) -> None:
-        self.dispatched: List[Event] = []
+        self.dispatched: list[Event] = []
 
     def dispatch_background(self, event: Event) -> None:
         self.dispatched.append(event)
 
-    def dispatch(self, event: Event) -> List:
+    def dispatch(self, event: Event) -> list:
         self.dispatched.append(event)
         return []
 
 
 def make_service(
-    config: Optional[AccessRuntimeConfig] = None,
-    directory: Optional[MagicMock] = None,
-    repo: Optional[FakeRepository] = None,
-    dispatcher: Optional[FakeDispatcher] = None,
+    config: AccessRuntimeConfig | None = None,
+    directory: MagicMock | None = None,
+    repo: FakeRepository | None = None,
+    dispatcher: FakeDispatcher | None = None,
     fallback_approver_slug: str = "sg-org-admins",
     min_approver_count: int = 1,
 ) -> tuple[AccessRequestService, FakeRepository, FakeDispatcher]:
@@ -128,9 +123,7 @@ def make_service(
     dispatcher = dispatcher or FakeDispatcher()
     if directory is None:
         directory = MagicMock()
-        directory.get_group.return_value = OperationResult.success(
-            data=make_directory_group()
-        )
+        directory.get_group.return_value = OperationResult.success(data=make_directory_group())
 
         def _check_membership(group_key: str, user_email: str) -> OperationResult:
             # Target group check: user is not yet a member by default.
@@ -145,9 +138,7 @@ def make_service(
                 DirectoryMember(email="manager@example.com", role="OWNER"),
             ]
         )
-        directory.add_group_member.return_value = (
-            OperationResult.success()
-        )  # IDP write succeeds by default
+        directory.add_group_member.return_value = OperationResult.success()  # IDP write succeeds by default
     service = AccessRequestService(
         repository=repo,  # type: ignore[arg-type]
         directory=directory,
@@ -188,9 +179,7 @@ def test_submit_request_should_succeed_for_valid_self_request():
 @pytest.mark.unit
 def test_submit_request_should_reject_when_group_not_found():
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found"
-    )
+    directory.get_group.return_value = OperationResult.error(OperationStatus.NOT_FOUND, message="not found")
     service, _, _ = make_service(directory=directory)
 
     result = service.submit_request(
@@ -271,12 +260,8 @@ def test_submit_request_should_reject_when_mode_is_deactivated_with_token_key_ov
 @pytest.mark.unit
 def test_submit_request_should_reject_when_already_provisioned():
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=True)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=True))
     service, _, _ = make_service(directory=directory)
 
     result = service.submit_request(
@@ -319,12 +304,8 @@ def test_submit_request_should_auto_approve_delegated_requests():
 @pytest.mark.unit
 def test_submit_request_should_reject_when_no_approvers_found():
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=False)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
     directory.get_group_members.return_value = OperationResult.success(data=[])
 
     service, _, _ = make_service(directory=directory)
@@ -397,9 +378,7 @@ def test_approve_request_should_reject_self_approval():
     # Force actor into resolved_approvers for this test
 
     req = repo._store[submit.data.request_id]
-    repo._store[submit.data.request_id] = replace(
-        req, resolved_approvers=["actor@example.com"]
-    )
+    repo._store[submit.data.request_id] = replace(req, resolved_approvers=["actor@example.com"])
 
     result = service.approve_request(
         request_id=submit.data.request_id,
@@ -467,9 +446,7 @@ def test_approve_request_calls_add_group_member_on_approval():
         comment="LGTM.",
     )
 
-    service._directory.add_group_member.assert_called_once_with(
-        "sg-aws-admins@example.com", "user@example.com"
-    )
+    service._directory.add_group_member.assert_called_once_with("sg-aws-admins@example.com", "user@example.com")
 
 
 @pytest.mark.unit
@@ -507,21 +484,15 @@ def test_approve_request_should_fail_when_idp_write_fails():
 @pytest.mark.unit
 def test_submit_request_auto_approve_should_fail_when_idp_write_fails():
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=False)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
     directory.get_group_members.return_value = OperationResult.success(
         data=[
             DirectoryMember(email="approver@example.com", role="OWNER"),
             DirectoryMember(email="manager@example.com", role="OWNER"),
         ]
     )
-    directory.add_group_member.return_value = OperationResult.error(
-        OperationStatus.TRANSIENT_ERROR, message="IDP unavailable"
-    )
+    directory.add_group_member.return_value = OperationResult.error(OperationStatus.TRANSIENT_ERROR, message="IDP unavailable")
     service, repo, dispatcher = make_service(directory=directory)
 
     result = service.submit_request(
@@ -774,8 +745,8 @@ def _make_failed_request(repo: FakeRepository) -> str:
         status="failed",
         justification="Need access.",
         resolved_approvers=["approver@example.com"],
-        requested_at=datetime.now(tz=timezone.utc),
-        updated_at=datetime.now(tz=timezone.utc),
+        requested_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
     )
     repo.save_request(req)
     return request_id
@@ -799,8 +770,7 @@ def test_retry_request_should_succeed_and_transition_to_approved():
     assert decisions == []
     assert repo._store[request_id].status == "approved"
     assert any(
-        e.event_type == "access_requests.request_approved"
-        or e.event_type == "access_request_approved"
+        e.event_type == "access_requests.request_approved" or e.event_type == "access_request_approved"
         for e in dispatcher.dispatched
     )
 
@@ -863,12 +833,8 @@ def test_retry_request_should_return_not_found_for_missing_request():
 def test_retry_request_should_keep_failed_state_when_idp_write_fails_again():
 
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=False)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
     directory.get_group_members.return_value = OperationResult.success(
         data=[
             __import__(
@@ -897,10 +863,7 @@ def test_retry_request_should_keep_failed_state_when_idp_write_fails_again():
     # Status remains failed
     assert repo._store[request_id].status == "failed"
     # Audit event recorded
-    assert any(
-        getattr(e, "event_type", None) == "access_request_retry_failed"
-        for e in repo._audit
-    )
+    assert any(getattr(e, "event_type", None) == "access_request_retry_failed" for e in repo._audit)
     # No domain event dispatched
     assert dispatcher.dispatched == []
 
@@ -914,12 +877,8 @@ def test_retry_request_should_keep_failed_state_when_idp_write_fails_again():
 def test_revoke_request_should_reject_when_user_not_a_member():
     """Grant pre-check is inverted: revoke rejects if user is NOT a member."""
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=False)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
     directory.get_group_members.return_value = OperationResult.success(
         data=[DirectoryMember(email="approver@example.com", role="OWNER")]
     )
@@ -944,12 +903,8 @@ def test_revoke_request_should_reject_when_user_not_a_member():
 def test_revoke_request_should_succeed_when_user_is_a_member():
     """Revoke proceeds to pending_approval when user is currently a member."""
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=True)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=True))
     directory.get_group_members.return_value = OperationResult.success(
         data=[DirectoryMember(email="approver@example.com", role="OWNER")]
     )
@@ -975,12 +930,8 @@ def test_revoke_request_should_succeed_when_user_is_a_member():
 def test_revoke_delegated_auto_approves_and_calls_remove_group_member():
     """Delegated revoke auto-approves and calls remove_group_member, not add."""
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=True)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=True))
     directory.get_group_members.return_value = OperationResult.success(
         data=[
             DirectoryMember(email="approver@example.com", role="OWNER"),
@@ -1003,9 +954,7 @@ def test_revoke_delegated_auto_approves_and_calls_remove_group_member():
 
     assert result.is_success
     assert result.data.status == "approved"
-    directory.remove_group_member.assert_called_once_with(
-        "sg-aws-admins@example.com", "user@example.com"
-    )
+    directory.remove_group_member.assert_called_once_with("sg-aws-admins@example.com", "user@example.com")
     directory.add_group_member.assert_not_called()
     event_types = [e.event_type for e in dispatcher.dispatched]
     assert "access_request_approved" in event_types
@@ -1015,12 +964,8 @@ def test_revoke_delegated_auto_approves_and_calls_remove_group_member():
 def test_revoke_approve_calls_remove_group_member():
     """Approving a revoke request calls remove_group_member on the IDP."""
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=True)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=True))
     directory.get_group_members.return_value = OperationResult.success(
         data=[DirectoryMember(email="approver@example.com", role="OWNER")]
     )
@@ -1051,9 +996,7 @@ def test_revoke_approve_calls_remove_group_member():
     assert updated.status == "approved"
     assert len(decisions) == 1
     assert decisions[0].decision == "approved"
-    directory.remove_group_member.assert_called_once_with(
-        "sg-aws-admins@example.com", "user@example.com"
-    )
+    directory.remove_group_member.assert_called_once_with("sg-aws-admins@example.com", "user@example.com")
     directory.add_group_member.assert_not_called()
     event_types = [e.event_type for e in dispatcher.dispatched]
     assert "access_request_approved" in event_types
@@ -1063,12 +1006,8 @@ def test_revoke_approve_calls_remove_group_member():
 def test_revoke_request_type_in_approved_event_metadata():
     """request_type is included in the REQUEST_APPROVED event metadata."""
     directory = MagicMock()
-    directory.get_group.return_value = OperationResult.success(
-        data=make_directory_group()
-    )
-    directory.check_membership.return_value = OperationResult.success(
-        data=make_membership(is_member=True)
-    )
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=True))
     directory.get_group_members.return_value = OperationResult.success(
         data=[
             DirectoryMember(email="approver@example.com", role="OWNER"),
@@ -1089,7 +1028,5 @@ def test_revoke_request_type_in_approved_event_metadata():
         justification="Off-boarding.",
     )
 
-    approved_event = next(
-        e for e in dispatcher.dispatched if e.event_type == "access_request_approved"
-    )
+    approved_event = next(e for e in dispatcher.dispatched if e.event_type == "access_request_approved")
     assert approved_event.metadata["request_type"] == "revoke"

--- a/app/tests/unit/packages/access/sync/conftest.py
+++ b/app/tests/unit/packages/access/sync/conftest.py
@@ -19,7 +19,6 @@ from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
 from packages.access.common.settings import AccessSyncSettings
 from packages.access.sync.policies import AdapterCapabilities
 
-
 # ---------------------------------------------------------------------------
 # Settings factory
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/packages/access/sync/test_access_sync_application_service_naming.py
+++ b/app/tests/unit/packages/access/sync/test_access_sync_application_service_naming.py
@@ -29,9 +29,7 @@ def test_sync_providers_return_annotation_uses_application_service() -> None:
 @pytest.mark.unit
 def test_sync_ingress_dependency_uses_application_service_port() -> None:
     """Shared ingress should accept the renamed application service protocol."""
-    ingress_module = importlib.import_module(
-        "packages.access.sync.interactions.ingress"
-    )
+    ingress_module = importlib.import_module("packages.access.sync.interactions.ingress")
 
     coordinator_type = get_type_hints(ingress_module.enqueue_user_sync)["coordinator"]
 

--- a/app/tests/unit/packages/access/sync/test_access_sync_package_init.py
+++ b/app/tests/unit/packages/access/sync/test_access_sync_package_init.py
@@ -46,9 +46,7 @@ def test_sync_startup_warmup_registers_handlers_and_warms_runtime_config(monkeyp
         provider_warm_called = True
         return object()
 
-    monkeypatch.setattr(
-        sync_pkg, "get_access_runtime_config", _runtime_config, raising=False
-    )
+    monkeypatch.setattr(sync_pkg, "get_access_runtime_config", _runtime_config, raising=False)
     monkeypatch.setattr(sync_pkg, "get_access_sync_settings", lambda: _Settings())
     monkeypatch.setattr(sync_pkg, "get_access_sync_coordinator", _warm_provider)
 
@@ -100,17 +98,13 @@ def test_sync_startup_warmup_registers_handlers_via_event_dispatcher(monkeypatch
     monkeypatch.setattr(
         sync_pkg,
         "register_event_handler",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("direct register_event_handler usage is forbidden")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("direct register_event_handler usage is forbidden")),
         raising=False,
     )
     monkeypatch.setattr(
         sync_pkg,
         "get_handlers_for_event",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("direct get_handlers_for_event usage is forbidden")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("direct get_handlers_for_event usage is forbidden")),
         raising=False,
     )
 
@@ -175,9 +169,7 @@ def test_sync_register_background_job_registers_reconciliation_when_enabled(
 
     class _BackgroundJobRegistry:
         def register(self, *, job_name: str, schedule: str, job) -> None:
-            registrations.append(
-                {"job_name": job_name, "schedule": schedule, "job": job}
-            )
+            registrations.append({"job_name": job_name, "schedule": schedule, "job": job})
 
     monkeypatch.setattr(sync_pkg, "get_access_sync_settings", lambda: _Settings())
 
@@ -211,9 +203,7 @@ def test_sync_register_background_job_skips_registration_when_disabled(
 
     class _BackgroundJobRegistry:
         def register(self, *, job_name: str, schedule: str, job) -> None:
-            registrations.append(
-                {"job_name": job_name, "schedule": schedule, "job": job}
-            )
+            registrations.append({"job_name": job_name, "schedule": schedule, "job": job})
 
     monkeypatch.setattr(sync_pkg, "get_access_sync_settings", lambda: _Settings())
 

--- a/app/tests/unit/packages/access/sync/test_access_sync_routes.py
+++ b/app/tests/unit/packages/access/sync/test_access_sync_routes.py
@@ -22,11 +22,7 @@ from packages.access.sync.schemas import UserSyncRequest
 
 def _get_route(path: str, method: str) -> APIRoute:
     for route in router.routes:
-        if (
-            isinstance(route, APIRoute)
-            and route.path == path
-            and method in route.methods
-        ):
+        if isinstance(route, APIRoute) and route.path == path and method in route.methods:
             return route
     raise AssertionError(f"Route {method} {path} not found")
 
@@ -175,15 +171,15 @@ def test_sync_endpoint_returns_503_when_disabled():
             "packages.access.sync.interactions.http.get_idempotency_service",
             return_value=fake_idempotency,
         ),
+        pytest.raises(HTTPException) as exc_info,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            sync_endpoint(
-                _make_request(),
-                response=Response(),
-                coordinator=_FakeCoordinator(OperationResult.success()),
-                settings=_Settings(enabled=False),
-                current_user=_make_user(),
-            )
+        sync_endpoint(
+            _make_request(),
+            response=Response(),
+            coordinator=_FakeCoordinator(OperationResult.success()),
+            settings=_Settings(enabled=False),
+            current_user=_make_user(),
+        )
 
     assert exc_info.value.status_code == 503
 
@@ -200,9 +196,7 @@ def test_sync_endpoint_returns_503_without_coordinator_dependency_assembly():
         coordinator_provider_called = True
         raise AssertionError("coordinator dependency should not be assembled")
 
-    app.dependency_overrides[get_access_sync_settings] = lambda: _Settings(
-        enabled=False
-    )
+    app.dependency_overrides[get_access_sync_settings] = lambda: _Settings(enabled=False)
     app.dependency_overrides[get_access_sync_coordinator] = _coordinator_provider
     app.dependency_overrides[get_current_user] = _make_user
 

--- a/app/tests/unit/packages/access/sync/test_application.py
+++ b/app/tests/unit/packages/access/sync/test_application.py
@@ -8,7 +8,7 @@ Covers:
   F-05  UNSUPPORTED_OPERATION from adapter sets requires_manual_action
 """
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 import pytest
 
@@ -36,7 +36,6 @@ from packages.access.sync.policies import (
     PolicyEngine,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
@@ -47,12 +46,12 @@ class FakeAdapter:
 
     def __init__(
         self,
-        current_entitlement_ids: Optional[Set[str]] = None,
+        current_entitlement_ids: set[str] | None = None,
         user_exists: bool = True,
         disable_fails: bool = False,
     ) -> None:
-        self.calls: List[tuple] = []
-        self._current_ids: Set[str] = current_entitlement_ids or set()
+        self.calls: list[tuple] = []
+        self._current_ids: set[str] = current_entitlement_ids or set()
         self._user_exists = user_exists
         self._disable_fails = disable_fails
 
@@ -95,16 +94,14 @@ class FakeAdapter:
 
     def _assess(self, email: str) -> AdapterAssessment:
         if not self._user_exists:
-            return AdapterAssessment(
-                platform_user_exists=False, current_entitlement_ids=set()
-            )
+            return AdapterAssessment(platform_user_exists=False, current_entitlement_ids=set())
         return AdapterAssessment(
             platform_user_exists=True,
             current_entitlement_ids=set(self._current_ids),
         )
 
     def _execute(self, email: str, planned: list) -> SyncOutcome:
-        applied: List[str] = []
+        applied: list[str] = []
         requires_manual = False
         for action in planned:
             if action.action == "provision_user":
@@ -114,13 +111,9 @@ class FakeAdapter:
             elif action.action == "remove_user":
                 r = self.remove_user(email)
             elif action.action == "apply_entitlement":
-                r = self.apply_entitlement(
-                    email, action.entitlement_type or "", action.entitlement_id or ""
-                )
+                r = self.apply_entitlement(email, action.entitlement_type or "", action.entitlement_id or "")
             elif action.action == "remove_entitlement":
-                r = self.remove_entitlement(
-                    email, action.entitlement_type or "", action.entitlement_id or ""
-                )
+                r = self.remove_entitlement(email, action.entitlement_type or "", action.entitlement_id or "")
             else:
                 continue
             if r.is_success:
@@ -175,11 +168,9 @@ class FakeAdapter:
             current_members_by_entitlement={},
             authn_removal_mode=context.authn_removal_mode,
         )
-        actions_by_user: Dict[str, List[PlannedAction]] = {}
+        actions_by_user: dict[str, list[PlannedAction]] = {}
         for email in sorted(plan.users_to_provision):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="provision_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="provision_user"))
         for entitlement_id, members in sorted(plan.entitlement_adds_by_id.items()):
             for email in sorted(members):
                 actions_by_user.setdefault(email, []).append(
@@ -190,15 +181,11 @@ class FakeAdapter:
                     )
                 )
         for email in sorted(plan.users_to_disable):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="disable_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="disable_user"))
         for email in sorted(plan.users_to_remove):
-            actions_by_user.setdefault(email, []).append(
-                PlannedAction(action="remove_user")
-            )
+            actions_by_user.setdefault(email, []).append(PlannedAction(action="remove_user"))
 
-        per_user: Dict[str, SyncOutcome] = {}
+        per_user: dict[str, SyncOutcome] = {}
         users_converged = 0
         for email, planned in sorted(actions_by_user.items()):
             if dry_run:
@@ -230,13 +217,13 @@ class FakeDirectory:
     def __init__(
         self,
         is_member: bool = True,
-        groups: Optional[Set[str]] = None,
-        user_group_slugs: Optional[Set[str]] = None,
+        groups: set[str] | None = None,
+        user_group_slugs: set[str] | None = None,
     ) -> None:
         self._is_member = is_member
-        self._per_group: Dict[str, bool] = {}
-        self._groups: Set[str] = groups or set()
-        self._user_group_slugs: Optional[Set[str]] = user_group_slugs
+        self._per_group: dict[str, bool] = {}
+        self._groups: set[str] = groups or set()
+        self._user_group_slugs: set[str] | None = user_group_slugs
 
     def set_membership(self, group_slug: str, value: bool) -> None:
         self._per_group[group_slug] = value
@@ -245,11 +232,7 @@ class FakeDirectory:
         if self._user_group_slugs is not None:
             slugs = self._user_group_slugs
         else:
-            slugs = {
-                slug
-                for slug in self._groups
-                if self._per_group.get(slug, self._is_member)
-            }
+            slugs = {slug for slug in self._groups if self._per_group.get(slug, self._is_member)}
         return OperationResult.success(
             data=[
                 DirectoryGroup(
@@ -283,28 +266,22 @@ class FakeDirectory:
             )
         )
 
-    def get_group_members(
-        self, group_email: str, include_member_types: Optional[set] = None
-    ) -> OperationResult:
+    def get_group_members(self, group_email: str, include_member_types: set | None = None) -> OperationResult:
         slug = group_email.split("@", 1)[0]
         if slug not in (self._user_group_slugs or set()):
             return OperationResult.success(data=[])
-        return OperationResult.success(
-            data=[DirectoryMember(email="alice@example.com", member_type="USER")]
-        )
+        return OperationResult.success(data=[DirectoryMember(email="alice@example.com", member_type="USER")])
 
     def get_group_members_batch(
         self,
-        group_emails: List[str],
-        include_member_types: Optional[set] = None,
+        group_emails: list[str],
+        include_member_types: set | None = None,
     ) -> OperationResult:
-        mapping: Dict[str, List[DirectoryMember]] = {}
+        mapping: dict[str, list[DirectoryMember]] = {}
         for group_email in group_emails:
             slug = group_email.split("@", 1)[0]
             if slug in (self._user_group_slugs or set()):
-                mapping[group_email] = [
-                    DirectoryMember(email="alice@example.com", member_type="USER")
-                ]
+                mapping[group_email] = [DirectoryMember(email="alice@example.com", member_type="USER")]
             else:
                 mapping[group_email] = []
         return OperationResult.success(data=mapping)
@@ -326,15 +303,13 @@ def make_coordinator(
     platform: str = "aws",
     authn_removal_mode: str = "delete",
     is_member: bool = True,
-    current_ids: Optional[Set[str]] = None,
+    current_ids: set[str] | None = None,
     user_exists: bool = True,
-    adapter: Optional[FakeAdapter] = None,
-    discovered_groups: Optional[Set[str]] = None,
+    adapter: FakeAdapter | None = None,
+    discovered_groups: set[str] | None = None,
 ) -> tuple:
     if adapter is None:
-        adapter = FakeAdapter(
-            current_entitlement_ids=current_ids or set(), user_exists=user_exists
-        )
+        adapter = FakeAdapter(current_entitlement_ids=current_ids or set(), user_exists=user_exists)
     config = AccessRuntimeConfig(
         dir_prefix="sg",
         platforms={
@@ -345,9 +320,7 @@ def make_coordinator(
         },
     )
     authn_slug = config.authn_group_slug(platform)
-    user_group_slugs = (
-        ({authn_slug} | (discovered_groups or set())) if is_member else set()
-    )
+    user_group_slugs = ({authn_slug} | (discovered_groups or set())) if is_member else set()
     directory = FakeDirectory(
         is_member=is_member,
         groups=discovered_groups or set(),
@@ -397,9 +370,7 @@ def test_sync_user_new_member_provisions_user():
 
 @pytest.mark.unit
 def test_sync_user_non_member_removes_user():
-    coordinator, adapter = make_coordinator(
-        is_member=False, authn_removal_mode="delete"
-    )
+    coordinator, adapter = make_coordinator(is_member=False, authn_removal_mode="delete")
     result = coordinator.sync_user("alice@example.com", "aws")
     assert result.is_success
     assert "remove_user" in result.data.planned_actions

--- a/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
+++ b/app/tests/unit/packages/access/sync/test_aws_identity_center_adapter.py
@@ -19,12 +19,8 @@ class FakeIdentityStoreClient:
         self.describe_user_result: OperationResult = OperationResult.success(
             data={"UserId": "user-123", "UserName": "alice@example.com"}
         )
-        self.user_lookup_result: OperationResult = OperationResult.success(
-            data={"UserId": "user-123"}
-        )
-        self.create_user_result: OperationResult = OperationResult.success(
-            data={"UserId": "user-123"}
-        )
+        self.user_lookup_result: OperationResult = OperationResult.success(data={"UserId": "user-123"})
+        self.create_user_result: OperationResult = OperationResult.success(data={"UserId": "user-123"})
         self.membership_lookup_result: OperationResult = OperationResult.error(
             OperationStatus.NOT_FOUND,
             message="membership not found",
@@ -32,19 +28,11 @@ class FakeIdentityStoreClient:
         )
         self.create_membership_result: OperationResult = OperationResult.success()
         self.delete_membership_result: OperationResult = OperationResult.success()
-        self.list_group_memberships_for_member_result: OperationResult = (
-            OperationResult.success(data=[])
-        )
-        self.list_group_memberships_result: OperationResult = OperationResult.success(
-            data=[]
-        )
+        self.list_group_memberships_for_member_result: OperationResult = OperationResult.success(data=[])
+        self.list_group_memberships_result: OperationResult = OperationResult.success(data=[])
         self.describe_group_result: OperationResult = OperationResult.success(data={})
-        self.get_group_id_by_group_name_result: OperationResult = (
-            OperationResult.success(data={"GroupId": "group-123"})
-        )
-        self.list_groups_with_memberships_result: OperationResult = (
-            OperationResult.success(data=[])
-        )
+        self.get_group_id_by_group_name_result: OperationResult = OperationResult.success(data={"GroupId": "group-123"})
+        self.list_groups_with_memberships_result: OperationResult = OperationResult.success(data=[])
         self.list_groups_result: OperationResult = OperationResult.success(data=[])
         self.list_users_result: OperationResult = OperationResult.success(data=[])
         self.delete_user_result: OperationResult = OperationResult.success()
@@ -172,9 +160,7 @@ def test_ensure_user_create_payload_matches_identitystore_requirements() -> None
     assert payload["UserName"] == "sre-bot@cds-snc.ca"
     assert payload["DisplayName"] == "Sre Bot"
     assert payload["Name"] == {"GivenName": "Sre", "FamilyName": "Bot"}
-    assert payload["Emails"] == [
-        {"Value": "sre-bot@cds-snc.ca", "Primary": True, "Type": "WORK"}
-    ]
+    assert payload["Emails"] == [{"Value": "sre-bot@cds-snc.ca", "Primary": True, "Type": "WORK"}]
 
 
 @pytest.mark.unit
@@ -304,9 +290,7 @@ def test_list_members_for_groups_falls_back_when_bulk_fails() -> None:
 
 
 @pytest.mark.unit
-def test_list_members_for_groups_bulk_resolves_member_ids_without_user_details() -> (
-    None
-):
+def test_list_members_for_groups_bulk_resolves_member_ids_without_user_details() -> None:
     """Bulk group read should resolve MemberId.UserId when UserDetails is omitted."""
     client = FakeIdentityStoreClient()
     group_1_id = "11111111-2222-3333-4444-555555555555"
@@ -352,9 +336,7 @@ def test_apply_entitlement_resolves_group_name_to_group_id() -> None:
         message="group id not found",
         error_code="GROUP_NOT_FOUND",
     )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("team1-prd-admin", "resolved-group-id"))
-    )
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("team1-prd-admin", "resolved-group-id")))
     adapter = make_adapter(client)
 
     result = adapter.apply_entitlement(
@@ -364,9 +346,7 @@ def test_apply_entitlement_resolves_group_name_to_group_id() -> None:
     )
 
     assert result.is_success
-    create_call = next(
-        call for call in client.calls if call[0] == "create_group_membership"
-    )
+    create_call = next(call for call in client.calls if call[0] == "create_group_membership")
     assert create_call[1]["GroupId"] == "resolved-group-id"
 
 
@@ -396,9 +376,7 @@ def test_resolve_group_id_uuid_passthrough() -> None:
     """A UUID that describe_group confirms should be returned as-is without index."""
     client = FakeIdentityStoreClient()
     group_id = "11111111-2222-3333-4444-555555555555"
-    client.describe_group_result = OperationResult.success(
-        data={"GroupId": group_id, "DisplayName": "Admin"}
-    )
+    client.describe_group_result = OperationResult.success(data={"GroupId": group_id, "DisplayName": "Admin"})
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", group_id)
@@ -413,12 +391,8 @@ def test_resolve_group_id_uuid_passthrough() -> None:
 def test_resolve_group_id_exact_display_name() -> None:
     """A token that exactly matches an AWS IC display name resolves via the index."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("admin", "group-admin-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("admin", "group-admin-id")))
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", "admin")
@@ -431,9 +405,7 @@ def test_resolve_group_id_exact_display_name() -> None:
 def test_resolve_group_id_non_uuid_skips_describe_group() -> None:
     """Display-name tokens should not trigger describe_group UUID validation calls."""
     client = FakeIdentityStoreClient()
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("scratch", "group-scratch-id"))
-    )
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("scratch", "group-scratch-id")))
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", "scratch")
@@ -447,12 +419,8 @@ def test_resolve_group_id_non_uuid_skips_describe_group() -> None:
 def test_resolve_group_id_normalized_display_name() -> None:
     """A token whose casefold matches an AWS IC group resolves via the index."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("FinOps-ReadOnly", "group-finops-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("FinOps-ReadOnly", "group-finops-id")))
     adapter = make_adapter(client)
 
     # Token "finops-readonly" normalizes via casefold to "finops-readonly"
@@ -467,9 +435,7 @@ def test_resolve_group_id_normalized_display_name() -> None:
 def test_resolve_group_id_ambiguous_name_returns_error() -> None:
     """When normalized token matches multiple groups, AMBIGUOUS_GROUP_NAME is returned."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
     client.list_groups_result = OperationResult.success(
         data=_make_group_list(
             ("Admin", "group-admin-1"),
@@ -488,12 +454,8 @@ def test_resolve_group_id_ambiguous_name_returns_error() -> None:
 def test_resolve_group_id_not_found_returns_error() -> None:
     """When no group matches the token, GROUP_ID_NOT_FOUND is returned."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("other-group", "group-other-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("other-group", "group-other-id")))
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", "missing")
@@ -506,12 +468,8 @@ def test_resolve_group_id_not_found_returns_error() -> None:
 def test_resolve_group_id_caches_result() -> None:
     """Repeated resolution of the same token should not re-call list_groups."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("admin", "group-cached-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("admin", "group-cached-id")))
     adapter = make_adapter(client)
 
     result1 = adapter.canonicalize_entitlement_id("group", "admin")
@@ -526,9 +484,7 @@ def test_resolve_group_id_caches_result() -> None:
 def test_resolve_group_id_list_groups_failure_propagates() -> None:
     """If list_groups fails, the error propagates from canonicalize_entitlement_id."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
     client.list_groups_result = OperationResult.error(
         OperationStatus.TRANSIENT_ERROR,
         message="throttled",
@@ -546,12 +502,8 @@ def test_resolve_group_id_list_groups_failure_propagates() -> None:
 def test_resolve_group_id_no_prefix_matches_full_slug() -> None:
     """Token passed directly (pre-stripped) resolves via exact display-name match."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("platform-admin", "group-platform-admin-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("platform-admin", "group-platform-admin-id")))
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", "platform-admin")
@@ -564,12 +516,8 @@ def test_resolve_group_id_no_prefix_matches_full_slug() -> None:
 def test_resolve_group_id_token_direct_lookup() -> None:
     """Pre-stripped token resolves directly without any prefix handling."""
     client = FakeIdentityStoreClient()
-    client.describe_group_result = OperationResult.error(
-        OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND"
-    )
-    client.list_groups_result = OperationResult.success(
-        data=_make_group_list(("ops-team", "group-ops-id"))
-    )
+    client.describe_group_result = OperationResult.error(OperationStatus.NOT_FOUND, message="not found", error_code="NOT_FOUND")
+    client.list_groups_result = OperationResult.success(data=_make_group_list(("ops-team", "group-ops-id")))
     adapter = make_adapter(client)
 
     result = adapter.canonicalize_entitlement_id("group", "ops-team")

--- a/app/tests/unit/packages/access/sync/test_config.py
+++ b/app/tests/unit/packages/access/sync/test_config.py
@@ -14,7 +14,6 @@ from packages.access.common.config import (
 )
 from packages.access.common.settings import AccessSettings
 
-
 # ---------------------------------------------------------------------------
 # AccessSyncSettings defaults
 # ---------------------------------------------------------------------------
@@ -132,9 +131,7 @@ def test_inline_json_loader_preserves_extensions_for_catalog():
                     "mode_overrides": {},
                 }
             },
-            "extensions": {
-                "catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}
-            },
+            "extensions": {"catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}},
         }
     )
 
@@ -142,9 +139,7 @@ def test_inline_json_loader_preserves_extensions_for_catalog():
 
     assert result.is_success
     assert result.data is not None
-    assert result.data.extensions == {
-        "catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}
-    }
+    assert result.data.extensions == {"catalog": {"platform_display_names": {"aws": "Amazon Web Services"}}}
 
 
 @pytest.mark.unit

--- a/app/tests/unit/packages/access/sync/test_job_models.py
+++ b/app/tests/unit/packages/access/sync/test_job_models.py
@@ -13,7 +13,6 @@ from packages.access.sync.job_models import (
     UserRunningRecord,
 )
 
-
 # ---------------------------------------------------------------------------
 # JobStatus / SyncJobError constants
 # ---------------------------------------------------------------------------
@@ -177,9 +176,7 @@ def test_completed_platform_record_carries_reconciliation_metrics():
     assert d["unchanged_user_count"] == 43
     assert d["action_counts"]["apply_entitlement"] == 4
     assert d["lifecycle_actions"]["remove_user"] == ["carol@example.com"]
-    assert d["entitlements_by_action"]["apply_entitlement"]["sg-aws-admin"] == [
-        "alice@example.com"
-    ]
+    assert d["entitlements_by_action"]["apply_entitlement"]["sg-aws-admin"] == ["alice@example.com"]
     assert d["status"] == JobStatus.COMPLETED
 
 

--- a/app/tests/unit/packages/access/sync/test_job_runner.py
+++ b/app/tests/unit/packages/access/sync/test_job_runner.py
@@ -1,7 +1,8 @@
 """Unit tests for access sync transport job_runner module."""
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.sync.domain import ReconciliationOutcome, SyncOutcome
@@ -10,7 +11,6 @@ from packages.access.sync.job_runner import (
     run_platform_sync_job,
     run_user_sync_job,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -207,9 +207,7 @@ def test_run_platform_sync_job_writes_in_progress_sentinel_then_completed():
     assert final["unchanged_user_count"] == 6
     assert final["action_counts"]["apply_entitlement"] == 2
     assert final["lifecycle_actions"]["remove_user"] == ["carol@example.com"]
-    assert final["entitlements_by_action"]["apply_entitlement"]["sg-aws-admin"] == [
-        "alice@example.com"
-    ]
+    assert final["entitlements_by_action"]["apply_entitlement"]["sg-aws-admin"] == ["alice@example.com"]
 
 
 @pytest.mark.unit

--- a/app/tests/unit/packages/access/sync/test_policies.py
+++ b/app/tests/unit/packages/access/sync/test_policies.py
@@ -4,6 +4,8 @@ import pytest
 
 from packages.access.common.config import (
     AccessRuntimeConfig as AccessSyncRuntimeConfig,
+)
+from packages.access.common.config import (
     PlatformPolicy,
 )
 from packages.access.sync.policies import (
@@ -14,7 +16,6 @@ from packages.access.sync.policies import (
     PolicyEngine,
     resolve_effective_policy,
 )
-
 
 # ---------------------------------------------------------------------------
 # Local helpers (policies-specific)
@@ -237,9 +238,7 @@ def test_plan_actions_user_should_exist_with_entitlements():
     )
 
     assert any(a.action == "provision_user" for a in actions)
-    assert any(
-        a.action == "apply_entitlement" and a.entitlement_id == "admin" for a in actions
-    )
+    assert any(a.action == "apply_entitlement" and a.entitlement_id == "admin" for a in actions)
 
 
 @pytest.mark.unit
@@ -325,10 +324,7 @@ def test_plan_actions_removes_stale_entitlements():
         current_entitlement_ids={"admin"},
         platform_user_exists=True,
     )
-    assert any(
-        a.action == "remove_entitlement" and a.entitlement_id == "admin"
-        for a in actions
-    )
+    assert any(a.action == "remove_entitlement" and a.entitlement_id == "admin" for a in actions)
 
 
 @pytest.mark.unit
@@ -370,7 +366,5 @@ def test_plan_actions_entitlement_only_removal_mode_no_lifecycle():
         user_should_exist=False,
         required_entitlements=[],
     )
-    lifecycle = [
-        a.action for a in actions if a.action in {"disable_user", "remove_user"}
-    ]
+    lifecycle = [a.action for a in actions if a.action in {"disable_user", "remove_user"}]
     assert lifecycle == []

--- a/app/tests/unit/packages/access/sync/test_presenters.py
+++ b/app/tests/unit/packages/access/sync/test_presenters.py
@@ -1,6 +1,6 @@
 """Unit tests for access sync transport presenters."""
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -10,7 +10,6 @@ from packages.access.sync.presenters import (
     to_slack_status_message,
 )
 from packages.access.sync.schemas import SyncJobStatusResponse
-
 
 # ---------------------------------------------------------------------------
 # to_http_status_response
@@ -89,7 +88,7 @@ def test_to_http_status_response_maps_failed_record():
 @pytest.mark.unit
 def test_to_slack_status_message_in_progress_contains_job_id():
     """In-progress status message must include the job ID."""
-    record: Dict[str, Any] = {
+    record: dict[str, Any] = {
         "job_id": "j-4",
         "platform": "aws",
         "dry_run": False,
@@ -108,7 +107,7 @@ def test_to_slack_status_message_in_progress_contains_job_id():
 @pytest.mark.unit
 def test_to_slack_status_message_completed_platform_contains_metrics():
     """Completed platform status message must include reconciliation metrics."""
-    record: Dict[str, Any] = {
+    record: dict[str, Any] = {
         "job_id": "j-5",
         "platform": "aws",
         "sync_type": "platform",
@@ -158,7 +157,7 @@ def test_to_slack_status_message_completed_platform_contains_metrics():
 @pytest.mark.unit
 def test_to_slack_status_message_completed_user_contains_email():
     """Completed user status message must include the user email."""
-    record: Dict[str, Any] = {
+    record: dict[str, Any] = {
         "job_id": "j-6",
         "platform": "aws",
         "sync_type": "user",
@@ -186,7 +185,7 @@ def test_to_slack_status_message_completed_user_contains_email():
 @pytest.mark.unit
 def test_to_slack_status_message_failed_contains_error():
     """Failed status message must include the error string."""
-    record: Dict[str, Any] = {
+    record: dict[str, Any] = {
         "job_id": "j-7",
         "platform": "aws",
         "dry_run": False,
@@ -206,7 +205,7 @@ def test_to_slack_status_message_failed_contains_error():
 @pytest.mark.unit
 def test_to_slack_status_message_unknown_status_does_not_raise():
     """Unknown status must not raise — it should return a fallback message."""
-    record: Dict[str, Any] = {
+    record: dict[str, Any] = {
         "job_id": "j-8",
         "platform": "aws",
         "dry_run": False,

--- a/app/tests/unit/packages/access/sync/test_providers.py
+++ b/app/tests/unit/packages/access/sync/test_providers.py
@@ -2,10 +2,10 @@
 
 import pytest
 
+from packages.access.common.config import AccessRuntimeConfig as AccessSyncRuntimeConfig
 from packages.access.sync import providers
 from packages.access.sync.adapters.aws_identity_center import AwsIdentityCenterAdapter
 from packages.access.sync.adapters.fake_platform import FakePlatformAdapter
-from packages.access.common.config import AccessRuntimeConfig as AccessSyncRuntimeConfig
 
 
 @pytest.mark.unit

--- a/app/tests/unit/packages/access/test_access_interactions_imports.py
+++ b/app/tests/unit/packages/access/test_access_interactions_imports.py
@@ -4,7 +4,6 @@ import importlib
 
 import pytest
 
-
 EXPECTED_INTERACTIONS_MODULES = (
     "packages.access.catalog.interactions.http",
     "packages.access.request.interactions.http",

--- a/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
+++ b/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@me'
 created_date: '2026-07-23 14:19'
-updated_date: '2026-07-23 20:59'
+updated_date: '2026-07-23 21:09'
 labels: []
 dependencies:
   - TASK-15.9
@@ -38,13 +38,13 @@ Expected size: ~60 files. If reviewers require <50, split into two PRs by access
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 git diff feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access is empty
-- [ ] #2 force-exclude + RUFF_SCOPE include packages/access and tests/unit/packages/access; make lint-ci && make fmt-ci pass
+- [x] #1 git diff feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access is empty
+- [x] #2 force-exclude + RUFF_SCOPE include packages/access and tests/unit/packages/access; make lint-ci && make fmt-ci pass
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
+- [x] #1 make test passes; PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -70,3 +70,24 @@ AC-to-step traceability:
 - AC#2 (force-exclude + RUFF_SCOPE include packages/access and tests/unit/packages/access; make lint-ci && make fmt-ci pass) <- steps 3, 4, verified by step 6.
 - DoD#1 (make test passes; PR references decisions/toolchain.md + TASK-15) <- step 6 (user-run, deferred) + PR description (human/PR action).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented per plan (mirrors TASK-15.1/15.7/15.8/15.9 recipe):
+1. git checkout feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access (60 files changed vs main, no adds/deletes -- matches expected ~60). git diff feat/dev_env_setup_ruff -- <same paths> empty (AC#1 verified). packages/access/sync/application.py confirmed carrying the 4 reviewed S101 noqa markers (assert adapter/effective is not None) verbatim, per task note -- kept as-is.
+2. app/pyproject.toml [tool.black] force-exclude: appended `| packages/access` and `| tests/unit/packages/access` to the existing alternation. [tool.ruff.lint] select/extend-select and all prior force-exclude entries (api, infrastructure, integrations, modules, utils, models, jobs, bin, server + their test dirs) unchanged.
+3. app/Makefile RUFF_SCOPE: appended 'packages/access tests/unit/packages/access'. fmt/lint/fmt-ci/lint-ci target bodies untouched (already generic).
+4. .github/workflows/scripts/run_bandit_scan.sh RUFF_MIGRATED_PATHS updated in sync: appended /data/app/packages/access,/data/app/tests/unit/packages/access.
+5. Single PR kept at ~60 files per the task's own stated tolerance (no reviewer objection raised); matches the established pattern of prior TASK-15.x siblings -- pure mechanical formatting/typing churn, no behavior change, so no split into sync/common vs catalog/request sub-PRs was needed.
+6. Validation from app/:
+   - uv run ruff check . -> "All checks passed!"
+   - uv run ruff check --extend-select=I,B,UP,C4,SIM,S <RUFF_SCOPE incl. packages/access> -> "All checks passed!"
+   - uv run black --check . --target-version py311 -> "All done!" (packages/access correctly force-excluded)
+   - uv run ruff format --check <RUFF_SCOPE incl. packages/access> -> 591 files already formatted
+   - uv run pytest tests/unit/packages/access -q -> 253 passed, 1 pre-existing asyncio deprecation warning only
+   - mypy (soft-fail via existing "|| true"): 129 errors in 46 files (up from 128/45 pre-migration baseline on this branch). The +1 is packages/access/catalog/service.py:229 "object has no attribute warning" [attr-defined] -- traced to the reference branch's mechanical `getattr(log, "warning")(...)` -> `log.warning(...)` rewrite (log param is typed `object`); this is inherited content from feat/dev_env_setup_ruff (file is byte-identical to the reference branch per AC#1) and must not be hand-edited to add a type-ignore, consistent with the "never hand-edit migrated source" rule and the established migration-debt pattern from prior TASK-15.x PRs (mypy remains soft-failing and out of scope here).
+   - git diff feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access -> empty (AC#1 re-confirmed post-commit).
+   - make test (full suite, run directly by the user from app/) -> exit 0, all green.
+DoD#1 verified: user ran `make test` directly and confirmed all green (exit 0). All ACs and DoD checked. PR should reference decisions/toolchain.md and TASK-15. Task left at In Progress for human review/merge and status transition to Done.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
+++ b/backlog/tasks/task-15.10 - Ruff-migration-10-packages-access.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15.10
 title: 'Ruff migration 10: packages/access'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-23 14:19'
+updated_date: '2026-07-23 20:59'
 labels: []
 dependencies:
   - TASK-15.9
@@ -44,3 +46,27 @@ Expected size: ~60 files. If reviewers require <50, split into two PRs by access
 <!-- DOD:BEGIN -->
 - [ ] #1 make test passes; PR references decisions/toolchain.md and TASK-15
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Branch (done): feat/dev_env_setup_ruff_10, branched from main after TASK-15.9 merged.
+2. Pull migrated content for this slice from the reference branch (never hand-edit migrated source):
+   git checkout feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access
+   Verified against current main: git diff --stat main feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access -> 60 files changed, no adds/deletes (git diff --diff-filter=AD --name-status empty). Matches expected ~60 files in the task description.
+   Note: packages/access/sync/application.py carries reviewed S101 type-narrowing noqa markers (4 occurrences: "assert adapter is not None  # noqa: S101 ..." / "assert effective is not None  # noqa: S101 ...", guarded by preceding error checks) -- confirmed present in the reference branch diff; keep verbatim, do not edit.
+3. Edit app/pyproject.toml [tool.black] force-exclude: append to the existing alternation (after tests/unit/models, before the closing )/'''):
+     | packages/access
+     | tests/unit/packages/access
+   Leave [tool.ruff.lint] select/extend-select and all prior force-exclude entries (api, infrastructure, integrations, modules, utils, models, jobs, bin, server + their test dirs) unchanged.
+4. Edit app/Makefile RUFF_SCOPE (line 3): append 'packages/access tests/unit/packages/access' to the existing space-separated list. Do not touch fmt/lint/fmt-ci/lint-ci target bodies (already generic, using $(RUFF_SCOPE)).
+5. Edit .github/workflows/scripts/run_bandit_scan.sh RUFF_MIGRATED_PATHS (line 23) to stay in sync: append ,/data/app/packages/access,/data/app/tests/unit/packages/access to the comma-separated list.
+6. Validate from app/: make lint-ci && make fmt-ci (both ruff invocations + black --check must pass). Run a scoped pytest first to keep iteration fast: uv run pytest tests/unit/packages/access -q. Defer the full `make test` (long-running) to the user to run directly as the final DoD check before closing this task -- do not run it as the agent.
+7. Confirm git diff feat/dev_env_setup_ruff -- app/packages/access app/tests/unit/packages/access is empty (AC#1).
+8. Ship one mechanical PR; reference decisions/toolchain.md and TASK-15. No split into sub-PRs needed since 60 files is within the task's own stated tolerance and matches the established single-PR pattern of prior TASK-15.x siblings (pure mechanical formatting/typing churn, no behavior change).
+
+AC-to-step traceability:
+- AC#1 (byte-identical to reference branch) <- step 2, verified by step 7.
+- AC#2 (force-exclude + RUFF_SCOPE include packages/access and tests/unit/packages/access; make lint-ci && make fmt-ci pass) <- steps 3, 4, verified by step 6.
+- DoD#1 (make test passes; PR references decisions/toolchain.md + TASK-15) <- step 6 (user-run, deferred) + PR description (human/PR action).
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request modernizes type annotations throughout the `packages/access/catalog` module and related files, replacing legacy `Optional`, `List`, `Dict`, and `Set` types with standard Python 3.9+ generics (e.g., `str | None`, `list[...]`, `dict[...]`, `set[...]`). It also updates imports and streamlines code formatting for improved readability and consistency. Additionally, it expands the code linting and scanning scope to include the new `packages/access` directories.

**Type annotation modernization:**

* Replaced all uses of `Optional`, `List`, `Dict`, and `Set` with the newer `| None`, `list[...]`, `dict[...]`, and `set[...]` syntax across the `domain.py`, `schemas.py`, `parsers.py`, `providers.py`, and `service.py` files. This affects both class attributes and function signatures. [[1]](diffhunk://#diff-f8a852789e4c0b75b7a6513f4a435f466d284e69199d598feaf62eb0ec483e9dL26-R29) [[2]](diffhunk://#diff-f8a852789e4c0b75b7a6513f4a435f466d284e69199d598feaf62eb0ec483e9dL40-R40) [[3]](diffhunk://#diff-f8a852789e4c0b75b7a6513f4a435f466d284e69199d598feaf62eb0ec483e9dL52-R53) [[4]](diffhunk://#diff-ab0a729931981717685cef4830e9fe730e13e8c45f6a59c24c05084f0977e219L17-R20) [[5]](diffhunk://#diff-ab0a729931981717685cef4830e9fe730e13e8c45f6a59c24c05084f0977e219L30-R36) [[6]](diffhunk://#diff-ab0a729931981717685cef4830e9fe730e13e8c45f6a59c24c05084f0977e219L47-R55) [[7]](diffhunk://#diff-82ed4c735745ad9d9559caead42732fa77b169a53b450ff4c5a8ddc79badf64bL13-R13) [[8]](diffhunk://#diff-82ed4c735745ad9d9559caead42732fa77b169a53b450ff4c5a8ddc79badf64bL51-R51) [[9]](diffhunk://#diff-82ed4c735745ad9d9559caead42732fa77b169a53b450ff4c5a8ddc79badf64bL60-R68) [[10]](diffhunk://#diff-82ed4c735745ad9d9559caead42732fa77b169a53b450ff4c5a8ddc79badf64bL80-R81) [[11]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL11) [[12]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL30-R37) [[13]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL69-R68) [[14]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL12-R12) [[15]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL33-R39) [[16]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL58-R61) [[17]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL74-R74) [[18]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL85-R85) [[19]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL104-R104) [[20]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL43-R49) [[21]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL168-R157)

* Updated function parameters and return types to use the new annotations, improving type clarity and leveraging modern Python features. [[1]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL43-R49) [[2]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL168-R157) [[3]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL33-R39) [[4]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL104-R104)

**Code formatting and import improvements:**

* Cleaned up and reordered imports for clarity and to avoid unnecessary imports (e.g., removing unused `List`, `Optional`, `Set` imports and adjusting import order). [[1]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL12-R19) [[2]](diffhunk://#diff-f93b5d451cc940eca7a846cfdeb23809c2571163093957e629c4ba943ddeeba9L9-R14) [[3]](diffhunk://#diff-0dc89b2ad85be7119a10aa4dff33d1c7ae0dae0c8c9a1510aa13fe59ee9e3d6fL11) [[4]](diffhunk://#diff-82ed4c735745ad9d9559caead42732fa77b169a53b450ff4c5a8ddc79badf64bL13-R13) [[5]](diffhunk://#diff-ab0a729931981717685cef4830e9fe730e13e8c45f6a59c24c05084f0977e219L7-R7) [[6]](diffhunk://#diff-949866f241d647c248ef431b0a1700a588b58602edc5f050d5f70e1dec58e72eL12-R12)

* Reformatted function and class definitions for better readability—such as collapsing multi-line argument lists and docstrings where appropriate. [[1]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL89-R90) [[2]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL116-R120) [[3]](diffhunk://#diff-8d38b3c3973e5d5abe9f7f0e459c8471ffcc192e9c3581fb1bf5df425ac44c3fL138-R132)

**Linting and static analysis scope expansion:**

* Updated `RUFF_SCOPE` in `app/Makefile` and `RUFF_MIGRATED_PATHS` in `.github/workflows/scripts/run_bandit_scan.sh` to include `packages/access` and its test directories, ensuring these new modules are covered by linting and static analysis tools. [[1]](diffhunk://#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451L3-R3) [[2]](diffhunk://#diff-54b7883058a186a68e8ffe24eaa7104d9edfc21f11a453c5eb9db48d2a8ec38fL23-R23)