### PR TITLE
Add CanadaLogin App, IC, and PSO rotations to slack sync package

### DIFF
--- a/app/packages/oncall_sync/rotations.json
+++ b/app/packages/oncall_sync/rotations.json
@@ -4,5 +4,23 @@
     "opsgenie_rotation_name": "OL-SRE-Rotation",
     "slack_handle": "cl-oncall-platform",
     "slack_name": "CanadaLogin OnCall - Platform"
+  },
+  {
+    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
+    "opsgenie_rotation_name": "OL-App-Rotation",
+    "slack_handle": "cl-oncall-app",
+    "slack_name": "CanadaLogin OnCall - App"
+  },
+  {
+    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
+    "opsgenie_rotation_name": "IC_rotation",
+    "slack_handle": "cl-oncall-ic",
+    "slack_name": "CanadaLogin OnCall - IC"
+  },
+  {
+    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
+    "opsgenie_rotation_name": "PSO_rotation",
+    "slack_handle": "cl-oncall-pso",
+    "slack_name": "CanadaLogin OnCall - PSO"
   }
 ]


### PR DESCRIPTION
# Summary | Résumé

This PR adds configuration necessary to sync the other three CanadaLogin on-call rotations with Slack user groups.

The three groups do not exist in Slack yet but should be automatically created on the first sync.

# Test instructions | Instructions pour tester la modification

This is a configuration change that is hard to test before shipping. I'll validate manually after this merges.
