### PR TITLE
fix: case insensitive regex filter

### DIFF
--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -4,18 +4,14 @@ locals {
   error_namespace          = "SREBot"
   warning_logged           = "SREBotWarningLogged"
 
-  # Plain-text terms that indicate an error-worthy log line
-  error_logged_filters = [
-    "ERROR",
-    "Exception",
-  ]
-  # Regexes (CloudWatch %...% syntax, no literal quotes allowed) matched against the raw log
-  # line to exclude known false positives from the error metric. Extend to silence new ones.
-  error_logged_skip_filters = [
-    "level.{0,6}warning", # structlog JSON renders {"level": "warning", ...} with a space after the colon; \S excludes that space
-    "level.{0,6}info",    # same rationale, but for {"level": "info", ...}
-  ]
-  error_logged_pattern = "[(w=\"*${join("*\" || w=\"*", local.error_logged_filters)}*\") && ${join(" && ", [for term in local.error_logged_skip_filters : "w!=%${term}%"])}]"
+  # Case-insensitive regex for error-worthy log lines.
+  # CloudWatch metric filter matching for plain text terms is case-sensitive,
+  # so each letter is expanded with a character class.
+  error_logged_regex_filter = "[eE][rR][rR][oO][rR]|[eE][xX][cC][eE][pP][tT][iI][oO][nN]"
+  # Regex matched against the raw log line to exclude known false positives
+  # from the error metric. Extend to silence new ones.
+  error_logged_skip_regex_filter = "level.{0,6}warning|level.{0,6}info"
+  error_logged_pattern           = "[w=%${local.error_logged_regex_filter}% && w!=%${local.error_logged_skip_regex_filter}%]"
 
   # Plain-text terms that indicate a warning-level log line
   warning_logged_filters = [


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the way error log lines are detected and filtered in `terraform/local.tf`, switching from basic string matching to more robust case-insensitive regular expressions. This improves the accuracy and flexibility of error log detection in CloudWatch metric filters.

**Improvements to error log detection:**

* Replaced the plain-text `error_logged_filters` with a case-insensitive regex `error_logged_regex_filter` to better match variations of "ERROR" and "Exception" in log lines.
* Updated the exclusion logic to use a single regex `error_logged_skip_regex_filter`, simplifying the way known false positives (like warnings and info-level logs) are filtered out.
* Refactored `error_logged_pattern` to use the new regex-based filters, making the CloudWatch metric filter more accurate and maintainable.