### PR TITLE
Feat/idempotency rewrite 4 1

### DIFF
--- a/app/packages/access/sync/interactions/http.py
+++ b/app/packages/access/sync/interactions/http.py
@@ -15,7 +15,6 @@ from typing import Annotated, Protocol
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Response, Security
 
-from infrastructure.idempotency import get_idempotency_service
 from infrastructure.operations import OperationResult
 from infrastructure.security import get_current_user
 from infrastructure.security.models import User
@@ -27,6 +26,7 @@ from packages.access.sync.interactions.ingress import (
 from packages.access.sync.presenters import to_http_status_response
 from packages.access.sync.providers import (
     get_access_sync_coordinator,
+    get_access_sync_job_status_store,
     get_access_sync_lock_store,
     get_access_sync_settings,
 )
@@ -141,13 +141,13 @@ def sync_endpoint(
 
     coordinator_dep = _resolve_coordinator(coordinator)
 
-    idempotency = get_idempotency_service()
+    job_status_store = get_access_sync_job_status_store()
     lock_store = get_access_sync_lock_store()
 
     if isinstance(request, UserSyncRequest):
         result = enqueue_user_sync(
             coordinator=coordinator_dep,
-            idempotency=idempotency,
+            job_status_store=job_status_store,
             lock_store=lock_store,
             settings=settings,
             user_email=str(request.user_email),
@@ -172,7 +172,7 @@ def sync_endpoint(
     # Platform sync
     result = enqueue_platform_sync(
         coordinator=coordinator_dep,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         settings=settings,
         platform=request.platform,
@@ -213,8 +213,8 @@ def get_sync_job_status(
     current_user: Annotated[User, Security(get_current_user, scopes=["sre-bot:access-sync"])],
 ) -> SyncJobStatusResponse:
     """Return the current status and outcome of a sync job."""
-    idempotency = get_idempotency_service()
-    record = idempotency.get(job_id)
+    job_status_store = get_access_sync_job_status_store()
+    record = job_status_store.get(job_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Sync job not found or has expired")
     return to_http_status_response(record)

--- a/app/packages/access/sync/interactions/ingress.py
+++ b/app/packages/access/sync/interactions/ingress.py
@@ -14,13 +14,14 @@ from typing import Protocol
 
 import structlog
 
-from infrastructure.idempotency import IdempotencyService, IdempotencyStore
+from infrastructure.idempotency import IdempotencyStore
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.sync.application import AccessSyncApplicationServicePort
 from packages.access.sync.job_runner import (
     spawn_platform_sync_thread,
     spawn_user_sync_thread,
 )
+from packages.access.sync.job_status_store import JobStatusStore
 from packages.access.sync.platform_lock import (
     acquire_lock,
     current_holder,
@@ -52,7 +53,7 @@ class EnqueuedJob:
 
 def enqueue_user_sync(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     settings: _IngressSettings,
     user_email: str,
@@ -91,10 +92,10 @@ def enqueue_user_sync(
         lock_key=lock_key,
         payload=lock_payload,
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=settings.job_ttl_seconds,
     ):
-        running = current_holder(lock_key, idempotency) or {}
+        running = current_holder(lock_key, job_status_store) or {}
         existing_job_id = running.get("job_id", "")
         logger.bind(platform=platform, user_email=user_email).info("user_sync_already_running", existing_job_id=existing_job_id)
         return OperationResult.success(
@@ -110,7 +111,7 @@ def enqueue_user_sync(
 
     spawn_user_sync_thread(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id=job_id,
         user_email=user_email,
@@ -134,7 +135,7 @@ def enqueue_user_sync(
 
 def enqueue_platform_sync(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     settings: _IngressSettings,
     platform: str,
@@ -172,10 +173,10 @@ def enqueue_platform_sync(
         lock_key=lock_key,
         payload=lock_payload,
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=settings.job_ttl_seconds,
     ):
-        running = current_holder(lock_key, idempotency) or {}
+        running = current_holder(lock_key, job_status_store) or {}
         existing_job_id = running.get("job_id", "")
         logger.bind(platform=platform).info("platform_sync_already_running", existing_job_id=existing_job_id)
         return OperationResult.success(
@@ -191,7 +192,7 @@ def enqueue_platform_sync(
 
     spawn_platform_sync_thread(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id=job_id,
         platform=platform,

--- a/app/packages/access/sync/interactions/slack.py
+++ b/app/packages/access/sync/interactions/slack.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from infrastructure.i18n import t
-from infrastructure.idempotency import get_idempotency_service
 from integrations.slack.models import CommandPayload, CommandResponse
 from integrations.slack.parser import Argument, ArgumentType
 from packages.access.sync.interactions.ingress import (
@@ -24,6 +23,7 @@ from packages.access.sync.interactions.ingress import (
 from packages.access.sync.presenters import to_slack_status_message
 from packages.access.sync.providers import (
     get_access_sync_coordinator,
+    get_access_sync_job_status_store,
     get_access_sync_lock_store,
     get_access_sync_settings,
 )
@@ -177,13 +177,13 @@ def handle_sync_user_command(
     log.info("slack_command_received", text=payload.text)
 
     coordinator = get_access_sync_coordinator()
-    idempotency = get_idempotency_service()
+    job_status_store = get_access_sync_job_status_store()
     lock_store = get_access_sync_lock_store()
     settings = get_access_sync_settings()
 
     result = enqueue_user_sync(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         settings=settings,
         user_email=user_email,
@@ -271,13 +271,13 @@ def handle_sync_platform_command(
     log.info("slack_command_received", text=payload.text)
 
     coordinator = get_access_sync_coordinator()
-    idempotency = get_idempotency_service()
+    job_status_store = get_access_sync_job_status_store()
     lock_store = get_access_sync_lock_store()
     settings = get_access_sync_settings()
 
     result = enqueue_platform_sync(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         settings=settings,
         platform=platform,
@@ -359,8 +359,8 @@ def handle_sync_status_command(
     )
     log.info("slack_command_received", text=payload.text)
 
-    idempotency = get_idempotency_service()
-    record = idempotency.get(job_id)
+    job_status_store = get_access_sync_job_status_store()
+    record = job_status_store.get(job_id)
 
     if record is None:
         return CommandResponse(

--- a/app/packages/access/sync/job_models.py
+++ b/app/packages/access/sync/job_models.py
@@ -6,7 +6,7 @@ the ``dict[str, Any]`` pattern that caused key-drift across HTTP and Slack
 transport modules.
 
 All models are frozen so they cross thread boundaries safely.  ``to_dict()``
-converts to the wire representation expected by ``IdempotencyService``.
+converts to the wire representation expected by ``JobStatusStore``.
 """
 
 import dataclasses
@@ -30,8 +30,8 @@ class SyncJobError:
     """Sanitized error strings exposed to external callers.
 
     Internal error details are never surfaced — the external payload always
-    uses ``SYNC_FAILED`` so implementation details do not leak through the
-    idempotency store or API responses.
+    uses ``SYNC_FAILED`` so implementation details do not leak through status
+    storage or API responses.
     """
 
     SYNC_FAILED = "sync_failed"

--- a/app/packages/access/sync/job_runner.py
+++ b/app/packages/access/sync/job_runner.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 
 import structlog
 
-from infrastructure.idempotency import IdempotencyService, IdempotencyStore
+from infrastructure.idempotency import IdempotencyStore
 from packages.access.sync.application import AccessSyncApplicationServicePort
 from packages.access.sync.domain import ReconciliationOutcome, SyncOutcome
 from packages.access.sync.job_models import (
@@ -37,6 +37,7 @@ from packages.access.sync.job_models import (
     SyncJobError,
     UserRunningRecord,
 )
+from packages.access.sync.job_status_store import JobStatusStore
 from packages.access.sync.platform_lock import (
     platform_lock_key,
     release_lock,
@@ -53,7 +54,7 @@ logger = structlog.get_logger()
 
 def run_user_sync_job(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     job_id: str,
     user_email: str,
@@ -129,13 +130,13 @@ def run_user_sync_job(
         log.error("user_sync_job_error", error=str(exc), error_type=type(exc).__name__)
 
     payload = record.to_dict()
-    idempotency.set(job_id, payload, ttl_seconds=job_ttl_seconds)
+    job_status_store.put(job_id, payload, ttl_seconds=job_ttl_seconds)
     release_lock(user_lock_key(platform, user_email), lock_store)
 
 
 def run_platform_sync_job(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     job_id: str,
     platform: str,
@@ -155,7 +156,7 @@ def run_platform_sync_job(
         correlation_id=request_id,
         poll_path=f"/api/v1/access/sync-runs/{job_id}",
     )
-    idempotency.set(
+    job_status_store.put(
         job_id,
         PlatformRunningRecord(
             job_id=job_id,
@@ -234,7 +235,7 @@ def run_platform_sync_job(
         )
 
     payload = record.to_dict()
-    idempotency.set(job_id, payload, ttl_seconds=job_ttl_seconds)
+    job_status_store.put(job_id, payload, ttl_seconds=job_ttl_seconds)
     release_lock(platform_lock_key(platform), lock_store)
 
 
@@ -245,7 +246,7 @@ def run_platform_sync_job(
 
 def spawn_user_sync_thread(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     job_id: str,
     user_email: str,
@@ -268,12 +269,12 @@ def spawn_user_sync_thread(
         started_at=started_at,
     )
     job_record = {**lock_record.to_dict(), "status": JobStatus.IN_PROGRESS}
-    idempotency.set(job_id, job_record, ttl_seconds=job_ttl_seconds)
+    job_status_store.put(job_id, job_record, ttl_seconds=job_ttl_seconds)
     thread = threading.Thread(
         target=run_user_sync_job,
         kwargs={
             "coordinator": coordinator,
-            "idempotency": idempotency,
+            "job_status_store": job_status_store,
             "lock_store": lock_store,
             "job_id": job_id,
             "user_email": user_email,
@@ -291,7 +292,7 @@ def spawn_user_sync_thread(
 
 def spawn_platform_sync_thread(
     coordinator: AccessSyncApplicationServicePort,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     lock_store: IdempotencyStore,
     job_id: str,
     platform: str,
@@ -308,12 +309,12 @@ def spawn_platform_sync_thread(
         started_at=started_at,
     )
     job_record = {**lock_record.to_dict(), "status": JobStatus.IN_PROGRESS}
-    idempotency.set(job_id, job_record, ttl_seconds=job_ttl_seconds)
+    job_status_store.put(job_id, job_record, ttl_seconds=job_ttl_seconds)
     thread = threading.Thread(
         target=run_platform_sync_job,
         kwargs={
             "coordinator": coordinator,
-            "idempotency": idempotency,
+            "job_status_store": job_status_store,
             "lock_store": lock_store,
             "job_id": job_id,
             "platform": platform,

--- a/app/packages/access/sync/job_status_store.py
+++ b/app/packages/access/sync/job_status_store.py
@@ -1,0 +1,62 @@
+"""Access Sync job and holder status storage.
+
+Wraps ``StorageService`` for job-status polling and lock-holder metadata used by
+the access-sync package. Access Sync owns the record serialization and key
+scheme while infrastructure owns DynamoDB transport concerns.
+
+Records are stored as JSON strings in the shared ``sre_bot_idempotency`` table
+to preserve exact primitive types on round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import structlog
+
+from infrastructure.storage import StorageService
+
+logger = structlog.get_logger()
+
+
+class JobStatusStore:
+    """DynamoDB-backed status store for access-sync job and holder records."""
+
+    TABLE = "sre_bot_idempotency"
+
+    def __init__(self, storage: StorageService) -> None:
+        self._storage = storage
+
+    def put(self, key: str, record: dict[str, Any], ttl_seconds: int) -> None:
+        """Persist a record with TTL. Errors are logged and not propagated."""
+        item = {
+            "idempotency_key": key,
+            "record_json": json.dumps(record),
+            "ttl": int(time.time()) + ttl_seconds,
+        }
+        result = self._storage.put(self.TABLE, item)
+        if not result.is_success:
+            logger.error("job_status_store_put_failed", key=key, error=result.message)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        """Fetch and deserialize a record. Returns None for misses or malformed data."""
+        result = self._storage.get(self.TABLE, {"idempotency_key": key})
+        if not result.is_success:
+            return None
+
+        item = result.data if isinstance(result.data, dict) else None
+        if item is None:
+            return None
+
+        raw = item.get("record_json")
+        if not isinstance(raw, str) or not raw:
+            return None
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+        return parsed if isinstance(parsed, dict) else None

--- a/app/packages/access/sync/platform_lock.py
+++ b/app/packages/access/sync/platform_lock.py
@@ -2,7 +2,8 @@
 
 from typing import Any
 
-from infrastructure.idempotency import IdempotencyService, IdempotencyStore, acquire_lease, release_lease
+from infrastructure.idempotency import IdempotencyStore, acquire_lease, release_lease
+from packages.access.sync.job_status_store import JobStatusStore
 
 
 def platform_lock_key(platform: str) -> str:
@@ -17,19 +18,19 @@ def acquire_lock(
     lock_key: str,
     payload: dict[str, Any],
     lock_store: IdempotencyStore,
-    idempotency: IdempotencyService,
+    job_status_store: JobStatusStore,
     ttl_seconds: int,
 ) -> bool:
     """Atomically acquire lock and write holder metadata when successful."""
     acquired = acquire_lease(lock_store, lock_key)
     if acquired:
-        idempotency.set(f"{lock_key}:holder", payload, ttl_seconds=ttl_seconds)
+        job_status_store.put(f"{lock_key}:holder", payload, ttl_seconds=ttl_seconds)
     return acquired
 
 
-def current_holder(lock_key: str, idempotency: IdempotencyService) -> dict[str, Any] | None:
+def current_holder(lock_key: str, job_status_store: JobStatusStore) -> dict[str, Any] | None:
     """Best-effort holder metadata for already-running reporting only."""
-    return idempotency.get(f"{lock_key}:holder")
+    return job_status_store.get(f"{lock_key}:holder")
 
 
 def release_lock(

--- a/app/packages/access/sync/providers.py
+++ b/app/packages/access/sync/providers.py
@@ -12,6 +12,7 @@ from packages.access.sync.adapters.aws_identity_center import AwsIdentityCenterA
 from packages.access.sync.adapters.fake_platform import FakePlatformAdapter
 from packages.access.sync.application import AccessSyncApplicationService
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
+from packages.access.sync.job_status_store import JobStatusStore
 from packages.access.sync.store import SyncRunRepository
 
 
@@ -47,6 +48,12 @@ def get_access_sync_adapters() -> dict[str, AccessSyncAdapter]:
 def get_sync_run_repository() -> SyncRunRepository:
     """Return the singleton SyncRunRepository instance."""
     return SyncRunRepository(storage=get_storage_service())
+
+
+@functools.lru_cache(maxsize=1)
+def get_access_sync_job_status_store() -> JobStatusStore:
+    """Return the singleton JobStatusStore instance."""
+    return JobStatusStore(storage=get_storage_service())
 
 
 @functools.lru_cache(maxsize=1)

--- a/app/tests/unit/packages/access/sync/test_access_sync_routes.py
+++ b/app/tests/unit/packages/access/sync/test_access_sync_routes.py
@@ -101,13 +101,13 @@ def _make_user() -> User:
 @pytest.mark.unit
 def test_sync_endpoint_user_sync_enqueues_job_and_returns_202():
     """User sync should enqueue a background job and return 202 with a job_id."""
-    fake_idempotency = MagicMock()
-    fake_idempotency.get.return_value = None  # no existing lock
+    fake_job_status_store = MagicMock()
+    fake_job_status_store.get.return_value = None  # no existing lock
 
     with (
         patch(
-            "packages.access.sync.interactions.http.get_idempotency_service",
-            return_value=fake_idempotency,
+            "packages.access.sync.interactions.http.get_access_sync_job_status_store",
+            return_value=fake_job_status_store,
         ),
         patch(
             "packages.access.sync.interactions.http.get_access_sync_lock_store",
@@ -141,8 +141,8 @@ def test_sync_endpoint_user_sync_enqueues_job_and_returns_202():
 def test_sync_endpoint_user_sync_returns_existing_job_when_lock_held():
     """When a user sync lock is active, return the existing job without spawning a new thread."""
     existing_job_id = "existing-job-123"
-    fake_idempotency = MagicMock()
-    fake_idempotency.get.return_value = {
+    fake_job_status_store = MagicMock()
+    fake_job_status_store.get.return_value = {
         "job_id": existing_job_id,
         "status": "running",
         "started_at": "2026-04-20T10:00:00+00:00",
@@ -151,8 +151,8 @@ def test_sync_endpoint_user_sync_returns_existing_job_when_lock_held():
 
     with (
         patch(
-            "packages.access.sync.interactions.http.get_idempotency_service",
-            return_value=fake_idempotency,
+            "packages.access.sync.interactions.http.get_access_sync_job_status_store",
+            return_value=fake_job_status_store,
         ),
         patch(
             "packages.access.sync.interactions.http.get_access_sync_lock_store",
@@ -164,7 +164,7 @@ def test_sync_endpoint_user_sync_returns_existing_job_when_lock_held():
         ),
         patch(
             "packages.access.sync.interactions.ingress.current_holder",
-            return_value=fake_idempotency.get.return_value,
+            return_value=fake_job_status_store.get.return_value,
         ),
         patch(
             "packages.access.sync.job_runner.threading",
@@ -189,11 +189,10 @@ def test_sync_endpoint_user_sync_returns_existing_job_when_lock_held():
 def test_sync_endpoint_returns_503_when_disabled():
     """Sync endpoint should return 503 when the feature flag is disabled."""
 
-    fake_idempotency = MagicMock()
     with (
         patch(
-            "packages.access.sync.interactions.http.get_idempotency_service",
-            return_value=fake_idempotency,
+            "packages.access.sync.interactions.http.get_access_sync_job_status_store",
+            return_value=MagicMock(),
         ),
         pytest.raises(HTTPException) as exc_info,
     ):
@@ -267,7 +266,7 @@ def test_access_sync_routes_expose_explicit_openapi_metadata() -> None:
 @pytest.mark.unit
 def test_run_user_sync_job_stores_completed_outcome():
     """Background job should store completed status with action details."""
-    fake_idempotency = MagicMock()
+    fake_job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _FakeCoordinator(
         OperationResult.success(
@@ -281,7 +280,7 @@ def test_run_user_sync_job_stores_completed_outcome():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=fake_idempotency,
+        job_status_store=fake_job_status_store,
         lock_store=lock_store,
         job_id="job-1",
         user_email="user@example.com",
@@ -292,10 +291,10 @@ def test_run_user_sync_job_stores_completed_outcome():
         job_ttl_seconds=86400,
     )
 
-    assert fake_idempotency.set.call_count == 1
+    assert fake_job_status_store.put.call_count == 1
 
     # Check job outcome record
-    args, _ = fake_idempotency.set.call_args_list[0]
+    args, _ = fake_job_status_store.put.call_args_list[0]
     assert args[0] == "job-1"
     stored = args[1]
     assert stored["status"] == "completed"
@@ -308,7 +307,7 @@ def test_run_user_sync_job_stores_completed_outcome():
 @pytest.mark.unit
 def test_run_user_sync_job_stores_failed_outcome_on_coordinator_error():
     """Background job should store failed status when coordinator returns an error."""
-    fake_idempotency = MagicMock()
+    fake_job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _FakeCoordinator(
         OperationResult.error(
@@ -320,7 +319,7 @@ def test_run_user_sync_job_stores_failed_outcome_on_coordinator_error():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=fake_idempotency,
+        job_status_store=fake_job_status_store,
         lock_store=lock_store,
         job_id="job-2",
         user_email="user@example.com",
@@ -331,9 +330,9 @@ def test_run_user_sync_job_stores_failed_outcome_on_coordinator_error():
         job_ttl_seconds=86400,
     )
 
-    assert fake_idempotency.set.call_count == 1
+    assert fake_job_status_store.put.call_count == 1
 
-    args, _ = fake_idempotency.set.call_args_list[0]
+    args, _ = fake_job_status_store.put.call_args_list[0]
     assert args[0] == "job-2"
     stored = args[1]
     assert stored["status"] == "failed"
@@ -345,7 +344,7 @@ def test_run_user_sync_job_stores_failed_outcome_on_coordinator_error():
 @pytest.mark.unit
 def test_sync_endpoint_passes_lock_store_to_ingress_enqueue():
     """HTTP sync endpoint should resolve lock_store once and pass it into ingress."""
-    fake_idempotency = MagicMock()
+    fake_job_status_store = MagicMock()
     sentinel_lock_store = object()
     enqueued = EnqueuedJob(
         job_id="job-lock-store-wire-1",
@@ -358,8 +357,8 @@ def test_sync_endpoint_passes_lock_store_to_ingress_enqueue():
 
     with (
         patch(
-            "packages.access.sync.interactions.http.get_idempotency_service",
-            return_value=fake_idempotency,
+            "packages.access.sync.interactions.http.get_access_sync_job_status_store",
+            return_value=fake_job_status_store,
         ),
         patch(
             "packages.access.sync.interactions.http.get_access_sync_lock_store",
@@ -385,14 +384,14 @@ def test_sync_endpoint_passes_lock_store_to_ingress_enqueue():
 @pytest.mark.unit
 def test_run_user_sync_job_stores_failed_outcome_on_exception():
     """Background job should store failed status and not propagate exceptions."""
-    fake_idempotency = MagicMock()
+    fake_job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = MagicMock()
     coordinator.sync_user.side_effect = RuntimeError("unexpected crash")
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=fake_idempotency,
+        job_status_store=fake_job_status_store,
         lock_store=lock_store,
         job_id="job-3",
         user_email="user@example.com",
@@ -403,8 +402,8 @@ def test_run_user_sync_job_stores_failed_outcome_on_exception():
         job_ttl_seconds=86400,
     )
 
-    assert fake_idempotency.set.call_count == 1
-    args, _ = fake_idempotency.set.call_args_list[0]
+    assert fake_job_status_store.put.call_count == 1
+    args, _ = fake_job_status_store.put.call_args_list[0]
     assert args[0] == "job-3"
     assert args[1]["status"] == "failed"
     assert args[1]["error"] == "sync_failed"
@@ -413,14 +412,14 @@ def test_run_user_sync_job_stores_failed_outcome_on_exception():
 @pytest.mark.unit
 def test_run_user_sync_job_sanitizes_error_to_sync_failed_on_exception():
     """Exception details must never appear in the external error payload."""
-    fake_idempotency = MagicMock()
+    fake_job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = MagicMock()
     coordinator.sync_user.side_effect = ValueError("secret internal detail")
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=fake_idempotency,
+        job_status_store=fake_job_status_store,
         lock_store=lock_store,
         job_id="job-4",
         user_email="user@example.com",
@@ -431,7 +430,7 @@ def test_run_user_sync_job_sanitizes_error_to_sync_failed_on_exception():
         job_ttl_seconds=86400,
     )
 
-    args, _ = fake_idempotency.set.call_args_list[0]
+    args, _ = fake_job_status_store.put.call_args_list[0]
     payload = args[1]
     # Internal exception text must not leak
     assert "secret internal detail" not in payload.get("error", "")

--- a/app/tests/unit/packages/access/sync/test_access_sync_slack_status.py
+++ b/app/tests/unit/packages/access/sync/test_access_sync_slack_status.py
@@ -1,0 +1,65 @@
+"""Unit tests for access sync Slack status command handling."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from integrations.slack.models import CommandPayload, CommandResponse
+from packages.access.sync.interactions.slack import handle_sync_status_command
+
+
+@pytest.mark.unit
+def test_handle_sync_status_command_returns_status_message_when_job_found() -> None:
+    """Status command should render a presenter-backed message when a job exists."""
+    payload = CommandPayload(text="status job-123", user_id="U123", channel_id="C123")
+    parsed_args = {"job_id": "job-123"}
+    fake_store = MagicMock()
+    fake_store.get.return_value = {
+        "job_id": "job-123",
+        "sync_type": "platform",
+        "platform": "aws",
+        "dry_run": False,
+        "status": "completed",
+        "started_at": "2026-07-27T12:00:00+00:00",
+        "completed_at": "2026-07-27T12:10:00+00:00",
+        "users_synced": 3,
+        "users_converged": 3,
+        "orphans_found": 0,
+        "requires_manual_action_count": 0,
+        "changed_user_count": 1,
+        "unchanged_user_count": 2,
+        "action_counts": {},
+        "lifecycle_actions": {},
+        "entitlements_by_action": {},
+    }
+
+    with patch(
+        "packages.access.sync.interactions.slack.get_access_sync_job_status_store",
+        return_value=fake_store,
+    ):
+        result = handle_sync_status_command(payload, parsed_args)
+
+    assert isinstance(result, CommandResponse)
+    assert result.ephemeral is True
+    assert "job-123" in result.message
+    assert "completed" in result.message.lower()
+
+
+@pytest.mark.unit
+def test_handle_sync_status_command_returns_not_found_message_when_job_missing() -> None:
+    """Status command should return a clear not-found message when no record exists."""
+    payload = CommandPayload(text="status missing-job", user_id="U123", channel_id="C123")
+    parsed_args = {"job_id": "missing-job"}
+    fake_store = MagicMock()
+    fake_store.get.return_value = None
+
+    with patch(
+        "packages.access.sync.interactions.slack.get_access_sync_job_status_store",
+        return_value=fake_store,
+    ):
+        result = handle_sync_status_command(payload, parsed_args)
+
+    assert isinstance(result, CommandResponse)
+    assert result.ephemeral is True
+    assert "No sync job found" in result.message
+    assert "missing-job" in result.message

--- a/app/tests/unit/packages/access/sync/test_job_runner.py
+++ b/app/tests/unit/packages/access/sync/test_job_runner.py
@@ -32,7 +32,7 @@ def _make_coordinator(result: OperationResult) -> MagicMock:
 @pytest.mark.unit
 def test_run_user_sync_job_writes_completed_record_with_action_lists():
     """Completed user sync must write typed record with planned/applied lists."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.success(
@@ -46,7 +46,7 @@ def test_run_user_sync_job_writes_completed_record_with_action_lists():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-completed-1",
         user_email="alice@example.com",
@@ -57,8 +57,8 @@ def test_run_user_sync_job_writes_completed_record_with_action_lists():
         job_ttl_seconds=86400,
     )
 
-    assert idempotency.set.call_count == 1
-    job_args, _ = idempotency.set.call_args_list[0]
+    assert job_status_store.put.call_count == 1
+    job_args, _ = job_status_store.put.call_args_list[0]
     record = job_args[1]
     assert record["status"] == JobStatus.COMPLETED
     assert record["actions_planned"] == ["provision_user", "apply_entitlement"]
@@ -70,7 +70,7 @@ def test_run_user_sync_job_writes_completed_record_with_action_lists():
 @pytest.mark.unit
 def test_run_user_sync_job_writes_failed_record_on_coordinator_failure():
     """Failed coordinator result must produce a typed failed record."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.error(
@@ -82,7 +82,7 @@ def test_run_user_sync_job_writes_failed_record_on_coordinator_failure():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-fail-1",
         user_email="bob@example.com",
@@ -93,7 +93,7 @@ def test_run_user_sync_job_writes_failed_record_on_coordinator_failure():
         job_ttl_seconds=86400,
     )
 
-    job_args, _ = idempotency.set.call_args_list[0]
+    job_args, _ = job_status_store.put.call_args_list[0]
     record = job_args[1]
     assert record["status"] == JobStatus.FAILED
     assert "error" in record
@@ -103,14 +103,14 @@ def test_run_user_sync_job_writes_failed_record_on_coordinator_failure():
 @pytest.mark.unit
 def test_run_user_sync_job_sanitizes_exception_to_sync_failed():
     """Unhandled exceptions must be sanitized — internal detail must not appear in the record."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = MagicMock()
     coordinator.sync_user.side_effect = RuntimeError("internal database credential")
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-exc-1",
         user_email="carol@example.com",
@@ -121,7 +121,7 @@ def test_run_user_sync_job_sanitizes_exception_to_sync_failed():
         job_ttl_seconds=86400,
     )
 
-    job_args, _ = idempotency.set.call_args_list[0]
+    job_args, _ = job_status_store.put.call_args_list[0]
     record = job_args[1]
     assert record["status"] == JobStatus.FAILED
     assert record["error"] == SyncJobError.SYNC_FAILED
@@ -132,7 +132,7 @@ def test_run_user_sync_job_sanitizes_exception_to_sync_failed():
 @pytest.mark.unit
 def test_run_user_sync_job_releases_lock_after_completion():
     """After completion the user lock must be released through the lock store."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.success(
@@ -146,7 +146,7 @@ def test_run_user_sync_job_releases_lock_after_completion():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-lock-1",
         user_email="dave@example.com",
@@ -168,7 +168,7 @@ def test_run_user_sync_job_releases_lock_after_completion():
 @pytest.mark.unit
 def test_run_platform_sync_job_writes_in_progress_sentinel_then_completed():
     """Platform sync must write in_progress first, then final completed record."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.success(
@@ -193,7 +193,7 @@ def test_run_platform_sync_job_writes_in_progress_sentinel_then_completed():
 
     run_platform_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="plat-job-1",
         platform="aws",
@@ -204,12 +204,12 @@ def test_run_platform_sync_job_writes_in_progress_sentinel_then_completed():
     )
 
     # Calls: sentinel (in_progress), final record, lock release
-    assert idempotency.set.call_count == 2
+    assert job_status_store.put.call_count == 2
 
-    sentinel_args, _ = idempotency.set.call_args_list[0]
+    sentinel_args, _ = job_status_store.put.call_args_list[0]
     assert sentinel_args[1]["status"] == JobStatus.IN_PROGRESS
 
-    final_args, _ = idempotency.set.call_args_list[1]
+    final_args, _ = job_status_store.put.call_args_list[1]
     final = final_args[1]
     assert final["status"] == JobStatus.COMPLETED
     assert final["users_synced"] == 10
@@ -226,7 +226,7 @@ def test_run_platform_sync_job_writes_in_progress_sentinel_then_completed():
 @pytest.mark.unit
 def test_run_platform_sync_job_releases_platform_lock_on_failure():
     """Platform lock must be released even when the sync fails."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.error(
@@ -238,7 +238,7 @@ def test_run_platform_sync_job_releases_platform_lock_on_failure():
 
     run_platform_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="plat-fail-1",
         platform="aws",
@@ -248,7 +248,7 @@ def test_run_platform_sync_job_releases_platform_lock_on_failure():
         job_ttl_seconds=86400,
     )
 
-    final_args, _ = idempotency.set.call_args_list[-1]
+    final_args, _ = job_status_store.put.call_args_list[-1]
     assert final_args[1]["status"] == JobStatus.FAILED
     lock_store.release.assert_called_once_with("access_sync:platform_lock:aws")
 
@@ -256,14 +256,14 @@ def test_run_platform_sync_job_releases_platform_lock_on_failure():
 @pytest.mark.unit
 def test_run_platform_sync_job_sanitizes_exception_to_sync_failed():
     """Unhandled exceptions in platform sync must be sanitized."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = MagicMock()
     coordinator.sync_platform.side_effect = ConnectionError("network down")
 
     run_platform_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="plat-exc-1",
         platform="aws",
@@ -274,7 +274,7 @@ def test_run_platform_sync_job_sanitizes_exception_to_sync_failed():
     )
 
     # Find the final (non-sentinel) set call for the job record
-    final_args, _ = idempotency.set.call_args_list[-1]
+    final_args, _ = job_status_store.put.call_args_list[-1]
     record = final_args[1]
     assert record["status"] == JobStatus.FAILED
     assert record["error"] == SyncJobError.SYNC_FAILED
@@ -285,7 +285,7 @@ def test_run_platform_sync_job_sanitizes_exception_to_sync_failed():
 @pytest.mark.unit
 def test_run_user_sync_job_releases_via_lock_store_not_idempotency_set():
     """User job completion should release the lock through lock_store.release only."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.success(
@@ -299,7 +299,7 @@ def test_run_user_sync_job_releases_via_lock_store_not_idempotency_set():
 
     run_user_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-lock-store-user-1",
         user_email="eve@example.com",
@@ -310,14 +310,14 @@ def test_run_user_sync_job_releases_via_lock_store_not_idempotency_set():
         job_ttl_seconds=86400,
     )
 
-    assert idempotency.set.call_count == 1
+    assert job_status_store.put.call_count == 1
     lock_store.release.assert_called_once_with("access_sync:user_lock:aws:eve@example.com")
 
 
 @pytest.mark.unit
 def test_run_platform_sync_job_releases_via_lock_store_not_idempotency_set():
     """Platform job completion should release the lock through lock_store.release only."""
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = MagicMock()
     coordinator = _make_coordinator(
         OperationResult.success(
@@ -338,7 +338,7 @@ def test_run_platform_sync_job_releases_via_lock_store_not_idempotency_set():
 
     run_platform_sync_job(
         coordinator=coordinator,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         lock_store=lock_store,
         job_id="job-lock-store-platform-1",
         platform="aws",
@@ -348,5 +348,5 @@ def test_run_platform_sync_job_releases_via_lock_store_not_idempotency_set():
         job_ttl_seconds=86400,
     )
 
-    assert idempotency.set.call_count == 2
+    assert job_status_store.put.call_count == 2
     lock_store.release.assert_called_once_with("access_sync:platform_lock:aws")

--- a/app/tests/unit/packages/access/sync/test_job_status_store.py
+++ b/app/tests/unit/packages/access/sync/test_job_status_store.py
@@ -1,0 +1,73 @@
+"""Unit tests for access sync job status storage wrapper."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from packages.access.sync.job_status_store import JobStatusStore
+
+from infrastructure.operations import OperationResult, OperationStatus
+
+
+@pytest.mark.unit
+def test_put_serializes_record_as_json_with_ttl() -> None:
+    """Put should write idempotency key, JSON payload, and computed ttl."""
+    storage = MagicMock()
+    storage.put.return_value = OperationResult.success()
+    store = JobStatusStore(storage=storage)
+
+    with patch("packages.access.sync.job_status_store.time.time", return_value=1_000):
+        store.put(
+            key="job-123",
+            record={"job_id": "job-123", "status": "in_progress"},
+            ttl_seconds=90,
+        )
+
+    storage.put.assert_called_once()
+    args, _ = storage.put.call_args
+    assert args[0] == "sre_bot_idempotency"
+    item = args[1]
+    assert item["idempotency_key"] == "job-123"
+    assert item["ttl"] == 1_090
+    assert json.loads(item["record_json"]) == {"job_id": "job-123", "status": "in_progress"}
+
+
+@pytest.mark.unit
+def test_get_returns_deserialized_record() -> None:
+    """Get should deserialize JSON payload when storage hit succeeds."""
+    storage = MagicMock()
+    storage.get.return_value = OperationResult.success(
+        data={
+            "idempotency_key": "job-124",
+            "record_json": '{"job_id":"job-124","status":"completed"}',
+        }
+    )
+    store = JobStatusStore(storage=storage)
+
+    result = store.get("job-124")
+
+    assert result == {"job_id": "job-124", "status": "completed"}
+    storage.get.assert_called_once_with("sre_bot_idempotency", {"idempotency_key": "job-124"})
+
+
+@pytest.mark.unit
+def test_get_returns_none_when_not_found() -> None:
+    """Get should return None when the storage service reports a miss."""
+    storage = MagicMock()
+    storage.get.return_value = OperationResult.error(OperationStatus.NOT_FOUND, message="missing")
+    store = JobStatusStore(storage=storage)
+
+    assert store.get("job-missing") is None
+
+
+@pytest.mark.unit
+def test_get_returns_none_when_record_json_missing_or_malformed() -> None:
+    """Get should return None for malformed or missing JSON payloads."""
+    storage = MagicMock()
+    store = JobStatusStore(storage=storage)
+
+    storage.get.return_value = OperationResult.success(data={"idempotency_key": "job-1"})
+    assert store.get("job-1") is None
+
+    storage.get.return_value = OperationResult.success(data={"idempotency_key": "job-2", "record_json": "{"})
+    assert store.get("job-2") is None

--- a/app/tests/unit/packages/access/sync/test_job_status_store.py
+++ b/app/tests/unit/packages/access/sync/test_job_status_store.py
@@ -4,9 +4,9 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from packages.access.sync.job_status_store import JobStatusStore
 
 from infrastructure.operations import OperationResult, OperationStatus
+from packages.access.sync.job_status_store import JobStatusStore
 
 
 @pytest.mark.unit

--- a/app/tests/unit/packages/access/sync/test_platform_lock.py
+++ b/app/tests/unit/packages/access/sync/test_platform_lock.py
@@ -22,7 +22,7 @@ def _store() -> InMemoryIdempotencyStore:
 
 
 def test_acquire_lock_succeeds_once_and_persists_holder_payload() -> None:
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = _store()
     payload = {
         "job_id": "job-123",
@@ -30,18 +30,18 @@ def test_acquire_lock_succeeds_once_and_persists_holder_payload() -> None:
         "started_at": "2026-07-27T12:00:00+00:00",
         "dry_run": False,
     }
-    idempotency.get.return_value = payload
+    job_status_store.get.return_value = payload
 
     acquired = platform_lock.acquire_lock(
         lock_key="access_sync:user_lock:aws:alice@example.com",
         payload=payload,
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=14400,
     )
 
     assert acquired is True
-    idempotency.set.assert_called_once_with(
+    job_status_store.put.assert_called_once_with(
         "access_sync:user_lock:aws:alice@example.com:holder",
         payload,
         ttl_seconds=14400,
@@ -49,11 +49,11 @@ def test_acquire_lock_succeeds_once_and_persists_holder_payload() -> None:
 
     current_holder = getattr(platform_lock, "current_holder", None)
     assert callable(current_holder), "packages.access.sync.platform_lock.current_holder must exist"
-    assert current_holder("access_sync:user_lock:aws:alice@example.com", idempotency) == payload
+    assert current_holder("access_sync:user_lock:aws:alice@example.com", job_status_store) == payload
 
 
 def test_acquire_lock_rejects_second_claim_and_preserves_existing_holder() -> None:
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = _store()
     payload = {
         "job_id": "job-111",
@@ -61,14 +61,14 @@ def test_acquire_lock_rejects_second_claim_and_preserves_existing_holder() -> No
         "started_at": "2026-07-27T12:00:00+00:00",
         "dry_run": False,
     }
-    idempotency.get.return_value = payload
+    job_status_store.get.return_value = payload
 
     assert (
         platform_lock.acquire_lock(
             lock_key="access_sync:platform_lock:aws",
             payload=payload,
             lock_store=lock_store,
-            idempotency=idempotency,
+            job_status_store=job_status_store,
             ttl_seconds=14400,
         )
         is True
@@ -78,16 +78,16 @@ def test_acquire_lock_rejects_second_claim_and_preserves_existing_holder() -> No
         lock_key="access_sync:platform_lock:aws",
         payload={"job_id": "job-222", "status": "running"},
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=14400,
     )
 
     assert second is False
-    idempotency.set.assert_called_once()
+    job_status_store.put.assert_called_once()
 
 
 def test_release_lock_allows_future_claim() -> None:
-    idempotency = MagicMock()
+    job_status_store = MagicMock()
     lock_store = _store()
     key = "access_sync:platform_lock:aws"
 
@@ -95,7 +95,7 @@ def test_release_lock_allows_future_claim() -> None:
         lock_key=key,
         payload={"job_id": "job-1", "status": "running"},
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=14400,
     )
 
@@ -105,7 +105,7 @@ def test_release_lock_allows_future_claim() -> None:
         lock_key=key,
         payload={"job_id": "job-2", "status": "running"},
         lock_store=lock_store,
-        idempotency=idempotency,
+        job_status_store=job_status_store,
         ttl_seconds=14400,
     )
 

--- a/app/tests/unit/packages/access/sync/test_providers.py
+++ b/app/tests/unit/packages/access/sync/test_providers.py
@@ -126,3 +126,29 @@ def test_get_access_sync_lock_store_uses_lock_stale_seconds(monkeypatch: pytest.
     assert store is sentinel
     assert observed == [222]
     cache_clear()
+
+
+@pytest.mark.unit
+def test_get_access_sync_job_status_store_returns_singleton(monkeypatch: pytest.MonkeyPatch):
+    """Job status store provider should cache one instance for the process."""
+    get_job_status_store = getattr(providers, "get_access_sync_job_status_store", None)
+    assert callable(get_job_status_store), "packages.access.sync.providers.get_access_sync_job_status_store must exist"
+
+    cache_clear = getattr(get_job_status_store, "cache_clear", None)
+    assert callable(cache_clear)
+    cache_clear()
+
+    sentinel_storage = object()
+    built: list[object] = [object(), object()]
+
+    monkeypatch.setattr(providers, "get_storage_service", lambda: sentinel_storage)
+    monkeypatch.setattr(
+        "packages.access.sync.providers.JobStatusStore",
+        lambda storage: (built.pop(0), storage)[0],
+    )
+
+    first = get_job_status_store()
+    second = get_job_status_store()
+
+    assert first is second
+    cache_clear()

--- a/backlog/tasks/task-5.4 - Access-Sync-extract-job-status-polling-into-its-own-store-delete-legacy-IdempotencyService.md
+++ b/backlog/tasks/task-5.4 - Access-Sync-extract-job-status-polling-into-its-own-store-delete-legacy-IdempotencyService.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-24 17:58'
-updated_date: '2026-07-27 14:00'
+updated_date: '2026-07-27 18:53'
 labels:
   - security
   - phase-0
@@ -57,5 +57,14 @@ Note: if TASK-5.2 and/or TASK-5.3 have not yet migrated their own call sites off
 created: 2026-07-27 14:00
 ---
 TASK-5.2 was re-scoped (2026-07-27) from migrating the dead legacy_slack_listener onto claim/complete/release to simply DELETING app/integrations/slack/utils.py (zero callers; wrong layer; obsoleted by the async-Bolt direction). That deletion removes the last app/integrations/ reference to the legacy get_idempotency_service, so it is now a prerequisite for this task's deletion of the legacy IdempotencyService stack - added TASK-5.2 to dependencies alongside TASK-5.1.
+---
+
+created: 2026-07-27 18:53
+---
+Decomposed 2026-07-27 per the single-PR size gate (implementation-planning skill): the full scope (new JobStatusStore + 5 consumer rewires + deleting 4 legacy files/protocols + ~9 test files, ~13 production/test files touched) exceeds the ~10-file single-PR threshold. Split into:
+- TASK-5.4.1 (expand+migrate): new package-owned JobStatusStore built on infrastructure.storage.StorageService (DRY reuse of the same generic capability SyncRunRepository already uses; confirmed with the human citing 12factor.net "backing services as attached resources"), reusing the existing sre_bot_idempotency table (no terraform change). Migrates ALL 5 legacy get_idempotency_service()/IdempotencyService call sites in app/packages/access/sync, including platform_lock.py's holder-info reporting (added by TASK-5.3; not named in this task's original Scope paragraph but confirmed in scope with the human since it blocks 5.4.2's deletion step).
+- TASK-5.4.2 (contract, depends on 5.4.1): deletes infrastructure/idempotency/cache.py + service.py, removes DynamoDBCache from dynamodb.py and the IdempotencyService Protocol from protocol.py, prunes factory.py/__init__.py, and removes the now-obsolete tests. Closes this task's AC#3/DoD#1.
+
+This coordinator task's own ACs/DoD are unchanged - they remain the "all children done" bar. Do not implement against this task's description directly; see TASK-5.4.1 for the approved, fully-grounded implementation plan.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
+++ b/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
@@ -3,10 +3,11 @@ id: TASK-5.4.1
 title: >-
   Access Sync: introduce package-owned JobStatusStore; migrate job-status
   polling and lock holder-info off legacy IdempotencyService
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-27 18:43'
-updated_date: '2026-07-27 19:02'
+updated_date: '2026-07-27 19:10'
 labels:
   - security
   - phase-0

--- a/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
+++ b/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
@@ -3,11 +3,11 @@ id: TASK-5.4.1
 title: >-
   Access Sync: introduce package-owned JobStatusStore; migrate job-status
   polling and lock holder-info off legacy IdempotencyService
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-27 18:43'
-updated_date: '2026-07-27 19:10'
+updated_date: '2026-07-27 19:16'
 labels:
   - security
   - phase-0
@@ -32,16 +32,16 @@ Expand+migrate slice of TASK-5.4. Introduce app/packages/access/sync/job_status_
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 JobStatusStore concrete class exists in app/packages/access/sync/job_status_store.py, built on infrastructure.storage.StorageService - named and shaped like SyncRunRepository/AccessRequestRepository (no separate Protocol, no vendor-prefixed class name such as DynamoDBJobStatusStore); placement confirmed against packages-python.instructions.md and layers.md Path A guidance
-- [ ] #2 job_runner.py, interactions/http.py, interactions/slack.py, interactions/ingress.py, and platform_lock.py (including its holder-info reporting) are migrated off get_idempotency_service()/IdempotencyService onto the new JobStatusStore, type-hinted directly as the concrete class (not a Protocol)
-- [ ] #3 get_access_sync_job_status_store() singleton provider added to packages/access/sync/providers.py, built via get_storage_service()
-- [ ] #4 grep confirms (a) no remaining get-then-put job-status/holder-info pattern via legacy IdempotencyService anywhere in app/packages/access/sync, and (b) no Dynamo/DynamoDB/boto3 substring appears in any class, function, or variable name in app/packages/access/sync (prose in docstrings/README describing the backing store is acceptable, matching existing SyncRunRepository/AccessRequestRepository style)
+- [x] #1 JobStatusStore concrete class exists in app/packages/access/sync/job_status_store.py, built on infrastructure.storage.StorageService - named and shaped like SyncRunRepository/AccessRequestRepository (no separate Protocol, no vendor-prefixed class name such as DynamoDBJobStatusStore); placement confirmed against packages-python.instructions.md and layers.md Path A guidance
+- [x] #2 job_runner.py, interactions/http.py, interactions/slack.py, interactions/ingress.py, and platform_lock.py (including its holder-info reporting) are migrated off get_idempotency_service()/IdempotencyService onto the new JobStatusStore, type-hinted directly as the concrete class (not a Protocol)
+- [x] #3 get_access_sync_job_status_store() singleton provider added to packages/access/sync/providers.py, built via get_storage_service()
+- [x] #4 grep confirms (a) no remaining get-then-put job-status/holder-info pattern via legacy IdempotencyService anywhere in app/packages/access/sync, and (b) no Dynamo/DynamoDB/boto3 substring appears in any class, function, or variable name in app/packages/access/sync (prose in docstrings/README describing the backing store is acceptable, matching existing SyncRunRepository/AccessRequestRepository style)
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Tests pass: new job_status_store tests, updated job_runner/ingress/http/slack/platform_lock tests all green
-- [ ] #2 PR references decisions/reliability.md; notes TASK-5.4.2 as the follow-up contract slice that deletes the now-unreferenced legacy files
+- [x] #1 Tests pass: new job_status_store tests, updated job_runner/ingress/http/slack/platform_lock tests all green
+- [x] #2 PR references decisions/reliability.md; notes TASK-5.4.2 as the follow-up contract slice that deletes the now-unreferenced legacy files
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -120,3 +120,9 @@ New file `app/tests/unit/packages/access/sync/test_access_sync_slack_status.py` 
 - A single `git revert` of this PR fully restores prior behavior: legacy `cache.py`/`service.py`/`get_idempotency_service()` remain in place and unmodified in this slice, so reverting simply un-migrates the five call sites back onto them - no ordering constraint, no manifest/env var changes.
 - Runtime risk: if `JobStatusStore` has a bug, blast radius is limited to job-status polling (GET /sync-runs/{job_id}, Slack status command returning "not found" instead of real status) and lock holder-info display (Slack "already running" message losing the existing job_id detail) - the actual lock correctness (claim/release, TASK-5.3) is unaffected since it uses the separate `IdempotencyStore`/lease primitive, not this store.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented package-owned JobStatusStore in app/packages/access/sync/job_status_store.py on top of infrastructure.storage.StorageService (shared sre_bot_idempotency table, JSON record serialization, TTL writes).\n\nMigrated all access-sync job-status and holder-info call paths off legacy IdempotencyService to JobStatusStore: app/packages/access/sync/job_runner.py, app/packages/access/sync/interactions/ingress.py, app/packages/access/sync/interactions/http.py, app/packages/access/sync/interactions/slack.py, and app/packages/access/sync/platform_lock.py. Added singleton provider get_access_sync_job_status_store() in app/packages/access/sync/providers.py.\n\nAlso aligned prose in app/packages/access/sync/job_models.py to reference JobStatusStore.\n\nTest evidence:\n- cd /workspace/app && uv run pytest tests/unit/packages/access/sync/test_job_status_store.py tests/unit/packages/access/sync/test_access_sync_slack_status.py tests/unit/packages/access/sync/test_job_runner.py tests/unit/packages/access/sync/test_platform_lock.py tests/unit/packages/access/sync/test_access_sync_routes.py tests/unit/packages/access/sync/test_providers.py  -> 34 passed\n- cd /workspace/app && uv run ruff check .  -> passed\n- cd /workspace/app && uv run pytest tests --ignore=tests/smoke -q  -> 2950 passed, 37 skipped\n- cd /workspace/app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'  -> fails in pre-existing unrelated modules (integrations/aws, modules/incident, packages/geolocate, infrastructure/resilience)\n- grep checks:\n  * grep -Rni --include='*.py' -E 'get_idempotency_service|IdempotencyService' packages/access/sync  -> no matches\n  * grep -Rni --include='*.py' -E 'dynamo|dynamodb|boto3' packages/access/sync  -> matches only prose/docstrings (no class/function/variable names)\n\nDoD items left for human verification:\n- Ensure PR description references decisions/reliability.md.\n- Ensure PR notes call out TASK-5.4.2 as follow-up contract slice deleting now-unreferenced legacy idempotency files.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
+++ b/backlog/tasks/task-5.4.1 - Access-Sync-introduce-package-owned-JobStatusStore-migrate-job-status-polling-and-lock-holder-info-off-legacy-IdempotencyService.md
@@ -1,0 +1,121 @@
+---
+id: TASK-5.4.1
+title: >-
+  Access Sync: introduce package-owned JobStatusStore; migrate job-status
+  polling and lock holder-info off legacy IdempotencyService
+status: To Do
+assignee: []
+created_date: '2026-07-27 18:43'
+updated_date: '2026-07-27 19:02'
+labels:
+  - security
+  - phase-0
+  - reliability
+milestone: m-0
+dependencies:
+  - TASK-5.1
+  - TASK-5.2
+references:
+  - decisions/reliability.md
+  - decisions/layers.md
+parent_task_id: TASK-5.4
+priority: high
+ordinal: 86000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expand+migrate slice of TASK-5.4. Introduce app/packages/access/sync/job_status_store.py: a concrete JobStatusStore class - mirroring the existing SyncRunRepository (store.py) / AccessRequestRepository conventions in this codebase: no separate Protocol, no vendor-prefixed class name - built on infrastructure.storage.StorageService, reusing the existing sre_bot_idempotency table (hash key idempotency_key, ttl attribute already enabled) - no terraform change. Migrate ALL current get_idempotency_service()/IdempotencyService call sites in app/packages/access/sync off the legacy service onto the new store: job_runner.py (run_user_sync_job, run_platform_sync_job, spawn_user_sync_thread, spawn_platform_sync_thread job-status writes), interactions/http.py (sync_endpoint + get_sync_job_status), interactions/slack.py (handle_sync_user_command, handle_sync_platform_command, handle_sync_status_command), interactions/ingress.py (enqueue_user_sync, enqueue_platform_sync), and platform_lock.py (acquire_lock/current_holder lock-holder-info reporting - added by TASK-5.3, not in TASK-5.4's original Scope paragraph but required for TASK-5.4.2's AC#3 to be reachable). Add get_access_sync_job_status_store() singleton provider to providers.py. End state after this slice + TASK-5.4.2: app/packages/access/sync contains zero AWS/DynamoDB-branded symbol names (class/function/variable names) - only the pre-existing, precedent-consistent prose mentions of the backing store in docstrings/README (same style already used by SyncRunRepository/AccessRequestRepository), plus the required table-name string constant. This slice keeps infrastructure/idempotency/{cache.py,service.py} and DynamoDBCache/IdempotencyService in place (unreferenced but not yet deleted) - deletion is TASK-5.4.2.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 JobStatusStore concrete class exists in app/packages/access/sync/job_status_store.py, built on infrastructure.storage.StorageService - named and shaped like SyncRunRepository/AccessRequestRepository (no separate Protocol, no vendor-prefixed class name such as DynamoDBJobStatusStore); placement confirmed against packages-python.instructions.md and layers.md Path A guidance
+- [ ] #2 job_runner.py, interactions/http.py, interactions/slack.py, interactions/ingress.py, and platform_lock.py (including its holder-info reporting) are migrated off get_idempotency_service()/IdempotencyService onto the new JobStatusStore, type-hinted directly as the concrete class (not a Protocol)
+- [ ] #3 get_access_sync_job_status_store() singleton provider added to packages/access/sync/providers.py, built via get_storage_service()
+- [ ] #4 grep confirms (a) no remaining get-then-put job-status/holder-info pattern via legacy IdempotencyService anywhere in app/packages/access/sync, and (b) no Dynamo/DynamoDB/boto3 substring appears in any class, function, or variable name in app/packages/access/sync (prose in docstrings/README describing the backing store is acceptable, matching existing SyncRunRepository/AccessRequestRepository style)
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Tests pass: new job_status_store tests, updated job_runner/ingress/http/slack/platform_lock tests all green
+- [ ] #2 PR references decisions/reliability.md; notes TASK-5.4.2 as the follow-up contract slice that deletes the now-unreferenced legacy files
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Decomposition context: second-level leaf slice (TASK-5.4 -> TASK-5.4.1/5.4.2 per the implementation-planning skill's single-PR size gate - trigger: TASK-5.4 as originally scoped touches ~13 files across app/packages/access/sync + app/infrastructure/idempotency, exceeding the ~10-file threshold, and is a textbook expand/migrate/contract candidate). This task is the expand+migrate half; TASK-5.4.2 is the contract half (delete legacy files) and depends on this one.
+
+## Grounding (call sites enumerated)
+
+Legacy `get_idempotency_service()`/`IdempotencyService` references in app/packages/access/sync today (repo-wide grep, confirmed 2026-07-27; TASK-5.1/5.2/5.3 all Done):
+- interactions/http.py:18 (import), :144-145 (`idempotency = get_idempotency_service()` in `sync_endpoint`, passed into `enqueue_user_sync`/`enqueue_platform_sync`), :~213 (`get_sync_job_status`: `idempotency = get_idempotency_service(); record = idempotency.get(job_id)`).
+- interactions/slack.py:17 (import), :~180 (`handle_sync_user_command`), :~276 (`handle_sync_platform_command`), :~357 (`handle_sync_status_command`: `idempotency = get_idempotency_service(); record = idempotency.get(job_id)`).
+- interactions/ingress.py:17 (imports `IdempotencyService, IdempotencyStore`), `enqueue_user_sync`/`enqueue_platform_sync` take `idempotency: IdempotencyService` and pass it to `acquire_lock(..., idempotency=idempotency, ...)`, `current_holder(lock_key, idempotency)`, and `spawn_user_sync_thread`/`spawn_platform_sync_thread`.
+- job_runner.py:27 (imports `IdempotencyService, IdempotencyStore`); `run_user_sync_job`, `run_platform_sync_job`, `spawn_user_sync_thread`, `spawn_platform_sync_thread` all take `idempotency: IdempotencyService` and call `idempotency.set(job_id, payload, ttl_seconds=job_ttl_seconds)` for job-status writes only (no `.get()` calls here).
+- platform_lock.py:5 (imports `IdempotencyService`); `acquire_lock`/`current_holder` take `idempotency: IdempotencyService` and call `idempotency.set(f"{lock_key}:holder", payload, ttl_seconds=...)` / `idempotency.get(f"{lock_key}:holder")` for best-effort holder-info (added by TASK-5.3; NOT in TASK-5.4's original Scope paragraph but blocks TASK-5.4.2's AC#3 if left unmigrated - confirmed with the human via the decomposition-approval questions).
+
+Existing precedent for the new store's shape (found in codebase, reused directly, confirmed with the human 2026-07-27):
+- `packages/access/sync/store.py::SyncRunRepository` and `packages/access/request/store.py::AccessRequestRepository` are the two existing package-level repository precedents. BOTH are plain concrete classes with no separate Protocol layer, and NEITHER has a vendor-prefixed name (not `DynamoDBSyncRunRepository`) even though their docstrings say "DynamoDB-backed repository" in prose. `SyncRunRepository` is even type-hinted directly as the concrete class at its only consumer (`application.py:74`: `repository: SyncRunRepository | None = None`) - there is no repository-level Protocol anywhere in this package today. The swappable seam is `StorageService` itself (infrastructure-level), not a per-repository Protocol - `infrastructure/storage/service.py`'s docstring: "Feature packages MUST NOT call DynamoDBClient or dynamodb_next directly... define a thin repository class that takes StorageService as a constructor argument." `decisions/cloud-portability.md`'s check is "no boto3/botocore imports outside app/integrations/ and app/infrastructure/" - it does not ban descriptive prose about the current backing store, only vendor SDK imports/leakage at the package layer. Conclusion (human-confirmed): `JobStatusStore` must be a single concrete class, same shape as these two precedents - no separate Protocol, no vendor-prefixed name like `DynamoDBJobStatusStore`.
+- `terraform/dynamodb.tf:86-103`: `sre_bot_idempotency` table has hash key `idempotency_key` (no range key), TTL attribute `ttl` already enabled. decisions/reliability.md explicitly sanctions sharing this table for the new capability ("even if it happens to share a table with idempotency records"). Reusing it means zero terraform change.
+- Legacy `infrastructure/idempotency/dynamodb.py::DynamoDBCache.get/set` serialize the record as a `response_json` JSON string attribute (not nested-dict via TypeSerializer) - deliberately mirrored below to avoid a real behavior-changing risk: boto3's `TypeSerializer`/`TypeDeserializer` round-trips nested ints as `Decimal`, not `int`, if the record dict were stored as a native nested attribute instead of a JSON string. Job records contain int fields (`users_synced`, `orphans_found`, etc. in `CompletedPlatformRecord`) - storing as JSON preserves exact types with zero behavior change.
+
+## Human-approved design decisions
+
+1. **Package-owned, not infra-owned.** Unlike TASK-5.3's lease helper (promoted to `infrastructure/idempotency/lease.py` because TASK-6's cross-cutting scheduler also needs it), nothing outside access-sync needs job-status/holder-info records today - this stays a package-owned class per `.github/instructions/packages-python.instructions.md` and decisions/layers.md's Path-A-vs-Path-B guidance, confirmed with the human.
+2. **Built on `infrastructure.storage.StorageService`, not a new DynamoDB access path.** DRY / 12-factor "backing services as attached resources" - reuse the existing generic, swappable storage capability (same as `SyncRunRepository`) instead of hand-rolling a second boto3-facing store; confirmed with the human citing https://12factor.net/backing-services.
+3. **Reuse the `sre_bot_idempotency` table**, no terraform change - confirmed with the human.
+4. **Migrate `platform_lock.py`'s holder-info too**, even though the original TASK-5.4 Scope paragraph didn't name it - confirmed with the human as required for TASK-5.4.2's AC#3.
+5. **`JobStatusStore` is a single concrete class, not a Protocol+implementation pair, and carries no vendor prefix.** Corrected 2026-07-27 after the human asked whether any AWS/DynamoDB terminology would remain in app/packages/access/ after both subtasks: the original plan's `JobStatusStore` Protocol + `DynamoDBJobStatusStore` implementation deviated from this codebase's own precedent (`SyncRunRepository`/`AccessRequestRepository`, both plain concrete classes, no vendor prefix) and needlessly introduced a vendor-branded symbol name into the package layer. Fixed to match precedent exactly - no transitory/inconsistent state is left after this slice.
+
+## Ordered steps
+
+1. **app/packages/access/sync/job_status_store.py (NEW)**: single concrete `JobStatusStore` class (no separate Protocol, mirrors `SyncRunRepository`/`AccessRequestRepository`). Constructor takes `storage: StorageService`. `put(key: str, record: dict[str, Any], ttl_seconds: int) -> None` writes `{"idempotency_key": key, "record_json": json.dumps(record), "ttl": int(time.time()) + ttl_seconds}` via `storage.put(TABLE, item)`. `get(key: str) -> dict[str, Any] | None` calls `storage.get(TABLE, {"idempotency_key": key})`, returns `None` on `is_success=False` (covers not-found) or malformed/missing `record_json`, otherwise `json.loads(record_json)`. `TABLE = "sre_bot_idempotency"`. Module docstring documents the reliability.md rationale (not idempotency dedup; shares the table deliberately; JSON serialization chosen to avoid Decimal round-trip changes) using the same "DynamoDB-backed" prose style as `SyncRunRepository`'s docstring - descriptive prose about the backing store is fine and precedent-consistent; only the class name itself must stay vendor-neutral.
+2. **app/packages/access/sync/providers.py**: add `from packages.access.sync.job_status_store import JobStatusStore`; add `get_access_sync_job_status_store() -> JobStatusStore` (`functools.lru_cache(maxsize=1)`) returning `JobStatusStore(storage=get_storage_service())` (mirrors `get_sync_run_repository()`'s exact shape).
+3. **app/packages/access/sync/platform_lock.py**: replace `IdempotencyService` import with `JobStatusStore` from `packages.access.sync.job_status_store`; rename `acquire_lock`'s and `current_holder`'s `idempotency: IdempotencyService` parameter to `job_status_store: JobStatusStore`; swap `idempotency.set(...)` -> `job_status_store.put(...)` and `idempotency.get(...)` -> `job_status_store.get(...)`.
+4. **app/packages/access/sync/interactions/ingress.py**: replace `IdempotencyService` import; rename `enqueue_user_sync`/`enqueue_platform_sync`'s `idempotency` parameter to `job_status_store: JobStatusStore`; update the `acquire_lock(..., job_status_store=job_status_store, ...)` and `current_holder(lock_key, job_status_store)` call sites; update the `spawn_user_sync_thread`/`spawn_platform_sync_thread` calls to pass `job_status_store=job_status_store`.
+5. **app/packages/access/sync/job_runner.py**: replace `IdempotencyService` import with `JobStatusStore`; rename the `idempotency` parameter to `job_status_store` in `run_user_sync_job`, `run_platform_sync_job`, `spawn_user_sync_thread`, `spawn_platform_sync_thread`; swap all `idempotency.set(job_id, payload, ttl_seconds=job_ttl_seconds)` -> `job_status_store.put(job_id, payload, ttl_seconds=job_ttl_seconds)`.
+6. **app/packages/access/sync/interactions/http.py**: replace `from infrastructure.idempotency import get_idempotency_service` with `get_access_sync_job_status_store` added to the existing `packages.access.sync.providers` import; in `sync_endpoint`, `job_status_store = get_access_sync_job_status_store()` passed as `job_status_store=` into `enqueue_user_sync`/`enqueue_platform_sync`; in `get_sync_job_status`, `job_status_store = get_access_sync_job_status_store(); record = job_status_store.get(job_id)`.
+7. **app/packages/access/sync/interactions/slack.py**: same import swap; update all three handlers (`handle_sync_user_command`, `handle_sync_platform_command`, `handle_sync_status_command`) to construct/use `job_status_store` instead of `idempotency`.
+8. **Final verification (part of AC#4, run before marking done)**: `grep -rniE "dynamo|boto3" app/packages/access/sync --include=*.py | grep -viE "docstring|^.*#.*dynamo"` reviewed by hand to confirm any remaining hits are only prose in docstrings/comments (consistent with `SyncRunRepository`/`AccessRequestRepository` style), never a class/function/variable identifier. Expected zero identifier-level hits.
+
+## AC traceability
+
+- AC#1 (concrete class, precedent-consistent naming) <- step 1; test: `test_job_status_store.py` (direct unit tests against the concrete `JobStatusStore` class - no protocol-satisfaction test needed, matching how `SyncRunRepository` is tested).
+- AC#2 (all 5 call sites migrated) <- steps 3-7; tests: updated `test_job_runner.py`, `test_platform_lock.py`, `test_access_sync_routes.py` (all pass with renamed `job_status_store` fixtures/kwargs and no reference to `get_idempotency_service`), plus new `test_access_sync_slack_status.py`.
+- AC#3 (provider added) <- step 2; test: `test_providers.py::test_get_access_sync_job_status_store_returns_singleton`.
+- AC#4 (grep clean, both legacy-call and vendor-naming) <- steps 3-7 collectively plus step 8; verified via `grep -rn "get_idempotency_service\|IdempotencyService" app/packages/access/sync` returning empty, and the step-8 vendor-naming review; both run as manual verification steps before marking AC#4, not pytest assertions.
+
+## Test matrix
+
+New file `app/tests/unit/packages/access/sync/test_job_status_store.py`:
+- `test_put_serializes_record_as_json_with_ttl` - mock `StorageService.put`, assert item has `idempotency_key`, `record_json` (valid JSON matching input dict), `ttl` ~= now + ttl_seconds.
+- `test_get_returns_deserialized_record` - mock `StorageService.get` success with `record_json`.
+- `test_get_returns_none_when_not_found` - mock `StorageService.get` returning `is_success=False` (NOT_FOUND).
+- `test_get_returns_none_when_record_json_missing_or_malformed` - defensive path (boundary).
+
+Updated files (mechanical rename, no behavior change - verify with existing assertions unchanged apart from names):
+- `test_job_runner.py`: rename `idempotency` MagicMock/kwarg to `job_status_store` in all ~12 call sites; assertions `idempotency.set.call_count`/`call_args_list` -> `job_status_store.put...`.
+- `test_platform_lock.py`: rename `idempotency=idempotency` kwargs to `job_status_store=job_status_store`; `idempotency.set.assert_called_once_with(...)` -> `job_status_store.put.assert_called_once_with(...)`; `current_holder(key, idempotency)` -> `current_holder(key, job_status_store)`.
+- `test_access_sync_routes.py`: patch target `packages.access.sync.interactions.http.get_idempotency_service` -> `packages.access.sync.interactions.http.get_access_sync_job_status_store`; rename `fake_idempotency` -> `fake_job_status_store` (still a MagicMock with `.get.return_value`).
+- `test_providers.py`: add a case for the new provider's singleton behavior.
+
+New file `app/tests/unit/packages/access/sync/test_access_sync_slack_status.py` (no direct slack-handler tests exist today - this is new coverage required by AC#2 naming slack.py as a migration target):
+- `test_handle_sync_status_command_returns_status_message_when_job_found` - patch `get_access_sync_job_status_store` to return a store whose `.get()` yields a completed-record dict; assert the formatted `CommandResponse` message.
+- `test_handle_sync_status_command_returns_not_found_message_when_job_missing` - store `.get()` returns `None`; assert the not-found message/ephemeral flag.
+
+## Assumptions and doubts
+
+- Assumes `StorageService.get`'s `NOT_FOUND` `OperationResult` (`is_success=False`) is the only "miss" signal the new store needs to distinguish from a real error for logging purposes; verified by reading `infrastructure/storage/service.py::DynamoDBStorageService.get` (returns `OperationResult.error(OperationStatus.NOT_FOUND, ...)` on missing item). `get()` will not log at error level for this expected case (mirrors legacy `DynamoDBCache.get`'s debug-level miss logging).
+- Assumes no other package currently or imminently needs a generic job-status-shaped store (checked: TASK-6's Tier-2 lease is a different capability, already served by `infrastructure/idempotency/lease.py`). If that assumption changes, promote `job_status_store.py` to `infrastructure/` in a follow-up, mirroring TASK-5.3's precedent - do not preemptively over-generalize now.
+- Assumes storing `record_json` as a JSON string (not a native nested DynamoDB map via `StorageService`'s `TypeSerializer`) is acceptable even though `SyncRunRepository` stores fields as native top-level attributes; this is a deliberate deviation to avoid the Decimal-coercion risk documented above, not an oversight - flagged explicitly in the module docstring for future readers.
+- Assumes existing lock-holder `:holder` keys and bare `job_id` keys (no prefix) can be reused unchanged (no re-keying/migration) - in-flight held locks or job records at deploy time will simply stop being found by `.get()` for old-format keys only if the key string itself changes, which it does not; only the writer class changes. No data migration needed.
+
+## Blast radius and rollback
+
+- Scope confined to `app/packages/access/sync/**` (one package) plus a new provider dependency on the already-shared `infrastructure/storage` service; `infrastructure/idempotency/**` is untouched in this slice (TASK-5.4.2 handles deletion), so any problem here cannot break other TASK-5.x consumers of `IdempotencyStore`/lease.
+- A single `git revert` of this PR fully restores prior behavior: legacy `cache.py`/`service.py`/`get_idempotency_service()` remain in place and unmodified in this slice, so reverting simply un-migrates the five call sites back onto them - no ordering constraint, no manifest/env var changes.
+- Runtime risk: if `JobStatusStore` has a bug, blast radius is limited to job-status polling (GET /sync-runs/{job_id}, Slack status command returning "not found" instead of real status) and lock holder-info display (Slack "already running" message losing the existing job_id detail) - the actual lock correctness (claim/release, TASK-5.3) is unaffected since it uses the separate `IdempotencyStore`/lease primitive, not this store.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-5.4.2 - Access-Sync-delete-legacy-IdempotencyService-DynamoDBCache-stack-now-unreferenced.md
+++ b/backlog/tasks/task-5.4.2 - Access-Sync-delete-legacy-IdempotencyService-DynamoDBCache-stack-now-unreferenced.md
@@ -1,0 +1,41 @@
+---
+id: TASK-5.4.2
+title: >-
+  Access Sync: delete legacy IdempotencyService/DynamoDBCache stack now
+  unreferenced
+status: To Do
+assignee: []
+created_date: '2026-07-27 18:43'
+labels:
+  - security
+  - phase-0
+  - reliability
+milestone: m-0
+dependencies:
+  - TASK-5.4.1
+references:
+  - decisions/reliability.md
+parent_task_id: TASK-5.4
+priority: high
+ordinal: 87000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Contract slice of TASK-5.4, depends on TASK-5.4.1 (which migrates every access-sync call site off the legacy service). Delete app/infrastructure/idempotency/cache.py (IdempotencyCache ABC) and service.py (DynamoDBIdempotencyService) outright. Remove the DynamoDBCache class from dynamodb.py (keep DynamoDBIdempotencyStore - the TASK-5.1 claim/complete/release primitive, still used by lease.py). Remove the IdempotencyService Protocol (and its IdempotencyCache import) from protocol.py. Remove get_cache/reset_cache/get_idempotency_service and the _cache_instance singleton from factory.py (keep get_idempotency_store/build_idempotency_store/reset_idempotency_store). Prune the corresponding exports from __init__.py. Delete/update the now-obsolete tests: app/tests/unit/infrastructure/idempotency/{test_cache.py,test_dynamodb_cache.py,test_narrow_slice.py,test_idempotency_protocol.py} and app/tests/integration/infrastructure/idempotency/test_dynamodb_cache_integration.py (delete); prune conftest.py and test_factory.py's TestCacheFactory/imports. This is the final contract step that closes TASK-5's original 'delete the get-then-put path' DoD item.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 infrastructure/idempotency/cache.py and service.py are deleted
+- [ ] #2 DynamoDBCache is removed from dynamodb.py; IdempotencyService Protocol removed from protocol.py; get_cache/reset_cache/get_idempotency_service removed from factory.py and __init__.py
+- [ ] #3 grep confirms zero remaining references to IdempotencyService/DynamoDBIdempotencyService/get_cache/reset_cache/get_idempotency_service anywhere in app/
+- [ ] #4 Obsolete tests for the deleted symbols are removed; remaining idempotency test suite (IdempotencyStore/lease/settings) passes unchanged
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Tests pass: full app/tests/unit and app/tests/integration idempotency suites green after deletion
+- [ ] #2 PR references decisions/reliability.md and cross-references TASK-5.4.1
+<!-- DOD:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the access sync job status and idempotency handling to use a new `JobStatusStore` abstraction instead of the previous `IdempotencyService`. This change affects how job status records are stored, retrieved, and passed through the application, and it simplifies and unifies the handling of job status persistence across HTTP and Slack interfaces, as well as internal job runner logic.

The most important changes are:

**Core Infrastructure Refactor:**
* Introduced the new `JobStatusStore` class in `job_status_store.py`, which wraps the underlying storage service for job status and lock-holder metadata, replacing direct usage of `IdempotencyService` for job status tracking.
* Updated all sync job orchestration and runner functions (`enqueue_user_sync`, `enqueue_platform_sync`, `run_user_sync_job`, `run_platform_sync_job`, and their corresponding thread spawners) to use `JobStatusStore` instead of `IdempotencyService`. [[1]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L55-R56) [[2]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L94-R98) [[3]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L113-R114) [[4]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L137-R138) [[5]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L175-R179) [[6]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L194-R195) [[7]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L56-R57) [[8]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L132-R139) [[9]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L158-R159) [[10]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L237-R238) [[11]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L248-R249) [[12]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L271-R277) [[13]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L294-R295) [[14]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L311-R317)

**Dependency Injection and Provider Updates:**
* Updated dependency injection and provider functions in both HTTP and Slack interaction modules to use `get_access_sync_job_status_store` instead of `get_idempotency_service`. [[1]](diffhunk://#diff-75b8ce7a7945caec2e41f69c257372bd246367e3e7bfcaba9a62f7223d469c04R29) [[2]](diffhunk://#diff-0f0ba1279331df0d70a4a4596eea8c16e156af0b294b9f4b98994e9c43497dc0R26)
* Updated all handler functions to retrieve and pass `job_status_store` instead of `idempotency`, and to fetch job status records from the new store. [[1]](diffhunk://#diff-75b8ce7a7945caec2e41f69c257372bd246367e3e7bfcaba9a62f7223d469c04L144-R150) [[2]](diffhunk://#diff-75b8ce7a7945caec2e41f69c257372bd246367e3e7bfcaba9a62f7223d469c04L175-R175) [[3]](diffhunk://#diff-75b8ce7a7945caec2e41f69c257372bd246367e3e7bfcaba9a62f7223d469c04L216-R217) [[4]](diffhunk://#diff-0f0ba1279331df0d70a4a4596eea8c16e156af0b294b9f4b98994e9c43497dc0L180-R186) [[5]](diffhunk://#diff-0f0ba1279331df0d70a4a4596eea8c16e156af0b294b9f4b98994e9c43497dc0L274-R280) [[6]](diffhunk://#diff-0f0ba1279331df0d70a4a4596eea8c16e156af0b294b9f4b98994e9c43497dc0L362-R363)

**Documentation and Model Updates:**
* Updated docstrings and comments to reference `JobStatusStore` instead of `IdempotencyService`, and clarified that implementation details do not leak through status storage or API responses. [[1]](diffhunk://#diff-b5835e5356d9dfedad98a6deb7a356a946aa23fb65f47075cda8567c2b38d5c9L9-R9) [[2]](diffhunk://#diff-b5835e5356d9dfedad98a6deb7a356a946aa23fb65f47075cda8567c2b38d5c9L33-R34)

**Imports and Cleanup:**
* Removed unused imports of `IdempotencyService` and related functions from affected modules, and added imports for `JobStatusStore` where needed. [[1]](diffhunk://#diff-75b8ce7a7945caec2e41f69c257372bd246367e3e7bfcaba9a62f7223d469c04L18) [[2]](diffhunk://#diff-1e1e3213f82c0e75774dfa8bec1675161b61fdd4f12fe6b714e29c49ba4edd58L17-R24) [[3]](diffhunk://#diff-a367487b748933766ecc11115fed1b276deb256ecd6ca1ccaf8c59b684e3f777L27-R27) [[4]](diffhunk://#diff-0f0ba1279331df0d70a4a4596eea8c16e156af0b294b9f4b98994e9c43497dc0L17) [[5]](diffhunk://#diff-3b3ac311efaf012afe939ea96273de9699273ab75ebb5808ac0b59ff00313828L5-R6)

This refactor centralizes and improves reliability and clarity of job status persistence, preparing the codebase for future enhancements and easier maintenance.