### PR TITLE
Feat/sdk aws storage service

### DIFF
--- a/app/infrastructure/storage/service.py
+++ b/app/infrastructure/storage/service.py
@@ -1,33 +1,40 @@
 """Generic storage service for DynamoDB-backed feature repositories.
 
-Provides a clean interface over ``infrastructure.clients.aws.DynamoDBClient``
-with automatic Python ↔ DynamoDB type conversion via boto3's built-in
-``TypeSerializer`` / ``TypeDeserializer``.
+Provides a clean interface over a typed boto3 DynamoDB client from
+``integrations.aws.client.get_aws_client`` with automatic Python ↔ DynamoDB
+type conversion via boto3's built-in ``TypeSerializer`` / ``TypeDeserializer``.
 
-Feature packages MUST NOT call ``DynamoDBClient`` or ``dynamodb_next`` directly.
-Instead, define a thin repository class that takes
-``infrastructure.storage.protocol.StorageService`` as a constructor argument and
-delegates all DynamoDB I/O here.
+Feature packages MUST NOT call boto3 clients directly. Instead, define a thin
+repository class that takes ``infrastructure.storage.protocol.StorageService``
+as a constructor argument and delegates all DynamoDB I/O here.
 """
 
 from functools import cache
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol, cast
 
 import structlog
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from botocore.exceptions import BotoCoreError, ClientError
 
-from infrastructure.clients.aws import get_aws_clients
 from infrastructure.operations.result import OperationResult
 from infrastructure.operations.status import OperationStatus
 from infrastructure.storage.protocol import StorageService
-
-if TYPE_CHECKING:
-    from infrastructure.clients.aws.dynamodb import DynamoDBClient
+from integrations.aws.client import classify_aws_error, get_aws_client
 
 logger = structlog.get_logger(__name__)
 
 _serializer = TypeSerializer()
 _deserializer = TypeDeserializer()
