### PR TITLE
Introduce schedule-level OpsGenie -> Slack UserGroup sync

### DIFF
--- a/app/packages/oncall_sync/README.md
+++ b/app/packages/oncall_sync/README.md
@@ -6,7 +6,7 @@ Sync OpsGenie on-call schedules to Slack UserGroups to make contacting on-call f
 
 Synced rotations are defined in [rotations.json](./rotations.json).
 
-Every 5 minutes, SRE Bot will fetch the current on-call individual for each rotation and update the linked Slack UserGroup if necessary.
+Every 5 minutes, SRE Bot will fetch the current on-call individual for each rotation and update the linked Slack UserGroup if necessary. SRE Bot will also update the schedule-level UserGroup to contain all folks on-call for the nested rotations.
 
 ## Getting started
 

--- a/app/packages/oncall_sync/__init__.py
+++ b/app/packages/oncall_sync/__init__.py
@@ -1,9 +1,11 @@
 """On-call sync feature package.
 
-Polls each configured on-call rotation every 5 minutes and updates the
-matching messaging user group so it mirrors the current on-call user.
-Missing user groups are created automatically. The job runs whenever at
-least one rotation is configured in ``rotations.json``.
+Polls each configured on-call schedule every 5 minutes and updates the
+matching messaging user groups so they mirror the current on-call users.
+For each schedule, each rotation gets its own single-user group, and the
+schedule itself gets an aggregate group containing all on-call users across
+its rotations. Missing user groups are created automatically. The job runs
+whenever at least one schedule is configured in ``rotations.json``.
 
 Business logic lives in ``service.py`` and is platform-neutral; concrete
 vendor adapters live under ``adapters/``. Swapping OpsGenie or Slack is a
@@ -15,7 +17,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from infrastructure.plugins import hookimpl
-from packages.oncall_sync.settings import get_oncall_rotations
+from packages.oncall_sync.settings import get_oncall_schedules
 
 SYNC_INTERVAL = timedelta(minutes=5)
 
@@ -31,7 +33,7 @@ def _run_oncall_sync() -> None:
 def register_background_jobs(registry) -> None:
     """Register the recurring on-call sync job."""
 
-    if not get_oncall_rotations():
+    if not get_oncall_schedules():
         return
 
     registry.register_interval(
@@ -45,17 +47,20 @@ def register_background_jobs(registry) -> None:
 def startup_warmup(logger) -> None:
     """Log effective configuration at startup."""
 
-    rotations = get_oncall_rotations()
+    schedules = get_oncall_schedules()
+    rotation_count = sum(len(s.rotations) for s in schedules)
     logger.info(
         "oncall_sync_settings_loaded",
         sync_interval_seconds=int(SYNC_INTERVAL.total_seconds()),
-        rotation_count=len(rotations),
+        schedule_count=len(schedules),
+        rotation_count=rotation_count,
     )
-    if not rotations:
+    if not schedules:
         logger.warning(
-            "oncall_sync_no_rotations",
+            "oncall_sync_no_schedules",
             hint="Add entries to packages/oncall_sync/rotations.json to activate.",
         )
+
 
 
 __all__ = ["register_background_jobs", "startup_warmup"]

--- a/app/packages/oncall_sync/__init__.py
+++ b/app/packages/oncall_sync/__init__.py
@@ -62,5 +62,4 @@ def startup_warmup(logger) -> None:
         )
 
 
-
 __all__ = ["register_background_jobs", "startup_warmup"]

--- a/app/packages/oncall_sync/adapters/slack.py
+++ b/app/packages/oncall_sync/adapters/slack.py
@@ -1,11 +1,9 @@
 """Slack adapter — implements ``UserGroupSyncTarget``.
 
 Resolves on-call user emails to Slack user IDs, finds (or creates) the
-matching user group, re-enables it if it was deleted, then updates membership:
-
-- Rotation groups are set to exactly one user (the current on-call person).
-- Schedule aggregate groups are set to all currently on-call users across the
-  schedule's rotations.
+matching user group, re-enables it if it was deleted, then sets its membership
+to exactly the provided users. Used for both single-user rotation groups and
+multi-user schedule aggregate groups.
 """
 
 from __future__ import annotations
@@ -17,7 +15,6 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from packages.oncall_sync.ports import OnCallSyncError
-from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
 
 logger = structlog.get_logger()
 
@@ -30,61 +27,33 @@ class SlackUserGroupTarget:
 
     def sync_user_group(
         self,
-        rotation: OnCallRotation,
-        on_call_email: str,
+        handle: str,
+        name: str,
+        description: str,
+        emails: Sequence[str],
     ) -> None:
-        """Set the rotation user group to the single on-call user."""
-        log = logger.bind(
-            slack_handle=rotation.slack_handle,
-            opsgenie_schedule_id=rotation.opsgenie_schedule_id,
-            opsgenie_rotation_name=rotation.opsgenie_rotation_name,
-        )
-
-        user_id = self._resolve_user_id(on_call_email, log)
-        if user_id is None:
-            # Email did not resolve to a Slack user (the on-call user's
-            # OpsGenie email differs from their Slack email). Already
-            # logged; skip this rotation rather than emptying the group.
-            return
-
-        try:
-            usergroup_id = self._find_or_create_usergroup(
-                rotation.slack_handle, rotation.slack_name, rotation.slack_description, log
-            )
-            self._client.usergroups_users_update(usergroup=usergroup_id, users=user_id)
-        except SlackApiError as exc:
-            raise OnCallSyncError(f"Slack API call failed: {exc.response.get('error')}") from exc
-
-        log.info("oncall_sync_usergroup_updated", usergroup_id=usergroup_id)
-
-    def sync_schedule_user_group(
-        self,
-        schedule: OnCallScheduleConfig,
-        on_call_emails: Sequence[str],
-    ) -> None:
-        """Set the schedule aggregate user group to all currently on-call users."""
-        log = logger.bind(slack_handle=schedule.slack_handle)
+        """Set the user group to contain exactly the resolved on-call users."""
+        log = logger.bind(slack_handle=handle)
 
         user_ids = [
             uid
-            for email in on_call_emails
+            for email in emails
             if (uid := self._resolve_user_id(email, log)) is not None
         ]
         if not user_ids:
-            log.info("oncall_sync_schedule_group_no_resolvable_users")
+            # No emails resolved to Slack users — skip rather than empty the group.
+            log.info("oncall_sync_usergroup_no_resolvable_users")
             return
 
         try:
-            usergroup_id = self._find_or_create_usergroup(
-                schedule.slack_handle, schedule.slack_name, schedule.slack_description, log
-            )
+            usergroup_id = self._find_or_create_usergroup(handle, name, description, log)
             self._client.usergroups_users_update(
                 usergroup=usergroup_id, users=",".join(user_ids)
             )
         except SlackApiError as exc:
             raise OnCallSyncError(f"Slack API call failed: {exc.response.get('error')}") from exc
 
-        log.info("oncall_sync_schedule_usergroup_updated", usergroup_id=usergroup_id)
+        log.info("oncall_sync_usergroup_updated", usergroup_id=usergroup_id)
 
     def _resolve_user_id(self, email: str, log) -> str | None:
         try:

--- a/app/packages/oncall_sync/adapters/slack.py
+++ b/app/packages/oncall_sync/adapters/slack.py
@@ -1,24 +1,29 @@
 """Slack adapter — implements ``UserGroupSyncTarget``.
 
