### PR TITLE
Feat/dynamodb storage moto

### DIFF
--- a/app/tests/integration/infrastructure/storage/conftest.py
+++ b/app/tests/integration/infrastructure/storage/conftest.py
@@ -1,0 +1,49 @@
+"""Fixtures for DynamoDBStorageService integration tests."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from infrastructure.storage.service import DynamoDBStorageService
+from integrations.aws import client as aws_client
+from integrations.aws.client import AWS_REGION
+
+STORAGE_TEST_TABLE_NAME = "test-sre-bot-storage-service"
+
+
+def _set_moto_aws_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set dummy AWS credentials so moto never touches real AWS."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setattr(aws_client.app_settings, "ENVIRONMENT", "test")
+
+
+def _create_storage_table(client: Any) -> None:
+    client.create_table(
+        TableName=STORAGE_TEST_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture
+def storage_service(monkeypatch: pytest.MonkeyPatch) -> Iterator[DynamoDBStorageService]:
+    moto = pytest.importorskip("moto")
+    boto3 = pytest.importorskip("boto3")
+    _set_moto_aws_credentials(monkeypatch)
+
+    with moto.mock_aws():
+        client = boto3.client("dynamodb", region_name=AWS_REGION)
+        _create_storage_table(client)
+        yield DynamoDBStorageService(dynamodb=client)

--- a/app/tests/integration/infrastructure/storage/test_storage_service_conformance.py
+++ b/app/tests/integration/infrastructure/storage/test_storage_service_conformance.py
@@ -1,0 +1,109 @@
+"""Moto-backed conformance suite for DynamoDBStorageService.
+
+Exercises real DynamoDB ConditionExpression and paginator semantics that
+MagicMock-based unit tests cannot verify.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from infrastructure.operations.status import OperationStatus
+from infrastructure.storage.service import DynamoDBStorageService
+
+from .conftest import STORAGE_TEST_TABLE_NAME
+
+TABLE = STORAGE_TEST_TABLE_NAME
+
+pytestmark = pytest.mark.integration
+
+
+class TestPutAndGet:
+    """put/get roundtrip including numeric and boolean field serialization."""
+
+    def test_put_get_roundtrip(self, storage_service: DynamoDBStorageService) -> None:
+        item = {"pk": "test-pk-1", "sk": "2026-01-01", "count": 42, "active": True}
+        put_result = storage_service.put(TABLE, item)
+        assert put_result.is_success
+
+        get_result = storage_service.get(TABLE, {"pk": "test-pk-1", "sk": "2026-01-01"})
+        assert get_result.is_success
+        data = get_result.data
+        assert data is not None
+        assert data["pk"] == "test-pk-1"
+        assert data["sk"] == "2026-01-01"
+        assert data["count"] == Decimal("42")
+        assert data["active"] is True
+
+    def test_get_missing_key_returns_not_found(self, storage_service: DynamoDBStorageService) -> None:
+        result = storage_service.get(TABLE, {"pk": "nonexistent", "sk": "nonexistent"})
+        assert not result.is_success
+        assert result.status == OperationStatus.NOT_FOUND
+
+
+class TestPutIfNotExists:
+    """real attribute_not_exists ConditionExpression rejects duplicates."""
+
+    def test_first_call_creates_item(self, storage_service: DynamoDBStorageService) -> None:
+        item = {"pk": "unique-pk", "sk": "sk-1", "value": "hello"}
+        result = storage_service.put_if_not_exists(TABLE, item, pk_attribute="pk")
+        assert result.is_success
+        assert result.data is True
+
+    def test_second_call_with_same_key_is_rejected(self, storage_service: DynamoDBStorageService) -> None:
+        # attribute_not_exists(pk) guards the exact (pk, sk) coordinate in a composite-key table.
+        item = {"pk": "duplicate-pk", "sk": "sk-1", "value": "first"}
+        storage_service.put_if_not_exists(TABLE, item, pk_attribute="pk")
+
+        duplicate = {"pk": "duplicate-pk", "sk": "sk-1", "value": "second"}
+        result = storage_service.put_if_not_exists(TABLE, duplicate, pk_attribute="pk")
+        assert result.is_success
+        assert result.data is False
+
+
+class TestDelete:
+    """delete removes the item; subsequent get returns NOT_FOUND."""
+
+    def test_delete_removes_item(self, storage_service: DynamoDBStorageService) -> None:
+        item = {"pk": "delete-pk", "sk": "sk-1", "value": "to-be-deleted"}
+        storage_service.put(TABLE, item)
+
+        delete_result = storage_service.delete(TABLE, {"pk": "delete-pk", "sk": "sk-1"})
+        assert delete_result.is_success
+
+        get_result = storage_service.get(TABLE, {"pk": "delete-pk", "sk": "sk-1"})
+        assert get_result.status == OperationStatus.NOT_FOUND
+
+
+class TestQuery:
+    """pagination via get_paginator aggregates items across page boundaries."""
+
+    def _put_items(self, storage_service: DynamoDBStorageService) -> None:
+        for i in range(1, 4):
+            storage_service.put(TABLE, {"pk": "query-pk", "sk": f"sk-{i}", "idx": i})
+
+    def test_query_returns_all_items(self, storage_service: DynamoDBStorageService) -> None:
+        self._put_items(storage_service)
+        result = storage_service.query(
+            TABLE,
+            key_condition="pk = :pk",
+            expression_values={":pk": "query-pk"},
+        )
+        assert result.is_success
+        assert result.data is not None
+        assert len(result.data) == 3
+        sk_values = {item["sk"] for item in result.data}
+        assert sk_values == {"sk-1", "sk-2", "sk-3"}
+
+    def test_query_with_limit_forces_pagination(self, storage_service: DynamoDBStorageService) -> None:
+        self._put_items(storage_service)
+        # Limit=1 forces the paginator to walk multiple pages; all items must still be returned.
+        result = storage_service.query(
+            TABLE,
+            key_condition="pk = :pk",
+            expression_values={":pk": "query-pk"},
+            Limit=1,
+        )
+        assert result.is_success
+        assert result.data is not None
+        assert len(result.data) == 3

