### PR TITLE
List /sre incident draft in the incident channel welcome message

### DIFF
--- a/app/modules/incident/core.py
+++ b/app/modules/incident/core.py
@@ -579,6 +579,7 @@ def initiate_resources_creation(
 • `/sre incident updates add` - Add incident updates
 • `/sre incident show` - View incident details
 • `/sre incident summarize` - Summarize the channel to catch up someone joining the incident (optionally add `--since 30m` or `--since 2h` to limit the time range)
+• `/sre incident draft` - Draft an incident report from this channel into a new document, ready for you to review and edit
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings

--- a/app/modules/incident/incident_helper.py
+++ b/app/modules/incident/incident_helper.py
@@ -63,6 +63,7 @@ Usage:
 • close        - Close the current incident
 • list         - List incidents or resources
 • summarize    - Summarize the channel to catch up someone joining the incident
+• draft        - Draft an incident report from the channel into a new document
 • help         - Show this help message
 • schedule     - Schedule an event for the incident
 • show         - Show details of the current incident
@@ -75,6 +76,7 @@ Usage:
 - `/sre incident summarize`
 - `/sre incident summarize --since 30m --limit 100`
 - `/sre incident summarize --since 2h --limit 100`
+- `/sre incident draft`
 - `/sre incident products create "foo bar"`
 - `/sre incident schedule retro`
 - `/sre incident status update Ready to be Reviewed`
@@ -109,6 +111,7 @@ Utilisation:
 • close        - Clore l'incident en cours
 • list         - Lister les incidents ou ressources
 • summarize    - Résumer le canal pour informer une personne rejoignant l'incident
+• draft        - Rédiger une ébauche de rapport d'incident à partir du canal
 • help         - Afficher ce message d'aide
 • schedule     - Planifier un événement pour l'incident
 • show         - Afficher les détails de l'incident en cours
@@ -121,6 +124,7 @@ Utilisation:
 - `/sre incident summarize`
 - `/sre incident summarize --since 30m --limit 100`
 - `/sre incident summarize --since 2h --limit 100`
+- `/sre incident draft`
 - `/sre incident products create "foo bar"`
 - `/sre incident schedule retro`
 - `/sre incident status update Ready to be Reviewed`

--- a/app/tests/modules/incident/test_incident_core.py
+++ b/app/tests/modules/incident/test_incident_core.py
@@ -119,6 +119,7 @@ def test_initiate_resources_creation_succeeds(
 • `/sre incident updates add` - Add incident updates
 • `/sre incident show` - View incident details
 • `/sre incident summarize` - Summarize the channel to catch up someone joining the incident (optionally add `--since 30m` or `--since 2h` to limit the time range)
+• `/sre incident draft` - Draft an incident report from this channel into a new document, ready for you to review and edit
 
 *Quick Actions:*
 📋 Use the bookmarked incident report above to document findings


### PR DESCRIPTION


# Summary | Résumé

`/sre incident draft` was registered and working but never advertised, so responders only found it if they already knew it existed. It's now listed in the "Available Commands" message posted when an incident channel is created, right after `/sre incident summarize`. Also added to `/sre incident help` — the actions list and examples, in both the English and French blocks — since the welcome message points people there for the complete list and draft was missing from it. Text only; no behaviour change.