-Resolves the on-call user's Slack user ID by email, finds (or creates) the
-user group identified by ``rotation.slack_handle``, re-enables it if it was
-deleted, then sets its membership to the single on-call user.
+Resolves on-call user emails to Slack user IDs, finds (or creates) the
+matching user group, re-enables it if it was deleted, then updates membership:
+
+- Rotation groups are set to exactly one user (the current on-call person).
+- Schedule aggregate groups are set to all currently on-call users across the
+  schedule's rotations.
 """
 
 from __future__ import annotations
+
+from collections.abc import Sequence
 
 import structlog
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from packages.oncall_sync.ports import OnCallSyncError
-from packages.oncall_sync.settings import OnCallRotation
+from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
 
 logger = structlog.get_logger()
 
 
 class SlackUserGroupTarget:
-    """Mirror the current on-call user into a Slack user group."""
+    """Mirror on-call membership into Slack user groups."""
 
     def __init__(self, client: WebClient) -> None:
         self._client = client
@@ -28,6 +33,7 @@ class SlackUserGroupTarget:
         rotation: OnCallRotation,
         on_call_email: str,
     ) -> None:
+        """Set the rotation user group to the single on-call user."""
         log = logger.bind(
             slack_handle=rotation.slack_handle,
             opsgenie_schedule_id=rotation.opsgenie_schedule_id,
@@ -42,12 +48,43 @@ class SlackUserGroupTarget:
             return
 
         try:
-            usergroup_id = self._find_or_create_usergroup(rotation, log)
+            usergroup_id = self._find_or_create_usergroup(
+                rotation.slack_handle, rotation.slack_name, rotation.slack_description, log
+            )
             self._client.usergroups_users_update(usergroup=usergroup_id, users=user_id)
         except SlackApiError as exc:
             raise OnCallSyncError(f"Slack API call failed: {exc.response.get('error')}") from exc
 
         log.info("oncall_sync_usergroup_updated", usergroup_id=usergroup_id)
+
+    def sync_schedule_user_group(
+        self,
+        schedule: OnCallScheduleConfig,
+        on_call_emails: Sequence[str],
+    ) -> None:
+        """Set the schedule aggregate user group to all currently on-call users."""
+        log = logger.bind(slack_handle=schedule.slack_handle)
+
+        user_ids = [
+            uid
+            for email in on_call_emails
+            if (uid := self._resolve_user_id(email, log)) is not None
+        ]
+        if not user_ids:
+            log.info("oncall_sync_schedule_group_no_resolvable_users")
+            return
+
+        try:
+            usergroup_id = self._find_or_create_usergroup(
+                schedule.slack_handle, schedule.slack_name, schedule.slack_description, log
+            )
+            self._client.usergroups_users_update(
+                usergroup=usergroup_id, users=",".join(user_ids)
+            )
+        except SlackApiError as exc:
+            raise OnCallSyncError(f"Slack API call failed: {exc.response.get('error')}") from exc
+
+        log.info("oncall_sync_schedule_usergroup_updated", usergroup_id=usergroup_id)
 
     def _resolve_user_id(self, email: str, log) -> str | None:
         try:
@@ -64,8 +101,10 @@ class SlackUserGroupTarget:
             return user_id
         return None
 
-    def _find_or_create_usergroup(self, rotation: OnCallRotation, log) -> str:
-        existing = self._lookup_usergroup(rotation.slack_handle)
+    def _find_or_create_usergroup(
+        self, handle: str, name: str, description: str, log
+    ) -> str:
+        existing = self._lookup_usergroup(handle)
         if existing is not None:
             group_id, is_disabled = existing
             if is_disabled:
@@ -73,9 +112,9 @@ class SlackUserGroupTarget:
             return group_id
 
         created = self._client.usergroups_create(
-            name=rotation.slack_name,
-            handle=rotation.slack_handle,
-            description=rotation.slack_description,
+            name=name,
+            handle=handle,
+            description=description,
         )
         usergroup_id: str = created["usergroup"]["id"]
         log.info("oncall_sync_usergroup_created", usergroup_id=usergroup_id)

--- a/app/packages/oncall_sync/adapters/slack.py
+++ b/app/packages/oncall_sync/adapters/slack.py
@@ -35,11 +35,7 @@ class SlackUserGroupTarget:
         """Set the user group to contain exactly the resolved on-call users."""
         log = logger.bind(slack_handle=handle)
 
-        user_ids = [
-            uid
-            for email in emails
-            if (uid := self._resolve_user_id(email, log)) is not None
-        ]
+        user_ids = [uid for email in emails if (uid := self._resolve_user_id(email, log)) is not None]
         if not user_ids:
             # No emails resolved to Slack users — skip rather than empty the group.
             log.info("oncall_sync_usergroup_no_resolvable_users")
@@ -47,9 +43,7 @@ class SlackUserGroupTarget:
 
         try:
             usergroup_id = self._find_or_create_usergroup(handle, name, description, log)
-            self._client.usergroups_users_update(
-                usergroup=usergroup_id, users=",".join(user_ids)
-            )
+            self._client.usergroups_users_update(usergroup=usergroup_id, users=",".join(user_ids))
         except SlackApiError as exc:
             raise OnCallSyncError(f"Slack API call failed: {exc.response.get('error')}") from exc
 
@@ -70,9 +64,7 @@ class SlackUserGroupTarget:
             return user_id
         return None
 
-    def _find_or_create_usergroup(
-        self, handle: str, name: str, description: str, log
-    ) -> str:
+    def _find_or_create_usergroup(self, handle: str, name: str, description: str, log) -> str:
         existing = self._lookup_usergroup(handle)
         if existing is not None:
             group_id, is_disabled = existing

--- a/app/packages/oncall_sync/ports.py
+++ b/app/packages/oncall_sync/ports.py
@@ -9,9 +9,10 @@ protocols and wiring it in the provider — no changes to ``service.py``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol
 
-from packages.oncall_sync.settings import OnCallRotation
+from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
 
 
 class OnCallScheduleProvider(Protocol):
@@ -28,18 +29,31 @@ class OnCallScheduleProvider(Protocol):
 
 
 class UserGroupSyncTarget(Protocol):
-    """Messaging-platform user group that should mirror the on-call user."""
+    """Messaging-platform user groups that should mirror on-call membership."""
 
     def sync_user_group(
         self,
         rotation: OnCallRotation,
         on_call_email: str,
     ) -> None:
-        """Ensure the configured user group contains exactly ``on_call_email``.
+        """Ensure the rotation user group contains exactly ``on_call_email``.
 
         Implementations should be idempotent. Raise ``OnCallSyncError`` to
         signal a transport/permission failure that should be reported but
         should not abort the remaining rotations.
+        """
+        ...
+
+    def sync_schedule_user_group(
+        self,
+        schedule: OnCallScheduleConfig,
+        on_call_emails: Sequence[str],
+    ) -> None:
+        """Ensure the schedule aggregate group contains all ``on_call_emails``.
+
+        Called once per schedule after all rotation groups have been
+        successfully synced. Implementations should be idempotent. Raise
+        ``OnCallSyncError`` to signal a transport/permission failure.
         """
         ...
 

--- a/app/packages/oncall_sync/ports.py
+++ b/app/packages/oncall_sync/ports.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Protocol
 
-from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
+from packages.oncall_sync.settings import OnCallRotation
 
 
 class OnCallScheduleProvider(Protocol):
@@ -29,31 +29,20 @@ class OnCallScheduleProvider(Protocol):
 
 
 class UserGroupSyncTarget(Protocol):
-    """Messaging-platform user groups that should mirror on-call membership."""
+    """Messaging-platform user group that should mirror on-call membership."""
 
     def sync_user_group(
         self,
-        rotation: OnCallRotation,
-        on_call_email: str,
+        handle: str,
+        name: str,
+        description: str,
+        emails: Sequence[str],
     ) -> None:
-        """Ensure the rotation user group contains exactly ``on_call_email``.
+        """Ensure the user group identified by ``handle`` contains exactly ``emails``.
 
         Implementations should be idempotent. Raise ``OnCallSyncError`` to
         signal a transport/permission failure that should be reported but