--- a/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
+++ b/backlog/tasks/task-22.2 - Migrate-storage-service-off-infrastructure-clients-aws-DynamoDB-onto-integrations-aws-dynamodb_next.md
@@ -3,11 +3,11 @@ id: TASK-22.2
 title: >-
   Migrate storage service off infrastructure/clients/aws DynamoDB onto
   integrations/aws/dynamodb_next
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-29 21:10'
-updated_date: '2026-08-04 17:46'
+updated_date: '2026-08-04 19:25'
 labels:
   - clients
   - phase-3
@@ -45,7 +45,7 @@ Test migration: keep storage tests in tests/unit/infrastructure/storage/ (alread
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Behavior-neutral at the StorageService Protocol boundary: OperationResult outcomes identical; PR references decisions/layers.md, decisions/outbound-clients.md, and decisions/sdk-typing.md
+- [x] #1 Behavior-neutral at the StorageService Protocol boundary: OperationResult outcomes identical; PR references decisions/layers.md, decisions/outbound-clients.md, and decisions/sdk-typing.md
 <!-- DOD:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-22.3 - Migrate-access-sync-AWS-adapter-off-infrastructure-clients-aws-IdentityStore-onto-integrations-aws-identity_store_next.md
+++ b/backlog/tasks/task-22.3 - Migrate-access-sync-AWS-adapter-off-infrastructure-clients-aws-IdentityStore-onto-integrations-aws-identity_store_next.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-29 21:11'
-updated_date: '2026-07-31 17:05'
+updated_date: '2026-08-04 19:39'
 labels:
   - clients
   - phase-3
@@ -39,6 +39,7 @@ Test migration: relocate app/tests/integrations/aws/test_identity_store_next.py 
 - [ ] #1 packages/access/sync/providers.py and adapters/aws_identity_center.py no longer import infrastructure.clients.aws; the Path B adapter calls a typed boto3 identitystore client from get_aws_client("identitystore") directly and classifies via classify_aws_error - no AWSClients facade, no identity_store_next dependency, no wrapper class
 - [ ] #2 All access-sync adapter unit + integration tests pass behavior-neutral (same OperationResult status/error_code per method, including ResourceNotFoundException -> NOT_FOUND normalization), verified against the method-name mapping (get_user_id_by_username, describe_group, create/delete_group_membership, etc.)
 - [ ] #3 classify_aws_error (from TASK-22.2) is reused and extended with any identitystore-specific families, with coverage under tests/unit/integrations/aws/; identity_store_next is left untouched for TASK-23 to delete; any touched vendor test lands under tests/unit or tests/integration (legacy tests/integrations/ count does not grow)
+- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise the identitystore consumer's create_user/delete_user/get_user_id/describe_user/list_users/create_group_membership/delete_group_membership/list_group_memberships operations against real identitystore semantics via moto.mock_aws() (mirroring tests/integration/infrastructure/idempotency/conftest.py's fixture pattern), additive alongside existing MagicMock-based unit tests -- not a replacement
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
+updated_date: '2026-08-04 19:39'
 labels:
   - clients
   - phase-3
