### PR TITLE
Add top-level /rant slash command

### DIFF
--- a/app/packages/rant/README.md
+++ b/app/packages/rant/README.md
@@ -1,0 +1,47 @@
+# Rant
+
+Shout a message to the current channel in **bold uppercase**. Handy for venting
+about flaky deploys, loudly celebrating a win, or just adding emphasis.
+
+## Usage
+
+```
+/rant <text>
+```
+
+The full text after the command is uppercased, wrapped in Slack bold markers,
+and posted to the channel as a visible (non-ephemeral) message.
+
+### Examples
+
+| Input | Posted to channel |
+| --- | --- |
+| `/rant deploys keep failing` | **DEPLOYS KEEP FAILING** |
+| `/rant 500 errors @ 3am!` | **500 ERRORS @ 3AM!** |
+
+Running `/rant` with no text returns a private (ephemeral) usage hint and posts
+nothing to the channel.
+
+## How it works
+
+- [`service.format_rant`](./service.py) holds the platform-agnostic transform:
+  `text -> *TEXT.upper()*`.
+- [`platforms/slack.py`](./platforms/slack.py) registers the command and maps the
+  Slack `CommandPayload` to a `CommandResponse`.
+- Registration happens at startup via the `register_slack_commands` hookimpl in
+  [`__init__.py`](./__init__.py). The command is registered with **no parent**, so
+  the Slack provider auto-registers it as a top-level slash command (`/rant`)
+  rather than a `/sre` subcommand.
+
+## Enabling the slash command in Slack
+
+Because `/rant` is a top-level command, it must be declared in the Slack app
+configuration before Slack will deliver it to the bot:
+
+1. Open your Slack app settings → **Slash Commands** → **Create New Command**.
+2. Set the command to `/rant` (matching the deployed `SLACK__COMMAND_PREFIX`).
+3. Point it at the bot. In Socket Mode no request URL is required, but the
+   command must still be declared.
+
+> In local development the `dev-` prefix is applied, so the command is invoked as
+> `/dev-rant` (see `make dev`).

--- a/app/packages/rant/__init__.py
+++ b/app/packages/rant/__init__.py
@@ -1,0 +1,20 @@
+"""Rant package - shout a message to the channel in bold uppercase."""
+
+from infrastructure.plugins import hookimpl
+from packages.rant.platforms import slack
+from packages.rant.service import format_rant
+
+
+@hookimpl
+def register_slack_commands(provider):
+    """Register rant Slack commands.
+
+    Args:
+        provider: Slack platform provider instance.
+    """
+    slack.register_commands(provider)
+
+
+__all__ = [
+    "format_rant",
+]

--- a/app/packages/rant/platforms/__init__.py
+++ b/app/packages/rant/platforms/__init__.py
@@ -1,0 +1,1 @@
+"""Platform implementations for the rant package."""

