### PR TITLE
feat(incident): add /sre incident summarize AI catch-up command

### DIFF
--- a/app/integrations/openai/__init__.py
+++ b/app/integrations/openai/__init__.py
@@ -1,0 +1,24 @@
+"""OpenAI integration package.
+
+Authenticated client construction, error classification, and the
+``Summarizer`` behavior port with its OpenAI-backed adapter. No import-time
+side effects.
+"""
+
+from integrations.openai.client import build_openai_client, classify_openai_error
+from integrations.openai.settings import OpenAISettings, get_openai_settings
+from integrations.openai.summarizer import (
+    OpenAISummarizer,
+    Summarizer,
+    get_summarizer,
+)
+
+__all__ = [
+    "OpenAISettings",
+    "OpenAISummarizer",
+    "Summarizer",
+    "build_openai_client",
+    "classify_openai_error",
+    "get_openai_settings",
+    "get_summarizer",
+]

--- a/app/integrations/openai/client.py
+++ b/app/integrations/openai/client.py
@@ -1,0 +1,113 @@
+"""OpenAI vendor client: authenticated client factory and error
+classification.
+
+Per ``decisions/outbound-clients.md``: this module provides authenticated
+client construction and ``classify_openai_error``. It raises typed httpx
+exceptions and contains no business logic; the adapter in
+``app.integrations.openai.summarizer`` is the boundary that calls into this
+module inside ``try/except`` and classifies. No hand-rolled retry loops --
+httpx owns transport, and the OpenAI REST API is called directly (the same
+approach the GitHub integration takes with its REST API).
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import httpx
+
+from infrastructure.operations.result import OperationResult
+from infrastructure.operations.status import OperationStatus
+from integrations.openai.settings import OpenAISettings, get_openai_settings
+
+
+def build_openai_client(settings: OpenAISettings | None = None) -> httpx.AsyncClient:
+    """Build an authenticated httpx client for the OpenAI REST API.
+
+    Caller manages the client's lifecycle (use as an async context manager).
+    """
+    settings = settings or get_openai_settings()
+    return httpx.AsyncClient(
+        base_url=settings.BASE_URL,
+        headers={
+            "Authorization": f"Bearer {settings.API_KEY.get_secret_value()}",
+            "Content-Type": "application/json",
+        },
+        timeout=settings.TIMEOUT_SECONDS,
+    )
+
+
+def classify_openai_error(exc: Exception) -> OperationResult:
+    """Map OpenAI/HTTP exceptions to ``OperationResult``.
+
+    Unmapped exceptions propagate uncaught -- they are bugs, not outcomes.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        response = exc.response
+        status_code = response.status_code
+
+        if status_code == 401:
+            return OperationResult.error(
+                OperationStatus.PERMANENT_ERROR,
+                "OpenAI authentication failed",
+                error_code="UNAUTHORIZED",
+                provider="openai",
+            )
+        if status_code == 403:
+            return OperationResult.error(
+                OperationStatus.PERMANENT_ERROR,
+                "OpenAI API access forbidden",
+                error_code="FORBIDDEN",
+                provider="openai",
+            )
+        if status_code == 404:
+            return OperationResult.error(
+                OperationStatus.NOT_FOUND,
+                "OpenAI resource not found",
+                error_code="NOT_FOUND",
+                provider="openai",
+            )
+        if status_code == 429:
+            retry_after = 60
+            header_value = response.headers.get("Retry-After")
+            if header_value:
+                with contextlib.suppress(TypeError, ValueError):
+                    retry_after = int(header_value)
+            return OperationResult.error(
+                OperationStatus.TRANSIENT_ERROR,
+                "OpenAI API rate limited",
+                error_code="RATE_LIMITED",
+                retry_after=retry_after,
+                provider="openai",
+            )
+        if 500 <= status_code < 600:
+            return OperationResult.error(
+                OperationStatus.TRANSIENT_ERROR,
+                f"OpenAI API server error ({status_code})",
+                error_code="SERVER_ERROR",
+                provider="openai",
+            )
+        return OperationResult.error(
+            OperationStatus.PERMANENT_ERROR,
+            f"OpenAI API client error ({status_code})",
+            error_code="HTTP_ERROR",
+            provider="openai",
+        )
+
+    if isinstance(exc, httpx.TimeoutException):
+        return OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            "OpenAI API request timed out",
+            error_code="TIMEOUT",
+            provider="openai",
+        )
+
+    if isinstance(exc, httpx.HTTPError):
+        return OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            "OpenAI API request failed",
+            error_code="CONNECTION_ERROR",
+            provider="openai",
+        )
+
+    raise exc

--- a/app/integrations/openai/client.py
+++ b/app/integrations/openai/client.py
@@ -1,10 +1,10 @@
 """OpenAI vendor client: authenticated client factory and error
 classification.
 
-This module provides authenticated client construction and ``classify_openai_error``. 
+This module provides authenticated client construction and ``classify_openai_error``.
 exceptions and contains no business logic. The adapter in
 ``app.integrations.openai.summarizer`` is the boundary that calls into this
-module inside ``try/except`` and classifies. 
+module inside ``try/except`` and classifies.
 """
 
 from __future__ import annotations

--- a/app/integrations/openai/client.py
+++ b/app/integrations/openai/client.py
@@ -1,13 +1,10 @@
 """OpenAI vendor client: authenticated client factory and error
 classification.
 
-Per ``decisions/outbound-clients.md``: this module provides authenticated
-client construction and ``classify_openai_error``. It raises typed httpx
-exceptions and contains no business logic; the adapter in
+This module provides authenticated client construction and ``classify_openai_error``. 
+exceptions and contains no business logic. The adapter in
 ``app.integrations.openai.summarizer`` is the boundary that calls into this
-module inside ``try/except`` and classifies. No hand-rolled retry loops --
-httpx owns transport, and the OpenAI REST API is called directly (the same
-approach the GitHub integration takes with its REST API).
+module inside ``try/except`` and classifies. 
 """
 
 from __future__ import annotations

--- a/app/integrations/openai/settings.py
+++ b/app/integrations/openai/settings.py
@@ -6,8 +6,7 @@ consumed by ``app.integrations.openai.client`` -- and the cached
 
 Only OpenAI-transport concerns belong here (API key, model, token/timeout
 limits, base URL). Feature-domain configuration (what gets summarized, how
-history is bounded) lives with the consuming feature per
-``decisions/configuration.md``.
+history is bounded) lives with the consuming feature.
 """
 
 from __future__ import annotations
@@ -22,7 +21,6 @@ class OpenAISettings(BaseSettings):
     """Vendor-credential and transport settings for the OpenAI API."""
 
     model_config = SettingsConfigDict(
-        env_file=".env",
         case_sensitive=True,
         extra="ignore",
     )

--- a/app/integrations/openai/settings.py
+++ b/app/integrations/openai/settings.py
@@ -21,6 +21,7 @@ class OpenAISettings(BaseSettings):
     """Vendor-credential and transport settings for the OpenAI API."""
 
     model_config = SettingsConfigDict(
+        env_file=".env",
         case_sensitive=True,
         extra="ignore",
     )

--- a/app/integrations/openai/settings.py
+++ b/app/integrations/openai/settings.py
@@ -1,0 +1,40 @@
+"""Vendor settings for the OpenAI API client.
+
+Exposes ``OpenAISettings`` -- the vendor-credential and transport surface
+consumed by ``app.integrations.openai.client`` -- and the cached
+``get_openai_settings()`` provider.
+
+Only OpenAI-transport concerns belong here (API key, model, token/timeout
+limits, base URL). Feature-domain configuration (what gets summarized, how
+history is bounded) lives with the consuming feature per
+``decisions/configuration.md``.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class OpenAISettings(BaseSettings):
+    """Vendor-credential and transport settings for the OpenAI API."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    API_KEY: SecretStr = Field(alias="OPENAI_API_KEY")
+    MODEL: str = Field(default="gpt-5.4-nano", alias="OPENAI_MODEL")
+    MAX_OUTPUT_TOKENS: int = Field(default=800, alias="OPENAI_MAX_OUTPUT_TOKENS")
+    TIMEOUT_SECONDS: float = Field(default=30.0, alias="OPENAI_TIMEOUT_SECONDS")
+    BASE_URL: str = Field(default="https://ai.cdssandbox.xyz", alias="OPENAI_BASE_URL")
+
+
+@lru_cache(maxsize=1)
+def get_openai_settings() -> OpenAISettings:
+    """Return the process-wide ``OpenAISettings`` singleton."""
+    return OpenAISettings()

--- a/app/integrations/openai/summarizer.py
+++ b/app/integrations/openai/summarizer.py
@@ -34,9 +34,7 @@ _DEFAULT_INSTRUCTIONS = (
 class Summarizer(Protocol):
     """Behavior contract for producing a text summary of a transcript."""
 
-    async def summarize(
-        self, transcript: str, *, instructions: str | None = None
-    ) -> OperationResult[str]:
+    async def summarize(self, transcript: str, *, instructions: str | None = None) -> OperationResult[str]:
         """Return an ``OperationResult`` carrying the summary text on success."""
         ...
 
@@ -47,9 +45,7 @@ class OpenAISummarizer:
     def __init__(self, settings: OpenAISettings | None = None) -> None:
         self._settings = settings or get_openai_settings()
 
-    async def summarize(
-        self, transcript: str, *, instructions: str | None = None
-    ) -> OperationResult[str]:
+    async def summarize(self, transcript: str, *, instructions: str | None = None) -> OperationResult[str]:
         """Summarize ``transcript`` via the OpenAI chat completions endpoint."""
         payload = {
             "model": self._settings.MODEL,

--- a/app/integrations/openai/summarizer.py
+++ b/app/integrations/openai/summarizer.py
@@ -2,8 +2,7 @@
 
 ``Summarizer`` is the narrow behavior contract feature packages depend on
 (per the model-boundary rules: ``Protocol`` for service contracts). The
-``OpenAISummarizer`` adapter is the boundary tier described in
-``decisions/outbound-clients.md``: it calls the vendor client inside
+``OpenAISummarizer`` adapter is the boundary tier: it calls the vendor client inside
 ``try/except``, classifies failures via ``classify_openai_error``, and
 returns ``OperationResult``. Unmapped exceptions propagate -- they are bugs,
 not outcomes.

--- a/app/integrations/openai/summarizer.py
+++ b/app/integrations/openai/summarizer.py
@@ -1,0 +1,93 @@
+"""Summarizer behavior port and its OpenAI-backed adapter.
+
+``Summarizer`` is the narrow behavior contract feature packages depend on
+(per the model-boundary rules: ``Protocol`` for service contracts). The
+``OpenAISummarizer`` adapter is the boundary tier described in
+``decisions/outbound-clients.md``: it calls the vendor client inside
+``try/except``, classifies failures via ``classify_openai_error``, and
+returns ``OperationResult``. Unmapped exceptions propagate -- they are bugs,
+not outcomes.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Protocol, runtime_checkable
+
+import structlog
+
+from infrastructure.operations.result import OperationResult
+from integrations.openai.client import build_openai_client, classify_openai_error
+from integrations.openai.settings import OpenAISettings, get_openai_settings
+
+logger = structlog.get_logger()
+
+_DEFAULT_INSTRUCTIONS = (
+    "You are an incident-response assistant. Summarize the following chat "
+    "transcript from an incident channel so that a responder joining now can "
+    "quickly catch up. Be concise and factual. Cover: what is happening, key "
+    "events in order, current status, actions taken, and any open questions or "
+    "next steps. Do not invent details that are not in the transcript."
+)
+
+
+@runtime_checkable
+class Summarizer(Protocol):
+    """Behavior contract for producing a text summary of a transcript."""
+
+    async def summarize(
+        self, transcript: str, *, instructions: str | None = None
+    ) -> OperationResult[str]:
+        """Return an ``OperationResult`` carrying the summary text on success."""
+        ...
+
+
+class OpenAISummarizer:
+    """``Summarizer`` implementation backed by the OpenAI chat completions API."""
+
+    def __init__(self, settings: OpenAISettings | None = None) -> None:
+        self._settings = settings or get_openai_settings()
+
+    async def summarize(
+        self, transcript: str, *, instructions: str | None = None
+    ) -> OperationResult[str]:
+        """Summarize ``transcript`` via the OpenAI chat completions endpoint."""
+        payload = {
+            "model": self._settings.MODEL,
+            "max_completion_tokens": self._settings.MAX_OUTPUT_TOKENS,
+            "messages": [
+                {"role": "system", "content": instructions or _DEFAULT_INSTRUCTIONS},
+                {"role": "user", "content": transcript},
+            ],
+        }
+
+        try:
+            async with build_openai_client(self._settings) as client:
+                response = await client.post("/chat/completions", json=payload)
+                response.raise_for_status()
+                body = response.json()
+        except Exception as exc:
+            logger.warning("openai_summarize_failed", error=str(exc))
+            return classify_openai_error(exc)
+
+        summary = _extract_summary(body)
+        return OperationResult.success(
+            data=summary,
+            provider="openai",
+            operation="summarize",
+        )
+
+
+def _extract_summary(body: dict) -> str:
+    """Pull the assistant message text out of a chat completions response."""
+    choices = body.get("choices") or []
+    if not choices:
+        return ""
+    message = choices[0].get("message") or {}
+    return (message.get("content") or "").strip()
+
+
+@lru_cache(maxsize=1)
+def get_summarizer() -> OpenAISummarizer:
+    """Return the process-wide ``OpenAISummarizer`` singleton (the ``Summarizer`` port)."""
+    return OpenAISummarizer()

