### PR TITLE
feat(rant): post /rant messages as the invoking user's name and avatar

### DIFF
--- a/app/integrations/slack/provider.py
+++ b/app/integrations/slack/provider.py
@@ -562,6 +562,18 @@ class SlackPlatformProvider:
         return self._formatter
 
     @property
+    def client(self) -> Any:
+        """Get the Slack Web API client.
+
+        Available after the provider has been started (``start()``). May be
+        ``None`` before initialization.
+
+        Returns:
+            The Slack Bolt ``WebClient`` instance, or ``None`` if not started.
+        """
+        return self._client
+
+    @property
     def settings(self):
         """Get Slack platform settings.
 

--- a/app/packages/rant/README.md
+++ b/app/packages/rant/README.md
@@ -10,14 +10,21 @@ about flaky deploys, loudly celebrating a win, or just adding emphasis.
 ```
 
 The full text after the command is uppercased, wrapped in Slack bold markers,
-and posted to the channel as a visible (non-ephemeral) message.
+and posted to the channel as a visible (non-ephemeral) message. The message is
+posted with the invoking user's **display name and avatar** (via Slack's
+`chat:write.customize`), so it visually appears to come from that user. The bot
+remains the technical author, shown by a small **APP** badge next to the name.
+
+If the user's profile can't be resolved or the customized post fails (for
+example, the `chat:write.customize` scope is missing), the command gracefully
+falls back to posting as the bot with a mention prefix (`@you ranted: ...`).
 
 ### Examples
 
 | Input | Posted to channel |
 | --- | --- |
-| `/rant deploys keep failing` | **DEPLOYS KEEP FAILING** |
-| `/rant 500 errors @ 3am!` | **500 ERRORS @ 3AM!** |
+| `/rant deploys keep failing` | (as you) **DEPLOYS KEEP FAILING** |
+| `/rant 500 errors @ 3am!` | (as you) **500 ERRORS @ 3AM!** |
 
 Running `/rant` with no text returns a private (ephemeral) usage hint and posts
 nothing to the channel.
@@ -26,8 +33,10 @@ nothing to the channel.
 
 - [`service.format_rant`](./service.py) holds the platform-agnostic transform:
   `text -> *TEXT.upper()*`.
-- [`platforms/slack.py`](./platforms/slack.py) registers the command and maps the
-  Slack `CommandPayload` to a `CommandResponse`.
+- [`platforms/slack.py`](./platforms/slack.py) registers the command, looks up the
+  invoking user's profile (`users.info`), and posts the message with that user's
+  name and avatar via `chat.postMessage` (`chat:write.customize`). On any failure
+  it falls back to a mention-prefixed bot message.
 - Registration happens at startup via the `register_slack_commands` hookimpl in
   [`__init__.py`](./__init__.py). The command is registered with **no parent**, so
   the Slack provider auto-registers it as a top-level slash command (`/rant`)
@@ -45,3 +54,30 @@ configuration before Slack will deliver it to the bot:
 
 > In local development the `dev-` prefix is applied, so the command is invoked as
 > `/dev-rant` (see `make dev`).
+
+## Required Slack scopes
+
+To post as the invoking user (name + avatar), the bot token needs the
+`chat:write.customize` OAuth scope (in addition to `chat:write`) and
+`users:read` for the profile lookup. Add them under **OAuth & Permissions →
+Bot Token Scopes** and reinstall the app. Without `chat:write.customize`, the
+command still works but posts as the bot with a mention prefix.
+
+> After changing scopes and reinstalling, **restart the bot process** — the
+> Slack Web API client is created once at startup and won't pick up new
+> authorization until then.
+
+## Where it works
+
+Posting as the user uses `chat.postMessage`, which has stricter requirements
+than the slash command itself:
+
+- **Public channels:** the bot must be a member (`/invite @bot`), or the app
+  must hold the `chat:write.public` scope to post without being invited.
+- **Private channels:** the bot must be invited; `chat:write.public` does not
+  apply.
+- **Direct messages:** posting as the user is not supported (Slack returns
+  `channel_not_found`), so `/rant` falls back to the mention-prefix message.
+
+In every unsupported case the command still responds via the mention-prefix
+fallback, so it never fails outright.

--- a/app/packages/rant/platforms/slack.py
+++ b/app/packages/rant/platforms/slack.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
+from slack_sdk import WebClient
 
 from integrations.slack.models import CommandPayload, CommandResponse
 from packages.rant.service import format_rant
@@ -21,28 +22,52 @@ def register_commands(provider: SlackPlatformProvider) -> None:
     Registered without a parent so it is exposed as a root slash command
     (``/rant``) rather than a subcommand of ``/sre``.
 
+    The registered handler is wrapped so it receives the provider's Slack Web
+    API client at dispatch time, which is needed to post the message with the
+    invoking user's name and avatar (``chat:write.customize``).
+
     Args:
         provider: Slack platform provider instance.
     """