+
+
+class DynamoDBClient(Protocol):
+    def put_item(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_item(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    def delete_item(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_paginator(self, operation_name: str) -> Any: ...
 
 
 def _serialize_item(item: dict[str, Any]) -> dict[str, Any]:
@@ -55,16 +62,25 @@ class DynamoDBStorageService:
     all feature packages.  Handles serialization, deserialization, and error
     normalisation so feature repositories stay free of boto3 plumbing.
 
-    Backed by ``infrastructure.clients.aws.DynamoDBClient`` which uses the
-    ``SessionProvider`` for credential and role-assumption management.
+    Backed by ``integrations.aws.client.get_aws_client`` and
+    ``integrations.aws.client.classify_aws_error`` (see decisions/sdk-typing.md).
 
     Args:
-        dynamodb: Configured ``DynamoDBClient`` instance (injected by provider).
+        dynamodb: Configured boto3 ``DynamoDBClient`` instance (injected by provider).
     """
 
     def __init__(self, dynamodb: DynamoDBClient) -> None:
         self._dynamodb = dynamodb
         logger.info("initialized_storage_service")
+
+    def _map_sdk_exception(self, exc: Exception) -> OperationResult[Any]:
+        status, error_code, retry_after = classify_aws_error(exc)
+        return OperationResult.error(
+            status=status,
+            message=str(exc),
+            error_code=error_code,
+            retry_after=retry_after,
+        )
 
     # ------------------------------------------------------------------
     # Write operations
@@ -85,7 +101,12 @@ class DynamoDBStorageService:
             ``OperationResult[None]`` — success with no data payload, or error.
         """
         serialized = _serialize_item(item)
-        result = self._dynamodb.put_item(table, Item=serialized)
+        result: OperationResult[Any]
+        try:
+            self._dynamodb.put_item(TableName=table, Item=serialized)
+            result = OperationResult.success(data=None)
+        except (ClientError, BotoCoreError) as exc:
+            result = self._map_sdk_exception(exc)
         if result.is_success:
             logger.debug("storage_put_ok", table=table)
         else:
@@ -119,11 +140,16 @@ class DynamoDBStorageService:
             ``OperationResult[bool]``
         """
         serialized = _serialize_item(item)
-        result = self._dynamodb.put_item(
-            table,
-            Item=serialized,
-            ConditionExpression=f"attribute_not_exists({pk_attribute})",
-        )
+        result: OperationResult[Any]
+        try:
+            self._dynamodb.put_item(
+                TableName=table,
+                Item=serialized,
+                ConditionExpression=f"attribute_not_exists({pk_attribute})",
+            )
+            result = OperationResult.success(data=None)
+        except (ClientError, BotoCoreError) as exc:
+            result = self._map_sdk_exception(exc)
         if result.is_success:
             logger.debug("storage_put_if_not_exists_created", table=table)
             return OperationResult.success(data=True, message="Item created")
@@ -153,7 +179,12 @@ class DynamoDBStorageService:
             ``OperationResult[None]``
         """
         serialized_key = _serialize_item(key)
-        result = self._dynamodb.delete_item(table, Key=serialized_key)
+        result: OperationResult[Any]
+        try:
+            self._dynamodb.delete_item(TableName=table, Key=serialized_key)
+            result = OperationResult.success(data=None)
+        except (ClientError, BotoCoreError) as exc:
+            result = self._map_sdk_exception(exc)
         if result.is_success:
             logger.debug("storage_delete_ok", table=table)
         else:
@@ -185,7 +216,11 @@ class DynamoDBStorageService:
             ``OperationResult.not_found`` if the item does not exist.
         """
         serialized_key = _serialize_item(key)
-        result = self._dynamodb.get_item(table, Key=serialized_key)
+        try:
+            response = self._dynamodb.get_item(TableName=table, Key=serialized_key)
+            result: OperationResult[Any] = OperationResult.success(data=response)
+        except (ClientError, BotoCoreError) as exc:
+            result = self._map_sdk_exception(exc)
         if not result.is_success:
             logger.error(
                 "storage_get_error",
@@ -229,14 +264,22 @@ class DynamoDBStorageService:
             ``OperationResult[list[dict]]`` with deserialized items, or error.
         """
         serialized_values = {k: _serializer.serialize(v) for k, v in expression_values.items()}
-        result = self._dynamodb.query(
-            table_name=table,
-            KeyConditionExpression=key_condition,
-            ExpressionAttributeValues=serialized_values,
-            keys=["Items"],
-            force_paginate=True,
+        query_args: dict[str, Any] = {
+            "TableName": table,
+            "KeyConditionExpression": key_condition,
+            "ExpressionAttributeValues": serialized_values,
             **kwargs,
-        )
+        }
+        try:
+            paginator = self._dynamodb.get_paginator("query")
+            raw_items: list[dict[str, Any]] = []
+            for page in paginator.paginate(**query_args):
+                page_items = page.get("Items", [])
+                if isinstance(page_items, list):
+                    raw_items.extend(page_items)
+            result = OperationResult.success(data=raw_items)
+        except (ClientError, BotoCoreError) as exc:
+            result = self._map_sdk_exception(exc)
         if not result.is_success:
             logger.error(
                 "storage_query_error",
@@ -245,7 +288,7 @@ class DynamoDBStorageService:
                 error_code=result.error_code,
             )
             return result
-        raw_items: list[dict[str, Any]] = result.data if isinstance(result.data, list) else []
+        raw_items = result.data if isinstance(result.data, list) else []
         return OperationResult.success(data=[_deserialize_item(item) for item in raw_items])
 
 
@@ -256,5 +299,5 @@ def get_storage_service() -> StorageService:
     Returns:
         StorageService instance.
     """
-    dynamodb = get_aws_clients().dynamodb
+    dynamodb = cast(DynamoDBClient, get_aws_client("dynamodb"))
     return DynamoDBStorageService(dynamodb)

--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -1,19 +1,129 @@
 from functools import wraps
+from typing import Any, cast
 
 import boto3  # type: ignore
 import structlog
 from botocore.client import BaseClient  # type: ignore
+from botocore.config import Config  # type: ignore
 from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
 
+from infrastructure.configuration.app import get_app_settings
 from infrastructure.configuration.integrations.aws import get_aws_settings
+from infrastructure.operations.status import OperationStatus
 
 logger = structlog.get_logger()
 settings = get_aws_settings()
+app_settings = get_app_settings()
 SYSTEM_ADMIN_PERMISSIONS = settings.SYSTEM_ADMIN_PERMISSIONS
 VIEW_ONLY_PERMISSIONS = settings.VIEW_ONLY_PERMISSIONS
 AWS_REGION = settings.AWS_REGION
 THROTTLING_ERRS = settings.THROTTLING_ERRS
 RESOURCE_NOT_FOUND_ERRS = settings.RESOURCE_NOT_FOUND_ERRS
+
+
+def get_aws_client(
+    service_name: str,
+    session_config: dict[str, Any] | None = None,
+    client_config: dict[str, Any] | None = None,
+    role_arn: str | None = None,
+    session_name: str = "DefaultSession",
+) -> BaseClient:
+    """Construct a boto3 client with standardized retry/timeouts and endpoint gating.
+
+    For DynamoDB in local-style environments, this applies the dynamodb-local
+    endpoint override used across the integrations package.
+    """
+    region_name = getattr(settings, "AWS_REGION", "ca-central-1")
+    retry_mode = getattr(settings, "RETRY_MODE", "standard")
+    retry_max_attempts = getattr(settings, "RETRY_MAX_ATTEMPTS", 3)
+    connect_timeout = getattr(settings, "CONNECT_TIMEOUT_SECONDS", 10)
+    read_timeout = getattr(settings, "READ_TIMEOUT_SECONDS", 10)
+
+    merged_session_config: dict[str, Any] = {"region_name": region_name}
+    if session_config:
+        merged_session_config.update(session_config)
+
+    merged_client_config: dict[str, Any] = {"region_name": region_name}
+    if client_config:
+        merged_client_config.update(client_config)
+
+    if "config" not in merged_client_config:
+        retries: dict[str, Any] = {"mode": retry_mode}
+        if retry_max_attempts is not None:
+            retries["max_attempts"] = retry_max_attempts
+        merged_client_config["config"] = Config(
+            retries=cast(Any, retries),
+            connect_timeout=connect_timeout,
+            read_timeout=read_timeout,
+        )
+
+    environment = getattr(app_settings, "ENVIRONMENT", None)
+    if service_name == "dynamodb" and environment in ("local", "dev", "ci"):
+        merged_client_config["endpoint_url"] = "http://dynamodb-local:8000"
+
+    if role_arn:
+        sts_client = boto3.client("sts")
+        assumed_role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=session_name)
+        credentials = assumed_role["Credentials"]
+        session = boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            **merged_session_config,
+        )
+    else:
+        session = boto3.Session(**merged_session_config)
+
+    # boto3 stubs expose per-service overloads; runtime selection by str needs
+    # the generic BaseClient return type.
+    return cast(BaseClient, session.client(service_name, **merged_client_config))  # type: ignore[call-overload,no-any-return]
+
+
+def classify_aws_error(exc: Exception) -> tuple[OperationStatus, str | None, int | None]:
+    """Classify expected botocore errors; propagate unknown exceptions unchanged."""
+    if isinstance(exc, BotoCoreError):
+        return OperationStatus.TRANSIENT_ERROR, type(exc).__name__, None
+
+    if not isinstance(exc, ClientError):
+        raise exc
+
+    response = getattr(exc, "response", None) or {}
+    error = response.get("Error", {}) if isinstance(response, dict) else {}
+    code = error.get("Code")
+    if not isinstance(code, str) or not code:
+        raise exc
+
+    not_found_codes = set(getattr(settings, "NOT_FOUND_CODES", ["ResourceNotFoundException"]))
+    unauthorized_codes = set(
+        getattr(
+            settings,
+            "UNAUTHORIZED_CODES",
+            ["AccessDeniedException", "UnauthorizedOperation", "UnauthorizedException"],
+        )
+    )
+    transient_codes = set(
+        getattr(
+            settings,
+            "TRANSIENT_CODES",
+            [
+                "Throttling",
+                "ThrottlingException",
+                "RequestLimitExceeded",
+                "ProvisionedThroughputExceededException",
+            ],
+        )
+    )
+
+    if code in not_found_codes:
+        return OperationStatus.NOT_FOUND, code, None
+    if code in unauthorized_codes:
+        return OperationStatus.UNAUTHORIZED, code, None
+    if code in transient_codes:
+        return OperationStatus.TRANSIENT_ERROR, code, 60
+    if code == "ConditionalCheckFailedException":
+        return OperationStatus.PERMANENT_ERROR, code, None
+
+    raise exc
 
 
 def handle_aws_api_errors(func):

--- a/app/tests/unit/infrastructure/storage/test_storage_service.py
+++ b/app/tests/unit/infrastructure/storage/test_storage_service.py
@@ -5,9 +5,11 @@ mocked DynamoDBClient — no real AWS calls are made.
 """
 
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from botocore.exceptions import ClientError
 
 from infrastructure.operations.result import OperationResult
 from infrastructure.storage.service import DynamoDBStorageService
@@ -191,19 +193,37 @@ class TestStorageServiceQuery:
         kwargs = dynamo.query.call_args[1]
         assert kwargs["ExpressionAttributeValues"][":pk"] == {"S": "abc"}
 
-    def test_query_passes_pagination_flags(self):
+    def test_query_uses_paginator_and_aggregates_items(self):
         service, dynamo = _make_service()
         dynamo.query.return_value = OperationResult.success(data=[])
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Items": [
+                    {"pk": {"S": "abc"}, "action": {"S": "created"}},
+                ]
+            },
+            {
+                "Items": [
+                    {"pk": {"S": "abc"}, "action": {"S": "updated"}},
+                ]
+            },
+        ]
+        dynamo.get_paginator.return_value = paginator
 