-        should not abort the remaining rotations.
-        """
-        ...
-
-    def sync_schedule_user_group(
-        self,
-        schedule: OnCallScheduleConfig,
-        on_call_emails: Sequence[str],
-    ) -> None:
-        """Ensure the schedule aggregate group contains all ``on_call_emails``.
-
-        Called once per schedule after all rotation groups have been
-        successfully synced. Implementations should be idempotent. Raise
-        ``OnCallSyncError`` to signal a transport/permission failure.
+        should not abort the remaining syncs.
         """
         ...
 

--- a/app/packages/oncall_sync/providers.py
+++ b/app/packages/oncall_sync/providers.py
@@ -20,7 +20,7 @@ from packages.oncall_sync.ports import (
     UserGroupSyncTarget,
 )
 from packages.oncall_sync.service import OnCallSyncService
-from packages.oncall_sync.settings import get_oncall_rotations
+from packages.oncall_sync.settings import get_oncall_schedules
 
 
 @lru_cache(maxsize=1)
@@ -44,5 +44,5 @@ def get_oncall_sync_service() -> OnCallSyncService:
     return OnCallSyncService(
         on_call=get_oncall_schedule_provider(),
         target=get_user_group_sync_target(),
-        rotations=get_oncall_rotations(),
+        schedules=get_oncall_schedules(),
     )

--- a/app/packages/oncall_sync/rotations.json
+++ b/app/packages/oncall_sync/rotations.json
@@ -1,26 +1,31 @@
-[
-  {
-    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
-    "opsgenie_rotation_name": "OL-SRE-Rotation",
-    "slack_handle": "cl-oncall-platform",
-    "slack_name": "CanadaLogin OnCall - Platform"
-  },
-  {
-    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
-    "opsgenie_rotation_name": "OL-App-Rotation",
-    "slack_handle": "cl-oncall-app",
-    "slack_name": "CanadaLogin OnCall - App"
-  },
-  {
-    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
-    "opsgenie_rotation_name": "IC_rotation",
-    "slack_handle": "cl-oncall-ic",
-    "slack_name": "CanadaLogin OnCall - IC"
-  },
-  {
-    "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
-    "opsgenie_rotation_name": "PSO_rotation",
-    "slack_handle": "cl-oncall-pso",
-    "slack_name": "CanadaLogin OnCall - PSO"
-  }
-]
+{
+  "schedules": [
+    {
+      "opsgenie_schedule_id": "657ce41a-2ff6-4d23-b2a2-53571995d710",
+      "slack_handle": "cl-oncall",
+      "slack_name": "CanadaLogin OnCall",
+      "rotations": [
+        {
+          "opsgenie_rotation_name": "OL-SRE-Rotation",
+          "slack_handle": "cl-oncall-platform",
+          "slack_name": "CanadaLogin OnCall - Platform"
+        },
+        {
+          "opsgenie_rotation_name": "OL-App-Rotation",
+          "slack_handle": "cl-oncall-app",
+          "slack_name": "CanadaLogin OnCall - App"
+        },
+        {
+          "opsgenie_rotation_name": "IC_rotation",
+          "slack_handle": "cl-oncall-ic",
+          "slack_name": "CanadaLogin OnCall - IC"
+        },
+        {
+          "opsgenie_rotation_name": "PSO_rotation",
+          "slack_handle": "cl-oncall-pso",
+          "slack_name": "CanadaLogin OnCall - PSO"
+        }
+      ]
+    }
+  ]
+}

--- a/app/packages/oncall_sync/service.py
+++ b/app/packages/oncall_sync/service.py
@@ -46,35 +46,38 @@ class OnCallSyncService:
             self._sync_schedule(schedule)
 
     def _sync_schedule(self, schedule: OnCallScheduleConfig) -> None:
+        log = logger.bind(slack_handle=schedule.slack_handle)
         on_call_emails: list[str] = []
         any_rotation_failed = False
 
         for rotation_config in schedule.rotations:
             rotation = _resolve_rotation(schedule, rotation_config)
-            email, failed = self._sync_rotation(rotation)
-            if failed:
+            try:
+                email = self._sync_rotation(rotation)
+            except OnCallSyncError:
                 any_rotation_failed = True
-            elif email is not None:
+                continue
+            if email is not None:
                 on_call_emails.append(email)
 
         if any_rotation_failed:
-            logger.error(
+            log.error(
                 "oncall_sync_schedule_group_skipped",
-                slack_handle=schedule.slack_handle,
                 reason="one_or_more_rotations_failed",
             )
             return
 
         if not on_call_emails:
-            logger.info(
-                "oncall_sync_schedule_group_empty",
-                slack_handle=schedule.slack_handle,
-            )
+            log.info("oncall_sync_schedule_group_empty")
             return
 
-        log = logger.bind(slack_handle=schedule.slack_handle)
         try:
-            self._target.sync_schedule_user_group(schedule, on_call_emails)
+            self._target.sync_user_group(
+                schedule.slack_handle,
+                schedule.slack_name,
+                schedule.slack_description,
+                on_call_emails,
+            )
         except OnCallSyncError as exc:
             cause = exc.__cause__
             log.error(
@@ -85,13 +88,12 @@ class OnCallSyncService:
             return
         log.info("oncall_sync_schedule_group_synced")
 
-    def _sync_rotation(self, rotation: OnCallRotation) -> tuple[str | None, bool]:
-        """Sync one rotation group.
+    def _sync_rotation(self, rotation: OnCallRotation) -> str | None:
+        """Sync one rotation's user group.
 
-        Returns ``(email, failed)`` where ``email`` is the on-call address
-        (or ``None`` if the rotation is empty) and ``failed`` is ``True``
-        when an ``OnCallSyncError`` was raised by either the provider or the
-        target.
+        Returns the on-call email on success, or ``None`` if the rotation has
+        no current participant. Raises ``OnCallSyncError`` (already logged) on
+        provider or target failure.
         """
         log = logger.bind(
             slack_handle=rotation.slack_handle,
@@ -107,14 +109,19 @@ class OnCallSyncService:
                 error=str(exc),
                 error_type=type(cause).__name__ if cause is not None else None,
             )
-            return None, True
+            raise
 
         if email is None:
             log.info("oncall_sync_rotation_empty")
-            return None, False
+            return None
 
         try:
-            self._target.sync_user_group(rotation, email)
+            self._target.sync_user_group(
+                rotation.slack_handle,
+                rotation.slack_name,
+                rotation.slack_description,
+                [email],
+            )
         except OnCallSyncError as exc:
             cause = exc.__cause__
             log.error(
@@ -122,10 +129,10 @@ class OnCallSyncService:
                 error=str(exc),
                 error_type=type(cause).__name__ if cause is not None else None,
             )
-            return None, True
+            raise
 
         log.info("oncall_sync_rotation_synced")
-        return email, False
+        return email
 
 
 def _resolve_rotation(

--- a/app/packages/oncall_sync/service.py
+++ b/app/packages/oncall_sync/service.py
@@ -1,9 +1,9 @@
 """Platform-neutral on-call sync orchestrator.
 
-Iterates the configured rotations, asks the on-call provider who is
-currently on call, and tells the user-group target to mirror that user.
-Per-rotation failures are isolated so one bad rotation does not block
-the others.
+Iterates the configured schedules. For each schedule, syncs each rotation's
+user group to its single on-call user, then syncs the schedule's aggregate
+user group to the union of all on-call users. If any rotation fails, the
+schedule group update is skipped and an error is logged.
 """
 
 from __future__ import annotations
@@ -17,31 +17,82 @@ from packages.oncall_sync.ports import (
     OnCallSyncError,
     UserGroupSyncTarget,
 )
-from packages.oncall_sync.settings import OnCallRotation
+from packages.oncall_sync.settings import (
+    OnCallRotation,
+    OnCallRotationConfig,
+    OnCallScheduleConfig,
+)
 
 logger = structlog.get_logger()
 
 
 class OnCallSyncService:
-    """Coordinates on-call -> user-group sync across all configured rotations."""
+    """Coordinates on-call -> user-group sync across all configured schedules."""
 
     def __init__(
         self,
         *,
         on_call: OnCallScheduleProvider,
         target: UserGroupSyncTarget,
-        rotations: Iterable[OnCallRotation],
+        schedules: Iterable[OnCallScheduleConfig],
     ) -> None:
         self._on_call = on_call
         self._target = target
-        self._rotations = list(rotations)
+        self._schedules = list(schedules)
 
     def sync_all(self) -> None:
-        """Sync every configured rotation; isolate per-rotation failures."""
-        for rotation in self._rotations:
-            self._sync_one(rotation)
+        """Sync every configured schedule; isolate per-schedule failures."""
+        for schedule in self._schedules:
+            self._sync_schedule(schedule)
 
-    def _sync_one(self, rotation: OnCallRotation) -> None:
+    def _sync_schedule(self, schedule: OnCallScheduleConfig) -> None:
+        on_call_emails: list[str] = []
+        any_rotation_failed = False
+
+        for rotation_config in schedule.rotations:
+            rotation = _resolve_rotation(schedule, rotation_config)
+            email, failed = self._sync_rotation(rotation)
+            if failed:
+                any_rotation_failed = True
+            elif email is not None:
+                on_call_emails.append(email)
+
+        if any_rotation_failed:
+            logger.error(
+                "oncall_sync_schedule_group_skipped",
+                slack_handle=schedule.slack_handle,
+                reason="one_or_more_rotations_failed",
+            )
+            return
+
+        if not on_call_emails:
+            logger.info(
+                "oncall_sync_schedule_group_empty",
+                slack_handle=schedule.slack_handle,
+            )
+            return
+
+        log = logger.bind(slack_handle=schedule.slack_handle)
+        try:
+            self._target.sync_schedule_user_group(schedule, on_call_emails)
+        except OnCallSyncError as exc:
+            cause = exc.__cause__
+            log.error(
+                "oncall_sync_schedule_group_failed",
+                error=str(exc),
+                error_type=type(cause).__name__ if cause is not None else None,
+            )
+            return
+        log.info("oncall_sync_schedule_group_synced")
+
+    def _sync_rotation(self, rotation: OnCallRotation) -> tuple[str | None, bool]:
+        """Sync one rotation group.
+
+        Returns ``(email, failed)`` where ``email`` is the on-call address
+        (or ``None`` if the rotation is empty) and ``failed`` is ``True``
+        when an ``OnCallSyncError`` was raised by either the provider or the
+        target.
+        """
         log = logger.bind(
             slack_handle=rotation.slack_handle,
             opsgenie_schedule_id=rotation.opsgenie_schedule_id,
@@ -49,9 +100,20 @@ class OnCallSyncService:
         )
         try:
             email = self._on_call.get_current_on_call_email(rotation)
-            if email is None:
-                log.info("oncall_sync_rotation_empty")
-                return
+        except OnCallSyncError as exc:
+            cause = exc.__cause__
+            log.error(
+                "oncall_sync_rotation_failed",
+                error=str(exc),
+                error_type=type(cause).__name__ if cause is not None else None,
+            )
+            return None, True
+
+        if email is None:
+            log.info("oncall_sync_rotation_empty")
+            return None, False
+
+        try:
             self._target.sync_user_group(rotation, email)
         except OnCallSyncError as exc:
             cause = exc.__cause__
@@ -60,5 +122,21 @@ class OnCallSyncService:
                 error=str(exc),
                 error_type=type(cause).__name__ if cause is not None else None,
             )
-            return
+            return None, True
+
         log.info("oncall_sync_rotation_synced")