--- a/app/integrations/openai/summarizer.py
+++ b/app/integrations/openai/summarizer.py
@@ -24,9 +24,9 @@ logger = structlog.get_logger()
 _DEFAULT_INSTRUCTIONS = (
     "You are an incident-response assistant. Summarize the following chat "
     "transcript from an incident channel so that a responder joining now can "
-    "quickly catch up. Be concise and factual. Cover: what is happening, key "
-    "events in order, current status, actions taken, and any open questions or "
-    "next steps. Do not invent details that are not in the transcript."
+    "quickly catch up. Be concise and factual. Cover: what is happening, "
+    "current status, actions taken, and next steps. Do not invent details "
+    "that are not in the transcript."
 )
 
 

--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -578,6 +578,7 @@ def initiate_resources_creation(
 • `/sre incident status update <status>` - Update incident status
 • `/sre incident updates add` - Add incident updates
 • `/sre incident show` - View incident details
+• `/sre incident summarize` - Summarize the channel to catch up someone joining the incident (optionally add `--since 30m` or `--since 2h` to limit the time range)
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -62,6 +62,7 @@ Usage:
 • create       - Create a new incident
 • close        - Close the current incident
 • list         - List incidents or resources
+• summarize    - Summarize the channel to catch up someone joining the incident
 • help         - Show this help message
 • schedule     - Schedule an event for the incident
 • show         - Show details of the current incident
@@ -71,6 +72,9 @@ Usage:
 - `/sre incident list --stale`
 - `/sre incident close`
 - `/sre incident show`
+- `/sre incident summarize`
+- `/sre incident summarize --since 30m --limit 100`
+- `/sre incident summarize --since 2h --limit 100`
 - `/sre incident products create "foo bar"`
 - `/sre incident schedule retro`
 - `/sre incident status update Ready to be Reviewed`
@@ -104,6 +108,7 @@ Utilisation:
 • create       - Créer un nouvel incident
 • close        - Clore l'incident en cours
 • list         - Lister les incidents ou ressources
+• summarize    - Résumer le canal pour informer une personne rejoignant l'incident
 • help         - Afficher ce message d'aide
 • schedule     - Planifier un événement pour l'incident
 • show         - Afficher les détails de l'incident en cours
@@ -113,6 +118,9 @@ Utilisation:
 - `/sre incident list --stale`
 - `/sre incident close`
 - `/sre incident show`
+- `/sre incident summarize`
+- `/sre incident summarize --since 30m --limit 100`
+- `/sre incident summarize --since 2h --limit 100`
 - `/sre incident products create "foo bar"`
 - `/sre incident schedule retro`
 - `/sre incident status update Ready to be Reviewed`

--- a/app/packages/incident_summary/README.md
+++ b/app/packages/incident_summary/README.md
@@ -1,0 +1,74 @@
+# incident_summary
+
+`/sre incident summarize` — an AI-generated catch-up summary of the current
+channel, for someone jumping into an incident.
+
+## What it does
+
+Fetches recent channel history, resolves author display names, builds a plain
+transcript, and asks the `Summarizer` port (OpenAI, see
+`app/integrations/openai/`) to produce a concise, factual summary: what is
+happening, key events in order, current status, actions taken, and open
+questions. The summary is returned **ephemerally** — only the person who ran
+the command sees it, so it never adds noise to the incident channel.
+
+## Usage
+
+```
+/sre incident summarize                      # since channel creation, up to 500 messages (defaults)
+/sre incident summarize --since 30m           # last 30 minutes
+/sre incident summarize --since 2h           # last 2 hours
+/sre incident summarize --since 90m --limit 100
+/sre incident summarize --since 1d --limit 300
+```
+
+- `--since` — how far back to summarize: `30m`, `2h`, `1d` (a bare number is
+  treated as hours). Omitted → the incident channel's creation time (falling
+  back to `INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS`, 24h, if the channel start
+  cannot be determined).
+- `--limit` — maximum messages to include. Omitted/invalid → default (500);
+  capped at `INCIDENT_SUMMARY__MAX_HISTORY_LIMIT` (1000).
+
+## Settings
+
+Feature-domain settings live in `settings.py` (`IncidentSummarySettings`); all
+have safe defaults:
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT` | `500` | Messages fetched when `--limit` is omitted |
+| `INCIDENT_SUMMARY__MAX_HISTORY_LIMIT` | `1000` | Hard cap on `--limit` |
+| `INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS` | `24` | Fallback look-back window when `--since` is omitted and the channel start cannot be determined |
+
+OpenAI credentials/model are **not** configured here — they belong to the
+vendor client (`OPENAI_API_KEY`, `OPENAI_MODEL`, …) in
+`app/integrations/openai/settings.py`.
+
+## Required Slack scopes
+
+The bot must be able to read channel history and look up users:
+
+- `channels:history` (public channels) / `groups:history` (private channels)
+- `users:read`
+
+The bot must be a member of the channel (or have `channels:history` via an
+appropriate install). After changing scopes, reinstall the app and restart the
+bot so the Web API client picks up the new token.
+
+## Architecture
+
+- `platforms/slack.py` — Slack adapter: registers the command under
+  `sre.incident`, parses `--since`/`--limit`, fetches history + names, calls the
+  service, renders an ephemeral response. Follows the five-step handler
+  discipline (parse → typed values → one service call → `OperationResult` →
+  render). No runtime `slack_sdk` import (typing only).
+- `service.py` — platform-agnostic: turns `TranscriptMessage` values into a
+  transcript and delegates to the `Summarizer` port, returning
+  `OperationResult`. No Slack/HTTP imports. Empty history →
+  `OperationResult` with `error_code="EMPTY_HISTORY"`.
+- `settings.py` — partitioned feature settings.
+- `locales/` — EN/FR message catalogues (`register_i18n_resources`).
+
+Registration is startup-driven via pluggy hookimpls in `__init__.py`
+(`register_slack_commands`, `register_i18n_resources`); no import-time side
+effects.

--- a/app/packages/incident_summary/README.md
+++ b/app/packages/incident_summary/README.md
@@ -8,8 +8,8 @@ channel, for someone jumping into an incident.
 Fetches recent channel history, resolves author display names, builds a plain
 transcript, and asks the `Summarizer` port (OpenAI, see
 `app/integrations/openai/`) to produce a concise, factual summary: what is
-happening, key events in order, current status, actions taken, and open
-questions. The summary is returned **ephemerally** — only the person who ran
+happening, current status, actions taken, and next steps. The summary is
+returned **ephemerally** — only the person who ran
 the command sees it, so it never adds noise to the incident channel.
 
 ## Usage

--- a/app/packages/incident_summary/__init__.py
+++ b/app/packages/incident_summary/__init__.py
@@ -1,0 +1,48 @@
+"""Platform-agnostic incident-summary feature package.
+
+Exposes the ``/sre incident summarize`` Slack subcommand and its i18n
+resources via pluggy hookimpls. Registration is startup-driven and side
+effect free at import time (only decorated hookimpls are defined here).
+"""
+
+from pathlib import Path
+
+from infrastructure.i18n.resources import I18nResourceSpec
+from infrastructure.plugins import hookimpl
+from packages.incident_summary.platforms import slack
+from packages.incident_summary.service import TranscriptMessage, summarize_transcript
+
+
+@hookimpl
+def register_slack_commands(provider):
+    """Register the incident_summary Slack commands.
+
+    Args:
+        provider: Slack platform provider instance.
+    """
+    slack.register_commands(provider)
+
+
+@hookimpl
+def register_i18n_resources(registry):
+    """Register incident_summary translation resource locations.
+
+    Args:
+        registry: I18nResourceRegistry for registering resource specifications.
+    """
+    locales_path = Path(__file__).parent / "locales"
+    registry.register(
+        I18nResourceSpec(
+            owner="packages.incident_summary",
+            path=str(locales_path),
+            required=False,
+            format="yaml",
+            domain="incident_summary",
+        )
+    )
+
+
+__all__ = [
+    "TranscriptMessage",
+    "summarize_transcript",
+]

--- a/app/packages/incident_summary/locales/incident_summary.en-US.yml
+++ b/app/packages/incident_summary/locales/incident_summary.en-US.yml
@@ -1,0 +1,7 @@
+incident_summary:
+  description: "Summarize what has happened in this channel so far, for someone jumping into the incident."
+  examples.default: "`/sre incident summarize` - Summarize recent channel activity."
+  examples.since: "`/sre incident summarize --since 2h --limit 100` - Summarize the last 2 hours (up to 100 messages)."
+  result.header: "\U0001F9FE Incident summary"
+  result.empty_history: "There's nothing to summarize yet in this channel."
+  result.error: "\u274C Couldn't generate a summary right now. Please try again shortly."

--- a/app/packages/incident_summary/locales/incident_summary.fr-FR.yml
+++ b/app/packages/incident_summary/locales/incident_summary.fr-FR.yml
@@ -1,0 +1,7 @@
+incident_summary:
+  description: "Résumer ce qui s'est passé dans ce canal jusqu'à présent, pour quelqu'un qui rejoint l'incident."
+  examples.default: "`/sre incident summarize` - Résumer l'activité récente du canal."
+  examples.since: "`/sre incident summarize --since 2h --limit 100` - Résumer les 2 dernières heures (jusqu'à 100 messages)."
+  result.header: "\U0001F9FE Résumé de l'incident"
+  result.empty_history: "Il n'y a rien à résumer pour le moment dans ce canal."
+  result.error: "\u274C Impossible de générer un résumé pour le moment. Veuillez réessayer sous peu."

--- a/app/packages/incident_summary/platforms/__init__.py
+++ b/app/packages/incident_summary/platforms/__init__.py
@@ -1,0 +1,1 @@
+"""Platform adapters for the incident_summary package."""

--- a/app/packages/incident_summary/platforms/slack.py
+++ b/app/packages/incident_summary/platforms/slack.py
@@ -1,0 +1,379 @@
+"""Slack platform adapter for the incident_summary package.
+
+Registers ``/sre incident summarize`` as a child of ``sre.incident`` and
+turns recent channel history into an ephemeral catch-up summary. The adapter
+owns the Slack-specific work (fetching history, resolving display names) and
+delegates the actual summarization to the platform-agnostic
+``packages.incident_summary.service``.
+
+The Slack Web API client is captured lazily from the provider at dispatch
+time (it only exists after startup); ``slack_sdk`` is imported for typing
+only, keeping the package free of a runtime Slack SDK dependency per
+``decisions/transport-slack.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from infrastructure.i18n import t
+from integrations.slack.models import (
+    Argument,
+    ArgumentType,
+    CommandPayload,
+    CommandResponse,
+)
+from packages.incident_summary.service import (
+    EMPTY_HISTORY_CODE,
+    TranscriptMessage,
+    summarize_transcript,
+)
+from packages.incident_summary.settings import (
+    IncidentSummarySettings,
+    get_incident_summary_settings,
+)
+
+if TYPE_CHECKING:
+    from slack_sdk import WebClient
+
+    from integrations.slack.provider import SlackPlatformProvider
+
+logger = structlog.get_logger()
+
+_DOMAIN = "incident_summary"
+_SINCE_UNITS = {"m": 60, "h": 3600, "d": 86400}
+
+# Slack renders its own "mrkdwn", not standard/GitHub Markdown: headers (``#``)
+# and ``**bold**`` show up as literal text. Steer the model toward Slack-safe
+# formatting so the ephemeral summary renders correctly.
+_SLACK_FORMAT_INSTRUCTIONS = (
+    "Format the summary using Slack mrkdwn, NOT standard Markdown. "
+    "Rules: use *single asterisks* for bold (never **double**); use _underscores_ "
+    "for italics; do NOT use Markdown headings (#, ##, ###) -- make section titles "
+    "a bold line instead (e.g. *Key events*); start bullet lines with '• '; "
+    "separate sections with a blank line. Keep links as plain URLs."
+)
+
+
+def register_commands(provider: SlackPlatformProvider) -> None:
+    """Register the ``/sre incident summarize`` subcommand with the provider.
+
+    The command works with no arguments (using safe defaults) as well as with
+    ``--since``/``--limit``; a ``fallback_handler`` handles the no-argument
+    invocation so the provider does not show help instead of running.
+
+    Args:
+        provider: Slack platform provider instance.
+    """
+
+    def _dispatch(payload: CommandPayload, parsed_args: dict[str, Any]) -> CommandResponse:
+        return handle_summarize_command(payload, parsed_args, provider.client)
+
+    def _dispatch_default(payload: CommandPayload) -> CommandResponse:
+        return handle_summarize_command(payload, {}, provider.client)
+
+    provider.register_command(
+        command="summarize",
+        handler=_dispatch,
+        parent="sre.incident",
+        description=(
+            "Summarize what has happened in this channel so far for someone "
+            "joining the incident"
+        ),
+        description_key=f"{_DOMAIN}.description",
+        usage_hint="[--since 2h] [--limit 100]",
+        examples=["", "--since 2h --limit 100"],
+        example_keys=[f"{_DOMAIN}.examples.default", f"{_DOMAIN}.examples.since"],
+        arguments=[
+            Argument(
+                name="--since",
+                type=ArgumentType.STRING,
+                required=False,
+                description=(
+                    "How far back to summarize, e.g. 30m, 2h, 1d "
+                    "(defaults to the start of the incident channel)"
+                ),
+            ),
+            Argument(
+                name="--limit",
+                type=ArgumentType.INTEGER,
+                required=False,
+                description="Maximum number of messages to include",
+            ),
+        ],
+        fallback_handler=_dispatch_default,
+    )
+
+
+def handle_summarize_command(
+    payload: CommandPayload,
+    parsed_args: dict[str, Any],
+    client: WebClient | None,
+) -> CommandResponse:
+    """Handle ``/sre incident summarize`` and return an ephemeral summary.
+
+    Follows the five-step handler discipline: parse (framework) -> typed
+    values -> gather inputs + one service call -> ``OperationResult`` ->
+    render. All responses are ephemeral so the summary is only shown to the
+    invoking responder.
+
+    Args:
+        payload: Command payload from the Slack platform provider.
+        parsed_args: Parsed ``--since``/``--limit`` arguments (empty for the
+            no-argument invocation). When ``--since`` is omitted the summary
+            covers the whole incident, starting from channel creation.
+        client: Slack Web API client, or ``None`` before startup.
+
+    Returns:
+        An ephemeral ``CommandResponse`` carrying the summary, an
+        empty-history notice, or a generic error message.
+    """
+    locale = payload.user_locale or "en-US"
+    log = logger.bind(
+        command="incident_summarize",
+        user_id=payload.user_id,
+        channel_id=payload.channel_id,
+    )
+
+    if client is None or not payload.channel_id:
+        log.warning("incident_summary_no_client_or_channel")
+        return _error_response(locale)
+
+    settings = get_incident_summary_settings()
+
+    limit = _resolve_limit(parsed_args.get("--limit"), settings)
+    oldest = _resolve_oldest(parsed_args.get("--since"))
+    if oldest is None:
+        # No explicit window: summarize the whole incident from when the
+        # channel (incident) was created.
+        oldest = _resolve_channel_start(client, payload.channel_id, settings, log)
+
+    messages = _fetch_transcript(
+        client, payload.channel_id, limit=limit, oldest=oldest, log=log
+    )
+
+    result = asyncio.run(
+        summarize_transcript(messages, instructions=_SLACK_FORMAT_INSTRUCTIONS)
+    )
+
+    if result.is_success:
+        header = t(f"{_DOMAIN}.result.header", locale, "🧾 Incident summary")
+        body = _to_slack_mrkdwn(result.data or "")
+        return CommandResponse(message=f"{header}\n\n{body}", ephemeral=True)
+
+    if result.error_code == EMPTY_HISTORY_CODE:
+        msg = t(
+            f"{_DOMAIN}.result.empty_history",
+            locale,
+            "There's nothing to summarize yet in this channel.",
+        )
+        return CommandResponse(message=msg, ephemeral=True)
+
+    log.warning(
+        "incident_summary_service_error",
+        status=result.status,
+        error=result.message,
+    )
+    return _error_response(locale)
+
+
+def _fetch_transcript(
+    client: WebClient,
+    channel_id: str,
+    *,
+    limit: int,
+    oldest: float,
+    log: structlog.stdlib.BoundLogger,
+) -> list[TranscriptMessage]:
+    """Fetch channel history and resolve authors into transcript messages.
+
+    Returns messages in chronological order. On any Slack API failure an empty
+    list is returned so the caller renders the empty-history path.
+    """
+    try:
+        response = client.conversations_history(
+            channel=channel_id, limit=limit, oldest=f"{oldest:.6f}"
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade to empty history on any API error
+        log.warning("incident_summary_history_fetch_failed", error=str(exc))
+        return []
+
+    raw_messages = response.get("messages") or []
+    name_cache: dict[str, str] = {}
+    messages: list[TranscriptMessage] = []
+
+    # conversations_history returns newest-first; summarize chronologically.
+    for raw in reversed(raw_messages):
+        text = (raw.get("text") or "").strip()
+        user_id = raw.get("user")
+        if not text or not user_id:
+            continue
+        author = _resolve_display_name(client, user_id, name_cache, log)
+        messages.append(TranscriptMessage(author=author, text=text))
+
+    log.info(
+        "incident_summary_history_fetched",
+        raw_count=len(raw_messages),
+        kept_count=len(messages),
+    )
+    return messages
+
+
+def _resolve_display_name(
+    client: WebClient,
+    user_id: str,
+    cache: dict[str, str],
+    log: structlog.stdlib.BoundLogger,
+) -> str:
+    """Resolve a Slack user's display name, caching lookups; fall back to the id."""
+    if user_id in cache:
+        return cache[user_id]
+
+    name = user_id
+    try:
+        info = client.users_info(user=user_id)
+        user: dict[str, Any] = info.get("user") or {}
+        profile: dict[str, Any] = user.get("profile") or {}
+        name = (
+            profile.get("display_name")
+            or profile.get("real_name")
+            or user.get("real_name")
+            or user_id
+        )
+    except Exception as exc:  # noqa: BLE001 - a missing name must not fail the summary
+        log.warning("incident_summary_user_lookup_failed", user_id=user_id, error=str(exc))
+
+    cache[user_id] = name
+    return name
+
+
+def _resolve_limit(raw: Any, settings: IncidentSummarySettings) -> int:
+    """Coerce the ``--limit`` value into a safe, capped message count."""
+    if raw is None:
+        return settings.DEFAULT_HISTORY_LIMIT
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        return settings.DEFAULT_HISTORY_LIMIT
+    if limit <= 0:
+        return settings.DEFAULT_HISTORY_LIMIT
+    return min(limit, settings.MAX_HISTORY_LIMIT)
+
+
+def _resolve_oldest(raw: Any) -> float | None:
+    """Convert ``--since`` into a Unix ``oldest`` timestamp.
+
+    Returns ``None`` when ``--since`` is absent or invalid so the caller can
+    default to the incident's start (channel creation time).
+    """
+    seconds = _parse_since_seconds(raw)
+    if seconds is None:
+        return None
+    return time.time() - seconds
+
+
+def _resolve_channel_start(
+    client: WebClient,
+    channel_id: str,
+    settings: IncidentSummarySettings,
+    log: structlog.stdlib.BoundLogger,
+) -> float:
+    """Return the channel's creation time as a Unix ``oldest`` timestamp.
+
+    Falls back to the configured default window if the channel info lookup
+    fails, so a missing ``channels:read``/``groups:read`` scope degrades
+    gracefully instead of failing the summary.
+    """
+    try:
+        info = client.conversations_info(channel=channel_id)
+        created = (info.get("channel") or {}).get("created")
+        if created is not None:
+            return float(created)
+    except Exception as exc:  # noqa: BLE001 - degrade to default window on any API error
+        log.warning("incident_summary_channel_info_failed", error=str(exc))
+
+    return time.time() - settings.DEFAULT_SINCE_HOURS * _SINCE_UNITS["h"]
+
+
+def _parse_since_seconds(raw: Any) -> int | None:
+    """Parse a ``--since`` duration (e.g. ``30m``, ``2h``, ``1d``) into seconds.
+
+    A bare number is treated as hours. Returns ``None`` for missing or invalid
+    input so the caller applies the configured default.
+    """
+    if not raw:
+        return None
+
+    value = str(raw).strip().lower()
+    unit = value[-1] if value else ""
+    if unit in _SINCE_UNITS:
+        number = value[:-1]
+    else:
+        unit = "h"
+        number = value
+
+    try:
+        amount = int(number)
+    except (TypeError, ValueError):
+        return None
+    if amount <= 0:
+        return None
+    return amount * _SINCE_UNITS[unit]
+
+
+def _to_slack_mrkdwn(text: str) -> str:
+    """Normalize model output into valid Slack ``mrkdwn``.
+
+    Models occasionally emit standard/GitHub Markdown despite instructions.
+    Slack does not render ``**bold**``, ``__bold__``, or ``#`` headings, and it
+    shows literal ``**`` characters. This is a defensive, format-only pass:
+
+    - ``**bold**``/``__bold__`` -> ``*bold*`` (Slack bold).
+    - Markdown headings (``#``..``######``) -> a bold line.
+    - Bullet markers (``-``, ``*``, ``+``, one or more ``•``) -> a single
+      ``• `` prefix, collapsing duplicates like ``• •``.
+
+    Content is never altered -- only formatting markers.
+    """
+    # **bold** / __bold__ -> *bold* first, so heading/bullet handling below
+    # never has to reason about double-marker runs.
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+    text = re.sub(r"__(.+?)__", r"*\1*", text)
+
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+        indent = line[: len(line) - len(stripped)]
+
+        # Markdown heading -> bold line (drop the leading #s).
+        heading = re.match(r"^#{1,6}\s+(.*)$", stripped)
+        if heading:
+            content = heading.group(1).strip().strip("*")
+            lines.append(f"*{content}*" if content else "")
+            continue
+
+        # Collapse any run of bullet markers (-, *, +, •) into a single "• ".
+        bullet = re.match(r"^(?:[-+\u2022]\s*)+(.*)$", stripped)
+        if bullet:
+            content = bullet.group(1).strip()
+            stripped = f"\u2022 {content}" if content else "\u2022"
+
+        lines.append(f"{indent}{stripped}")
+
+    return "\n".join(lines).strip()
+
+
+def _error_response(locale: str) -> CommandResponse:
+    """Build the generic ephemeral error response."""
+    msg = t(
+        f"{_DOMAIN}.result.error",
+        locale,
+        "❌ Couldn't generate a summary right now. Please try again shortly.",
+    )
+    return CommandResponse(message=msg, ephemeral=True)

--- a/app/packages/incident_summary/platforms/slack.py
+++ b/app/packages/incident_summary/platforms/slack.py
@@ -54,7 +54,7 @@ _SLACK_FORMAT_INSTRUCTIONS = (
     "Format the summary using Slack mrkdwn, NOT standard Markdown. "
     "Rules: use *single asterisks* for bold (never **double**); use _underscores_ "
     "for italics; do NOT use Markdown headings (#, ##, ###) -- make section titles "
-    "a bold line instead (e.g. *Key events*); start bullet lines with '• '; "
+    "a bold line instead (e.g. *Current status*); start bullet lines with '• '; "
     "separate sections with a blank line. Keep links as plain URLs."
 )
 

--- a/app/packages/incident_summary/platforms/slack.py
+++ b/app/packages/incident_summary/platforms/slack.py
@@ -8,8 +8,7 @@ delegates the actual summarization to the platform-agnostic
 
 The Slack Web API client is captured lazily from the provider at dispatch
 time (it only exists after startup); ``slack_sdk`` is imported for typing
-only, keeping the package free of a runtime Slack SDK dependency per
-``decisions/transport-slack.md``.
+only, keeping the package free of a runtime Slack SDK dependency.
 """
 
 from __future__ import annotations

--- a/app/packages/incident_summary/platforms/slack.py
+++ b/app/packages/incident_summary/platforms/slack.py
@@ -80,10 +80,7 @@ def register_commands(provider: SlackPlatformProvider) -> None:
         command="summarize",
         handler=_dispatch,
         parent="sre.incident",
-        description=(
-            "Summarize what has happened in this channel so far for someone "
-            "joining the incident"
-        ),
+        description=("Summarize what has happened in this channel so far for someone joining the incident"),
         description_key=f"{_DOMAIN}.description",
         usage_hint="[--since 2h] [--limit 100]",
         examples=["", "--since 2h --limit 100"],
@@ -93,10 +90,7 @@ def register_commands(provider: SlackPlatformProvider) -> None:
                 name="--since",
                 type=ArgumentType.STRING,
                 required=False,
-                description=(
-                    "How far back to summarize, e.g. 30m, 2h, 1d "
-                    "(defaults to the start of the incident channel)"
-                ),
+                description=("How far back to summarize, e.g. 30m, 2h, 1d (defaults to the start of the incident channel)"),
             ),
             Argument(
                 name="--limit",
@@ -152,13 +146,9 @@ def handle_summarize_command(
         # channel (incident) was created.
         oldest = _resolve_channel_start(client, payload.channel_id, settings, log)
 
-    messages = _fetch_transcript(
-        client, payload.channel_id, limit=limit, oldest=oldest, log=log
-    )
+    messages = _fetch_transcript(client, payload.channel_id, limit=limit, oldest=oldest, log=log)
 
-    result = asyncio.run(
-        summarize_transcript(messages, instructions=_SLACK_FORMAT_INSTRUCTIONS)
-    )
+    result = asyncio.run(summarize_transcript(messages, instructions=_SLACK_FORMAT_INSTRUCTIONS))
 
     if result.is_success:
         header = t(f"{_DOMAIN}.result.header", locale, "🧾 Incident summary")
@@ -195,9 +185,7 @@ def _fetch_transcript(
     list is returned so the caller renders the empty-history path.
     """
     try:
-        response = client.conversations_history(
-            channel=channel_id, limit=limit, oldest=f"{oldest:.6f}"
-        )
+        response = client.conversations_history(channel=channel_id, limit=limit, oldest=f"{oldest:.6f}")
     except Exception as exc:  # noqa: BLE001 - degrade to empty history on any API error
         log.warning("incident_summary_history_fetch_failed", error=str(exc))
         return []
@@ -238,12 +226,7 @@ def _resolve_display_name(
         info = client.users_info(user=user_id)
         user: dict[str, Any] = info.get("user") or {}
         profile: dict[str, Any] = user.get("profile") or {}
-        name = (
-            profile.get("display_name")
-            or profile.get("real_name")
-            or user.get("real_name")
-            or user_id
-        )
+        name = profile.get("display_name") or profile.get("real_name") or user.get("real_name") or user_id
     except Exception as exc:  # noqa: BLE001 - a missing name must not fail the summary
         log.warning("incident_summary_user_lookup_failed", user_id=user_id, error=str(exc))
 
@@ -257,7 +240,7 @@ def _resolve_limit(raw: Any, settings: IncidentSummarySettings) -> int:
         return settings.DEFAULT_HISTORY_LIMIT
     try:
         limit = int(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return settings.DEFAULT_HISTORY_LIMIT
     if limit <= 0:
         return settings.DEFAULT_HISTORY_LIMIT
@@ -318,7 +301,7 @@ def _parse_since_seconds(raw: Any) -> int | None:
 
     try:
         amount = int(number)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if amount <= 0:
         return None

--- a/app/packages/incident_summary/service.py
+++ b/app/packages/incident_summary/service.py
@@ -1,0 +1,101 @@
+"""Platform-agnostic incident-summary business logic.
+
+Builds a chat transcript from platform-neutral messages and delegates to the
+``Summarizer`` port (``integrations.openai``) to produce a catch-up summary
+for a responder joining an incident channel.
+
+This module is deliberately free of Slack and HTTP imports: it consumes
+``TranscriptMessage`` values and returns an ``OperationResult`` so any
+platform adapter can reuse it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import structlog
+
+from infrastructure.operations import OperationResult
+from integrations.openai import Summarizer, get_summarizer
+
+logger = structlog.get_logger()
+
+EMPTY_HISTORY_CODE = "EMPTY_HISTORY"
+
+# Incident-response content prompt owned by this feature. Platform adapters
+# supply additional formatting instructions (e.g. Slack mrkdwn) that are
+# appended to this base prompt.
+_CONTENT_INSTRUCTIONS = (
+    "You are an incident-response assistant. Summarize the following chat "
+    "transcript from an incident channel so that a responder joining now can "
+    "quickly catch up. Be brief and high-signal -- aim for a summary readable "
+    "in under 30 seconds. Cover, each in at most 1-2 short sentences: what is "
+    "happening, current status, and key actions taken. For key events, list "
+    "at most 5 of the most important turning points as short bullets (group "
+    "or omit minor back-and-forth; do not include timestamps unless essential). "
+    "End with any open questions or next steps as short bullets. Prefer fewer, "
+    "denser bullets over long chronological logs. Do not invent details that "
+    "are not in the transcript."
+)
+
+
+@dataclass(frozen=True)
+class TranscriptMessage:
+    """A single platform-neutral chat message to be summarized."""
+
+    author: str
+    text: str
+
+
+async def summarize_transcript(
+    messages: Sequence[TranscriptMessage],
+    *,
+    instructions: str | None = None,
+    summarizer: Summarizer | None = None,
+) -> OperationResult[str]:
+    """Summarize a chronological sequence of channel messages.
+
+    Args:
+        messages: Chronologically ordered messages to summarize.
+        instructions: Optional additional instructions (e.g. platform-specific
+            formatting rules) appended to this feature's incident-content
+            prompt before being sent to the ``Summarizer`` port.
+        summarizer: Optional ``Summarizer`` port; defaults to the process
+            singleton. Injected in tests.
+
+    Returns:
+        ``OperationResult`` carrying the summary text on success, a permanent
+        error with ``EMPTY_HISTORY`` when there is nothing to summarize, or the
+        summarizer's classified error otherwise.
+    """
+    log = logger.bind(operation="summarize_transcript", message_count=len(messages))
+
+    if not messages:
+        log.info("incident_summary_empty_history")
+        return OperationResult.permanent_error(
+            message="No channel history to summarize",
+            error_code=EMPTY_HISTORY_CODE,
+        )
+
+    transcript = _build_transcript(messages)
+    summarizer = summarizer or get_summarizer()
+    full_instructions = _CONTENT_INSTRUCTIONS
+    if instructions:
+        full_instructions = f"{_CONTENT_INSTRUCTIONS}\n\n{instructions}"
+    result = await summarizer.summarize(transcript, instructions=full_instructions)
+
+    if result.is_success:
+        log.info("incident_summary_generated")
+    else:
+        log.warning(
+            "incident_summary_failed",
+            status=result.status,
+            error=result.message,
+        )
+    return result
+
+
+def _build_transcript(messages: Sequence[TranscriptMessage]) -> str:
+    """Render messages as ``author: text`` lines in the given order."""
+    return "\n".join(f"{message.author}: {message.text}" for message in messages)

--- a/app/packages/incident_summary/service.py
+++ b/app/packages/incident_summary/service.py
@@ -31,12 +31,9 @@ _CONTENT_INSTRUCTIONS = (
     "transcript from an incident channel so that a responder joining now can "
     "quickly catch up. Be brief and high-signal -- aim for a summary readable "
     "in under 30 seconds. Cover, each in at most 1-2 short sentences: what is "
-    "happening, current status, and key actions taken. For key events, list "
-    "at most 5 of the most important turning points as short bullets (group "
-    "or omit minor back-and-forth; do not include timestamps unless essential). "
-    "End with any open questions or next steps as short bullets. Prefer fewer, "
-    "denser bullets over long chronological logs. Do not invent details that "
-    "are not in the transcript."
+    "happening, current status, and key actions taken. End with next steps as "
+    "short bullets. Prefer fewer, denser bullets over long chronological logs. "
+    "Do not invent details that are not in the transcript."
 )
 
 

--- a/app/packages/incident_summary/settings.py
+++ b/app/packages/incident_summary/settings.py
@@ -1,0 +1,41 @@
+"""Feature settings for the incident_summary package.
+
+Feature-domain configuration (how much channel history to summarize) lives
+with the consuming feature per ``decisions/configuration.md`` -- vendor
+transport concerns (OpenAI key/model/timeout) stay in
+``integrations.openai.settings``. All fields carry safe defaults so the
+package works with no environment configuration.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class IncidentSummarySettings(BaseSettings):
+    """History-bounding settings for the ``/sre incident summarize`` command."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    DEFAULT_HISTORY_LIMIT: int = Field(
+        default=500, alias="INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT"
+    )
+    MAX_HISTORY_LIMIT: int = Field(
+        default=1000, alias="INCIDENT_SUMMARY__MAX_HISTORY_LIMIT"
+    )
+    DEFAULT_SINCE_HOURS: int = Field(
+        default=24, alias="INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS"
+    )
+
+
+@lru_cache(maxsize=1)
+def get_incident_summary_settings() -> IncidentSummarySettings:
+    """Return the process-wide ``IncidentSummarySettings`` singleton."""
+    return IncidentSummarySettings()

--- a/app/packages/incident_summary/settings.py
+++ b/app/packages/incident_summary/settings.py
@@ -1,8 +1,7 @@
 """Feature settings for the incident_summary package.
 
 Feature-domain configuration (how much channel history to summarize) lives
-with the consuming feature per ``decisions/configuration.md`` -- vendor
-transport concerns (OpenAI key/model/timeout) stay in
+with the consuming feature -- vendor transport concerns (OpenAI key/model/timeout) stay in
 ``integrations.openai.settings``. All fields carry safe defaults so the
 package works with no environment configuration.
 """

--- a/app/packages/incident_summary/settings.py
+++ b/app/packages/incident_summary/settings.py
@@ -23,15 +23,9 @@ class IncidentSummarySettings(BaseSettings):
         extra="ignore",
     )
 
-    DEFAULT_HISTORY_LIMIT: int = Field(
-        default=500, alias="INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT"
-    )
-    MAX_HISTORY_LIMIT: int = Field(
-        default=1000, alias="INCIDENT_SUMMARY__MAX_HISTORY_LIMIT"
-    )
-    DEFAULT_SINCE_HOURS: int = Field(
-        default=24, alias="INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS"
-    )
+    DEFAULT_HISTORY_LIMIT: int = Field(default=500, alias="INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT")
+    MAX_HISTORY_LIMIT: int = Field(default=1000, alias="INCIDENT_SUMMARY__MAX_HISTORY_LIMIT")
+    DEFAULT_SINCE_HOURS: int = Field(default=24, alias="INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS")
 
 
 @lru_cache(maxsize=1)

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -118,6 +118,7 @@ def test_initiate_resources_creation_succeeds(
 • `/sre incident status update <status>` - Update incident status
 • `/sre incident updates add` - Add incident updates
 • `/sre incident show` - View incident details
+• `/sre incident summarize` - Summarize the channel to catch up someone joining the incident (optionally add `--since 30m` or `--since 2h` to limit the time range)
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings

--- a/app/tests/unit/integrations/openai/conftest.py
+++ b/app/tests/unit/integrations/openai/conftest.py
@@ -1,0 +1,43 @@
+"""Isolation fixtures for OpenAI integration unit tests.
+
+Clears cached settings and OPENAI_* environment variables between tests so
+that each test observes a clean configuration surface.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from integrations.openai.settings import OpenAISettings, get_openai_settings
+
+
+def _clear_openai_caches() -> None:
+    """Reset the cached settings singleton."""
+    get_openai_settings.cache_clear()
+
+
+def _clear_openai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every OPENAI_* variable so tests cannot read host values."""
+    for key in tuple(os.environ):
+        if key.startswith("OPENAI_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _openai_env_isolation(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Apply env + cache isolation for every OpenAI unit test."""
+    monkeypatch.setitem(OpenAISettings.model_config, "env_file", None)
+    _clear_openai_env(monkeypatch)
+    _clear_openai_caches()
+    yield
+    _clear_openai_caches()
+
+
+@pytest.fixture
+def openai_settings(monkeypatch: pytest.MonkeyPatch) -> OpenAISettings:
+    """A valid ``OpenAISettings`` instance with a dummy API key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    return OpenAISettings()

--- a/app/tests/unit/integrations/openai/test_openai_client.py
+++ b/app/tests/unit/integrations/openai/test_openai_client.py
@@ -1,0 +1,99 @@
+"""Tests for the OpenAI vendor client: authenticated client construction and
+error classification.
+
+No live network calls -- httpx error responses are constructed directly.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from infrastructure.operations.status import OperationStatus
+from integrations.openai.client import build_openai_client, classify_openai_error
+
+pytestmark = pytest.mark.unit
+
+
+def _http_status_error(
+    status_code: int, headers: dict[str, str] | None = None
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(
+        status_code=status_code, headers=headers or {}, request=request
+    )
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=request, response=response
+    )
+
+
+class TestBuildOpenAIClient:
+    def test_sets_auth_header_and_base_url(self, openai_settings):
+        client = build_openai_client(settings=openai_settings)
+
+        assert client.headers["Authorization"] == "Bearer sk-test-key"
+        assert client.headers["Content-Type"] == "application/json"
+        assert str(client.base_url).rstrip("/") == openai_settings.BASE_URL
+
+
+class TestClassifyOpenAIError:
+    def test_unauthorized(self):
+        result = classify_openai_error(_http_status_error(401))
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "UNAUTHORIZED"
+
+    def test_forbidden(self):
+        result = classify_openai_error(_http_status_error(403))
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "FORBIDDEN"
+
+    def test_not_found(self):
+        result = classify_openai_error(_http_status_error(404))
+
+        assert result.status == OperationStatus.NOT_FOUND
+        assert result.error_code == "NOT_FOUND"
+
+    def test_rate_limited_with_retry_after(self):
+        result = classify_openai_error(
+            _http_status_error(429, headers={"Retry-After": "42"})
+        )
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "RATE_LIMITED"
+        assert result.retry_after == 42
+
+    def test_rate_limited_default_retry_after(self):
+        result = classify_openai_error(_http_status_error(429))
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.retry_after == 60
+
+    def test_server_error_is_transient(self):
+        result = classify_openai_error(_http_status_error(503))
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "SERVER_ERROR"
+
+    def test_other_4xx_is_permanent(self):
+        result = classify_openai_error(_http_status_error(400))
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "HTTP_ERROR"
+
+    def test_timeout_is_transient(self):
+        result = classify_openai_error(httpx.TimeoutException("timed out"))
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "TIMEOUT"
+
+    def test_connection_error_is_transient(self):
+        result = classify_openai_error(httpx.ConnectError("connection refused"))
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "CONNECTION_ERROR"
+
+    def test_unmapped_exception_propagates(self):
+        with pytest.raises(KeyError):
+            classify_openai_error(KeyError("bug"))

--- a/app/tests/unit/integrations/openai/test_openai_client.py
+++ b/app/tests/unit/integrations/openai/test_openai_client.py
@@ -15,16 +15,10 @@ from integrations.openai.client import build_openai_client, classify_openai_erro
 pytestmark = pytest.mark.unit
 
 
-def _http_status_error(
-    status_code: int, headers: dict[str, str] | None = None
-) -> httpx.HTTPStatusError:
+def _http_status_error(status_code: int, headers: dict[str, str] | None = None) -> httpx.HTTPStatusError:
     request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
-    response = httpx.Response(
-        status_code=status_code, headers=headers or {}, request=request
-    )
-    return httpx.HTTPStatusError(
-        f"HTTP {status_code}", request=request, response=response
-    )
+    response = httpx.Response(status_code=status_code, headers=headers or {}, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
 
 
 class TestBuildOpenAIClient:
@@ -56,9 +50,7 @@ class TestClassifyOpenAIError:
         assert result.error_code == "NOT_FOUND"
 
     def test_rate_limited_with_retry_after(self):
-        result = classify_openai_error(
-            _http_status_error(429, headers={"Retry-After": "42"})
-        )
+        result = classify_openai_error(_http_status_error(429, headers={"Retry-After": "42"}))
 
         assert result.status == OperationStatus.TRANSIENT_ERROR
         assert result.error_code == "RATE_LIMITED"

--- a/app/tests/unit/integrations/openai/test_openai_settings.py
+++ b/app/tests/unit/integrations/openai/test_openai_settings.py
@@ -1,0 +1,44 @@
+"""Tests for OpenAI vendor settings resolution and defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.openai.settings import OpenAISettings, get_openai_settings
+
+pytestmark = pytest.mark.unit
+
+
+class TestOpenAISettings:
+    def test_reads_api_key_and_applies_defaults(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+
+        settings = OpenAISettings()
+
+        assert settings.API_KEY.get_secret_value() == "sk-secret"
+        assert settings.MODEL == "gpt-5.4-nano"
+        assert settings.MAX_OUTPUT_TOKENS == 800
+        assert settings.TIMEOUT_SECONDS == 30.0
+        assert settings.BASE_URL == "https://ai.cdssandbox.xyz"
+
+    def test_overrides_from_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+        monkeypatch.setenv("OPENAI_MODEL", "gpt-5.4-mini")
+        monkeypatch.setenv("OPENAI_MAX_OUTPUT_TOKENS", "1200")
+
+        settings = OpenAISettings()
+
+        assert settings.MODEL == "gpt-5.4-mini"
+        assert settings.MAX_OUTPUT_TOKENS == 1200
+
+    def test_api_key_not_exposed_in_repr(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+
+        settings = OpenAISettings()
+
+        assert "sk-secret" not in repr(settings)
+
+    def test_get_openai_settings_is_cached(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+
+        assert get_openai_settings() is get_openai_settings()

--- a/app/tests/unit/integrations/openai/test_openai_summarizer.py
+++ b/app/tests/unit/integrations/openai/test_openai_summarizer.py
@@ -59,9 +59,7 @@ class TestOpenAISummarizer:
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured["body"] = request.read().decode()
-            return httpx.Response(
-                200, json={"choices": [{"message": {"content": "ok"}}]}
-            )
+            return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
 
         summarizer = OpenAISummarizer(settings=openai_settings)
         with patch(

--- a/app/tests/unit/integrations/openai/test_openai_summarizer.py
+++ b/app/tests/unit/integrations/openai/test_openai_summarizer.py
@@ -1,0 +1,119 @@
+"""Tests for the OpenAI-backed Summarizer adapter.
+
+No live network calls -- an httpx MockTransport serves canned responses so the
+real request/response/raise_for_status path is exercised offline.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from infrastructure.operations.status import OperationStatus
+from integrations.openai.summarizer import OpenAISummarizer, Summarizer
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_client(handler, settings) -> httpx.AsyncClient:
+    """Build an httpx.AsyncClient wired to a MockTransport handler."""
+    return httpx.AsyncClient(
+        base_url=settings.BASE_URL,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+class TestOpenAISummarizer:
+    def test_satisfies_summarizer_protocol(self, openai_settings):
+        assert isinstance(OpenAISummarizer(settings=openai_settings), Summarizer)
+
+    @pytest.mark.asyncio
+    async def test_success_returns_summary(self, openai_settings):
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["body"] = request.read().decode()
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "  A concise summary.  "}}]},
+            )
+
+        summarizer = OpenAISummarizer(settings=openai_settings)
+        with patch(
+            "integrations.openai.summarizer.build_openai_client",
+            return_value=_mock_client(handler, openai_settings),
+        ):
+            result = await summarizer.summarize("alice: prod is down\nbob: on it")
+
+        assert result.status == OperationStatus.SUCCESS
+        assert result.data == "A concise summary."
+        assert captured["url"].endswith("/chat/completions")
+        assert "prod is down" in captured["body"]
+
+    @pytest.mark.asyncio
+    async def test_custom_instructions_are_sent(self, openai_settings):
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.read().decode()
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": "ok"}}]}
+            )
+
+        summarizer = OpenAISummarizer(settings=openai_settings)
+        with patch(
+            "integrations.openai.summarizer.build_openai_client",
+            return_value=_mock_client(handler, openai_settings),
+        ):
+            await summarizer.summarize("t", instructions="Be terse.")
+
+        assert "Be terse." in captured["body"]
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_returns_empty_summary(self, openai_settings):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"choices": []})
+
+        summarizer = OpenAISummarizer(settings=openai_settings)
+        with patch(
+            "integrations.openai.summarizer.build_openai_client",
+            return_value=_mock_client(handler, openai_settings),
+        ):
+            result = await summarizer.summarize("t")
+
+        assert result.status == OperationStatus.SUCCESS
+        assert result.data == ""
+
+    @pytest.mark.asyncio
+    async def test_http_error_is_classified(self, openai_settings):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "bad key"})
+
+        summarizer = OpenAISummarizer(settings=openai_settings)
+        with patch(
+            "integrations.openai.summarizer.build_openai_client",
+            return_value=_mock_client(handler, openai_settings),
+        ):
+            result = await summarizer.summarize("t")
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "UNAUTHORIZED"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_is_transient(self, openai_settings):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "7"})
+
+        summarizer = OpenAISummarizer(settings=openai_settings)
+        with patch(
+            "integrations.openai.summarizer.build_openai_client",
+            return_value=_mock_client(handler, openai_settings),
+        ):
+            result = await summarizer.summarize("t")
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "RATE_LIMITED"
+        assert result.retry_after == 7

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_locales.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_locales.py
@@ -1,0 +1,30 @@
+"""EN/FR locale catalogue parity for the incident_summary package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import packages.incident_summary as incident_summary_pkg
+
+pytestmark = pytest.mark.unit
+
+_LOCALES_DIR = Path(incident_summary_pkg.__file__).parent / "locales"
+
+
+def _keys(filename: str) -> set[str]:
+    data = yaml.safe_load((_LOCALES_DIR / filename).read_text(encoding="utf-8"))
+    return set(data["incident_summary"].keys())
+
+
+def test_en_fr_locales_have_identical_keys():
+    en_keys = _keys("incident_summary.en-US.yml")
+    fr_keys = _keys("incident_summary.fr-FR.yml")
+
+    assert en_keys == fr_keys, f"Locale key mismatch: {en_keys ^ fr_keys}"
+
+
+def test_locales_are_non_empty():
+    assert _keys("incident_summary.en-US.yml")

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_service.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_service.py
@@ -23,9 +23,7 @@ class _StubSummarizer:
         self.received_instructions: str | None = None
         self.calls = 0
 
-    async def summarize(
-        self, transcript: str, *, instructions: str | None = None
-    ) -> OperationResult[str]:
+    async def summarize(self, transcript: str, *, instructions: str | None = None) -> OperationResult[str]:
         self.calls += 1
         self.received_transcript = transcript
         self.received_instructions = instructions
@@ -62,9 +60,7 @@ class TestSummarizeTranscript:
         stub = _StubSummarizer(OperationResult.success(data="ok"))
         messages = [TranscriptMessage(author="Ada", text="prod is down")]
 
-        await summarize_transcript(
-            messages, instructions="USE SLACK MRKDWN", summarizer=stub
-        )
+        await summarize_transcript(messages, instructions="USE SLACK MRKDWN", summarizer=stub)
 
         assert stub.received_instructions is not None
         # Feature content prompt is always present...
@@ -84,9 +80,7 @@ class TestSummarizeTranscript:
 
     @pytest.mark.asyncio
     async def test_summarizer_error_is_propagated(self):
-        error = OperationResult.transient_error(
-            message="rate limited", error_code="RATE_LIMITED", retry_after=7
-        )
+        error = OperationResult.transient_error(message="rate limited", error_code="RATE_LIMITED", retry_after=7)
         stub = _StubSummarizer(error)
         messages = [TranscriptMessage(author="Ada", text="hello")]
 

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_service.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_service.py
@@ -1,0 +1,97 @@
+"""Tests for the platform-agnostic incident_summary service."""
+
+from __future__ import annotations
+
+import pytest
+
+from infrastructure.operations import OperationResult, OperationStatus
+from packages.incident_summary.service import (
+    EMPTY_HISTORY_CODE,
+    TranscriptMessage,
+    summarize_transcript,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _StubSummarizer:
+    """Minimal ``Summarizer`` stub capturing the transcript it receives."""
+
+    def __init__(self, result: OperationResult[str]) -> None:
+        self._result = result
+        self.received_transcript: str | None = None
+        self.received_instructions: str | None = None
+        self.calls = 0
+
+    async def summarize(
+        self, transcript: str, *, instructions: str | None = None
+    ) -> OperationResult[str]:
+        self.calls += 1
+        self.received_transcript = transcript
+        self.received_instructions = instructions
+        return self._result
+
+
+class TestSummarizeTranscript:
+    @pytest.mark.asyncio
+    async def test_empty_history_returns_permanent_error_without_calling_summarizer(self):
+        stub = _StubSummarizer(OperationResult.success(data="unused"))
+
+        result = await summarize_transcript([], summarizer=stub)
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == EMPTY_HISTORY_CODE
+        assert stub.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_success_builds_chronological_transcript_and_returns_summary(self):
+        stub = _StubSummarizer(OperationResult.success(data="A tidy summary"))
+        messages = [
+            TranscriptMessage(author="Ada", text="prod is down"),
+            TranscriptMessage(author="Bob", text="on it, rolling back"),
+        ]
+
+        result = await summarize_transcript(messages, summarizer=stub)
+
+        assert result.is_success
+        assert result.data == "A tidy summary"
+        assert stub.received_transcript == "Ada: prod is down\nBob: on it, rolling back"
+
+    @pytest.mark.asyncio
+    async def test_content_prompt_is_always_sent_and_formatting_is_appended(self):
+        stub = _StubSummarizer(OperationResult.success(data="ok"))
+        messages = [TranscriptMessage(author="Ada", text="prod is down")]
+
+        await summarize_transcript(
+            messages, instructions="USE SLACK MRKDWN", summarizer=stub
+        )
+
+        assert stub.received_instructions is not None
+        # Feature content prompt is always present...
+        assert "incident-response assistant" in stub.received_instructions
+        # ...with the caller's platform formatting appended after it.
+        assert stub.received_instructions.endswith("USE SLACK MRKDWN")
+
+    @pytest.mark.asyncio
+    async def test_content_prompt_sent_without_extra_instructions(self):
+        stub = _StubSummarizer(OperationResult.success(data="ok"))
+        messages = [TranscriptMessage(author="Ada", text="prod is down")]
+
+        await summarize_transcript(messages, summarizer=stub)
+
+        assert stub.received_instructions is not None
+        assert "incident-response assistant" in stub.received_instructions
+
+    @pytest.mark.asyncio
+    async def test_summarizer_error_is_propagated(self):
+        error = OperationResult.transient_error(
+            message="rate limited", error_code="RATE_LIMITED", retry_after=7
+        )
+        stub = _StubSummarizer(error)
+        messages = [TranscriptMessage(author="Ada", text="hello")]
+
+        result = await summarize_transcript(messages, summarizer=stub)
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "RATE_LIMITED"
+        assert result.retry_after == 7

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_settings.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_settings.py
@@ -1,0 +1,40 @@
+"""Tests for incident_summary feature settings defaults and overrides."""
+
+from __future__ import annotations
+
+import pytest
+
+from packages.incident_summary.settings import (
+    IncidentSummarySettings,
+    get_incident_summary_settings,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestIncidentSummarySettings:
+    def test_applies_safe_defaults(self, monkeypatch):
+        for var in (
+            "INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT",
+            "INCIDENT_SUMMARY__MAX_HISTORY_LIMIT",
+            "INCIDENT_SUMMARY__DEFAULT_SINCE_HOURS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        settings = IncidentSummarySettings()
+
+        assert settings.DEFAULT_HISTORY_LIMIT == 500
+        assert settings.MAX_HISTORY_LIMIT == 1000
+        assert settings.DEFAULT_SINCE_HOURS == 24
+
+    def test_overrides_from_env(self, monkeypatch):
+        monkeypatch.setenv("INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT", "50")
+        monkeypatch.setenv("INCIDENT_SUMMARY__MAX_HISTORY_LIMIT", "250")
+
+        settings = IncidentSummarySettings()
+
+        assert settings.DEFAULT_HISTORY_LIMIT == 50
+        assert settings.MAX_HISTORY_LIMIT == 250
+
+    def test_get_incident_summary_settings_is_cached(self):
+        assert get_incident_summary_settings() is get_incident_summary_settings()

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_slack.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_slack.py
@@ -80,14 +80,10 @@ class TestRegisterCommands:
 
 class TestHandleSummarizeCommand:
     def test_success_renders_ephemeral_summary(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "prod is down", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "prod is down", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="Everything is on fire")
-        )) as mock_service:
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="Everything is on fire"))) as mock_service:
             response = handle_summarize_command(payload, {}, client)
 
         assert response.ephemeral is True
@@ -98,27 +94,22 @@ class TestHandleSummarizeCommand:
         client = _client_with_history([])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.permanent_error(
-                message="nothing", error_code=EMPTY_HISTORY_CODE
-            )
-        )):
+        with patch(
+            _SUMMARIZE,
+            new=AsyncMock(return_value=OperationResult.permanent_error(message="nothing", error_code=EMPTY_HISTORY_CODE)),
+        ):
             response = handle_summarize_command(payload, {}, client)
 
         assert response.ephemeral is True
         assert "nothing to summarize" in response.message.lower()
 
     def test_summarizer_error_renders_generic_error(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "prod is down", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "prod is down", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.transient_error(
-                message="boom", error_code="SERVER_ERROR"
-            )
-        )):
+        with patch(
+            _SUMMARIZE, new=AsyncMock(return_value=OperationResult.transient_error(message="boom", error_code="SERVER_ERROR"))
+        ):
             response = handle_summarize_command(payload, {}, client)
 
         assert response.ephemeral is True
@@ -135,9 +126,7 @@ class TestHandleSummarizeCommand:
         mock_service.assert_not_awaited()
 
     def test_missing_channel_id_returns_error_without_calling_service(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "hi", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "hi", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="")
 
         with patch(_SUMMARIZE, new=AsyncMock()) as mock_service:
@@ -149,14 +138,10 @@ class TestHandleSummarizeCommand:
         client.conversations_history.assert_not_called()
 
     def test_success_message_includes_header(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "prod is down", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "prod is down", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="the summary body")
-        )):
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="the summary body"))):
             response = handle_summarize_command(payload, {}, client)
 
         # Header precedes the summary body, separated by a blank line.
@@ -165,15 +150,11 @@ class TestHandleSummarizeCommand:
         assert response.message != "the summary body"
 
     def test_summary_body_is_normalized_to_slack_mrkdwn(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "prod is down", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "prod is down", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
         raw = "## **Key events**\n- • first\n- second"
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data=raw)
-        )):
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data=raw))):
             response = handle_summarize_command(payload, {}, client)
 
         assert "**" not in response.message
@@ -182,14 +163,10 @@ class TestHandleSummarizeCommand:
         assert "*Key events*" in response.message
 
     def test_limit_argument_is_passed_to_history_fetch(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "hi", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "hi", "ts": "1"}])
         payload = CommandPayload(text="--limit 25", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )):
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))):
             handle_summarize_command(payload, {"--limit": 25}, client)
 
         assert client.conversations_history.call_args.kwargs["limit"] == 25
@@ -203,14 +180,10 @@ class TestHandleSummarizeCommand:
     def test_since_argument_sets_oldest_window(self):
         import time
 
-        client = _client_with_history(
-            [{"user": "U1", "text": "hi", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "hi", "ts": "1"}])
         payload = CommandPayload(text="--since 2h", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )):
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))):
             handle_summarize_command(payload, {"--since": "2h"}, client)
 
         oldest = float(client.conversations_history.call_args.kwargs["oldest"])
@@ -218,15 +191,11 @@ class TestHandleSummarizeCommand:
         assert abs((time.time() - 2 * 3600) - oldest) < 5
 
     def test_default_window_starts_at_channel_creation(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "hi", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "hi", "ts": "1"}])
         client.conversations_info.return_value = {"channel": {"created": 1_700_000_000}}
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )):
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))):
             handle_summarize_command(payload, {}, client)
 
         client.conversations_info.assert_called_once_with(channel="C123")
@@ -234,14 +203,10 @@ class TestHandleSummarizeCommand:
         assert oldest == 1_700_000_000.0
 
     def test_slack_mrkdwn_instructions_passed_to_service(self):
-        client = _client_with_history(
-            [{"user": "U1", "text": "hi", "ts": "1"}]
-        )
+        client = _client_with_history([{"user": "U1", "text": "hi", "ts": "1"}])
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )) as mock_service:
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))) as mock_service:
             handle_summarize_command(payload, {}, client)
 
         instructions = mock_service.await_args.kwargs["instructions"]
@@ -259,9 +224,7 @@ class TestHandleSummarizeCommand:
         )
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )) as mock_service:
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))) as mock_service:
             handle_summarize_command(payload, {}, client)
 
         messages = mock_service.await_args.args[0]
@@ -272,11 +235,10 @@ class TestHandleSummarizeCommand:
         client.conversations_history.side_effect = RuntimeError("slack exploded")
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.permanent_error(
-                message="nothing", error_code=EMPTY_HISTORY_CODE
-            )
-        )) as mock_service:
+        with patch(
+            _SUMMARIZE,
+            new=AsyncMock(return_value=OperationResult.permanent_error(message="nothing", error_code=EMPTY_HISTORY_CODE)),
+        ) as mock_service:
             response = handle_summarize_command(payload, {}, client)
 
         # A Slack API failure degrades to an empty transcript, so the service
@@ -297,9 +259,7 @@ class TestHandleSummarizeCommand:
         )
         payload = CommandPayload(text="", user_id="U9", channel_id="C123")
 
-        with patch(_SUMMARIZE, new=AsyncMock(
-            return_value=OperationResult.success(data="ok")
-        )) as mock_service:
+        with patch(_SUMMARIZE, new=AsyncMock(return_value=OperationResult.success(data="ok"))) as mock_service:
             handle_summarize_command(payload, {}, client)
 
         messages = mock_service.await_args.args[0]
@@ -383,9 +343,7 @@ class TestResolveDisplayName:
 
     def test_caches_lookups_to_avoid_repeat_api_calls(self):
         client = MagicMock()
-        client.users_info.return_value = {
-            "user": {"profile": {"display_name": "Ada"}}
-        }
+        client.users_info.return_value = {"user": {"profile": {"display_name": "Ada"}}}
         cache: dict[str, str] = {}
         log = structlog.get_logger()
 
@@ -437,9 +395,7 @@ class TestResolveChannelStart:
         client.conversations_info.return_value = {"channel": {"created": 1_700_000_000}}
         settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
 
-        oldest = _resolve_channel_start(
-            client, "C123", settings, structlog.get_logger()
-        )
+        oldest = _resolve_channel_start(client, "C123", settings, structlog.get_logger())
 
         assert oldest == 1_700_000_000.0
 
@@ -450,9 +406,7 @@ class TestResolveChannelStart:
         client.conversations_info.side_effect = RuntimeError("no scope")
         settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
 
-        oldest = _resolve_channel_start(
-            client, "C123", settings, structlog.get_logger()
-        )
+        oldest = _resolve_channel_start(client, "C123", settings, structlog.get_logger())
 
         assert abs((time.time() - 24 * 3600) - oldest) < 5
 
@@ -463,9 +417,7 @@ class TestResolveChannelStart:
         client.conversations_info.return_value = {"channel": {}}
         settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
 
-        oldest = _resolve_channel_start(
-            client, "C123", settings, structlog.get_logger()
-        )
+        oldest = _resolve_channel_start(client, "C123", settings, structlog.get_logger())
 
         assert abs((time.time() - 24 * 3600) - oldest) < 5
 
@@ -475,9 +427,7 @@ class TestFetchTranscript:
         client = MagicMock()
         client.conversations_history.side_effect = RuntimeError("boom")
 
-        messages = _fetch_transcript(
-            client, "C123", limit=200, oldest=0.0, log=structlog.get_logger()
-        )
+        messages = _fetch_transcript(client, "C123", limit=200, oldest=0.0, log=structlog.get_logger())
 
         assert messages == []
 
@@ -489,12 +439,8 @@ class TestFetchTranscript:
                 {"user": "U1", "text": "oldest", "ts": "1"},
             ]
         }
-        client.users_info.return_value = {
-            "user": {"profile": {"display_name": "Ada"}}
-        }
+        client.users_info.return_value = {"user": {"profile": {"display_name": "Ada"}}}
 
-        messages = _fetch_transcript(
-            client, "C123", limit=200, oldest=0.0, log=structlog.get_logger()
-        )
+        messages = _fetch_transcript(client, "C123", limit=200, oldest=0.0, log=structlog.get_logger())
 
         assert [m.text for m in messages] == ["oldest", "newest"]

--- a/app/tests/unit/packages/incident_summary/test_incident_summary_slack.py
+++ b/app/tests/unit/packages/incident_summary/test_incident_summary_slack.py
@@ -1,0 +1,500 @@
+"""Tests for the incident_summary Slack platform adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+
+from infrastructure.operations import OperationResult
+from integrations.slack.models import CommandPayload
+from packages.incident_summary.platforms.slack import (
+    _fetch_transcript,
+    _parse_since_seconds,
+    _resolve_channel_start,
+    _resolve_display_name,
+    _resolve_limit,
+    _resolve_oldest,
+    _to_slack_mrkdwn,
+    handle_summarize_command,
+    register_commands,
+)
+from packages.incident_summary.service import EMPTY_HISTORY_CODE
+from packages.incident_summary.settings import IncidentSummarySettings
+
+pytestmark = pytest.mark.unit
+
+_SUMMARIZE = "packages.incident_summary.platforms.slack.summarize_transcript"
+
+
+def _client_with_history(messages: list[dict], display_name: str = "Ada") -> MagicMock:
+    """Build a Slack client mock for conversations_history + users_info."""
+    client = MagicMock()
+    client.conversations_history.return_value = {"messages": messages}
+    client.conversations_info.return_value = {"channel": {"created": 1_700_000_000}}
+    client.users_info.return_value = {
+        "ok": True,
+        "user": {"profile": {"display_name": display_name}},
+    }
+    return client
+
+
+class TestRegisterCommands:
+    def test_registers_summarize_under_sre_incident(self):
+        provider = MagicMock()
+
+        register_commands(provider)
+
+        provider.register_command.assert_called_once()
+        kwargs = provider.register_command.call_args.kwargs
+        assert kwargs["command"] == "summarize"
+        assert kwargs["parent"] == "sre.incident"
+        assert kwargs["fallback_handler"] is not None
+        assert kwargs["handler"] is not None
+
+    def test_handler_dispatches_with_provider_client_and_parsed_args(self):
+        provider = MagicMock()
+        register_commands(provider)
+        handler = provider.register_command.call_args.kwargs["handler"]
+        payload = CommandPayload(text="--limit 5", user_id="U9", channel_id="C123")
+
+        target = "packages.incident_summary.platforms.slack.handle_summarize_command"
+        with patch(target) as mock_handle:
+            handler(payload, {"--limit": 5})
+
+        mock_handle.assert_called_once_with(payload, {"--limit": 5}, provider.client)
+
+    def test_fallback_dispatches_with_empty_args(self):
+        provider = MagicMock()
+        register_commands(provider)
+        fallback = provider.register_command.call_args.kwargs["fallback_handler"]
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        target = "packages.incident_summary.platforms.slack.handle_summarize_command"
+        with patch(target) as mock_handle:
+            fallback(payload)
+
+        mock_handle.assert_called_once_with(payload, {}, provider.client)
+
+
+class TestHandleSummarizeCommand:
+    def test_success_renders_ephemeral_summary(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "prod is down", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="Everything is on fire")
+        )) as mock_service:
+            response = handle_summarize_command(payload, {}, client)
+
+        assert response.ephemeral is True
+        assert "Everything is on fire" in response.message
+        mock_service.assert_awaited_once()
+
+    def test_empty_history_renders_localized_notice(self):
+        client = _client_with_history([])
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.permanent_error(
+                message="nothing", error_code=EMPTY_HISTORY_CODE
+            )
+        )):
+            response = handle_summarize_command(payload, {}, client)
+
+        assert response.ephemeral is True
+        assert "nothing to summarize" in response.message.lower()
+
+    def test_summarizer_error_renders_generic_error(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "prod is down", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.transient_error(
+                message="boom", error_code="SERVER_ERROR"
+            )
+        )):
+            response = handle_summarize_command(payload, {}, client)
+
+        assert response.ephemeral is True
+        assert response.message.startswith("❌")
+        assert "nothing to summarize" not in response.message.lower()
+
+    def test_missing_client_returns_error_without_calling_service(self):
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock()) as mock_service:
+            response = handle_summarize_command(payload, {}, None)
+
+        assert response.ephemeral is True
+        mock_service.assert_not_awaited()
+
+    def test_missing_channel_id_returns_error_without_calling_service(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "hi", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="")
+
+        with patch(_SUMMARIZE, new=AsyncMock()) as mock_service:
+            response = handle_summarize_command(payload, {}, client)
+
+        assert response.ephemeral is True
+        assert response.message.startswith("\u274c")
+        mock_service.assert_not_awaited()
+        client.conversations_history.assert_not_called()
+
+    def test_success_message_includes_header(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "prod is down", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="the summary body")
+        )):
+            response = handle_summarize_command(payload, {}, client)
+
+        # Header precedes the summary body, separated by a blank line.
+        assert response.message.endswith("the summary body")
+        assert response.message.split("\n\n", 1)[0].strip() != ""
+        assert response.message != "the summary body"
+
+    def test_summary_body_is_normalized_to_slack_mrkdwn(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "prod is down", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+        raw = "## **Key events**\n- • first\n- second"
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data=raw)
+        )):
+            response = handle_summarize_command(payload, {}, client)
+
+        assert "**" not in response.message
+        assert "##" not in response.message
+        assert "\u2022 \u2022" not in response.message
+        assert "*Key events*" in response.message
+
+    def test_limit_argument_is_passed_to_history_fetch(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "hi", "ts": "1"}]
+        )
+        payload = CommandPayload(text="--limit 25", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )):
+            handle_summarize_command(payload, {"--limit": 25}, client)
+
+        assert client.conversations_history.call_args.kwargs["limit"] == 25
+        # oldest must be a Slack "seconds.6digits" timestamp, not a raw float
+        # repr (a 7+ decimal value silently matches nothing and returns zero
+        # messages).
+        oldest = client.conversations_history.call_args.kwargs["oldest"]
+        assert isinstance(oldest, str)
+        assert len(oldest.rsplit(".", 1)[1]) == 6
+
+    def test_since_argument_sets_oldest_window(self):
+        import time
+
+        client = _client_with_history(
+            [{"user": "U1", "text": "hi", "ts": "1"}]
+        )
+        payload = CommandPayload(text="--since 2h", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )):
+            handle_summarize_command(payload, {"--since": "2h"}, client)
+
+        oldest = float(client.conversations_history.call_args.kwargs["oldest"])
+        # 2 hours ago, within a small tolerance for execution time.
+        assert abs((time.time() - 2 * 3600) - oldest) < 5
+
+    def test_default_window_starts_at_channel_creation(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "hi", "ts": "1"}]
+        )
+        client.conversations_info.return_value = {"channel": {"created": 1_700_000_000}}
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )):
+            handle_summarize_command(payload, {}, client)
+
+        client.conversations_info.assert_called_once_with(channel="C123")
+        oldest = float(client.conversations_history.call_args.kwargs["oldest"])
+        assert oldest == 1_700_000_000.0
+
+    def test_slack_mrkdwn_instructions_passed_to_service(self):
+        client = _client_with_history(
+            [{"user": "U1", "text": "hi", "ts": "1"}]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )) as mock_service:
+            handle_summarize_command(payload, {}, client)
+
+        instructions = mock_service.await_args.kwargs["instructions"]
+        assert "mrkdwn" in instructions.lower()
+
+    def test_bot_and_empty_messages_are_filtered_out(self):
+        # Only human messages with both text and a user survive; bot messages
+        # (no ``user``) and empty-text messages are dropped.
+        client = _client_with_history(
+            [
+                {"user": "U1", "text": "real message", "ts": "3"},
+                {"bot_id": "B1", "text": "posted by an app", "ts": "2"},
+                {"user": "U1", "text": "   ", "ts": "1"},
+            ]
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )) as mock_service:
+            handle_summarize_command(payload, {}, client)
+
+        messages = mock_service.await_args.args[0]
+        assert [m.text for m in messages] == ["real message"]
+
+    def test_history_fetch_error_renders_empty_history(self):
+        client = MagicMock()
+        client.conversations_history.side_effect = RuntimeError("slack exploded")
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.permanent_error(
+                message="nothing", error_code=EMPTY_HISTORY_CODE
+            )
+        )) as mock_service:
+            response = handle_summarize_command(payload, {}, client)
+
+        # A Slack API failure degrades to an empty transcript, so the service
+        # is called with no messages and the empty-history notice is shown.
+        assert mock_service.await_args.args[0] == []
+        assert response.ephemeral is True
+        assert "nothing to summarize" in response.message.lower()
+
+    def test_history_is_built_chronologically_with_resolved_names(self):
+        # conversations_history returns newest-first; the service must receive
+        # chronological "author: text" lines with display names resolved.
+        client = _client_with_history(
+            [
+                {"user": "U1", "text": "second", "ts": "2"},
+                {"user": "U1", "text": "first", "ts": "1"},
+            ],
+            display_name="Ada",
+        )
+        payload = CommandPayload(text="", user_id="U9", channel_id="C123")
+
+        with patch(_SUMMARIZE, new=AsyncMock(
+            return_value=OperationResult.success(data="ok")
+        )) as mock_service:
+            handle_summarize_command(payload, {}, client)
+
+        messages = mock_service.await_args.args[0]
+        assert [m.text for m in messages] == ["first", "second"]
+        assert all(m.author == "Ada" for m in messages)
+
+
+class TestArgumentParsingHelpers:
+    def test_parse_since_seconds_supports_unit_suffixes(self):
+        assert _parse_since_seconds("30m") == 1800
+        assert _parse_since_seconds("2h") == 7200
+        assert _parse_since_seconds("1d") == 86400
+
+    def test_parse_since_seconds_treats_bare_number_as_hours(self):
+        assert _parse_since_seconds("3") == 10800
+
+    @pytest.mark.parametrize("value", [None, "", "abc", "0h", "-5"])
+    def test_parse_since_seconds_returns_none_for_invalid(self, value):
+        assert _parse_since_seconds(value) is None
+
+    def test_resolve_oldest_uses_default_when_since_absent(self):
+        # Absent --since yields None so the caller defaults to channel start.
+        assert _resolve_oldest(None) is None
+
+    def test_resolve_oldest_computes_window_from_since(self):
+        import time
+
+        before = _resolve_oldest("2h")
+        assert before is not None
+        assert abs((time.time() - 2 * 3600) - before) < 5
+
+    def test_resolve_limit_defaults_and_caps(self):
+        # Fields use env-var aliases, so populate via alias to exercise the
+        # logic independently of the production defaults.
+        settings = IncidentSummarySettings.model_validate(
+            {
+                "INCIDENT_SUMMARY__DEFAULT_HISTORY_LIMIT": 200,
+                "INCIDENT_SUMMARY__MAX_HISTORY_LIMIT": 500,
+            }
+        )
+        assert _resolve_limit(None, settings) == 200
+        assert _resolve_limit(50, settings) == 50
+        assert _resolve_limit(9999, settings) == 500
+        assert _resolve_limit(0, settings) == 200
+        assert _resolve_limit("bad", settings) == 200
+
+
+class TestResolveDisplayName:
+    def test_prefers_display_name(self):
+        client = MagicMock()
+        client.users_info.return_value = {
+            "user": {
+                "profile": {"display_name": "Ada", "real_name": "Ada Lovelace"},
+                "real_name": "Ada Lovelace",
+            }
+        }
+
+        name = _resolve_display_name(client, "U1", {}, structlog.get_logger())
+
+        assert name == "Ada"
+
+    def test_falls_back_to_real_name_when_display_name_blank(self):
+        client = MagicMock()
+        client.users_info.return_value = {
+            "user": {
+                "profile": {"display_name": "", "real_name": "Ada Lovelace"},
+            }
+        }
+
+        name = _resolve_display_name(client, "U1", {}, structlog.get_logger())
+
+        assert name == "Ada Lovelace"
+
+    def test_falls_back_to_user_id_on_api_error(self):
+        client = MagicMock()
+        client.users_info.side_effect = RuntimeError("boom")
+
+        name = _resolve_display_name(client, "U1", {}, structlog.get_logger())
+
+        assert name == "U1"
+
+    def test_caches_lookups_to_avoid_repeat_api_calls(self):
+        client = MagicMock()
+        client.users_info.return_value = {
+            "user": {"profile": {"display_name": "Ada"}}
+        }
+        cache: dict[str, str] = {}
+        log = structlog.get_logger()
+
+        first = _resolve_display_name(client, "U1", cache, log)
+        second = _resolve_display_name(client, "U1", cache, log)
+
+        assert first == second == "Ada"
+        client.users_info.assert_called_once()
+
+
+class TestToSlackMrkdwn:
+    def test_converts_double_asterisk_bold_to_single(self):
+        assert _to_slack_mrkdwn("**Key events**") == "*Key events*"
+
+    def test_converts_double_underscore_bold_to_single(self):
+        assert _to_slack_mrkdwn("__Key events__") == "*Key events*"
+
+    def test_markdown_heading_becomes_bold_line(self):
+        assert _to_slack_mrkdwn("### Key events") == "*Key events*"
+
+    def test_heading_with_bold_markers_is_not_doubled(self):
+        assert _to_slack_mrkdwn("## **Key events**") == "*Key events*"
+
+    def test_collapses_double_bullets(self):
+        assert _to_slack_mrkdwn("\u2022 \u2022 item") == "\u2022 item"
+
+    def test_dash_bullet_becomes_slack_bullet(self):
+        assert _to_slack_mrkdwn("- item") == "\u2022 item"
+
+    def test_mixed_dash_and_bullet_markers_collapse(self):
+        assert _to_slack_mrkdwn("- \u2022 item") == "\u2022 item"
+
+    def test_bold_title_line_is_preserved_not_treated_as_bullet(self):
+        # A standalone *bold* title must not be mistaken for a bullet marker.
+        assert _to_slack_mrkdwn("*Key events*") == "*Key events*"
+
+    def test_plain_text_is_unchanged(self):
+        assert _to_slack_mrkdwn("just a sentence") == "just a sentence"
+
+    def test_multiline_document_is_normalized(self):
+        raw = "## **Key events**\n- \u2022 first thing\n- second thing"
+        expected = "*Key events*\n\u2022 first thing\n\u2022 second thing"
+        assert _to_slack_mrkdwn(raw) == expected
+
+
+class TestResolveChannelStart:
+    def test_returns_channel_created_timestamp(self):
+        client = MagicMock()
+        client.conversations_info.return_value = {"channel": {"created": 1_700_000_000}}
+        settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
+
+        oldest = _resolve_channel_start(
+            client, "C123", settings, structlog.get_logger()
+        )
+
+        assert oldest == 1_700_000_000.0
+
+    def test_falls_back_to_default_window_on_api_error(self):
+        import time
+
+        client = MagicMock()
+        client.conversations_info.side_effect = RuntimeError("no scope")
+        settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
+
+        oldest = _resolve_channel_start(
+            client, "C123", settings, structlog.get_logger()
+        )
+
+        assert abs((time.time() - 24 * 3600) - oldest) < 5
+
+    def test_falls_back_when_created_missing(self):
+        import time
+
+        client = MagicMock()
+        client.conversations_info.return_value = {"channel": {}}
+        settings = IncidentSummarySettings(DEFAULT_SINCE_HOURS=24)
+
+        oldest = _resolve_channel_start(
+            client, "C123", settings, structlog.get_logger()
+        )
+
+        assert abs((time.time() - 24 * 3600) - oldest) < 5
+
+
+class TestFetchTranscript:
+    def test_returns_empty_list_on_history_api_error(self):
+        client = MagicMock()
+        client.conversations_history.side_effect = RuntimeError("boom")
+
+        messages = _fetch_transcript(
+            client, "C123", limit=200, oldest=0.0, log=structlog.get_logger()
+        )
+
+        assert messages == []
+
+    def test_orders_messages_chronologically(self):
+        client = MagicMock()
+        client.conversations_history.return_value = {
+            "messages": [
+                {"user": "U1", "text": "newest", "ts": "3"},
+                {"user": "U1", "text": "oldest", "ts": "1"},
+            ]
+        }
+        client.users_info.return_value = {
+            "user": {"profile": {"display_name": "Ada"}}
+        }
+
+        messages = _fetch_transcript(
+            client, "C123", limit=200, oldest=0.0, log=structlog.get_logger()
+        )
+
+        assert [m.text for m in messages] == ["oldest", "newest"]


### PR DESCRIPTION
# Summary | Résumé

Adds `/sre incident summarize` — an ephemeral, AI-generated catch-up summary of an
incident channel so people joining mid-incident can get up to speed. Includes a new
OpenAI outbound client and a platform-agnostic `incident_summary` feature package.

<img width="981" height="467" alt="Screenshot 2026-08-14 at 3 31 44 PM" src="https://github.com/user-attachments/assets/7142582b-4deb-4a8c-898f-88a62ae16d28" />

## What's included

- **`integrations/openai/`** — `OpenAISettings` (partitioned), httpx client factory
  with error classification, and an `OpenAISummarizer` (`Summarizer` port) returning
  `OperationResult`.
- **`packages/incident_summary/`** — service (transcript → summarizer), Slack adapter
  under `sre.incident` (`--since 30m/2h/1d`, `--limit`; defaults look-back to channel
  creation), settings, EN/FR locales, README. Registered via pluggy hookimpls.
- **`modules/incident/`** — added `summarize` to `/sre incident help` (EN/FR) and the
  new-channel "Next Steps" message.

## Notes

- Response is ephemeral and rendered as Slack `mrkdwn`.
- Requires scopes `channels:history`/`groups:history` + `users:read` and bot channel
  membership.
- Unit tests cover the OpenAI client and the feature package (offline via
  `httpx.MockTransport`); existing incident tests updated. Doesn't regress current
  incident functionality.