+
+    def _dispatch(payload: CommandPayload) -> CommandResponse:
+        # Read the client lazily: it is only populated after the provider has
+        # started, which happens after command registration.
+        return handle_rant_command(payload, provider.client)
+
     provider.register_command(
         command="rant",
-        handler=handle_rant_command,
+        handler=_dispatch,
         description="Shout a message to the channel in bold uppercase",
         usage_hint="<text>",
         examples=["deploys keep failing"],
     )
 
 
-def handle_rant_command(payload: CommandPayload) -> CommandResponse:
+def handle_rant_command(payload: CommandPayload, client: WebClient | None) -> CommandResponse:
     """Handle ``/rant <text>`` by posting a bold, uppercase message.
+
+    The message is posted with the invoking user's display name and avatar via
+    the Slack ``chat:write.customize`` capability, so it visually appears to
+    come from that user (the bot remains the technical author, indicated by a
+    small ``APP`` badge).
+
+    If the user's identity cannot be resolved or the customized post fails (for
+    example, the ``chat:write.customize`` scope is missing), the command
+    gracefully falls back to posting as the bot with a mention prefix
+    (``<@user_id> ranted: ...``).
 
     Args:
         payload: Command payload from the Slack platform provider. ``text``
             holds the full message to shout.
+        client: Slack Web API client used to look up the user's profile and
+            post the customized message. May be ``None`` before startup.
 
     Returns:
-        A non-ephemeral CommandResponse posted to the channel, or an
-        ephemeral usage hint when no text is provided.
+        An ephemeral confirmation when the message is posted as the user, an
+        ephemeral usage hint when no text is provided, or a non-ephemeral
+        fallback message attributed via mention when customization is
+        unavailable.
     """
     log = logger.bind(command="rant", user_id=payload.user_id, channel_id=payload.channel_id)
     text = payload.text.strip()
@@ -54,5 +79,61 @@ def handle_rant_command(payload: CommandPayload) -> CommandResponse:
             ephemeral=True,
         )
 
-    log.info("rant_command_received")
-    return CommandResponse(message=format_rant(text), ephemeral=False)
+    formatted = format_rant(text)
+    identity = _resolve_user_identity(client, payload.user_id, log) if client else None
+
+    if client is not None and payload.channel_id and identity is not None:
+        username, icon_url = identity
+        try:
+            client.chat_postMessage(
+                channel=payload.channel_id,
+                text=formatted,
+                username=username,
+                icon_url=icon_url,
+            )
+            log.info("rant_command_posted_as_user")
+            return CommandResponse(message="✅ Ranted.", ephemeral=True)
+        except Exception as e:
+            log.warning("rant_post_as_user_failed", error=str(e))
+
+    # Fallback: post as the bot, attributed to the user via a mention prefix.
+    log.info("rant_command_posted_as_bot")
+    return CommandResponse(message=f"<@{payload.user_id}> ranted: {formatted}", ephemeral=False)
+
+
+def _resolve_user_identity(
+    client: WebClient,
+    user_id: str,
+    log: structlog.stdlib.BoundLogger,
+) -> tuple[str, str] | None:
+    """Resolve the display name and avatar URL for a Slack user.
+
+    Args:
+        client: Slack Web API client.
+        user_id: Slack user ID to look up.
+        log: Bound logger for contextual logging.
+
+    Returns:
+        A ``(display_name, icon_url)`` tuple, or ``None`` if the lookup fails
+        or returns no usable profile data.
+    """
+    try:
+        response = client.users_info(user=user_id)
+    except Exception as e:
+        log.warning("rant_user_identity_lookup_failed", error=str(e))
+        return None
+
+    if not response.get("ok"):
+        log.warning("rant_user_identity_lookup_not_ok", error=response.get("error"))
+        return None
+
+    user: dict[str, Any] = response.get("user") or {}
+    profile: dict[str, Any] = user.get("profile") or {}
+    display_name = profile.get("display_name") or profile.get("real_name")
+    icon_url = profile.get("image_512") or profile.get("image_192") or profile.get("image_72")
+
+    if not display_name or not icon_url:
+        log.warning("rant_user_identity_incomplete")
+        return None
+
+    return display_name, icon_url

--- a/app/tests/unit/packages/rant/test_rant_slack.py
+++ b/app/tests/unit/packages/rant/test_rant_slack.py
@@ -8,27 +8,88 @@ from integrations.slack.models import CommandPayload, CommandResponse
 from packages.rant.platforms.slack import handle_rant_command, register_commands
 
 