+        return email, False
+
+
+def _resolve_rotation(
+    schedule: OnCallScheduleConfig,
+    rotation: OnCallRotationConfig,
+) -> OnCallRotation:
+    """Produce the flat adapter type by copying the schedule ID onto the rotation."""
+    return OnCallRotation(
+        opsgenie_schedule_id=schedule.opsgenie_schedule_id,
+        opsgenie_rotation_name=rotation.opsgenie_rotation_name,
+        slack_handle=rotation.slack_handle,
+        slack_name=rotation.slack_name,
+        slack_description=rotation.slack_description,
+    )

--- a/app/packages/oncall_sync/settings.py
+++ b/app/packages/oncall_sync/settings.py
@@ -1,10 +1,14 @@
 """On-call sync feature settings — colocated with the consuming package.
 
-``OnCallRotation`` and the rotation loader define the declarative mappings
-between an on-call rotation (today: OpsGenie) and a messaging-platform user
-group (today: Slack). Rotations are loaded from the packaged
-``rotations.json`` resource via ``importlib.resources``, so the lookup is
-not coupled to the filesystem layout of the repo.
+``OnCallScheduleConfig`` and ``OnCallRotationConfig`` define the declarative
+mappings between OpsGenie schedules/rotations and Slack user groups. Schedules
+are loaded from the packaged ``rotations.json`` resource via
+``importlib.resources``, so the lookup is not coupled to the filesystem layout
+of the repo.
+
+Each schedule maps to one Slack aggregate user group (containing all currently
+on-call users across its rotations) plus one Slack user group per rotation
+(containing exactly the one on-call user for that rotation).
 """
 
 from __future__ import annotations
@@ -13,17 +17,68 @@ import json
 from functools import lru_cache
 from importlib.resources import files
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, model_validator
 
 ROTATIONS_RESOURCE = "rotations.json"
 
 
-class OnCallRotation(BaseModel):
-    """One on-call rotation mapped to one messaging-platform user group.
+class OnCallRotationConfig(BaseModel):
+    """One rotation within an OpsGenie schedule, mapped to a Slack user group.
 
-    Field names are vendor-prefixed so additional providers (e.g. JSM for
-    on-call, MS Teams for messaging) can be added later by introducing
-    optional sibling fields without breaking existing rotations.
+    The parent schedule's ``opsgenie_schedule_id`` is resolved at runtime by
+    the service when constructing the flat ``OnCallRotation`` passed to adapters.
+    """
+
+    opsgenie_rotation_name: str
+    slack_handle: str
+    slack_name: str
+    slack_description: str = "Auto-synced from OpsGenie"
+
+
+class OnCallScheduleConfig(BaseModel):
+    """An OpsGenie schedule with its child rotations and a Slack aggregate group.
+
+    The ``slack_handle`` / ``slack_name`` fields describe the schedule-level
+    aggregate Slack user group, which mirrors all currently on-call users
+    across every rotation in this schedule.
+    """
+
+    opsgenie_schedule_id: str
+    slack_handle: str
+    slack_name: str
+    slack_description: str = "Auto-synced from OpsGenie"
+    rotations: list[OnCallRotationConfig] = Field(default_factory=list)
+
+
+class OnCallSchedules(BaseModel):
+    """Validated container for the loaded schedules."""
+
+    schedules: list[OnCallScheduleConfig] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_unique_handles(self) -> OnCallSchedules:
+        handles: list[str] = []
+        for schedule in self.schedules:
+            handles.append(schedule.slack_handle)
+            handles.extend(r.slack_handle for r in schedule.rotations)
+        duplicates = {h for h in handles if handles.count(h) > 1}
+        if duplicates:
+            raise ValueError(f"rotations.json contains duplicate slack_handle values: {sorted(duplicates)}")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Flat rotation type — passed to ports and adapters
+# ---------------------------------------------------------------------------
+
+
+class OnCallRotation(BaseModel):
+    """Runtime-resolved rotation with its parent schedule ID baked in.
+
+    Constructed by the service from ``OnCallScheduleConfig`` +
+    ``OnCallRotationConfig``; passed to the ``OnCallScheduleProvider`` and
+    ``UserGroupSyncTarget`` adapters. Field names are vendor-prefixed so
+    additional providers can be added later without breaking existing rotations.
     """
 
     opsgenie_schedule_id: str
@@ -33,22 +88,7 @@ class OnCallRotation(BaseModel):
     slack_description: str = "Auto-synced from OpsGenie"
 
 
-class OnCallRotations(BaseModel):
-    """Validated container for the loaded rotations list."""
-
-    rotations: list[OnCallRotation] = Field(default_factory=list)
-
-    @field_validator("rotations", mode="after")
-    @classmethod
-    def _validate_unique_handles(cls, v: list[OnCallRotation]) -> list[OnCallRotation]:
-        handles = [r.slack_handle for r in v]
-        duplicates = {h for h in handles if handles.count(h) > 1}
-        if duplicates:
-            raise ValueError(f"rotations.json contains duplicate slack_handle values: {sorted(duplicates)}")
-        return v
-
-
-def load_rotations() -> list[OnCallRotation]:
+def load_schedules() -> list[OnCallScheduleConfig]:
     """Load and validate the packaged rotations resource.
 
     Returns an empty list if the resource is missing (feature inactive).
@@ -61,12 +101,12 @@ def load_rotations() -> list[OnCallRotation]:
         data = json.loads(resource.read_text())
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid JSON in {ROTATIONS_RESOURCE}: {exc}") from exc
-    if not isinstance(data, list):
-        raise ValueError(f"{ROTATIONS_RESOURCE} must contain a JSON list at the top level")
-    return OnCallRotations(rotations=data).rotations
+    if not isinstance(data, dict) or "schedules" not in data:
+        raise ValueError(f"{ROTATIONS_RESOURCE} must contain a JSON object with a 'schedules' key")
+    return OnCallSchedules(schedules=data["schedules"]).schedules
 
 
 @lru_cache(maxsize=1)
-def get_oncall_rotations() -> list[OnCallRotation]:
-    """Singleton provider for the loaded rotation mappings."""
-    return load_rotations()
+def get_oncall_schedules() -> list[OnCallScheduleConfig]:
+    """Singleton provider for the loaded schedule configurations."""
+    return load_schedules()

--- a/app/packages/oncall_sync/settings.py
+++ b/app/packages/oncall_sync/settings.py
@@ -1,13 +1,13 @@
 """On-call sync feature settings — colocated with the consuming package.
 
 ``OnCallScheduleConfig`` and ``OnCallRotationConfig`` define the declarative
-mappings between OpsGenie schedules/rotations and Slack user groups. Schedules
-are loaded from the packaged ``rotations.json`` resource via
-``importlib.resources``, so the lookup is not coupled to the filesystem layout
-of the repo.
+mappings between on-call schedules/rotations (today: OpsGenie) and
+messaging-platform user groups (today: Slack). Schedules are loaded from the
+packaged ``rotations.json`` resource via ``importlib.resources``, so the lookup
+is not coupled to the filesystem layout of the repo.
 
-Each schedule maps to one Slack aggregate user group (containing all currently
-on-call users across its rotations) plus one Slack user group per rotation
+Each schedule maps to one aggregate user group (containing all currently
+on-call users across its rotations) plus one user group per rotation
 (containing exactly the one on-call user for that rotation).
 """
 
@@ -23,7 +23,7 @@ ROTATIONS_RESOURCE = "rotations.json"
 
 
 class OnCallRotationConfig(BaseModel):
-    """One rotation within an OpsGenie schedule, mapped to a Slack user group.
+    """One on-call rotation within a schedule, mapped to a messaging-platform user group.
 
     The parent schedule's ``opsgenie_schedule_id`` is resolved at runtime by
     the service when constructing the flat ``OnCallRotation`` passed to adapters.
@@ -36,11 +36,11 @@ class OnCallRotationConfig(BaseModel):
 
 
 class OnCallScheduleConfig(BaseModel):
-    """An OpsGenie schedule with its child rotations and a Slack aggregate group.
+    """An on-call schedule with its child rotations and an aggregate user group.
 