@@ -35,4 +36,5 @@ Slice 1 of TASK-25.2 (smallest, done first). Migrate integrations/aws/{config,co
 - [ ] #1 integrations/aws/config.py, cost_explorer.py, guard_duty.py, and security_hub.py no longer call execute_aws_api_call/handle_aws_api_errors; each routes through get_aws_client(<service>) + classify_aws_error, raising/classifying per the outbound-clients.md contract
 - [ ] #2 modules/aws/aws_account_health.py and modules/aws/spending.py are updated to handle the new raise+classify contract explicitly (no silent False-swallowing); resulting behavior on error paths is documented and human-reviewed, not assumed zero-diff
 - [ ] #3 classify_aws_error gains any Config/CostExplorer/GuardDuty/SecurityHub-specific mapped families with unit coverage under tests/unit/integrations/aws/
+- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise cost_explorer.py's get_cost_and_usage and security_hub.py's get_findings against real ce/securityhub semantics via moto.mock_aws(), additive alongside existing MagicMock-based unit tests -- EXCLUDES config.py (its sole call, describe_aggregate_compliance_by_config_rules, is unimplemented in moto per getmoto/moto IMPLEMENTATION_COVERAGE.md) and guard_duty.py's get_findings_statistics (also unimplemented in moto); guard_duty.py's list_detectors MAY be moto-covered but is not required by this AC since get_findings_statistics cannot be, so this task's guardduty/config paths keep MagicMock-only coverage
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.2 - Migrate-legacy-non-_next-DynamoDB-consumers-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.2 - Migrate-legacy-non-_next-DynamoDB-consumers-off-execute_aws_api_call.md
@@ -4,6 +4,7 @@ title: Migrate legacy (non-_next) DynamoDB consumers off execute_aws_api_call
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
+updated_date: '2026-08-04 19:39'
 labels:
   - clients
   - phase-3
@@ -30,4 +31,5 @@ Slice 2 of TASK-25.2. Migrate integrations/aws/dynamodb.py (a THIRD, older Dynam
 - [ ] #1 integrations/aws/dynamodb.py no longer calls execute_aws_api_call/handle_aws_api_errors; routes through the SAME get_aws_client("dynamodb")/classify_aws_error instance TASK-22.2 built for infrastructure/storage (not a new one)
 - [ ] #2 modules/incident/incident_folder.py, modules/incident/db_operations.py, and modules/slack/webhooks.py are updated to the raise+classify contract explicitly; resulting error-path behavior documented and human-reviewed
 - [ ] #3 integrations/aws/dynamodb.py's hardcoded dynamodb-local endpoint gate is removed in favor of the single shared gate from TASK-22.2 (no duplicate ENVIRONMENT-check copies remain)
+- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise integrations/aws/dynamodb.py's query/scan/put_item/get_item/update_item/delete_item against real DynamoDB semantics via moto.mock_aws() (reuse/extend the TASK-69 conformance fixture pattern for the same get_aws_client("dynamodb") primitive rather than building a second one), additive alongside existing MagicMock-based unit tests
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
+++ b/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
+updated_date: '2026-08-04 19:39'
 labels:
   - clients
   - phase-3
@@ -33,4 +34,5 @@ Slice 3 of TASK-25.2 (tiny). Migrate integrations/aws/lambdas.py off execute_aws
 - [ ] #1 integrations/aws/lambdas.py no longer calls execute_aws_api_call/handle_aws_api_errors; routes through get_aws_client("lambda") + classify_aws_error
 - [ ] #2 modules/aws/lambdas.py is updated to the raise+classify contract explicitly; resulting error-path behavior documented and human-reviewed (not zero-diff, per the silent-False-swallow caveat noted in sibling slices)
 - [ ] #3 integrations/aws/sqs.py is deleted
+- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise integrations/aws/lambdas.py's list_functions/list_layers/get_layer_version against real Lambda semantics via moto.mock_aws() (mirroring tests/integration/infrastructure/idempotency/conftest.py's fixture pattern), additive alongside existing MagicMock-based unit tests
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:49'
+updated_date: '2026-08-04 19:39'
 labels:
   - clients
   - phase-3
@@ -36,4 +37,5 @@ Slice 4 (largest, done last) of TASK-25.2. Migrate integrations/aws/{organizatio
 - [ ] #1 integrations/aws/organizations.py and sso_admin.py no longer call execute_aws_api_call/handle_aws_api_errors; identity_store.py is repointed onto TASK-22.3's existing get_aws_client("identitystore")/classify_aws_error instance (not a new one)
 - [ ] #2 All identified consumer files behave per the raise+classify contract explicitly (no silent False-swallowing); resulting error-path behavior documented and human-reviewed per file, not assumed zero-diff
 - [ ] #3 integrations/aws/client.py is deleted (zero remaining execute_aws_api_call/handle_aws_api_errors callers repo-wide, verified via grep)
+- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise organizations.py's list_accounts/describe_account/list_tags_for_resource, sso_admin.py's create_account_assignment/delete_account_assignment/list_account_assignments_for_principal/list_accounts_for_provisioned_permission_set, and identity_store.py's ops already covered by TASK-22.3's suite (excluding get_group_membership_id, which moto does not implement) against real semantics via moto.mock_aws(), additive alongside existing MagicMock-based unit tests
 <!-- AC:END -->

--- a/backlog/tasks/task-69 - Add-moto-backed-DynamoDBStorageService-conformance-suite.md
+++ b/backlog/tasks/task-69 - Add-moto-backed-DynamoDBStorageService-conformance-suite.md
@@ -4,6 +4,7 @@ title: Add moto-backed DynamoDBStorageService conformance suite
 status: To Do
 assignee: []
 created_date: '2026-07-31 16:28'
+updated_date: '2026-08-04 19:36'
 labels:
   - testing
   - clients
@@ -30,3 +31,40 @@ Add a moto-backed integration conformance suite for DynamoDBStorageService (put/
 - [ ] #2 Existing tests/unit/infrastructure/storage/ MagicMock-based unit tests are left unchanged (this task is additive only, not a replacement)
 - [ ] #3 Fixture pattern mirrors tests/integration/infrastructure/idempotency/conftest.py (pytest.importorskip guards, dummy AWS creds via monkeypatch, ENVIRONMENT=test to bypass the local/dev/ci dynamodb-local endpoint override)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+GROUNDING (re-verified 2026-08-04, post TASK-22.2 Done): infrastructure/storage/service.py no longer depends on infrastructure.clients.aws or dynamodb_next -- DynamoDBStorageService is backed directly by integrations.aws.client.get_aws_client("dynamodb") + classify_aws_error (service.py:19-23). Its 5 public methods are put (line ~93), put_if_not_exists (line ~120, uses a real ConditionExpression `attribute_not_exists(pk)`), delete (line ~168), get (line ~193), query (line ~224, uses client.get_paginator("query") and aggregates Items across pages). get_storage_service() (line ~296, @cache) is the DI provider -- out of scope; this suite constructs DynamoDBStorageService directly, same as the existing unit tests. moto[dynamodb]>=5.2.2 is already an app/pyproject.toml:168 dependency and confirmed importable (moto 5.2.2) in the app venv. Verified against getmoto/moto's IMPLEMENTATION_COVERAGE.md (fetched 2026-08-04): dynamodb is 68% implemented with put_item, get_item, delete_item, query, scan, ConditionExpression support and paginator support all present -- fully sufficient for this suite's 5 target methods.
+
+STEPS:
+1. Create app/tests/integration/infrastructure/storage/__init__.py (empty, mirrors tests/integration/infrastructure/idempotency/__init__.py).
+2. Create app/tests/integration/infrastructure/storage/conftest.py mirroring tests/integration/infrastructure/idempotency/conftest.py's dynamodb_idempotency_store fixture pattern exactly, adapted to the module storage actually depends on:
+   - pytest.importorskip("moto") / pytest.importorskip("boto3") guards.
+   - _set_moto_aws_credentials(monkeypatch): dummy AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SECURITY_TOKEN/AWS_SESSION_TOKEN/AWS_DEFAULT_REGION env vars via monkeypatch.setenv, plus monkeypatch.setattr(integrations.aws.client.app_settings, "ENVIRONMENT", "test") -- NOT client_next/dynamodb_next's app_settings, since storage.py imports get_aws_client from integrations.aws.client (verified service.py:19; ENVIRONMENT gate lives at integrations/aws/client.py:61-63).
+   - STORAGE_TEST_TABLE_NAME = "test-sre-bot-storage-service" with KeySchema pk (HASH, S) + sk (RANGE, S) -- a composite key so query's KeyConditionExpression/pagination behavior is exercised realistically (existing idempotency table only has a single hash key).
+   - Fixture `storage_service(monkeypatch)`: enters moto.mock_aws(), builds the real client via integrations.aws.client.get_aws_client("dynamodb"), creates the table, yields DynamoDBStorageService(dynamodb=client).
+3. Create app/tests/integration/infrastructure/storage/test_storage_service_conformance.py, pytest.mark.integration, covering all 5 methods against real DynamoDB semantics:
+   - put + get roundtrip (serialize/deserialize fidelity, including a numeric and boolean field).
+   - get on a missing key returns OperationStatus.NOT_FOUND (real empty-Item response, not a mocked return value).
+   - put_if_not_exists first call -> success(data=True); second call with the same pk -> success(data=False), proving the real `attribute_not_exists` ConditionExpression rejects the duplicate (this is the behavior a MagicMock cannot verify).
+   - delete removes the item; a subsequent get on the same key returns NOT_FOUND.
+   - query: put >=3 items sharing one pk with distinct sk values, query with KeyConditionExpression "pk = :pk", assert all items returned; repeat with Limit=1 to force multiple paginator pages and assert the paginated aggregation in query() (service.py's get_paginator("query") loop) still returns the full item set across page boundaries.
+4. Do not modify anything under app/tests/unit/infrastructure/storage/ (AC#2) -- run that suite unchanged before/after to confirm zero diff in behavior.
+
+AC-TO-STEP-TO-TEST TRACEABILITY:
+- AC#1 (new conformance suite, moto-backed, real client + table, exercises put/put_if_not_exists/get/query/delete against real ConditionExpression + pagination) -> Steps 2-3; every listed test method.
+- AC#2 (existing MagicMock unit tests unchanged, additive only) -> Step 4; verified via `uv run pytest tests/unit/infrastructure/storage -v` producing identical results pre/post, and via `git status` showing no modifications under tests/unit/infrastructure/storage/.
+- AC#3 (fixture mirrors idempotency conftest.py: importorskip guards, dummy creds, ENVIRONMENT=test bypass) -> Step 2.
+
+TEST MATRIX:
+- put success (roundtrip); put_if_not_exists create + duplicate-rejected (real ConditionExpression); get found + get NOT_FOUND; delete + post-delete get NOT_FOUND; query single-page; query multi-page aggregation via Limit-forced pagination.
+- Commands: `cd app && uv run pytest tests/integration/infrastructure/storage -v`, then `uv run pytest tests --ignore=tests/smoke`, then `uv run ruff check .` and `uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'`.
+
+ASSUMPTIONS / DOUBTS (verified):
+- Assumption: moto's dynamodb backend (68% implemented per getmoto/moto IMPLEMENTATION_COVERAGE.md) fully covers put_item/get_item/delete_item/query/scan + ConditionExpression + paginator -- confirmed by direct inspection of that coverage doc (fetched 2026-08-04); no gap for this suite's 5 methods.
+- Doubt resolved: which app_settings module to monkeypatch ENVIRONMENT on -- integrations.aws.client.app_settings (service.py's actual dependency post-TASK-22.2), not client_next/dynamodb_next (those are separate, unrelated consumers per TASK-22.2's own scope note).
+- Assumption: get_storage_service()'s @cache provider is out of scope; tests construct DynamoDBStorageService directly (matches existing unit-test convention, service.py's constructor stays injectable per TASK-22.2 AC#1).
+
+BLAST RADIUS / ROLLBACK: purely additive -- 3 new files under app/tests/integration/infrastructure/storage/ (__init__.py, conftest.py, test_storage_service_conformance.py); zero production code changes; zero changes to any existing test file. Single git revert of the new directory fully rolls this back. No decomposition needed -- well under the single-PR size gate (new-file-only test addition, ~150-200 LOC, one subsystem).
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-69 - Add-moto-backed-DynamoDBStorageService-conformance-suite.md
+++ b/backlog/tasks/task-69 - Add-moto-backed-DynamoDBStorageService-conformance-suite.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-69
 title: Add moto-backed DynamoDBStorageService conformance suite
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-31 16:28'
-updated_date: '2026-08-04 19:36'
+updated_date: '2026-08-04 19:57'
 labels:
   - testing
   - clients
@@ -27,9 +28,9 @@ Add a moto-backed integration conformance suite for DynamoDBStorageService (put/
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New tests/integration/infrastructure/storage/test_storage_service_conformance.py exists, moto-backed via moto.mock_aws() + a real boto3 dynamodb client + a real created table, exercising DynamoDBStorageService.put/put_if_not_exists/get/query/delete against real ConditionExpression and pagination semantics
-- [ ] #2 Existing tests/unit/infrastructure/storage/ MagicMock-based unit tests are left unchanged (this task is additive only, not a replacement)
-- [ ] #3 Fixture pattern mirrors tests/integration/infrastructure/idempotency/conftest.py (pytest.importorskip guards, dummy AWS creds via monkeypatch, ENVIRONMENT=test to bypass the local/dev/ci dynamodb-local endpoint override)
+- [x] #1 New tests/integration/infrastructure/storage/test_storage_service_conformance.py exists, moto-backed via moto.mock_aws() + a real boto3 dynamodb client + a real created table, exercising DynamoDBStorageService.put/put_if_not_exists/get/query/delete against real ConditionExpression and pagination semantics
+- [x] #2 Existing tests/unit/infrastructure/storage/ MagicMock-based unit tests are left unchanged (this task is additive only, not a replacement)
+- [x] #3 Fixture pattern mirrors tests/integration/infrastructure/idempotency/conftest.py (pytest.importorskip guards, dummy AWS creds via monkeypatch, ENVIRONMENT=test to bypass the local/dev/ci dynamodb-local endpoint override)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -68,3 +69,9 @@ ASSUMPTIONS / DOUBTS (verified):
 
 BLAST RADIUS / ROLLBACK: purely additive -- 3 new files under app/tests/integration/infrastructure/storage/ (__init__.py, conftest.py, test_storage_service_conformance.py); zero production code changes; zero changes to any existing test file. Single git revert of the new directory fully rolls this back. No decomposition needed -- well under the single-PR size gate (new-file-only test addition, ~150-200 LOC, one subsystem).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented additive moto-backed DynamoDBStorageService conformance integration suite under app/tests/integration/infrastructure/storage with no production-code changes. Added/verified: app/tests/integration/infrastructure/storage/__init__.py, app/tests/integration/infrastructure/storage/conftest.py, app/tests/integration/infrastructure/storage/test_storage_service_conformance.py. Coverage exercises put, put_if_not_exists (real attribute_not_exists behavior), get (found + NOT_FOUND), delete, and query including paginator aggregation with Limit=1. Fixture uses pytest.importorskip for moto/boto3, dummy AWS credential env vars via monkeypatch, and ENVIRONMENT=test override on integrations.aws.client.app_settings to bypass dynamodb-local endpoint override. Existing MagicMock unit suite under app/tests/unit/infrastructure/storage was left unchanged. Evidence: uv run pytest tests/integration/infrastructure/storage -v => 7 passed; uv run pytest tests/unit/infrastructure/storage -v => 29 passed; uv run ruff check . => passed; user-reported make test => all green. Task remains In Progress for human DoD verification/closure.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-70 - Adopt-types-boto3-SDK-stubs-and-wire-the-sdk-typing-guardrails.md
+++ b/backlog/tasks/task-70 - Adopt-types-boto3-SDK-stubs-and-wire-the-sdk-typing-guardrails.md
@@ -3,11 +3,11 @@ id: TASK-70
 title: >-
   Adopt types-boto3 and google-api-python-client-stubs SDK stubs; wire the
   sdk-typing guardrails
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-31 16:54'
-updated_date: '2026-08-04 16:10'
+updated_date: '2026-08-04 19:25'
 labels:
   - clients
   - phase-3


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a comprehensive moto-backed integration test suite for the `DynamoDBStorageService`, ensuring that its core behaviors are covered against real DynamoDB semantics rather than just mocks. It adds a reusable pytest fixture for moto-based DynamoDB setup and a set of conformance tests that exercise all major storage service operations, including round-trip serialization, conditional puts, deletes, and paginated queries.

The most important changes are:

**New moto-backed test infrastructure:**
* Added `app/tests/integration/infrastructure/storage/conftest.py` with a pytest fixture (`storage_service`) that provisions a moto-backed DynamoDB table and yields a real `DynamoDBStorageService` instance for integration tests.

**DynamoDBStorageService conformance suite:**
* Added `app/tests/integration/infrastructure/storage/test_storage_service_conformance.py` containing integration tests for `put`, `get`, `put_if_not_exists`, `delete`, and `query` methods, verifying correct behavior for serialization, conditional expressions, deletion, and pagination.

**Backlog/task tracking:**
* Marked TASK-69 ("Add moto-backed DynamoDBStorageService conformance suite") as "In Progress" and assigned it to yourself.
* Updated TASK-22.2 ("Migrate storage service off infrastructure/clients/aws DynamoDB onto integrations/aws/dynamodb_next") to "Done" and checked off its behavior-neutrality requirement. [[1]](diffhunk://#diff-64c12eaca7b79525731052d524cd19c550580a740e54fb792fa7a8b0c8c71875L6-R10) [[2]](diffhunk://#diff-64c12eaca7b79525731052d524cd19c550580a740e54fb792fa7a8b0c8c71875L48-R48)

These changes ensure that the storage service implementation is robustly validated against real DynamoDB semantics, providing a strong foundation for future migrations and refactors.