--- a/app/packages/rant/platforms/slack.py
+++ b/app/packages/rant/platforms/slack.py
@@ -1,0 +1,58 @@
+"""Slack platform implementation for the rant package."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from integrations.slack.models import CommandPayload, CommandResponse
+from packages.rant.service import format_rant
+
+if TYPE_CHECKING:
+    from integrations.slack.provider import SlackPlatformProvider
+
+logger = structlog.get_logger()
+
+
+def register_commands(provider: SlackPlatformProvider) -> None:
+    """Register the top-level ``/rant`` Slack command with the provider.
+
+    Registered without a parent so it is exposed as a root slash command
+    (``/rant``) rather than a subcommand of ``/sre``.
+
+    Args:
+        provider: Slack platform provider instance.
+    """
+    provider.register_command(
+        command="rant",
+        handler=handle_rant_command,
+        description="Shout a message to the channel in bold uppercase",
+        usage_hint="<text>",
+        examples=["deploys keep failing"],
+    )
+
+
+def handle_rant_command(payload: CommandPayload) -> CommandResponse:
+    """Handle ``/rant <text>`` by posting a bold, uppercase message.
+
+    Args:
+        payload: Command payload from the Slack platform provider. ``text``
+            holds the full message to shout.
+
+    Returns:
+        A non-ephemeral CommandResponse posted to the channel, or an
+        ephemeral usage hint when no text is provided.
+    """
+    log = logger.bind(command="rant", user_id=payload.user_id, channel_id=payload.channel_id)
+    text = payload.text.strip()
+
+    if not text:
+        log.info("rant_command_empty")
+        return CommandResponse(
+            message="Usage: `/rant <text>` — shout a message in bold uppercase.",
+            ephemeral=True,
+        )
+
+    log.info("rant_command_received")
+    return CommandResponse(message=format_rant(text), ephemeral=False)

--- a/app/packages/rant/service.py
+++ b/app/packages/rant/service.py
@@ -1,0 +1,16 @@
+"""Business logic for the rant command.
+
+Platform-agnostic transformation of user text into a bold, uppercase shout.
+"""
+
+
+def format_rant(text: str) -> str:
+    """Format text as a bold, uppercase Slack message.
+
+    Args:
+        text: Raw user-supplied text.
+
+    Returns:
+        The text uppercased and wrapped in Slack bold markers.
+    """
+    return f"*{text.upper()}*"

--- a/app/tests/unit/packages/rant/__init__.py
+++ b/app/tests/unit/packages/rant/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for the rant feature."""

--- a/app/tests/unit/packages/rant/test_rant_service.py
+++ b/app/tests/unit/packages/rant/test_rant_service.py
@@ -1,0 +1,17 @@
+"""Tests for rant business logic."""
+
+import pytest
+
+from packages.rant.service import format_rant
+
+
+@pytest.mark.unit
+def test_format_rant_uppercases_and_bolds():
+    """Text is uppercased and wrapped in Slack bold markers."""
+    assert format_rant("deploys keep failing") == "*DEPLOYS KEEP FAILING*"
+
+
+@pytest.mark.unit
+def test_format_rant_preserves_numbers_and_symbols():
+    """Non-alphabetic characters pass through unchanged."""
+    assert format_rant("500 errors @ 3am!") == "*500 ERRORS @ 3AM!*"

--- a/app/tests/unit/packages/rant/test_rant_slack.py
+++ b/app/tests/unit/packages/rant/test_rant_slack.py
@@ -1,0 +1,45 @@
+"""Tests for the rant Slack platform handler."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from integrations.slack.models import CommandPayload, CommandResponse
+from packages.rant.platforms.slack import handle_rant_command, register_commands
+
+
+@pytest.mark.unit
+def test_handle_rant_command_posts_bold_uppercase_to_channel():
+    """A non-empty rant is posted to the channel in bold uppercase."""
+    payload = CommandPayload(text="deploys keep failing", user_id="U123", channel_id="C123")
+
+    result = handle_rant_command(payload)
+
+    assert isinstance(result, CommandResponse)
+    assert result.ephemeral is False
+    assert result.message == "*DEPLOYS KEEP FAILING*"
+
+
+@pytest.mark.unit
+def test_handle_rant_command_empty_text_returns_ephemeral_usage():
+    """An empty rant returns an ephemeral usage hint and posts nothing."""
+    payload = CommandPayload(text="   ", user_id="U123", channel_id="C123")
+
+    result = handle_rant_command(payload)
+
+    assert result.ephemeral is True
+    assert "/rant" in result.message
+
+
+@pytest.mark.unit
+def test_register_commands_registers_top_level_rant():
+    """The command registers as a root command with no parent."""
+    provider = MagicMock()
+
+    register_commands(provider)
+
+    provider.register_command.assert_called_once()
+    kwargs = provider.register_command.call_args.kwargs
+    assert kwargs["command"] == "rant"
+    assert kwargs["handler"] is handle_rant_command
+    assert kwargs.get("parent") is None


### PR DESCRIPTION
# Summary | Résumé

Adds a new `/rant` Slack slash command. Typing `/rant <text>` posts the text to
the channel in **bold uppercase**.

Example: `/rant deploys keep failing` → **DEPLOYS KEEP FAILING**