-    The ``slack_handle`` / ``slack_name`` fields describe the schedule-level
-    aggregate Slack user group, which mirrors all currently on-call users
-    across every rotation in this schedule.
+    The ``slack_handle`` / ``slack_name`` fields (vendor-prefixed) describe the
+    schedule-level aggregate user group, which mirrors all currently on-call
+    users across every rotation in this schedule.
     """
 
     opsgenie_schedule_id: str

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_package_init.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_package_init.py
@@ -31,9 +31,9 @@ class _Logger:
 
 
 @pytest.mark.unit
-def test_register_background_jobs_with_rotations(monkeypatch) -> None:
+def test_register_background_jobs_with_schedules(monkeypatch) -> None:
     pkg = _reload_pkg()
-    monkeypatch.setattr(pkg, "get_oncall_rotations", lambda: [object()])
+    monkeypatch.setattr(pkg, "get_oncall_schedules", lambda: [object()])
 
     registry = _Registry()
     pkg.register_background_jobs(registry=registry)
@@ -45,9 +45,9 @@ def test_register_background_jobs_with_rotations(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_register_background_jobs_noop_when_no_rotations(monkeypatch) -> None:
+def test_register_background_jobs_noop_when_no_schedules(monkeypatch) -> None:
     pkg = _reload_pkg()
-    monkeypatch.setattr(pkg, "get_oncall_rotations", lambda: [])
+    monkeypatch.setattr(pkg, "get_oncall_schedules", lambda: [])
 
     registry = _Registry()
     pkg.register_background_jobs(registry=registry)
@@ -56,24 +56,29 @@ def test_register_background_jobs_noop_when_no_rotations(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_startup_warmup_logs_rotation_count(monkeypatch) -> None:
+def test_startup_warmup_logs_schedule_and_rotation_counts(monkeypatch) -> None:
     pkg = _reload_pkg()
-    monkeypatch.setattr(pkg, "get_oncall_rotations", lambda: [object(), object()])
+
+    class _FakeSchedule:
+        rotations = [object(), object()]
+
+    monkeypatch.setattr(pkg, "get_oncall_schedules", lambda: [_FakeSchedule(), _FakeSchedule()])
 
     logger = _Logger()
     pkg.startup_warmup(logger=logger)
 
     loaded = next(evt for lvl, evt in logger.events if evt["event"] == "oncall_sync_settings_loaded")
-    assert loaded["rotation_count"] == 2
+    assert loaded["schedule_count"] == 2
+    assert loaded["rotation_count"] == 4
     assert loaded["sync_interval_seconds"] == 300
 
 
 @pytest.mark.unit
-def test_startup_warmup_warns_when_no_rotations(monkeypatch) -> None:
+def test_startup_warmup_warns_when_no_schedules(monkeypatch) -> None:
     pkg = _reload_pkg()
-    monkeypatch.setattr(pkg, "get_oncall_rotations", lambda: [])
+    monkeypatch.setattr(pkg, "get_oncall_schedules", lambda: [])
 
     logger = _Logger()
     pkg.startup_warmup(logger=logger)
 
-    assert any(lvl == "warning" and evt["event"] == "oncall_sync_no_rotations" for lvl, evt in logger.events)
+    assert any(lvl == "warning" and evt["event"] == "oncall_sync_no_schedules" for lvl, evt in logger.events)

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_providers.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_providers.py
@@ -10,7 +10,6 @@ import pytest
 
 from packages.oncall_sync import providers
 from packages.oncall_sync.adapters.slack import SlackUserGroupTarget
-from packages.oncall_sync.settings import OnCallRotation
 
 pytestmark = pytest.mark.unit
 
@@ -20,16 +19,6 @@ def _provider_cache_isolation() -> Iterator[None]:
     providers.get_user_group_sync_target.cache_clear()
     yield
     providers.get_user_group_sync_target.cache_clear()
-
-
-def _rotation() -> OnCallRotation:
-    return OnCallRotation(
-        opsgenie_schedule_id="abc",
-        opsgenie_rotation_name="rot",
-        slack_handle="oncall-x",
-        slack_name="On-call X",
-        slack_description="desc",
-    )
 
 
 def test_get_user_group_sync_target_builds_client_with_user_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -54,7 +43,7 @@ def test_usergroup_write_is_issued_via_user_scoped_client(monkeypatch: pytest.Mo
     web_client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
     web_client.usergroups_list.return_value = {"usergroups": [{"id": "S123", "handle": "oncall-x", "date_delete": 0}]}
 
-    target.sync_user_group(_rotation(), "a@x.ca")
+    target.sync_user_group("oncall-x", "On-call X", "desc", ["a@x.ca"])
 
     web_client.usergroups_users_update.assert_called_once_with(usergroup="S123", users="U1")
     assert target._client.token == "xoxp-user-token"

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
@@ -57,9 +57,7 @@ class _FakeTarget:
         self._raise_for = raise_for or set()
         self.calls: list[tuple[str, list[str]]] = []  # (handle, emails)
 
-    def sync_user_group(
-        self, handle: str, name: str, description: str, emails: Sequence[str]
-    ) -> None:
+    def sync_user_group(self, handle: str, name: str, description: str, emails: Sequence[str]) -> None:
         if handle in self._raise_for:
             raise OnCallSyncError("target failed")
         self.calls.append((handle, list(emails)))

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
@@ -55,20 +55,14 @@ class _FakeOnCall:
 class _FakeTarget:
     def __init__(self, *, raise_for: set[str] | None = None) -> None:
         self._raise_for = raise_for or set()
-        self.rotation_calls: list[tuple[OnCallRotation, str]] = []
-        self.schedule_calls: list[tuple[OnCallScheduleConfig, list[str]]] = []
+        self.calls: list[tuple[str, list[str]]] = []  # (handle, emails)
 
-    def sync_user_group(self, rotation: OnCallRotation, on_call_email: str) -> None:
-        if rotation.slack_handle in self._raise_for:
-            raise OnCallSyncError("target failed")
-        self.rotation_calls.append((rotation, on_call_email))
-
-    def sync_schedule_user_group(
-        self, schedule: OnCallScheduleConfig, on_call_emails: Sequence[str]
+    def sync_user_group(
+        self, handle: str, name: str, description: str, emails: Sequence[str]
     ) -> None:
-        if schedule.slack_handle in self._raise_for:
-            raise OnCallSyncError("schedule target failed")
-        self.schedule_calls.append((schedule, list(on_call_emails)))
+        if handle in self._raise_for:
+            raise OnCallSyncError("target failed")
+        self.calls.append((handle, list(emails)))
 
 
 @pytest.mark.unit
@@ -79,11 +73,9 @@ def test_sync_all_updates_rotation_and_schedule_groups() -> None:
 
     OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    assert [c[0].slack_handle for c in target.rotation_calls] == ["a", "b"]
-    assert [c[1] for c in target.rotation_calls] == ["alice@x.ca", "bob@x.ca"]
-    assert len(target.schedule_calls) == 1
-    assert target.schedule_calls[0][0].slack_handle == "oncall"
-    assert sorted(target.schedule_calls[0][1]) == ["alice@x.ca", "bob@x.ca"]
+    # Rotation groups: single email each; schedule group: union of both
+    assert target.calls[:2] == [("a", ["alice@x.ca"]), ("b", ["bob@x.ca"])]
+    assert target.calls[2] == ("oncall", ["alice@x.ca", "bob@x.ca"])
 
 
 @pytest.mark.unit
@@ -95,8 +87,7 @@ def test_sync_all_skips_empty_rotation_in_schedule_group() -> None:
     OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
     # Rotation b has no on-call user; schedule group gets only alice
-    assert len(target.schedule_calls) == 1
-    assert target.schedule_calls[0][1] == ["alice@x.ca"]
+    assert target.calls == [("a", ["alice@x.ca"]), ("oncall", ["alice@x.ca"])]
 
 
 @pytest.mark.unit
@@ -108,8 +99,8 @@ def test_sync_all_skips_schedule_group_when_rotation_fails() -> None:
     OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
     # b still gets its rotation group synced; schedule group is skipped
-    assert [c[0].slack_handle for c in target.rotation_calls] == ["b"]
-    assert target.schedule_calls == []
+    assert [h for h, _ in target.calls] == ["b"]
+    assert not any(h == "oncall" for h, _ in target.calls)
 
 
 @pytest.mark.unit
@@ -121,7 +112,7 @@ def test_sync_all_skips_schedule_group_when_rotation_target_fails() -> None:
     OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
     # a fails in target; schedule group is skipped
-    assert target.schedule_calls == []
+    assert not any(h == "oncall" for h, _ in target.calls)
 
 
 @pytest.mark.unit
@@ -132,8 +123,7 @@ def test_sync_all_skips_schedule_group_when_all_rotations_empty() -> None:
 
     OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    assert target.rotation_calls == []
-    assert target.schedule_calls == []
+    assert target.calls == []
 
 
 @pytest.mark.unit
@@ -154,8 +144,7 @@ def test_sync_all_noop_when_no_schedules() -> None:
     OnCallSyncService(on_call=on_call, target=target, schedules=[]).sync_all()
 
     assert on_call.calls == []
-    assert target.rotation_calls == []
-    assert target.schedule_calls == []
+    assert target.calls == []
 
 
 @pytest.mark.unit
@@ -182,6 +171,5 @@ def test_multiple_schedules_are_each_synced() -> None:
 
     OnCallSyncService(on_call=on_call, target=target, schedules=schedules).sync_all()
 
-    assert len(target.schedule_calls) == 2
-    schedule_handles = {c[0].slack_handle for c in target.schedule_calls}
-    assert schedule_handles == {"oncall-1", "oncall-2"}
+    # Each schedule has one rotation + one schedule group = 2 calls each, 4 total
+    assert {h for h, _ in target.calls} == {"a", "b", "oncall-1", "oncall-2"}

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_service.py
@@ -1,20 +1,36 @@
 """Unit tests for the platform-neutral ``OnCallSyncService`` orchestrator."""
 
-from typing import Any
+from collections.abc import Sequence
 
 import pytest
 
 from packages.oncall_sync.ports import OnCallSyncError
 from packages.oncall_sync.service import OnCallSyncService
-from packages.oncall_sync.settings import OnCallRotation
+from packages.oncall_sync.settings import (
+    OnCallRotation,
+    OnCallRotationConfig,
+    OnCallScheduleConfig,
+)
 
 
-def _rotation(handle: str = "oncall-x") -> OnCallRotation:
-    return OnCallRotation(
-        opsgenie_schedule_id="abc",
-        opsgenie_rotation_name="rot",
+def _rotation_config(handle: str = "oncall-x", name: str = "rot") -> OnCallRotationConfig:
+    return OnCallRotationConfig(
+        opsgenie_rotation_name=name,
         slack_handle=handle,
-        slack_name="On-call X",
+        slack_name=f"On-call {handle}",
+    )
+
+
+def _schedule(
+    handle: str = "oncall",
+    rotation_handles: list[str] | None = None,
+) -> OnCallScheduleConfig:
+    rotations = [_rotation_config(h) for h in (rotation_handles or ["oncall-x"])]
+    return OnCallScheduleConfig(
+        opsgenie_schedule_id="abc",
+        slack_handle=handle,
+        slack_name="On-call",
+        rotations=rotations,
     )
 
 
@@ -39,83 +55,133 @@ class _FakeOnCall:
 class _FakeTarget:
     def __init__(self, *, raise_for: set[str] | None = None) -> None:
         self._raise_for = raise_for or set()
-        self.calls: list[tuple[OnCallRotation, str]] = []
+        self.rotation_calls: list[tuple[OnCallRotation, str]] = []
+        self.schedule_calls: list[tuple[OnCallScheduleConfig, list[str]]] = []
 
     def sync_user_group(self, rotation: OnCallRotation, on_call_email: str) -> None:
         if rotation.slack_handle in self._raise_for:
             raise OnCallSyncError("target failed")
-        self.calls.append((rotation, on_call_email))
+        self.rotation_calls.append((rotation, on_call_email))
+
+    def sync_schedule_user_group(
+        self, schedule: OnCallScheduleConfig, on_call_emails: Sequence[str]
+    ) -> None:
+        if schedule.slack_handle in self._raise_for:
+            raise OnCallSyncError("schedule target failed")
+        self.schedule_calls.append((schedule, list(on_call_emails)))
 
 
 @pytest.mark.unit
-def test_sync_all_updates_target_for_each_rotation_with_on_call() -> None:
-    rotations = [_rotation("a"), _rotation("b")]
+def test_sync_all_updates_rotation_and_schedule_groups() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a", "b"])
     on_call = _FakeOnCall(emails={"a": "alice@x.ca", "b": "bob@x.ca"})
     target = _FakeTarget()
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=rotations).sync_all()
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    assert [c[0].slack_handle for c in target.calls] == ["a", "b"]
-    assert [c[1] for c in target.calls] == ["alice@x.ca", "bob@x.ca"]
+    assert [c[0].slack_handle for c in target.rotation_calls] == ["a", "b"]
+    assert [c[1] for c in target.rotation_calls] == ["alice@x.ca", "bob@x.ca"]
+    assert len(target.schedule_calls) == 1
+    assert target.schedule_calls[0][0].slack_handle == "oncall"
+    assert sorted(target.schedule_calls[0][1]) == ["alice@x.ca", "bob@x.ca"]
 
 
 @pytest.mark.unit
-def test_sync_all_skips_target_when_rotation_has_no_on_call() -> None:
-    on_call = _FakeOnCall(emails={"a": None})
+def test_sync_all_skips_empty_rotation_in_schedule_group() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a", "b"])
+    on_call = _FakeOnCall(emails={"a": "alice@x.ca", "b": None})
     target = _FakeTarget()
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=[_rotation("a")]).sync_all()
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    assert target.calls == []
+    # Rotation b has no on-call user; schedule group gets only alice
+    assert len(target.schedule_calls) == 1
+    assert target.schedule_calls[0][1] == ["alice@x.ca"]
 
 
 @pytest.mark.unit
-def test_sync_all_isolates_failure_in_one_rotation() -> None:
-    rotations = [_rotation("a"), _rotation("b")]
-    on_call = _FakeOnCall(
-        emails={"a": "alice@x.ca", "b": "bob@x.ca"},
-        raise_for={"a"},
-    )
+def test_sync_all_skips_schedule_group_when_rotation_fails() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a", "b"])
+    on_call = _FakeOnCall(emails={"a": "alice@x.ca", "b": "bob@x.ca"}, raise_for={"a"})
     target = _FakeTarget()
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=rotations).sync_all()
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    # b still processed despite a failing.
-    assert [c[0].slack_handle for c in target.calls] == ["b"]
+    # b still gets its rotation group synced; schedule group is skipped
+    assert [c[0].slack_handle for c in target.rotation_calls] == ["b"]
+    assert target.schedule_calls == []
 
 
 @pytest.mark.unit
-def test_sync_all_isolates_target_failure() -> None:
-    rotations = [_rotation("a"), _rotation("b")]
+def test_sync_all_skips_schedule_group_when_rotation_target_fails() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a", "b"])
     on_call = _FakeOnCall(emails={"a": "alice@x.ca", "b": "bob@x.ca"})
     target = _FakeTarget(raise_for={"a"})
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=rotations).sync_all()
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    # On-call provider was called for both; target was attempted for both
-    # but only b succeeded (a raised internally).
-    assert [c.slack_handle for c in on_call.calls] == ["a", "b"]
+    # a fails in target; schedule group is skipped
+    assert target.schedule_calls == []
 
 
 @pytest.mark.unit
-def test_sync_all_noop_when_no_rotations() -> None:
+def test_sync_all_skips_schedule_group_when_all_rotations_empty() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a", "b"])
+    on_call = _FakeOnCall(emails={"a": None, "b": None})
+    target = _FakeTarget()
+
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
+
+    assert target.rotation_calls == []
+    assert target.schedule_calls == []
+
+
+@pytest.mark.unit
+def test_sync_all_schedule_group_failure_is_isolated() -> None:
+    schedule = _schedule(handle="oncall", rotation_handles=["a"])
+    on_call = _FakeOnCall(emails={"a": "alice@x.ca"})
+    target = _FakeTarget(raise_for={"oncall"})
+
+    # Should not raise; schedule group failure is caught and logged
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
+
+
+@pytest.mark.unit
+def test_sync_all_noop_when_no_schedules() -> None:
     on_call = _FakeOnCall()
     target = _FakeTarget()
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=[]).sync_all()
+    OnCallSyncService(on_call=on_call, target=target, schedules=[]).sync_all()
 
     assert on_call.calls == []
-    assert target.calls == []
+    assert target.rotation_calls == []
+    assert target.schedule_calls == []
 
 
 @pytest.mark.unit
-def test_service_accepts_any_iterable_of_rotations() -> None:
+def test_rotation_resolved_with_parent_schedule_id() -> None:
+    """The flat OnCallRotation passed to adapters carries the schedule's OpsGenie ID."""
+    schedule = _schedule(handle="oncall", rotation_handles=["a"])
     on_call = _FakeOnCall(emails={"a": "alice@x.ca"})
     target = _FakeTarget()
 
