### PR TITLE
Add instructions to help people get started with the slack on-call sync

### DIFF
--- a/app/packages/oncall_sync/README.md
+++ b/app/packages/oncall_sync/README.md
@@ -1,5 +1,19 @@
 # On-call Sync
 
+Sync OpsGenie on-call schedules to Slack UserGroups to make contacting on-call folks in Slack easier. This allows folks to use @foo-on-call in Slack instead of trying to figure out who's currently on-call.
+
+## How it works
+
+Synced rotations are defined in [rotations.json](./rotations.json).
+
+Every 5 minutes, SRE Bot will fetch the current on-call individual for each rotation and update the linked Slack UserGroup if necessary.
+
+## Getting started
+
+1. Figure out your OpsGenie schedule ID and rotation names. To find the schedule ID, navigate to OpsGenie, click "Who is on-call" at the top, click on your schedule, then grab the ID from the URL. The rotation names are copied directly from this schedule view.
+2. Update [rotations.json](./rotations.json). **The Slack UserGroup handle and name does not need to already exist. SRE Bot will create the group automatically**.
+3. Push up a PR, get it approved, and merge. Your group should be created and live within 10-15 minutes.
+
 ## Slack Service Identity
 
 - Identity: Dedicated Slack service account for on-call user-group synchronization, with workspace Admin or Owner privileges.


### PR DESCRIPTION
# Summary | Résumé

Just some quick instructions to help folks get started with syncing their OpsGenie rotations to Slack.

# Test instructions | Instructions pour tester la modification

N/A, its docs :)