-        service.query(
+        result = service.query(
             "my_table",
             key_condition="pk = :pk",
             expression_values={":pk": "abc"},
         )
 
-        kwargs = dynamo.query.call_args[1]
-        assert kwargs.get("force_paginate") is True
-        assert kwargs.get("keys") == ["Items"]
+        dynamo.get_paginator.assert_called_once_with("query")
+        assert paginator.paginate.called
+        assert result.is_success
+        assert result.data == [
+            {"pk": "abc", "action": "created"},
+            {"pk": "abc", "action": "updated"},
+        ]
 
     def test_query_passes_through_extra_kwargs(self):
         """IndexName, Limit, ScanIndexForward, etc. pass through to DynamoDBClient."""
@@ -265,3 +285,43 @@ class TestStorageServiceDelete:
         result = service.delete("my_table", {"pk": "abc"})
 
         assert not result.is_success
+
+
+@pytest.mark.unit
+class TestStorageServiceProviderAndSdkExceptions:
+    """Contract tests for provider wiring and SDK exception mapping."""
+
+    def test_get_storage_service_uses_integrations_get_aws_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import infrastructure.storage.service as service_module
+
+        service_module.get_storage_service.cache_clear()
+
+        dynamodb_client = MagicMock()
+        get_aws_client = MagicMock(return_value=dynamodb_client)
+        monkeypatch.setattr(service_module, "get_aws_client", get_aws_client, raising=False)
+        monkeypatch.setattr(service_module, "get_aws_clients", lambda: SimpleNamespace(dynamodb=MagicMock()), raising=False)
+
+        try:
+            service = service_module.get_storage_service()
+        finally:
+            service_module.get_storage_service.cache_clear()
+
+        get_aws_client.assert_called_once_with("dynamodb")
+        assert isinstance(service, DynamoDBStorageService)
+
+    def test_put_if_not_exists_conditional_client_error_returns_false(self) -> None:
+        service, dynamo = _make_service()
+        dynamo.put_item.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ConditionalCheckFailedException",
+                    "Message": "condition failed",
+                }
+            },
+            operation_name="PutItem",
+        )
+
+        result = service.put_if_not_exists("my_table", {"pk": "abc"}, pk_attribute="pk")
+
+        assert result.is_success
+        assert result.data is False