-    def _generator() -> Any:
-        yield _rotation("a")
+    OnCallSyncService(on_call=on_call, target=target, schedules=[schedule]).sync_all()
 
-    OnCallSyncService(on_call=on_call, target=target, rotations=_generator()).sync_all()
+    assert on_call.calls[0].opsgenie_schedule_id == "abc"
+    assert on_call.calls[0].slack_handle == "a"
 
-    assert len(target.calls) == 1
+
+@pytest.mark.unit
+def test_multiple_schedules_are_each_synced() -> None:
+    schedules = [
+        _schedule(handle="oncall-1", rotation_handles=["a"]),
+        _schedule(handle="oncall-2", rotation_handles=["b"]),
+    ]
+    on_call = _FakeOnCall(emails={"a": "alice@x.ca", "b": "bob@x.ca"})
+    target = _FakeTarget()
+
+    OnCallSyncService(on_call=on_call, target=target, schedules=schedules).sync_all()
+
+    assert len(target.schedule_calls) == 2
+    schedule_handles = {c[0].slack_handle for c in target.schedule_calls}
+    assert schedule_handles == {"oncall-1", "oncall-2"}

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_settings.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_settings.py
@@ -7,26 +7,39 @@ import pytest
 
 from packages.oncall_sync import settings as settings_module
 from packages.oncall_sync.settings import (
-    OnCallRotation,
-    load_rotations,
+    OnCallRotationConfig,
+    OnCallScheduleConfig,
+    load_schedules,
 )
 
 _VALID_ROTATION = {
-    "opsgenie_schedule_id": "abc",
     "opsgenie_rotation_name": "rot",
     "slack_handle": "oncall-x",
     "slack_name": "On-call X",
 }
 
