### PR TITLE
fix: build base processors signature mismatch

### DIFF
--- a/app/infrastructure/logging/setup.py
+++ b/app/infrastructure/logging/setup.py
@@ -105,7 +105,6 @@ def _is_test_environment() -> bool:
 
 
 def _build_base_processors(
-    _prod_mode: bool,
     logging_settings: LoggingSettings,
 ) -> list[
     Callable[
@@ -202,10 +201,7 @@ def configure_logging(
 
     # Build processor pipeline per structlog best practices
     # Order matters: context vars first, then enrichment, then formatting
-    processors = _build_base_processors(
-        prod_mode=prod_mode,
-        logging_settings=resolved_logging_settings,
-    )
+    processors = _build_base_processors(logging_settings=resolved_logging_settings)
 
     # 6. Final rendering (environment-specific)
     if not prod_mode:  # Development mode

--- a/app/tests/unit/infrastructure/logging/test_setup.py
+++ b/app/tests/unit/infrastructure/logging/test_setup.py
@@ -4,6 +4,9 @@ Tests cover:
 - configure_logging function
 - Test logging suppression in test environment
 - Recursive redaction installed in the real processor chain (TASK-8)
+- The real (non-test-environment) processor-build code path (regression for
+  a prod_mode/_prod_mode call-site vs. signature mismatch that only
+  surfaced in production, see decisions/observability.md)
 """
 
 import logging
@@ -168,7 +171,7 @@ class TestPipelineRedaction:
 
     def test_pipeline_redacts_nested_sensitive_value(self):
         """AC#1: {"config": {"api_token": "x"}} renders with the token redacted."""
-        processors = _build_base_processors(_prod_mode=True, logging_settings=LoggingSettings())
+        processors = _build_base_processors(logging_settings=LoggingSettings())
 
         with capture_logs(processors=processors) as entries:
             logger = structlog.get_logger()
@@ -180,7 +183,7 @@ class TestPipelineRedaction:
     def test_pipeline_redaction_extra_keys_extend_defaults(self):
         """AC#3: redaction_extra_keys extends the deny-list through the real chain."""
         logging_settings = LoggingSettings(REDACTION_EXTRA_KEYS=("custom_secret",))
-        processors = _build_base_processors(_prod_mode=True, logging_settings=logging_settings)
+        processors = _build_base_processors(logging_settings=logging_settings)
 
         with capture_logs(processors=processors) as entries:
             logger = structlog.get_logger()
@@ -192,4 +195,61 @@ class TestPipelineRedaction:
 
         assert len(entries) == 1
         assert entries[0]["custom_secret"] == "***REDACTED***"
+        assert entries[0]["password"] == "***REDACTED***"
+
+
+@pytest.mark.unit
+class TestConfigureLoggingRealCodePath:
+    """Exercises configure_logging's non-test-environment branch.
+
+    ``configure_logging`` short-circuits to a minimal suppressed pipeline
+    whenever pytest is detected in sys.modules, which means the call to
+    ``_build_base_processors`` is never reached by any test running under
+    ``make test``. That let a call-site/signature mismatch (calling with
+    ``prod_mode=`` a function defined with ``_prod_mode``) reach production
+    while the full suite stayed green. These tests patch ``_is_test_environment``
+    to force the real branch, so the same class of bug fails CI immediately.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_structlog(self):
+        yield
+        structlog.reset_defaults()
+
+    def test_production_mode_builds_processors_without_error(self, mock_settings, monkeypatch):
+        """The real code path builds the pipeline in production mode without raising."""
+        monkeypatch.setattr("infrastructure.logging.setup._is_test_environment", lambda: False)
+        mock_settings.ENVIRONMENT = "production"
+
+        logger = configure_logging(settings=mock_settings)
+
+        assert logger is not None
+        config = structlog.get_config()
+        assert isinstance(config["processors"][-1], structlog.processors.JSONRenderer)
+
+    def test_development_mode_builds_processors_without_error(self, mock_settings, monkeypatch):
+        """The real code path builds the pipeline in development mode without raising."""
+        monkeypatch.setattr("infrastructure.logging.setup._is_test_environment", lambda: False)
+        mock_settings.ENVIRONMENT = "local"
+
+        logger = configure_logging(settings=mock_settings)
+
+        assert logger is not None
+        config = structlog.get_config()
+        assert isinstance(config["processors"][-1], structlog.dev.ConsoleRenderer)
+
+    def test_production_mode_redacts_through_full_pipeline(self, mock_settings, monkeypatch):
+        """Secrets are redacted end-to-end when the production pipeline is built for real."""
+        monkeypatch.setattr("infrastructure.logging.setup._is_test_environment", lambda: False)
+        mock_settings.ENVIRONMENT = "production"
+
+        configure_logging(settings=mock_settings)
+        config = structlog.get_config()
+        # Drop the JSONRenderer so capture_logs can inspect the event dict directly.
+        processors = config["processors"][:-1]
+
+        with capture_logs(processors=processors) as entries:
+            logger = structlog.get_logger()
+            logger.info("login_attempt", password="hunter2")
+
         assert entries[0]["password"] == "***REDACTED***"


### PR DESCRIPTION
# Summary | Résumé

This pull request addresses a production bug where a mismatch between the call signature and call site of `_build_base_processors` was not caught by tests, because the real code path was never exercised under test conditions. The changes remove the unused `_prod_mode` argument from `_build_base_processors`, update all call sites accordingly, and add new tests to ensure the production and development logging pipelines are properly built and exercised in CI.

**Bug fix and refactoring:**

* Removed the unused `_prod_mode` argument from the `_build_base_processors` function and updated all call sites to match the new signature, preventing call-site/signature mismatches. [[1]](diffhunk://#diff-525bc3334b5263eb06d4b8463f5fce81872030e655e69e6dbe3a41a8ba4f43c0L108) [[2]](diffhunk://#diff-525bc3334b5263eb06d4b8463f5fce81872030e655e69e6dbe3a41a8ba4f43c0L205-R204) [[3]](diffhunk://#diff-9c3e074d7b5d0dcf9c487787fbec6e73951227f2870b3327204712cb3483ae08L171-R174) [[4]](diffhunk://#diff-9c3e074d7b5d0dcf9c487787fbec6e73951227f2870b3327204712cb3483ae08L183-R186)

**Testing improvements:**

* Added a new test class `TestConfigureLoggingRealCodePath` to explicitly exercise the real (non-test-environment) code paths in `configure_logging`, ensuring that both production and development pipelines are built and secrets are redacted as expected. This prevents similar bugs from reaching production undetected.

**Documentation:**

* Updated the test docstring to explain the regression and how the new tests protect against it, referencing the relevant design decision documentation.