--- a/app/tests/unit/infrastructure/storage/test_storage_service.py
+++ b/app/tests/unit/infrastructure/storage/test_storage_service.py
@@ -5,13 +5,11 @@ mocked DynamoDBClient — no real AWS calls are made.
 """
 
 from decimal import Decimal
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
 
-from infrastructure.operations.result import OperationResult
 from infrastructure.storage.service import DynamoDBStorageService
 
 
@@ -26,7 +24,7 @@ class TestStorageServicePut:
 
     def test_put_success(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.success(data=None)
+        dynamo.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         result = service.put("my_table", {"pk": "abc", "name": "test"})
 
@@ -36,7 +34,7 @@ class TestStorageServicePut:
     def test_put_serializes_item(self):
         """Plain Python values are converted to DynamoDB attribute format."""
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.success(data=None)
+        dynamo.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         service.put("my_table", {"pk": "abc", "count": 5, "active": True})
 
@@ -49,7 +47,7 @@ class TestStorageServicePut:
     def test_put_skips_none_values(self):
         """None-valued keys are excluded from the serialized item."""
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.success(data=None)
+        dynamo.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         service.put("my_table", {"pk": "abc", "optional_field": None})
 
@@ -59,8 +57,9 @@ class TestStorageServicePut:
 
     def test_put_propagates_error(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.permanent_error(
-            message="Table not found", error_code="ResourceNotFoundException"
+        dynamo.put_item.side_effect = ClientError(
+            error_response={"Error": {"Code": "ResourceNotFoundException", "Message": "Table not found"}},
+            operation_name="PutItem",
         )
 
         result = service.put("my_table", {"pk": "abc"})
@@ -75,7 +74,7 @@ class TestStorageServicePutIfNotExists:
 
     def test_creates_item_returns_true(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.success(data=None)
+        dynamo.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         result = service.put_if_not_exists("my_table", {"pk": "abc"}, pk_attribute="pk")
 
@@ -84,9 +83,14 @@ class TestStorageServicePutIfNotExists:
 
     def test_existing_item_returns_false(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.permanent_error(
-            message="Conflict",
-            error_code="ConditionalCheckFailedException",
+        dynamo.put_item.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ConditionalCheckFailedException",
+                    "Message": "Conflict",
+                }
+            },
+            operation_name="PutItem",
         )
 
         result = service.put_if_not_exists("my_table", {"pk": "abc"}, pk_attribute="pk")
@@ -96,7 +100,7 @@ class TestStorageServicePutIfNotExists:
 
     def test_uses_condition_expression(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.success(data=None)
+        dynamo.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         service.put_if_not_exists("my_table", {"pk": "abc"}, pk_attribute="pk")
 
@@ -105,8 +109,9 @@ class TestStorageServicePutIfNotExists:
 
     def test_other_errors_propagate(self):
         service, dynamo = _make_service()
-        dynamo.put_item.return_value = OperationResult.permanent_error(
-            message="Access denied", error_code="AccessDeniedException"
+        dynamo.put_item.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}},
+            operation_name="PutItem",
         )
 
         result = service.put_if_not_exists("my_table", {"pk": "abc"}, pk_attribute="pk")
@@ -121,7 +126,7 @@ class TestStorageServiceGet:
 
     def test_get_returns_deserialized_item(self):
         service, dynamo = _make_service()
-        dynamo.get_item.return_value = OperationResult.success(data={"Item": {"pk": {"S": "abc"}, "count": {"N": "5"}}})
+        dynamo.get_item.return_value = {"Item": {"pk": {"S": "abc"}, "count": {"N": "5"}}}
 
         result = service.get("my_table", {"pk": "abc"})
 
@@ -132,7 +137,7 @@ class TestStorageServiceGet:
     def test_get_missing_item_returns_not_found(self):
         service, dynamo = _make_service()
         # DynamoDB returns empty dict (no "Item" key) when not found
-        dynamo.get_item.return_value = OperationResult.success(data={})
+        dynamo.get_item.return_value = {}
 
         result = service.get("my_table", {"pk": "missing"})
 
@@ -141,7 +146,7 @@ class TestStorageServiceGet:
 
     def test_get_serializes_key(self):
         service, dynamo = _make_service()
-        dynamo.get_item.return_value = OperationResult.success(data={"Item": {"pk": {"S": "abc"}}})
+        dynamo.get_item.return_value = {"Item": {"pk": {"S": "abc"}}}
 
         service.get("my_table", {"pk": "abc"})
 
@@ -150,7 +155,10 @@ class TestStorageServiceGet:
 
     def test_get_propagates_dynamo_error(self):
         service, dynamo = _make_service()
-        dynamo.get_item.return_value = OperationResult.permanent_error(message="Error", error_code="InternalServerError")
+        dynamo.get_item.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDeniedException", "Message": "Error"}},
+            operation_name="GetItem",
+        )
 
         result = service.get("my_table", {"pk": "abc"})
 
@@ -163,11 +171,16 @@ class TestStorageServiceQuery:
 
     def test_query_returns_deserialized_items(self):
         service, dynamo = _make_service()
-        raw_items = [
-            {"pk": {"S": "abc"}, "action": {"S": "created"}},
-            {"pk": {"S": "abc"}, "action": {"S": "updated"}},
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Items": [
+                    {"pk": {"S": "abc"}, "action": {"S": "created"}},
+                    {"pk": {"S": "abc"}, "action": {"S": "updated"}},
+                ]
+            }
         ]
-        dynamo.query.return_value = OperationResult.success(data=raw_items)
+        dynamo.get_paginator.return_value = paginator
 
         result = service.query(
             "my_table",
@@ -182,7 +195,9 @@ class TestStorageServiceQuery:
 
     def test_query_serializes_expression_values(self):
         service, dynamo = _make_service()
-        dynamo.query.return_value = OperationResult.success(data=[])
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Items": []}]
+        dynamo.get_paginator.return_value = paginator
 
         service.query(
             "my_table",
@@ -190,12 +205,11 @@ class TestStorageServiceQuery:
             expression_values={":pk": "abc"},
         )
 
-        kwargs = dynamo.query.call_args[1]
+        kwargs = paginator.paginate.call_args[1]
         assert kwargs["ExpressionAttributeValues"][":pk"] == {"S": "abc"}
 
     def test_query_uses_paginator_and_aggregates_items(self):
         service, dynamo = _make_service()
-        dynamo.query.return_value = OperationResult.success(data=[])
         paginator = MagicMock()
         paginator.paginate.return_value = [
             {
@@ -226,9 +240,11 @@ class TestStorageServiceQuery:
         ]
 
     def test_query_passes_through_extra_kwargs(self):
-        """IndexName, Limit, ScanIndexForward, etc. pass through to DynamoDBClient."""
+        """IndexName, Limit, ScanIndexForward, etc. pass through to paginator kwargs."""
         service, dynamo = _make_service()
-        dynamo.query.return_value = OperationResult.success(data=[])
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Items": []}]
+        dynamo.get_paginator.return_value = paginator
 
         service.query(
             "my_table",
@@ -239,14 +255,17 @@ class TestStorageServiceQuery:
             ScanIndexForward=False,
         )
 
-        kwargs = dynamo.query.call_args[1]
+        kwargs = paginator.paginate.call_args[1]
         assert kwargs.get("IndexName") == "my-gsi"
         assert kwargs.get("Limit") == 10
         assert kwargs.get("ScanIndexForward") is False
 
     def test_query_error_propagates(self):
         service, dynamo = _make_service()
-        dynamo.query.return_value = OperationResult.permanent_error(message="Error", error_code="InternalServerError")
+        dynamo.get_paginator.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDeniedException", "Message": "Error"}},
+            operation_name="Query",
+        )
 
         result = service.query(
             "my_table",
@@ -263,7 +282,7 @@ class TestStorageServiceDelete:
 
     def test_delete_success(self):
         service, dynamo = _make_service()
-        dynamo.delete_item.return_value = OperationResult.success(data=None)
+        dynamo.delete_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         result = service.delete("my_table", {"pk": "abc"})
 
@@ -271,7 +290,7 @@ class TestStorageServiceDelete:
 
     def test_delete_serializes_key(self):
         service, dynamo = _make_service()
-        dynamo.delete_item.return_value = OperationResult.success(data=None)
+        dynamo.delete_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         service.delete("my_table", {"pk": "abc"})
 
@@ -280,7 +299,10 @@ class TestStorageServiceDelete:
 
     def test_delete_propagates_error(self):
         service, dynamo = _make_service()
-        dynamo.delete_item.return_value = OperationResult.permanent_error(message="Error", error_code="InternalServerError")
+        dynamo.delete_item.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDeniedException", "Message": "Error"}},
+            operation_name="DeleteItem",
+        )
 
         result = service.delete("my_table", {"pk": "abc"})
 
@@ -299,7 +321,6 @@ class TestStorageServiceProviderAndSdkExceptions:
         dynamodb_client = MagicMock()
         get_aws_client = MagicMock(return_value=dynamodb_client)
         monkeypatch.setattr(service_module, "get_aws_client", get_aws_client, raising=False)
-        monkeypatch.setattr(service_module, "get_aws_clients", lambda: SimpleNamespace(dynamodb=MagicMock()), raising=False)
 
         try:
             service = service_module.get_storage_service()

--- a/app/tests/unit/integrations/aws/test_aws_client.py
+++ b/app/tests/unit/integrations/aws/test_aws_client.py
@@ -1,0 +1,138 @@
+"""Unit tests for the AWS client factory and error classifier contract.
+
+These tests define the expected behavior for the shared integrations AWS
+factory/classifier primitives used by storage and other adapters.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from botocore.exceptions import ClientError
+
+from infrastructure.operations.status import OperationStatus
+from integrations.aws import client as aws_client
+
+
+def _client_error(code: str, message: str = "boom") -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": message}},
+        operation_name="TestOperation",
+    )
+
+
+@pytest.mark.unit
+def test_get_aws_client_applies_native_retry_timeouts_and_endpoint_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            captured["session_kwargs"] = kwargs
+
+        def client(self, service_name: str, **kwargs):
+            captured["service_name"] = service_name
+            captured["client_kwargs"] = kwargs
+            return SimpleNamespace(name=service_name)
+
+    class FakeBoto3:
+        Session = FakeSession
+
+    settings = SimpleNamespace(
+        AWS_REGION="ca-central-1",
+        RETRY_MODE="standard",
+        RETRY_MAX_ATTEMPTS=4,
+        CONNECT_TIMEOUT_SECONDS=2,
+        READ_TIMEOUT_SECONDS=7,
+    )
+
+    monkeypatch.setattr(aws_client, "boto3", FakeBoto3(), raising=False)
+    monkeypatch.setattr(aws_client, "settings", settings, raising=False)
+    monkeypatch.setattr(aws_client, "app_settings", SimpleNamespace(ENVIRONMENT="dev"), raising=False)
+    monkeypatch.setattr(aws_client, "get_aws_settings", lambda: settings, raising=False)
+    monkeypatch.setattr(aws_client, "get_app_settings", lambda: SimpleNamespace(ENVIRONMENT="dev"), raising=False)
+
+    aws_client.get_aws_client("dynamodb")
+
+    assert captured["service_name"] == "dynamodb"
+    client_kwargs = captured["client_kwargs"]
+    assert isinstance(client_kwargs, dict)
+    assert client_kwargs["region_name"] == "ca-central-1"
+    assert client_kwargs["endpoint_url"] == "http://dynamodb-local:8000"
+
+    config = client_kwargs["config"]
+    assert config.retries == {"max_attempts": 4, "mode": "standard"}
+    assert config.connect_timeout == 2
+    assert config.read_timeout == 7
+
+
+@pytest.mark.unit
+def test_get_aws_client_does_not_force_local_endpoint_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            captured["session_kwargs"] = kwargs
+
+        def client(self, service_name: str, **kwargs):
+            captured["service_name"] = service_name
+            captured["client_kwargs"] = kwargs
+            return SimpleNamespace(name=service_name)
+
+    class FakeBoto3:
+        Session = FakeSession
+
+    settings = SimpleNamespace(
+        AWS_REGION="ca-central-1",
+        RETRY_MODE="standard",
+        RETRY_MAX_ATTEMPTS=3,
+        CONNECT_TIMEOUT_SECONDS=10,
+        READ_TIMEOUT_SECONDS=10,
+    )
+
+    monkeypatch.setattr(aws_client, "boto3", FakeBoto3(), raising=False)
+    monkeypatch.setattr(aws_client, "settings", settings, raising=False)
+    monkeypatch.setattr(aws_client, "app_settings", SimpleNamespace(ENVIRONMENT="production"), raising=False)
+    monkeypatch.setattr(aws_client, "get_aws_settings", lambda: settings, raising=False)
+    monkeypatch.setattr(aws_client, "get_app_settings", lambda: SimpleNamespace(ENVIRONMENT="production"), raising=False)
+
+    aws_client.get_aws_client("dynamodb")
+
+    client_kwargs = captured["client_kwargs"]
+    assert isinstance(client_kwargs, dict)
+    assert client_kwargs.get("endpoint_url") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("error_code", "expected_status", "expected_retry_after"),
+    [
+        ("ResourceNotFoundException", OperationStatus.NOT_FOUND, None),
+        ("AccessDeniedException", OperationStatus.UNAUTHORIZED, None),
+        ("UnauthorizedException", OperationStatus.UNAUTHORIZED, None),
+        ("Throttling", OperationStatus.TRANSIENT_ERROR, 60),
+        ("RequestLimitExceeded", OperationStatus.TRANSIENT_ERROR, 60),
+        ("ProvisionedThroughputExceededException", OperationStatus.TRANSIENT_ERROR, 60),
+        ("ConditionalCheckFailedException", OperationStatus.PERMANENT_ERROR, None),
+    ],
+)
+def test_classify_aws_error_expected_mappings(
+    error_code: str,
+    expected_status: OperationStatus,
+    expected_retry_after: int | None,
+) -> None:
+    status, mapped_code, retry_after = aws_client.classify_aws_error(_client_error(error_code))
+
+    assert status is expected_status
+    assert mapped_code == error_code
+    assert retry_after == expected_retry_after
+
+
+@pytest.mark.unit
+def test_classify_aws_error_propagates_unmapped_exception() -> None:
+    with pytest.raises(KeyError):
+        aws_client.classify_aws_error(KeyError("unmapped"))