+_VALID_SCHEDULE = {
+    "opsgenie_schedule_id": "abc",
+    "slack_handle": "oncall",
+    "slack_name": "On-call",
+    "rotations": [_VALID_ROTATION],
+}
+
 
 @pytest.mark.unit
-def test_rotation_default_description() -> None:
-    rotation = OnCallRotation(**_VALID_ROTATION)
+def test_rotation_config_default_description() -> None:
+    rotation = OnCallRotationConfig(**_VALID_ROTATION)
     assert rotation.slack_description == "Auto-synced from OpsGenie"
 
 
 @pytest.mark.unit
-def test_load_rotations_returns_empty_when_resource_missing(monkeypatch, tmp_path) -> None:
+def test_schedule_config_default_description() -> None:
+    schedule = OnCallScheduleConfig(**_VALID_SCHEDULE)
+    assert schedule.slack_description == "Auto-synced from OpsGenie"
+
+
+@pytest.mark.unit
+def test_load_schedules_returns_empty_when_resource_missing(monkeypatch, tmp_path) -> None:
     class _MissingResource:
         @staticmethod
         def joinpath(_: str) -> _MissingResource:
@@ -38,51 +51,94 @@ def test_load_rotations_returns_empty_when_resource_missing(monkeypatch, tmp_pat
 
     monkeypatch.setattr(settings_module, "files", lambda _pkg: _MissingResource())
 
-    assert load_rotations() == []
+    assert load_schedules() == []
 
 
 @pytest.mark.unit
-def test_load_rotations_parses_valid_file(monkeypatch, tmp_path) -> None:
-    rotations_file = tmp_path / "rotations.json"
-    rotations_file.write_text(json.dumps([_VALID_ROTATION]))
-
+def test_load_schedules_parses_valid_file(monkeypatch, tmp_path) -> None:
+    payload = {"schedules": [_VALID_SCHEDULE]}
+    (tmp_path / "rotations.json").write_text(json.dumps(payload))
     monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
 
-    rotations = load_rotations()
+    schedules = load_schedules()
 
-    assert len(rotations) == 1
-    assert rotations[0].slack_handle == "oncall-x"
+    assert len(schedules) == 1
+    assert schedules[0].slack_handle == "oncall"
+    assert len(schedules[0].rotations) == 1
+    assert schedules[0].rotations[0].slack_handle == "oncall-x"
 
 
 @pytest.mark.unit
-def test_load_rotations_raises_on_invalid_json(monkeypatch, tmp_path) -> None:
+def test_load_schedules_raises_on_invalid_json(monkeypatch, tmp_path) -> None:
     (tmp_path / "rotations.json").write_text("{not json")
     monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
 
     with pytest.raises(ValueError, match="Invalid JSON"):
-        load_rotations()
+        load_schedules()
 
 
 @pytest.mark.unit
-def test_load_rotations_rejects_non_list_top_level(monkeypatch, tmp_path) -> None:
+def test_load_schedules_rejects_missing_schedules_key(monkeypatch, tmp_path) -> None:
     (tmp_path / "rotations.json").write_text('{"oops": true}')
     monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
 
-    with pytest.raises(ValueError, match="must contain a JSON list"):
-        load_rotations()
+    with pytest.raises(ValueError, match="'schedules' key"):
+        load_schedules()
 
 
 @pytest.mark.unit
-def test_load_rotations_rejects_duplicate_slack_handles(monkeypatch, tmp_path) -> None:
-    payload = [
-        {**_VALID_ROTATION, "opsgenie_rotation_name": "rot1"},
-        {**_VALID_ROTATION, "opsgenie_rotation_name": "rot2"},
-    ]
+def test_load_schedules_rejects_duplicate_schedule_handles(monkeypatch, tmp_path) -> None:
+    payload = {
+        "schedules": [
+            {**_VALID_SCHEDULE, "rotations": []},
+            {**_VALID_SCHEDULE, "rotations": []},
+        ]
+    }
     (tmp_path / "rotations.json").write_text(json.dumps(payload))
     monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
 
     with pytest.raises(ValueError, match="duplicate slack_handle"):
-        load_rotations()
+        load_schedules()
+
+
+@pytest.mark.unit
+def test_load_schedules_rejects_duplicate_rotation_handles(monkeypatch, tmp_path) -> None:
+    payload = {
+        "schedules": [
+            {
+                **_VALID_SCHEDULE,
+                "rotations": [
+                    {**_VALID_ROTATION, "opsgenie_rotation_name": "rot1"},
+                    {**_VALID_ROTATION, "opsgenie_rotation_name": "rot2"},
+                ],
+            }
+        ]
+    }
+    (tmp_path / "rotations.json").write_text(json.dumps(payload))
+    monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
+
+    with pytest.raises(ValueError, match="duplicate slack_handle"):
+        load_schedules()
+
+
+@pytest.mark.unit
+def test_load_schedules_rejects_handle_collision_between_schedule_and_rotation(
+    monkeypatch, tmp_path
+) -> None:
+    payload = {
+        "schedules": [
+            {
+                **_VALID_SCHEDULE,
+                "slack_handle": "oncall-x",  # same as the rotation handle
+                "rotations": [_VALID_ROTATION],
+            }
+        ]
+    }
+    (tmp_path / "rotations.json").write_text(json.dumps(payload))
+    monkeypatch.setattr(settings_module, "files", lambda _pkg: _FakeResources(tmp_path))
+
+    with pytest.raises(ValueError, match="duplicate slack_handle"):
+        load_schedules()
 
 
 class _FakeResources:

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_settings.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_settings.py
@@ -122,9 +122,7 @@ def test_load_schedules_rejects_duplicate_rotation_handles(monkeypatch, tmp_path
 
 
 @pytest.mark.unit
-def test_load_schedules_rejects_handle_collision_between_schedule_and_rotation(
-    monkeypatch, tmp_path
-) -> None:
+def test_load_schedules_rejects_handle_collision_between_schedule_and_rotation(monkeypatch, tmp_path) -> None:
     payload = {
         "schedules": [
             {

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_slack_adapter.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_slack_adapter.py
@@ -7,7 +7,7 @@ from slack_sdk.errors import SlackApiError
 
 from packages.oncall_sync.adapters.slack import SlackUserGroupTarget
 from packages.oncall_sync.ports import OnCallSyncError
-from packages.oncall_sync.settings import OnCallRotation
+from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
 
 
 def _rotation() -> OnCallRotation:
@@ -20,10 +20,25 @@ def _rotation() -> OnCallRotation:
     )
 
 
+def _schedule(rotation_handles: list[str] | None = None) -> OnCallScheduleConfig:
+    return OnCallScheduleConfig(
+        opsgenie_schedule_id="abc",
+        slack_handle="oncall",
+        slack_name="On-call",
+        slack_description="schedule desc",
+        rotations=[],
+    )
+
+
 def _slack_error(code: str) -> SlackApiError:
     response = MagicMock()
     response.get = lambda key, default=None: {"error": code}.get(key, default)
     return SlackApiError("err", response)
+
+
+# ---------------------------------------------------------------------------
+# sync_user_group (single rotation, single user)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -85,5 +100,78 @@ def test_wraps_slack_api_error_in_oncall_sync_error() -> None:
 
     with pytest.raises(OnCallSyncError) as excinfo:
         SlackUserGroupTarget(client).sync_user_group(_rotation(), "a@x.ca")
+
+    assert isinstance(excinfo.value.__cause__, SlackApiError)
+
+
+# ---------------------------------------------------------------------------
+# sync_schedule_user_group (aggregate group, multiple users)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schedule_group_sets_all_resolved_users() -> None:
+    client = MagicMock()
+    client.users_lookupByEmail.side_effect = [
+        {"ok": True, "user": {"id": "U1"}},
+        {"ok": True, "user": {"id": "U2"}},
+    ]
+    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall", "date_delete": 0}]}
+
+    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca", "b@x.ca"])
+
+    client.usergroups_users_update.assert_called_once_with(usergroup="S1", users="U1,U2")
+
+
+@pytest.mark.unit
+def test_schedule_group_creates_group_when_missing() -> None:
+    client = MagicMock()
+    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
+    client.usergroups_list.return_value = {"usergroups": []}
+    client.usergroups_create.return_value = {"usergroup": {"id": "S999"}}
+
+    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca"])
+
+    client.usergroups_create.assert_called_once_with(
+        name="On-call", handle="oncall", description="schedule desc"
+    )
+    client.usergroups_users_update.assert_called_once_with(usergroup="S999", users="U1")
+
+
+@pytest.mark.unit
+def test_schedule_group_skips_unresolvable_emails() -> None:
+    client = MagicMock()
+    client.users_lookupByEmail.side_effect = [
+        {"ok": True, "user": {"id": "U1"}},
+        _slack_error("users_not_found"),
+    ]
+    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall", "date_delete": 0}]}
+
+    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca", "missing@x.ca"])
+
+    # Only U1 resolved; group is still updated with just U1
+    client.usergroups_users_update.assert_called_once_with(usergroup="S1", users="U1")
+
+
+@pytest.mark.unit
+def test_schedule_group_skips_update_when_no_users_resolve() -> None:
+    client = MagicMock()
+    client.users_lookupByEmail.side_effect = _slack_error("users_not_found")
+
+    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["missing@x.ca"])
+
+    client.usergroups_list.assert_not_called()
+    client.usergroups_users_update.assert_not_called()
+
+
+@pytest.mark.unit
+def test_schedule_group_wraps_slack_api_error_in_oncall_sync_error() -> None:
+    client = MagicMock()
+    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
+    client.usergroups_list.return_value = {"usergroups": []}
+    client.usergroups_create.side_effect = _slack_error("invalid_handle")
+
+    with pytest.raises(OnCallSyncError) as excinfo:
+        SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca"])
 
     assert isinstance(excinfo.value.__cause__, SlackApiError)

--- a/app/tests/unit/packages/oncall_sync/test_oncall_sync_slack_adapter.py
+++ b/app/tests/unit/packages/oncall_sync/test_oncall_sync_slack_adapter.py
@@ -7,27 +7,6 @@ from slack_sdk.errors import SlackApiError
 
 from packages.oncall_sync.adapters.slack import SlackUserGroupTarget
 from packages.oncall_sync.ports import OnCallSyncError
-from packages.oncall_sync.settings import OnCallRotation, OnCallScheduleConfig
-
-
-def _rotation() -> OnCallRotation:
-    return OnCallRotation(
-        opsgenie_schedule_id="abc",
-        opsgenie_rotation_name="rot",
-        slack_handle="oncall-x",
-        slack_name="On-call X",
-        slack_description="desc",
-    )
-
-
-def _schedule(rotation_handles: list[str] | None = None) -> OnCallScheduleConfig:
-    return OnCallScheduleConfig(
-        opsgenie_schedule_id="abc",
-        slack_handle="oncall",
-        slack_name="On-call",
-        slack_description="schedule desc",
-        rotations=[],
-    )
 
 
 def _slack_error(code: str) -> SlackApiError:
@@ -36,8 +15,12 @@ def _slack_error(code: str) -> SlackApiError:
     return SlackApiError("err", response)
 
 
+def _sync(client, emails: list[str], *, handle: str = "oncall-x", name: str = "On-call X", description: str = "desc") -> None:
+    SlackUserGroupTarget(client).sync_user_group(handle, name, description, emails)
+
+
 # ---------------------------------------------------------------------------
-# sync_user_group (single rotation, single user)
+# Single-email (rotation group) behaviour
 # ---------------------------------------------------------------------------
 
 
@@ -47,7 +30,7 @@ def test_updates_existing_user_group() -> None:
     client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
     client.usergroups_list.return_value = {"usergroups": [{"id": "S123", "handle": "oncall-x", "date_delete": 0}]}
 
-    SlackUserGroupTarget(client).sync_user_group(_rotation(), "a@x.ca")
+    _sync(client, ["a@x.ca"])
 
     client.usergroups_create.assert_not_called()
     client.usergroups_enable.assert_not_called()
@@ -61,7 +44,7 @@ def test_creates_user_group_when_missing() -> None:
     client.usergroups_list.return_value = {"usergroups": []}
     client.usergroups_create.return_value = {"usergroup": {"id": "S999"}}
 
-    SlackUserGroupTarget(client).sync_user_group(_rotation(), "a@x.ca")
+    _sync(client, ["a@x.ca"])
 
     client.usergroups_create.assert_called_once_with(name="On-call X", handle="oncall-x", description="desc")
     client.usergroups_users_update.assert_called_once_with(usergroup="S999", users="U1")
@@ -73,18 +56,18 @@ def test_reenables_disabled_user_group() -> None:
     client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
     client.usergroups_list.return_value = {"usergroups": [{"id": "S123", "handle": "oncall-x", "date_delete": 123456}]}
 
-    SlackUserGroupTarget(client).sync_user_group(_rotation(), "a@x.ca")
+    _sync(client, ["a@x.ca"])
 
     client.usergroups_enable.assert_called_once_with(usergroup="S123")
     client.usergroups_users_update.assert_called_once_with(usergroup="S123", users="U1")
 
 
 @pytest.mark.unit
-def test_skips_when_email_does_not_resolve_to_slack_user() -> None:
+def test_skips_when_email_does_not_resolve_to_user() -> None:
     client = MagicMock()
     client.users_lookupByEmail.side_effect = _slack_error("users_not_found")
 
-    SlackUserGroupTarget(client).sync_user_group(_rotation(), "missing@x.ca")
+    _sync(client, ["missing@x.ca"])
 
     client.usergroups_list.assert_not_called()
     client.usergroups_create.assert_not_called()
@@ -99,79 +82,50 @@ def test_wraps_slack_api_error_in_oncall_sync_error() -> None:
     client.usergroups_create.side_effect = _slack_error("invalid_handle")
 
     with pytest.raises(OnCallSyncError) as excinfo:
-        SlackUserGroupTarget(client).sync_user_group(_rotation(), "a@x.ca")
+        _sync(client, ["a@x.ca"])
 
     assert isinstance(excinfo.value.__cause__, SlackApiError)
 
 
 # ---------------------------------------------------------------------------
-# sync_schedule_user_group (aggregate group, multiple users)
+# Multi-email (schedule aggregate group) behaviour
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_schedule_group_sets_all_resolved_users() -> None:
+def test_sets_all_resolved_users_for_multi_email() -> None:
     client = MagicMock()
     client.users_lookupByEmail.side_effect = [
         {"ok": True, "user": {"id": "U1"}},
         {"ok": True, "user": {"id": "U2"}},
     ]
-    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall", "date_delete": 0}]}
+    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall-x", "date_delete": 0}]}
 
-    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca", "b@x.ca"])
+    _sync(client, ["a@x.ca", "b@x.ca"])
 
     client.usergroups_users_update.assert_called_once_with(usergroup="S1", users="U1,U2")
 
 
 @pytest.mark.unit
-def test_schedule_group_creates_group_when_missing() -> None:
-    client = MagicMock()
-    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
-    client.usergroups_list.return_value = {"usergroups": []}
-    client.usergroups_create.return_value = {"usergroup": {"id": "S999"}}
-
-    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca"])
-
-    client.usergroups_create.assert_called_once_with(
-        name="On-call", handle="oncall", description="schedule desc"
-    )
-    client.usergroups_users_update.assert_called_once_with(usergroup="S999", users="U1")
-
-
-@pytest.mark.unit
-def test_schedule_group_skips_unresolvable_emails() -> None:
+def test_skips_unresolvable_emails_in_multi_email() -> None:
     client = MagicMock()
     client.users_lookupByEmail.side_effect = [
         {"ok": True, "user": {"id": "U1"}},
         _slack_error("users_not_found"),
     ]
-    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall", "date_delete": 0}]}
+    client.usergroups_list.return_value = {"usergroups": [{"id": "S1", "handle": "oncall-x", "date_delete": 0}]}
 
-    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca", "missing@x.ca"])
+    _sync(client, ["a@x.ca", "missing@x.ca"])
 
-    # Only U1 resolved; group is still updated with just U1
     client.usergroups_users_update.assert_called_once_with(usergroup="S1", users="U1")
 
 
 @pytest.mark.unit
-def test_schedule_group_skips_update_when_no_users_resolve() -> None:
+def test_skips_update_when_no_emails_resolve() -> None:
     client = MagicMock()
     client.users_lookupByEmail.side_effect = _slack_error("users_not_found")
 
-    SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["missing@x.ca"])
+    _sync(client, ["missing@x.ca"])
 
     client.usergroups_list.assert_not_called()
     client.usergroups_users_update.assert_not_called()
-
-
-@pytest.mark.unit
-def test_schedule_group_wraps_slack_api_error_in_oncall_sync_error() -> None:
-    client = MagicMock()
-    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U1"}}
-    client.usergroups_list.return_value = {"usergroups": []}
-    client.usergroups_create.side_effect = _slack_error("invalid_handle")
-
-    with pytest.raises(OnCallSyncError) as excinfo:
-        SlackUserGroupTarget(client).sync_schedule_user_group(_schedule(), ["a@x.ca"])
-
-    assert isinstance(excinfo.value.__cause__, SlackApiError)


### PR DESCRIPTION
# Summary | Résumé

This PR reworks the `rotations.json` structure to nest rotations under schedules. This allows us to create schedule-level Slack UserGroups to aid in easily contacting folks on-call for entire schedules or services in incidents.

The bulk of the PR is refactor and test changes to support this structural change. Functionally, the rotation-level syncing is unchanged. We now also create and sync a schedule-level Slack UserGroup. This group contains all members on-call for nested rotations.

Note that this structure also maps to JSM for when that's eventually supported.

# Test instructions | Instructions pour tester la modification

Tests are added and passing. I'll also validate manually after we merge to see if the new UserGroup gets created.