+def _client_with_profile(display_name="Ada Lovelace", icon_url="https://img/512.png"):
+    """Build a mock Slack client whose users_info returns a usable profile."""
+    client = MagicMock()
+    client.users_info.return_value = {
+        "ok": True,
+        "user": {
+            "profile": {
+                "display_name": display_name,
+                "real_name": display_name,
+                "image_512": icon_url,
+            }
+        },
+    }
+    return client
+
+
 @pytest.mark.unit
-def test_handle_rant_command_posts_bold_uppercase_to_channel():
-    """A non-empty rant is posted to the channel in bold uppercase."""
+def test_handle_rant_command_posts_as_user_with_name_and_avatar():
+    """A rant is posted with the invoking user's name and avatar."""
+    client = _client_with_profile()
     payload = CommandPayload(text="deploys keep failing", user_id="U123", channel_id="C123")
 
-    result = handle_rant_command(payload)
+    result = handle_rant_command(payload, client)
 
-    assert isinstance(result, CommandResponse)
-    assert result.ephemeral is False
-    assert result.message == "*DEPLOYS KEEP FAILING*"
+    client.chat_postMessage.assert_called_once_with(
+        channel="C123",
+        text="*DEPLOYS KEEP FAILING*",
+        username="Ada Lovelace",
+        icon_url="https://img/512.png",
+    )
+    assert result.ephemeral is True
 
 
 @pytest.mark.unit
 def test_handle_rant_command_empty_text_returns_ephemeral_usage():
     """An empty rant returns an ephemeral usage hint and posts nothing."""
+    client = _client_with_profile()
     payload = CommandPayload(text="   ", user_id="U123", channel_id="C123")
 
-    result = handle_rant_command(payload)
+    result = handle_rant_command(payload, client)
 
     assert result.ephemeral is True
     assert "/rant" in result.message
+    client.chat_postMessage.assert_not_called()
+
+
+@pytest.mark.unit
+def test_handle_rant_command_falls_back_to_mention_when_post_as_user_fails():
+    """A failed customized post falls back to a mention-prefixed bot message."""
+    client = _client_with_profile()
+    client.chat_postMessage.side_effect = Exception("missing_scope")
+    payload = CommandPayload(text="deploys keep failing", user_id="U123", channel_id="C123")
+
+    result = handle_rant_command(payload, client)
+
+    assert result.ephemeral is False
+    assert result.message == "<@U123> ranted: *DEPLOYS KEEP FAILING*"
+
+
+@pytest.mark.unit
+def test_handle_rant_command_falls_back_when_identity_unavailable():
+    """An unusable profile falls back to a mention-prefixed bot message."""
+    client = MagicMock()
+    client.users_info.return_value = {"ok": False, "error": "user_not_found"}
+    payload = CommandPayload(text="deploys keep failing", user_id="U123", channel_id="C123")
+
+    result = handle_rant_command(payload, client)
+
+    assert result.ephemeral is False
+    assert result.message == "<@U123> ranted: *DEPLOYS KEEP FAILING*"
+    client.chat_postMessage.assert_not_called()
+
+
+@pytest.mark.unit
+def test_handle_rant_command_falls_back_when_no_client():
+    """Without a client the command still posts via mention fallback."""
+    payload = CommandPayload(text="deploys keep failing", user_id="U123", channel_id="C123")
+
+    result = handle_rant_command(payload, None)
+
+    assert result.ephemeral is False
+    assert result.message == "<@U123> ranted: *DEPLOYS KEEP FAILING*"
 
 
 @pytest.mark.unit
@@ -41,5 +102,20 @@ def test_register_commands_registers_top_level_rant():
     provider.register_command.assert_called_once()
     kwargs = provider.register_command.call_args.kwargs
     assert kwargs["command"] == "rant"
-    assert kwargs["handler"] is handle_rant_command
+    assert callable(kwargs["handler"])
     assert kwargs.get("parent") is None
+
+
+@pytest.mark.unit
+def test_registered_handler_uses_provider_client():
+    """The registered handler dispatches through the provider's Slack client."""
+    provider = MagicMock()
+    provider.client = _client_with_profile()
+    register_commands(provider)
+    handler = provider.register_command.call_args.kwargs["handler"]
+
+    payload = CommandPayload(text="hi", user_id="U123", channel_id="C123")
+    result = handler(payload)
+
+    provider.client.chat_postMessage.assert_called_once()
+    assert isinstance(result, CommandResponse)


### PR DESCRIPTION

# Summary | Résumé

Makes /rant post with the invoking user's display name and avatar (via Slack chat:write.customize) instead of appearing as the SRE bot. Falls back gracefully to a mention-prefixed bot message (@user ranted: ...) when customization isn't possible.

