### PR TITLE
fix: update log patterns to reduce false positive alerts

### DIFF
--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_metric_filter" "sre_bot_error" {
   provider       = aws.core_services
   name           = local.error_logged
-  pattern        = "?ERROR ?Exception"
+  pattern        = local.error_logged_pattern
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "sre_bot_error" {
 resource "aws_cloudwatch_log_metric_filter" "sre_bot_warning" {
   provider       = aws.core_services
   name           = local.warning_logged
-  pattern        = "WARNING"
+  pattern        = local.warning_logged_pattern
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -3,4 +3,26 @@ locals {
   error_logged             = "SREBotErrorLogged"
   error_namespace          = "SREBot"
   warning_logged           = "SREBotWarningLogged"
+
+  # Plain-text terms that indicate an error-worthy log line
+  error_logged_filters = [
+    "ERROR",
+    "Exception",
+  ]
+  # Regexes (CloudWatch %...% syntax, no literal quotes allowed) matched against the raw log
+  # line to exclude known false positives from the error metric. Extend to silence new ones.
+  error_logged_skip_filters = [
+    "level\\S*warning", # structlog logs at level=warning, e.g. {"level": "warning", ...}
+  ]
+  error_logged_pattern = "[(w=\"*${join("*\" || w=\"*", local.error_logged_filters)}*\") && ${join(" && ", [for term in local.error_logged_skip_filters : "w!=%${term}%"])}]"
+
+  # Plain-text terms that indicate a warning-level log line
+  warning_logged_filters = [
+    "WARNING",
+  ]
+  # Regexes matched against the raw log line to detect a structured warning-level log line
+  warning_logged_regex_filters = [
+    "level\\S*warning", # structlog logs at level=warning, e.g. {"level": "warning", ...}
+  ]
+  warning_logged_pattern = "[w=\"*${join("*\" || w=\"*", local.warning_logged_filters)}*\" || ${join(" || ", [for term in local.warning_logged_regex_filters : "w=%${term}%"])}]"
 }


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how CloudWatch log metric filters for errors and warnings are defined in Terraform. Instead of using hardcoded filter patterns, it introduces local variables to make the patterns more flexible and maintainable, allowing for easier updates and false positive suppression.

**Log metric filter improvements:**

* Replaced hardcoded error and warning filter patterns in `aws_cloudwatch_log_metric_filter.sre_bot_error` and `aws_cloudwatch_log_metric_filter.sre_bot_warning` with references to new local variables (`local.error_logged_pattern` and `local.warning_logged_pattern`). [[1]](diffhunk://#diff-50a6bca0c792ee7200a4f0418e9133a30595505f55cb6fb0d31664bec48a760cL4-R4) [[2]](diffhunk://#diff-50a6bca0c792ee7200a4f0418e9133a30595505f55cb6fb0d31664bec48a760cL35-R35)

**Pattern configuration enhancements:**

* Added new locals in `local.tf` for error and warning filter terms, skip filters (to exclude known false positives), and regex-based patterns for more accurate log matching. This includes arrays for filter terms and skip patterns, and constructs the final filter patterns dynamically.