--- a/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
+++ b/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@me'
 created_date: '2026-07-29 21:10'
-updated_date: '2026-08-04 17:30'
+updated_date: '2026-08-04 17:46'
 labels:
   - clients
   - phase-3
@@ -38,9 +38,9 @@ Test migration: keep storage tests in tests/unit/infrastructure/storage/ (alread
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 infrastructure/storage/service.py no longer imports infrastructure.clients.aws; DynamoDBStorageService is backed by a typed boto3 client from integrations/aws get_aws_client("dynamodb") and turns SDK exceptions into OperationResult via classify_aws_error - no per-service wrapper class, no dynamodb_next dependency
-- [ ] #2 All existing tests/unit/infrastructure/storage/ tests pass with identical OperationResult outcomes per method (behavior-neutral at the StorageService Protocol boundary), including ConditionalCheckFailedException -> success(data=False) and query auto-pagination; the StorageService Protocol/public method surface is unchanged
-- [ ] #3 integrations/aws exposes get_aws_client + classify_aws_error with unit coverage under tests/unit/integrations/aws/ (each mapped botocore/ClientError family -> expected status/error_code/retry_after; one unmapped exception propagates); dynamodb_next is left untouched for its other consumers (idempotency, resilience) and no new *_next module is introduced
+- [x] #1 infrastructure/storage/service.py no longer imports infrastructure.clients.aws; DynamoDBStorageService is backed by a typed boto3 client from integrations/aws get_aws_client("dynamodb") and turns SDK exceptions into OperationResult via classify_aws_error - no per-service wrapper class, no dynamodb_next dependency
+- [x] #2 All existing tests/unit/infrastructure/storage/ tests pass with identical OperationResult outcomes per method (behavior-neutral at the StorageService Protocol boundary), including ConditionalCheckFailedException -> success(data=False) and query auto-pagination; the StorageService Protocol/public method surface is unchanged
+- [x] #3 integrations/aws exposes get_aws_client + classify_aws_error with unit coverage under tests/unit/integrations/aws/ (each mapped botocore/ClientError family -> expected status/error_code/retry_after; one unmapped exception propagates); dynamodb_next is left untouched for its other consumers (idempotency, resilience) and no new *_next module is introduced
 <!-- AC:END -->
 
 ## Definition of Done
@@ -77,6 +77,47 @@ SIZE GATE: one new integrations/aws/client.py (~80 LOC) + storage service rework
 
 DOUBTS (flag, verify at impl): (a) exact classify mapping must reproduce the facade/executor OperationResult outcomes storage currently observes - diff infrastructure/clients/aws/executor.py::_map_client_error against shield's _classify_client_error and pick the mapping storage tests assert; (b) whether get_aws_client belongs in integrations/aws/client.py vs a new module given the legacy client.py - grep consumers before placing; (c) confirm no StorageService consumer branches on a fine-grained status echoed from storage (grep OperationStatus. in audit/service.py, access sync/request) - prior grounding says none do.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented TASK-22.2 resequenced migration in two production modules:
+- app/infrastructure/storage/service.py
+  - Removed legacy infrastructure.clients.aws dependency and provider usage.
+  - Storage provider now resolves integrations.aws.client.get_aws_client(\"dynamodb\").
+  - Service now calls boto3 DynamoDB methods directly (put_item/get_item/delete_item/query paginator).
+  - Added SDK exception -> OperationResult mapping via integrations.aws.client.classify_aws_error.
+  - Preserved protocol/public surface and boundary behavior (including ConditionalCheckFailedException => success(data=False), serialization/deserialization, query auto-pagination).
+- app/integrations/aws/client.py
+  - Added additive APIs: get_aws_client(...) and classify_aws_error(...).
+  - get_aws_client applies region, standard retry config, connect/read timeouts, and dynamodb-local endpoint gate for ENVIRONMENT in {local,dev,ci}.
+  - classify_aws_error maps expected AWS/botocore families to (status,error_code,retry_after) and propagates unmapped exceptions.
+
+Tests updated for direct boto3 call shape:
+- app/tests/unit/infrastructure/storage/test_storage_service.py
+
+Validation evidence:
+- Focused task tests:
+  - cd app && uv run pytest tests/unit/infrastructure/storage tests/unit/integrations/aws/test_aws_client.py -q
+  - Result: 39 passed
+- Task matrix:
+  - cd app && uv run pytest tests/unit/infrastructure/storage tests/unit/integrations/aws -v
+  - Result: 127 passed
+- Modified-file lint/type checks:
+  - cd app && uv run ruff check tests/unit/infrastructure/storage/test_storage_service.py infrastructure/storage/service.py integrations/aws/client.py
+  - Result: passed
+  - cd app && uv run mypy --no-incremental infrastructure/storage/service.py integrations/aws/client.py
+  - Result: Success, no issues in changed modules
+
+Repo-wide quality gate status at run time:
+- cd app && uv run ruff check . => passed
+- cd app && uv run pytest tests --ignore=tests/smoke -q => existing unrelated failures in modules/webhooks/aws_sns tests (2 failing assertions)
+- cd app && uv run mypy . --exclude '(?:^|/)\\.venv(?:/|$)' => existing unrelated baseline errors across many modules plus mypy incremental-cache crash (KeyError: is_bound)
+
+DoD items left for human verification:
+- Confirm behavior-neutrality at StorageService Protocol boundary in code review.
+- Ensure PR description references decisions/layers.md, decisions/outbound-clients.md, decisions/sdk-typing.md.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
+++ b/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
@@ -3,10 +3,11 @@ id: TASK-22.2
 title: >-
   Migrate storage service off infrastructure/clients/aws DynamoDB onto
   integrations/aws/dynamodb_next
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-29 21:10'
-updated_date: '2026-07-31 16:58'
+updated_date: '2026-08-04 17:30'
 labels:
   - clients
   - phase-3


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors the DynamoDB-backed storage service to use a standardized, typed boto3 client interface from `integrations.aws.client.get_aws_client`, and centralizes error classification and retry logic. It also updates the service to handle raw boto3 responses and exceptions, and adapts the unit tests accordingly.

The most important changes are:

**Infrastructure and Client Refactor:**
* The storage service now uses `integrations.aws.client.get_aws_client` to obtain a typed boto3 DynamoDB client, instead of the previous custom client, and all direct boto3 interactions are routed through this standardized client. [[1]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L3-R39) [[2]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L58-R84) [[3]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L259-R302)
* Added a `DynamoDBClient` protocol to define the expected DynamoDB client interface, improving type safety and clarity.

**Error Handling and Classification:**
* Centralized AWS error handling with a new `classify_aws_error` function, which maps botocore and ClientError exceptions to operation statuses and error codes, and is now used throughout the storage service for consistent error normalization. [[1]](diffhunk://#diff-dea0ee50a2ee5acfbc0bae081b5062475d0b9098b7c2ed471635e1502aea1cfaR2-R128) [[2]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L58-R84) [[3]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L88-R109) [[4]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L122-R152) [[5]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L156-R187) [[6]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L188-R223) [[7]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L232-R282)

**Storage Service Logic:**
* All DynamoDB operations (`put`, `put_if_not_exists`, `delete`, `get`, `query`) now handle raw boto3 responses and exceptions, rather than returning or expecting `OperationResult` directly from the client. This decouples the storage service from custom client implementations and aligns with boto3's native interface. [[1]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L88-R109) [[2]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L122-R152) [[3]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L156-R187) [[4]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L188-R223) [[5]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L232-R282) [[6]](diffhunk://#diff-53b55f9b942539c9b5c07d5ac1a4a8e0f300814efa598f4ff5912b86c210c769L248-R291)

**Test Adaptation:**
* Unit tests for the storage service have been updated to mock and assert against raw boto3 responses and exceptions, rather than custom `OperationResult` objects, ensuring alignment with the new service logic. [[1]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL27-R27) [[2]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL37-R37) [[3]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL50-R50) [[4]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL60-R62) [[5]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL76-R77) [[6]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL85-R93) [[7]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL97-R103) [[8]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL106-R114) [[9]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL122-R129) [[10]](diffhunk://#diff-80c371a3d98b4ea2d6beb889cbfb789c2a8c8936a77d6e7f20aaaf3bf9f8756cL133-R140)

**AWS Client Construction:**
* Introduced a configurable `get_aws_client` factory that standardizes boto3 client creation, including support for retries, timeouts, endpoint overrides for local environments, and optional role assumption.

These changes collectively improve maintainability, testability, and reliability of the DynamoDB storage integration.