### PR TITLE
fix: update regex patterns to improve false positive detection

### DIFF
--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -13,6 +13,7 @@ locals {
   # line to exclude known false positives from the error metric. Extend to silence new ones.
   error_logged_skip_filters = [
     "level.{0,6}warning", # structlog JSON renders {"level": "warning", ...} with a space after the colon; \S excludes that space
+    "level.{0,6}info",    # same rationale, but for {"level": "info", ...}
   ]
   error_logged_pattern = "[(w=\"*${join("*\" || w=\"*", local.error_logged_filters)}*\") && ${join(" && ", [for term in local.error_logged_skip_filters : "w!=%${term}%"])}]"
 

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -12,7 +12,7 @@ locals {
   # Regexes (CloudWatch %...% syntax, no literal quotes allowed) matched against the raw log
   # line to exclude known false positives from the error metric. Extend to silence new ones.
   error_logged_skip_filters = [
-    "level\\S*warning", # structlog logs at level=warning, e.g. {"level": "warning", ...}
+    "level.{0,6}warning", # structlog JSON renders {"level": "warning", ...} with a space after the colon; \S excludes that space
   ]
   error_logged_pattern = "[(w=\"*${join("*\" || w=\"*", local.error_logged_filters)}*\") && ${join(" && ", [for term in local.error_logged_skip_filters : "w!=%${term}%"])}]"
 
@@ -22,7 +22,7 @@ locals {
   ]
   # Regexes matched against the raw log line to detect a structured warning-level log line
   warning_logged_regex_filters = [
-    "level\\S*warning", # structlog logs at level=warning, e.g. {"level": "warning", ...}
+    "level.{0,6}warning", # structlog JSON renders {"level": "warning", ...} with a space after the colon; \S excludes that space
   ]
   warning_logged_pattern = "[w=\"*${join("*\" || w=\"*", local.warning_logged_filters)}*\" || ${join(" || ", [for term in local.warning_logged_regex_filters : "w=%${term}%"])}]"
 }


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the regular expressions used for log filtering in `terraform/local.tf` to better match structlog JSON output, specifically addressing cases where a space appears after the colon in the `level` field. The changes improve the accuracy of log filtering for both error and warning levels.

**Log filtering improvements:**

* Updated the regex in `error_logged_skip_filters` to `level.{0,6}warning` to correctly match log lines where a space may appear after the colon in the `level` field (e.g., `{"level": "warning", ...}`), instead of using `\S` which excluded spaces.
* Updated the regex in `warning_logged_regex_filters` to `level.{0,6}warning` for the same reason, ensuring accurate detection of warning-level logs.