### PR TITLE
Feat/migrate google directory consumers

### DIFF
--- a/app/bin/baselines/sdk_typing_antipatterns.txt
+++ b/app/bin/baselines/sdk_typing_antipatterns.txt
@@ -14,6 +14,5 @@ integrations/aws/organizations.py
 integrations/aws/security_hub.py
 integrations/aws/sqs.py
 integrations/aws/sso_admin.py
-integrations/google_workspace/google_directory.py
 integrations/google_workspace/google_drive.py
 integrations/google_workspace/google_service.py

--- a/app/infrastructure/directory/google.py
+++ b/app/infrastructure/directory/google.py
@@ -81,18 +81,22 @@ class GoogleDirectoryProvider:
         self,
         operation: str,
         resource: Any,
-        list_kwargs: dict[str, Any],
+        request: Any,
         response_key: str,
     ) -> OperationResult[list[dict[str, Any]]]:
-        """Execute a paginated Directory list call, aggregating all pages."""
+        """Aggregate every page of an already-built Directory list request.
+
+        Takes the built request rather than call parameters so each
+        ``list(...)`` call stays type-checked against the stub at its call site.
+        """
 
         def run() -> list[dict[str, Any]]:
             items: list[dict[str, Any]] = []
-            request = resource.list(**list_kwargs)
-            while request is not None:
-                response = request.execute(num_retries=_NUM_RETRIES)
+            next_request = request
+            while next_request is not None:
+                response = next_request.execute(num_retries=_NUM_RETRIES)
                 items.extend(response.get(response_key, []))
-                request = resource.list_next(request, response)
+                next_request = resource.list_next(next_request, response)
             return items
 
         return self._call(operation, run)
@@ -393,12 +397,14 @@ class GoogleDirectoryProvider:
         if limit <= 0:
             return OperationResult.success(data=[])
 
-        list_kwargs: dict[str, Any] = {"customer": self._customer_id, "maxResults": limit}
-        if query:
-            list_kwargs["query"] = query
-
         service = self._get_service(["https://www.googleapis.com/auth/admin.directory.user.readonly"])
-        result = self._paginate("list_users", service.users(), list_kwargs, "users")
+        users_resource = service.users()
+        result = self._paginate(
+            "list_users",
+            users_resource,
+            users_resource.list(customer=self._customer_id, maxResults=limit, query=query or None),
+            "users",
+        )
         if not result.is_success:
             return self._typed_error(result)
 
@@ -447,10 +453,11 @@ class GoogleDirectoryProvider:
         """
         normalized_group_key = self._normalize_email(group_key)
         service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.member.readonly"])
+        members_resource = service.members()
         result = self._paginate(
             "get_group_members",
-            service.members(),
-            {"groupKey": normalized_group_key, "includeDerivedMembership": True},
+            members_resource,
+            members_resource.list(groupKey=normalized_group_key, includeDerivedMembership=True),
             "members",
         )
         if not result.is_success:
@@ -742,6 +749,7 @@ class GoogleDirectoryProvider:
         """
         managed_prefix = self._managed_group_query_prefix(query)
         service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.readonly"])
+        groups_resource = service.groups()
         if managed_prefix is not None:
             self._logger.info(
                 "listing_groups_alias_aware",
@@ -750,16 +758,16 @@ class GoogleDirectoryProvider:
             )
             result = self._paginate(
                 "list_groups",
-                service.groups(),
-                {"customer": self._customer_id},
+                groups_resource,
+                groups_resource.list(customer=self._customer_id),
                 "groups",
             )
         else:
             google_query = f"email:{query}*" if ":" not in query and "=" not in query else query
             result = self._paginate(
                 "list_groups",
-                service.groups(),
-                {"customer": self._customer_id, "query": google_query},
+                groups_resource,
+                groups_resource.list(customer=self._customer_id, query=google_query),
                 "groups",
             )
         if not result.is_success:
@@ -815,10 +823,11 @@ class GoogleDirectoryProvider:
         log = self._logger.bind(operation="get_user_groups", user_email=user_email)
         normalized_email = self._normalize_email(user_email)
         service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.readonly"])
+        groups_resource = service.groups()
         result = self._paginate(
             "list_user_groups",
-            service.groups(),
-            {"userKey": normalized_email},
+            groups_resource,
+            groups_resource.list(userKey=normalized_email),
             "groups",
         )
         log.debug(

--- a/app/integrations/aws/identity_store.py
+++ b/app/integrations/aws/identity_store.py
@@ -1,6 +1,5 @@
 """AWS Identity Store module"""
 
-import pandas as pd
 import structlog
 
 from infrastructure.configuration.integrations.aws import get_aws_settings
@@ -378,43 +377,3 @@ def list_groups_with_memberships(
         count=len(groups_with_memberships),
     )
     return groups_with_memberships
-
-
-def convert_aws_groups_members_to_dataframe(groups):
-    """Converts a list of AWS groups with members to a DataFrame.
-
-    Args:
-        groups (list): A list of group objects with members.
-
-    Returns:
-        DataFrame: A DataFrame with group members.
-    """
-    flattened_data = []
-    for group in groups:
-        group_id = group.get("GroupId")
-        group_name = group.get("DisplayName")
-        group_description = group.get("Description")
-        group_identity_store_id = group.get("IdentityStoreId")
-
-        for membership in group.get("GroupMemberships", []):
-            member = membership.get("MemberId", {})
-            member_user_id = member.get("UserId")
-            member_email = member.get("UserName")
-            member_given_name = member.get("Name", {}).get("GivenName")
-            member_family_name = member.get("Name", {}).get("FamilyName")
-            member_display_name = member.get("DisplayName")
-
-            flattened_record = {
-                "group_id": group_id,
-                "group_name": group_name,
-                "group_description": group_description,
-                "group_identity_store_id": group_identity_store_id,
-                "member_user_id": member_user_id,
-                "member_email": member_email,
-                "member_given_name": member_given_name,
-                "member_family_name": member_family_name,
-                "member_display_name": member_display_name,
-            }
-            flattened_data.append(flattened_record)
-
-    return pd.DataFrame(flattened_data)

--- a/app/integrations/google_workspace/google_directory.py
+++ b/app/integrations/google_workspace/google_directory.py
@@ -1,172 +1,135 @@
 """Google Directory module to interact with the Google Workspace Directory API."""
 
-import pandas as pd
+from typing import Any
+
 import structlog
 
-from integrations.google_workspace import google_service
-from integrations.utils.api import convert_string_to_camel_case, retry_request
+from infrastructure.configuration.integrations.google import get_google_workspace_settings
+from integrations.google_workspace import client as google_service_client
+from integrations.utils.api import retry_request
 from utils import filters
 
-GOOGLE_WORKSPACE_CUSTOMER_ID = google_service.GOOGLE_WORKSPACE_CUSTOMER_ID
+GOOGLE_WORKSPACE_CUSTOMER_ID = get_google_workspace_settings().GOOGLE_WORKSPACE_CUSTOMER_ID
+DIRECTORY_USER_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
+DIRECTORY_GROUP_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
+
+_USERS_PAGE_SIZE = 500
+_GROUPS_PAGE_SIZE = 200
+_MEMBERS_PAGE_SIZE = 200
 
 logger = structlog.get_logger()
-handle_google_api_errors = google_service.handle_google_api_errors
 
 
-@handle_google_api_errors
-def get_user(user_key, fields=None, **kwargs):
-    """Get a user by user key in the Google Workspace domain.
+def _collect_pages(resource: Any, request: Any, response_key: str) -> list[dict]:
+    """Aggregate every page of an already-built Directory list request.
+
+    Takes the built request rather than call parameters so the ``list(...)``
+    call itself stays type-checked against the stub at each call site.
+    """
+    items: list[dict] = []
+    while request is not None:
+        response = google_service_client.execute_google_api_request(request)
+        items.extend(response.get(response_key, []))
+        request = resource.list_next(request, response)
+    return items
+
+
+def list_users(
+    customer: str | None = None,
+    query: str | None = None,
+    fields: str | None = None,
+    delegated_user_email: str | None = None,
+) -> list[dict]:
+    """List all users in the Google Workspace domain.
 
     Args:
-        user_key (str): The user's primary email address, alias email address, or unique user ID.
-        fields (list, optional): A list of fields to include in the response.
-        **kwargs: Additional keyword arguments to pass to the API call. e.g., `delegated_user_email`.
-
-    Returns:
-        dict: A user object.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/get
-    """
-
-    return google_service.execute_google_api_call(
-        "admin",
-        "directory_v1",
-        "users",
-        "get",
-        scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
-        userKey=user_key,
-        fields=fields,
-        **kwargs,
-    )
-
-
-@handle_google_api_errors
-def list_users(
-    customer=None,
-    **kwargs,
-):
-    """List all users in the Google Workspace domain.
+        customer: The unique ID for the Google Workspace customer. Defaults to
+            the configured customer ID.
+        query: Directory API query filtering the results.
+        fields: Partial-response projection, e.g. ``users(primaryEmail, name)``.
+        delegated_user_email: Account to impersonate for this call.
 
     Returns:
         list: A list of user objects.
+
+    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list
     """
-
-    if not customer:
-        customer = GOOGLE_WORKSPACE_CUSTOMER_ID
-    return google_service.execute_google_api_call(
-        "admin",
-        "directory_v1",
-        "users",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
-        paginate=True,
-        customer=customer,
-        maxResults=500,
+    users = google_service_client.get_admin_directory_service(
+        scopes=DIRECTORY_USER_READONLY_SCOPES,
+        delegated_user_email=delegated_user_email,
+    ).users()
+    request = users.list(
+        customer=customer or GOOGLE_WORKSPACE_CUSTOMER_ID,
+        maxResults=_USERS_PAGE_SIZE,
         orderBy="email",
-        **kwargs,
+        query=query,
+        fields=fields,
     )
+    return _collect_pages(users, request, "users")
 
 
-@handle_google_api_errors
 def list_groups(
-    customer=None,
-    **kwargs,
-):
-    """List all groups in the Google Workspace domain. A query can be provided to filter the results (e.g. query="email:prefix-*" will filter for all groups where the email starts with 'prefix-').
+    customer: str | None = None,
+    query: str | None = None,
+    fields: str | None = None,
+    delegated_user_email: str | None = None,
+) -> list[dict]:
+    """List all groups in the Google Workspace domain.
 
     Args:
-        customer (str): The unique ID for the Google Workspace customer. If not provided, it will use the default customer ID from the environment variable.
-        **kwargs: Additional keyword arguments to pass to the API call. e.g., `query`, `fields`.
+        customer: The unique ID for the Google Workspace customer. Defaults to
+            the configured customer ID.
+        query: Directory API query filtering the results, e.g.
+            ``email:prefix-*`` for all groups whose email starts with ``prefix-``.
+        fields: Partial-response projection, e.g. ``groups(email, name)``.
+        delegated_user_email: Account to impersonate for this call.
+
     Returns:
         list: A list of group objects.
 
     Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/list
     """
-    if not customer:
-        customer = GOOGLE_WORKSPACE_CUSTOMER_ID
-
-    kwargs = {convert_string_to_camel_case(k): v for k, v in kwargs.items()}
-    return google_service.execute_google_api_call(
-        "admin",
-        "directory_v1",
-        "groups",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        paginate=True,
-        customer=customer,
-        maxResults=200,
+    groups = google_service_client.get_admin_directory_service(
+        scopes=DIRECTORY_GROUP_READONLY_SCOPES,
+        delegated_user_email=delegated_user_email,
+    ).groups()
+    request = groups.list(
+        customer=customer or GOOGLE_WORKSPACE_CUSTOMER_ID,
+        maxResults=_GROUPS_PAGE_SIZE,
         orderBy="email",
-        **kwargs,
+        query=query,
+        fields=fields,
     )
+    return _collect_pages(groups, request, "groups")
 
 
-@handle_google_api_errors
-def list_group_members(group_key, fields=None, **kwargs):
-    """List all group members in the Google Workspace domain.
+def list_group_members(
+    group_key: str,
+    fields: str | None = None,
+    delegated_user_email: str | None = None,
+) -> list[dict]:
+    """List all members of a Google Workspace group.
 
     Args:
-        group_key (str): The group's email address or unique group ID.
-        fields (list, optional): A list of fields to include in the response.
-        **kwargs: Additional keyword arguments to pass to the API call. e.g., `delegated_user_email`.
+        group_key: The group's email address or unique group ID.
+        fields: Partial-response projection, e.g. ``members(email, role)``.
+        delegated_user_email: Account to impersonate for this call.
 
     Returns:
         list: A list of group member objects.
 
     Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/list
     """
-
-    return google_service.execute_google_api_call(
-        "admin",
-        "directory_v1",
-        "members",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        paginate=True,
+    members = google_service_client.get_admin_directory_service(
+        scopes=DIRECTORY_GROUP_READONLY_SCOPES,
+        delegated_user_email=delegated_user_email,
+    ).members()
+    request = members.list(
         groupKey=group_key,
-        maxResults=200,
+        maxResults=_MEMBERS_PAGE_SIZE,
         fields=fields,
-        **kwargs,
     )
-
-
-@handle_google_api_errors
-def get_group(group_key, fields=None, **kwargs):
-    """Get a group by group key in the Google Workspace domain.
-    Args:
-        group_key (str): The group's email address or unique group ID.
-        fields (list, optional): A list of fields to include in the response.
-        **kwargs: Additional keyword arguments to pass to the API call. e.g., `delegated_user_email`.
-    Returns:
-        dict: A group object.
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/get
-    """
-    return google_service.execute_google_api_call(
-        "admin",
-        "directory_v1",
-        "groups",
-        "get",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        groupKey=group_key,
-        fields=fields,
-        **kwargs,
-    )
-
-
-def add_users_to_group(group, group_key):
-    """Add users to a group in the Google Workspace domain.
-
-    Args:
-        group_key (str): The group's email address or unique group ID.
-
-    Returns:
-        list: A list of user objects.
-
-    Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/insert
-    """
-    result = list_group_members(group_key)
-    if result:
-        group["members"] = result
-    return group
+    return _collect_pages(members, request, "members")
 
 
 def list_groups_with_members(
@@ -264,46 +227,3 @@ def get_members_details(members: list[dict], users: list[dict], tolerate_errors=
         if user_details:
             member.update(user_details)
     return members if not error_occured or tolerate_errors else []
-
-
-def convert_google_groups_members_to_dataframe(groups):
-    """Converts a list of Google groups with members to a DataFrame.
-
-    Args:
-        groups (list): A list of group objects with members.
-
-    Returns:
-        DataFrame: A DataFrame with group members.
-    """
-    flattened_data = []
-    for group in groups:
-        group_email = group.get("email")
-        group_name = group.get("name")
-        group_direct_members_count = group.get("directMembersCount")
-        group_description = group.get("description")
-
-        for member in group.get("members", []):
-            member_email = member.get("email")
-            member_role = member.get("role")
-            member_type = member.get("type")
-            member_status = member.get("status")
-            member_primary_email = member.get("primaryEmail")
-            member_given_name = member.get("name", {}).get("givenName")
-            member_family_name = member.get("name", {}).get("familyName")
-
-            flattened_record = {
-                "group_email": group_email,
-                "group_name": group_name,
-                "group_direct_members_count": group_direct_members_count,
-                "group_description": group_description,
-                "member_email": member_email,
-                "member_role": member_role,
-                "member_type": member_type,
-                "member_status": member_status,
-                "member_primary_email": member_primary_email,
-                "member_given_name": member_given_name,
-                "member_family_name": member_family_name,
-            }
-            flattened_data.append(flattened_record)
-
-    return pd.DataFrame(flattened_data)

--- a/app/modules/provisioning/groups.py
+++ b/app/modules/provisioning/groups.py
@@ -12,7 +12,6 @@ def get_groups_from_integration(
     pre_processing_filters: list | None = None,
     post_processing_filters: list | None = None,
     query: str | None = None,
-    return_dataframe: bool = False,
 ) -> list:
     """Retrieve the users from an integration group source.
     Supported sources are:
@@ -24,7 +23,6 @@ def get_groups_from_integration(
         pre_processing_filters (list, optional): A list of filters to apply before processing the groups. Defaults to [].
         post_processing_filters (list, optional): A list of filters to apply after processing the groups. Defaults to [].
         query (str, optional): A query to filter the groups. Defaults to None.
-        return_dataframe (bool, optional): Return the groups as a DataFrame. Defaults to False.
 
     Returns:
         list: A list of groups with members, empty list if no groups are found.
@@ -42,7 +40,6 @@ def get_groups_from_integration(
     members = None
     members_display_key = None
     integration_name = integration_source
-    groups_dataframe = None
     match integration_source:
         case "google_groups":
             log.info(
@@ -54,8 +51,6 @@ def get_groups_from_integration(
                 groups_filters=pre_processing_filters,
                 query=query,
             )
-            if return_dataframe:
-                groups_dataframe = google_directory.convert_google_groups_members_to_dataframe(groups)
             integration_name = "Google"
             group_display_key = "name"
             members = "members"
@@ -68,8 +63,6 @@ def get_groups_from_integration(
             groups = identity_store.list_groups_with_memberships(
                 groups_filters=pre_processing_filters,
             )
-            if return_dataframe:
-                groups_dataframe = identity_store.convert_aws_groups_members_to_dataframe(groups)
             integration_name = "AWS"
             group_display_key = "DisplayName"
             members = "GroupMemberships"
@@ -87,7 +80,7 @@ def get_groups_from_integration(
         members_display_key=members_display_key,
         integration_name=integration_name,
     )
-    return groups_dataframe if groups_dataframe is not None else groups
+    return groups
 
 
 def log_groups(

--- a/app/tests/integrations/aws/test_identity_store.py
+++ b/app/tests/integrations/aws/test_identity_store.py
@@ -885,3 +885,7 @@ def test_list_groups_with_memberships_filtered(
     assert result == expected_output
     assert mock_list_group_memberships.call_count == 2
     assert mock_list_users.call_count == 1
+
+
+def test_convert_aws_groups_members_to_dataframe_is_deleted():
+    assert not hasattr(identity_store, "convert_aws_groups_members_to_dataframe")

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -1,253 +1,280 @@
-"""Unit tests for google_directory module."""
+"""Unit tests for google_directory module (factory-built, stub-typed Resource path)."""
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-import pandas as pd
+import pytest
+from googleapiclient.errors import HttpError
 
+from integrations.google_workspace import client as google_client
 from integrations.google_workspace import google_directory
 
+USER_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
+GROUP_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_get_user_returns_user(execute_google_api_call_mock):
-    execute_google_api_call_mock.return_value = {
-        "id": "test_user_id",
-        "name": "test_user",
-        "email": "user.name@domain.com",
-    }
 
-    assert google_directory.get_user("test_user_id") == {
-        "id": "test_user_id",
-        "name": "test_user",
-        "email": "user.name@domain.com",
-    }
+def _http_error(status: int, reason: str = "boom") -> HttpError:
+    class FakeResp(dict):
+        def __init__(self) -> None:
+            super().__init__()
+            self.status = status
+            self.reason = reason
 
-    execute_google_api_call_mock.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "users",
-        "get",
-        scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
-        userKey="test_user_id",
-        fields=None,
+    return HttpError(resp=FakeResp(), content=b"{}")
+
+
+@pytest.fixture
+def directory_client(monkeypatch):
+    """Patch the Admin Directory factory and expose the mocked Resource chain."""
+    service = MagicMock()
+    factory = MagicMock(return_value=service)
+    monkeypatch.setattr(google_client, "get_admin_directory_service", factory)
+    users = service.users.return_value
+    groups = service.groups.return_value
+    members = service.members.return_value
+    for resource in (users, groups, members):
+        resource.list_next.return_value = None
+    return SimpleNamespace(
+        factory=factory,
+        service=service,
+        users=users,
+        groups=groups,
+        members=members,
     )
+
+
+def _set_pages(resource, pages: list[dict]) -> list[MagicMock]:
+    """Wire resource.list/list_next so each page is returned by a distinct request mock."""
+    requests = [MagicMock(name=f"request_{index}") for index in range(len(pages))]
+    for request, page in zip(requests, pages, strict=True):
+        request.execute.return_value = page
+    resource.list.return_value = requests[0]
+    resource.list_next.side_effect = list(requests[1:]) + [None]
+    return requests
 
 
 @patch(
     "integrations.google_workspace.google_directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
     new="default_google_workspace_customer_id",
 )
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_users_returns_users(execute_google_api_call_mock):
-    # Mock the results
-    results = [
+def test_list_users_returns_users(directory_client):
+    users = [
         {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
         {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
     ]
+    _set_pages(directory_client.users, [{"users": users}])
 
-    execute_google_api_call_mock.return_value = results
+    assert google_directory.list_users() == users
 
-    assert google_directory.list_users() == results
-
-    execute_google_api_call_mock.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "users",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
-        paginate=True,
+    directory_client.factory.assert_called_once_with(scopes=USER_READONLY_SCOPES, delegated_user_email=None)
+    directory_client.users.list.assert_called_once_with(
         customer="default_google_workspace_customer_id",
         maxResults=500,
         orderBy="email",
     )
 
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_users_uses_custom_delegated_user_email_and_customer_id_if_provided(
-    execute_google_api_call_mock,
-):
-    # Mock the results
-    results = [
+def test_list_users_uses_custom_delegated_user_email_and_customer_id_if_provided(directory_client):
+    users = [
         {"id": "test_user_id", "name": "test_user", "email": "email@domain.com"},
         {"id": "test_user_id2", "name": "test_user2", "email": "email2@domain.com"},
     ]
+    _set_pages(directory_client.users, [{"users": users}])
 
-    execute_google_api_call_mock.return_value = results
-
-    custom_delegated_user_email = "custom.email@domain.com"
-    custom_customer_id = "custom_customer_id"
-
-    assert (
-        google_directory.list_users(
-            delegated_user_email=custom_delegated_user_email,
-            customer=custom_customer_id,
-        )
-        == results
+    result = google_directory.list_users(
+        delegated_user_email="custom.email@domain.com",
+        customer="custom_customer_id",
     )
 
-    execute_google_api_call_mock.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "users",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.user.readonly"],
-        paginate=True,
-        delegated_user_email=custom_delegated_user_email,
-        customer=custom_customer_id,
+    assert result == users
+    directory_client.factory.assert_called_once_with(
+        scopes=USER_READONLY_SCOPES,
+        delegated_user_email="custom.email@domain.com",
+    )
+    directory_client.users.list.assert_called_once_with(
+        customer="custom_customer_id",
         maxResults=500,
         orderBy="email",
     )
+
+
+def test_list_users_concatenates_pages(directory_client):
+    _set_pages(
+        directory_client.users,
+        [
+            {"users": [{"id": "user1"}], "nextPageToken": "token"},
+            {"users": [{"id": "user2"}]},
+        ],
+    )
+
+    assert google_directory.list_users() == [{"id": "user1"}, {"id": "user2"}]
+    assert directory_client.users.list.call_count == 1
+
+
+def test_list_users_skips_page_without_response_key(directory_client):
+    _set_pages(
+        directory_client.users,
+        [
+            {"nextPageToken": "token"},
+            {"users": [{"id": "user2"}]},
+        ],
+    )
+
+    assert google_directory.list_users() == [{"id": "user2"}]
+
+
+def test_list_users_propagates_http_error(directory_client):
+    error = _http_error(429)
+    directory_client.users.list.return_value.execute.side_effect = error
+
+    with pytest.raises(HttpError) as exc_info:
+        google_directory.list_users()
+
+    assert exc_info.value is error
 
 
 @patch(
     "integrations.google_workspace.google_directory.GOOGLE_WORKSPACE_CUSTOMER_ID",
     new="default_google_workspace_customer_id",
 )
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_groups_calls_execute_google_api_call(
-    mock_execute_google_api_call,
-):
-    google_directory.list_groups()
-    mock_execute_google_api_call.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "groups",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        paginate=True,
+def test_list_groups_calls_directory_groups_list(directory_client):
+    _set_pages(directory_client.groups, [{"groups": [{"id": "test_group_id"}]}])
+
+    assert google_directory.list_groups() == [{"id": "test_group_id"}]
+
+    directory_client.factory.assert_called_once_with(scopes=GROUP_READONLY_SCOPES, delegated_user_email=None)
+    directory_client.groups.list.assert_called_once_with(
         customer="default_google_workspace_customer_id",
         maxResults=200,
         orderBy="email",
     )
 
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_groups_uses_custom_delegated_user_email_and_customer_id_if_provided(
-    execute_google_api_call_mock,
-):
-    # Mock the results
-    results = [
+def test_list_groups_uses_custom_delegated_user_email_and_customer_id_if_provided(directory_client):
+    groups = [
         {"id": "test_group_id", "name": "test_group", "email": "email@domain.com"},
         {"id": "test_group_id2", "name": "test_group2", "email": "email2@domain.com"},
     ]
+    _set_pages(directory_client.groups, [{"groups": groups}])
 
-    execute_google_api_call_mock.return_value = results
-
-    custom_delegated_user_email = "custom.email@domain.com"
-    custom_customer_id = "custom_customer_id"
-
-    assert (
-        google_directory.list_groups(
-            delegated_user_email=custom_delegated_user_email,
-            customer=custom_customer_id,
-        )
-        == results
+    result = google_directory.list_groups(
+        delegated_user_email="custom.email@domain.com",
+        customer="custom_customer_id",
     )
 
-    execute_google_api_call_mock.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "groups",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        paginate=True,
-        delegatedUserEmail=custom_delegated_user_email,
-        customer=custom_customer_id,
+    assert result == groups
+    directory_client.factory.assert_called_once_with(
+        scopes=GROUP_READONLY_SCOPES,
+        delegated_user_email="custom.email@domain.com",
+    )
+    directory_client.groups.list.assert_called_once_with(
+        customer="custom_customer_id",
         maxResults=200,
         orderBy="email",
     )
 
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_group_members_calls_execute_google_api_call_with_correct_args(
-    mock_execute_google_api_call,
-):
-    group_key = "test_group_key"
-    google_directory.list_group_members(group_key)
-    mock_execute_google_api_call.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "members",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        paginate=True,
-        groupKey=group_key,
+def test_list_groups_converts_residual_kwargs_to_camel_case(directory_client):
+    _set_pages(directory_client.groups, [{"groups": []}])
+
+    google_directory.list_groups(customer="custom_customer_id", max_results=10)
+
+    assert directory_client.groups.list.call_args.kwargs["maxResults"] == 10
+
+
+def test_list_groups_concatenates_pages(directory_client):
+    _set_pages(
+        directory_client.groups,
+        [
+            {"groups": [{"id": "group1"}], "nextPageToken": "token"},
+            {"groups": [{"id": "group2"}]},
+        ],
+    )
+
+    assert google_directory.list_groups() == [{"id": "group1"}, {"id": "group2"}]
+
+
+def test_list_groups_propagates_http_error(directory_client):
+    error = _http_error(403)
+    directory_client.groups.list.return_value.execute.side_effect = error
+
+    with pytest.raises(HttpError) as exc_info:
+        google_directory.list_groups()
+
+    assert exc_info.value is error
+
+
+def test_list_group_members_calls_directory_members_list_with_correct_args(directory_client):
+    _set_pages(directory_client.members, [{"members": [{"id": "test_member_id"}]}])
+
+    assert google_directory.list_group_members("test_group_key") == [{"id": "test_member_id"}]
+
+    directory_client.factory.assert_called_once_with(scopes=GROUP_READONLY_SCOPES, delegated_user_email=None)
+    directory_client.members.list.assert_called_once_with(
+        groupKey="test_group_key",
         maxResults=200,
         fields=None,
     )
 
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_list_group_members_uses_custom_delegated_user_email_if_provided(
-    execute_google_api_call_mock,
-):
-    # Mock the results
-    results = [
+def test_list_group_members_uses_custom_delegated_user_email_and_fields_if_provided(directory_client):
+    members = [
         {"id": "test_member_id", "email": "member@domain.com"},
         {"id": "test_member_id2", "email": "member2@domain.com"},
     ]
+    _set_pages(directory_client.members, [{"members": members}])
 
-    execute_google_api_call_mock.return_value = results
+    result = google_directory.list_group_members(
+        "test_group_key",
+        fields="members(email)",
+        delegated_user_email="custom.email@domain.com",
+    )
 
-    group_key = "test_group_key"
-    custom_delegated_user_email = "custom.email@domain.com"
-
-    assert google_directory.list_group_members(group_key, delegated_user_email=custom_delegated_user_email) == results
-
-    execute_google_api_call_mock.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "members",
-        "list",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        delegated_user_email=custom_delegated_user_email,
-        paginate=True,
-        groupKey=group_key,
+    assert result == members
+    directory_client.factory.assert_called_once_with(
+        scopes=GROUP_READONLY_SCOPES,
+        delegated_user_email="custom.email@domain.com",
+    )
+    directory_client.members.list.assert_called_once_with(
+        groupKey="test_group_key",
         maxResults=200,
-        fields=None,
+        fields="members(email)",
     )
 
 
-@patch("integrations.google_workspace.google_directory.google_service.execute_google_api_call")
-def test_get_group_calls_execute_google_api_call_with_correct_args(
-    mock_execute_google_api_call,
-):
-    group_key = "test_group_key"
-    google_directory.get_group(group_key)
-    mock_execute_google_api_call.assert_called_once_with(
-        "admin",
-        "directory_v1",
-        "groups",
-        "get",
-        scopes=["https://www.googleapis.com/auth/admin.directory.group.readonly"],
-        groupKey=group_key,
-        fields=None,
+def test_list_group_members_concatenates_pages(directory_client):
+    _set_pages(
+        directory_client.members,
+        [
+            {"members": [{"id": "member1"}], "nextPageToken": "token"},
+            {"members": [{"id": "member2"}]},
+        ],
     )
 
-
-@patch("integrations.google_workspace.google_directory.list_group_members")
-def test_add_users_to_group_calls_list_group_members(mock_list_group_members):
-    group = {"id": "test_group_id"}
-    group_key = "test_group_id"
-    google_directory.add_users_to_group(group, group_key)
-    mock_list_group_members.assert_called_once_with(group_key)
+    assert google_directory.list_group_members("test_group_key") == [{"id": "member1"}, {"id": "member2"}]
 
 
-@patch("integrations.google_workspace.google_directory.list_group_members")
-def test_add_users_to_group_adds_members(mock_list_group_members):
-    mock_list_group_members.return_value = [{"id": "test_member_id"}]
-    group = {"id": "test_group_id"}
-    group_key = "test_group_id"
-    google_directory.add_users_to_group(group, group_key)
-    assert group["members"] == [{"id": "test_member_id"}]
+def test_list_group_members_propagates_http_error(directory_client):
+    error = _http_error(404)
+    directory_client.members.list.return_value.execute.side_effect = error
+
+    with pytest.raises(HttpError) as exc_info:
+        google_directory.list_group_members("test_group_key")
+
+    assert exc_info.value is error
 
 
-@patch("integrations.google_workspace.google_directory.list_group_members")
-def test_add_users_to_group_skips_when_no_members(mock_list_group_members):
-    mock_list_group_members.return_value = []
-    group = {"id": "test_group_id"}
-    group_key = "test_group_id"
-    google_directory.add_users_to_group(group, group_key)
-    assert group.get("members") is None
+@pytest.mark.parametrize(
+    "removed",
+    [
+        "get_user",
+        "get_group",
+        "add_users_to_group",
+        "convert_google_groups_members_to_dataframe",
+    ],
+)
+def test_removed_directory_functions_are_deleted(removed):
+    assert not hasattr(google_directory, removed)
 
 
 @patch("integrations.google_workspace.google_directory.list_users")
@@ -506,7 +533,7 @@ def test_list_groups_with_members_skips_when_no_groups(mock_list_groups):
 @patch("integrations.google_workspace.google_directory.list_users")
 @patch("integrations.google_workspace.google_directory.retry_request")
 @patch("integrations.google_workspace.google_directory.list_groups")
-def test_list_groups_with_members_filtered_dataframe(
+def test_list_groups_with_members_applies_groups_filters(
     mock_list_groups,
     mock_retry_request,
     mock_list_users,
@@ -531,24 +558,8 @@ def test_list_groups_with_members_filtered_dataframe(
     mock_filter_by_condition.return_value = groups[:2]
     groups_filters = [lambda group: "test-" in group["name"]]
 
-    groups_result = google_directory.list_groups_with_members(groups_filters=groups_filters)
-    result = google_directory.convert_google_groups_members_to_dataframe(groups_result)
-
-    assert isinstance(result, pd.DataFrame)
-    assert not result.empty
-    assert set(result.columns) == {
-        "group_email",
-        "group_name",
-        "group_direct_members_count",
-        "group_description",
-        "member_email",
-        "member_role",
-        "member_type",
-        "member_status",
-        "member_primary_email",
-        "member_given_name",
-        "member_family_name",
-    }
+    assert google_directory.list_groups_with_members(groups_filters=groups_filters) == groups_with_users
+    mock_filter_by_condition.assert_called_once_with(groups, groups_filters[0])
 
 
 def test_get_members_details_breaks_on_error():

--- a/app/tests/integrations/google_workspace/test_google_directory.py
+++ b/app/tests/integrations/google_workspace/test_google_directory.py
@@ -71,6 +71,8 @@ def test_list_users_returns_users(directory_client):
         customer="default_google_workspace_customer_id",
         maxResults=500,
         orderBy="email",
+        query=None,
+        fields=None,
     )
 
 
@@ -95,6 +97,8 @@ def test_list_users_uses_custom_delegated_user_email_and_customer_id_if_provided
         customer="custom_customer_id",
         maxResults=500,
         orderBy="email",
+        query=None,
+        fields=None,
     )
 
 
@@ -147,6 +151,8 @@ def test_list_groups_calls_directory_groups_list(directory_client):
         customer="default_google_workspace_customer_id",
         maxResults=200,
         orderBy="email",
+        query=None,
+        fields=None,
     )
 
 
@@ -171,15 +177,24 @@ def test_list_groups_uses_custom_delegated_user_email_and_customer_id_if_provide
         customer="custom_customer_id",
         maxResults=200,
         orderBy="email",
+        query=None,
+        fields=None,
     )
 
 
-def test_list_groups_converts_residual_kwargs_to_camel_case(directory_client):
+def test_list_groups_forwards_query_and_fields_verbatim(directory_client):
     _set_pages(directory_client.groups, [{"groups": []}])
 
-    google_directory.list_groups(customer="custom_customer_id", max_results=10)
+    google_directory.list_groups(query="email:prefix-*", fields="groups(email)")
 
-    assert directory_client.groups.list.call_args.kwargs["maxResults"] == 10
+    call_kwargs = directory_client.groups.list.call_args.kwargs
+    assert call_kwargs["query"] == "email:prefix-*"
+    assert call_kwargs["fields"] == "groups(email)"
+
+
+def test_list_groups_rejects_unsupported_keyword(directory_client):
+    with pytest.raises(TypeError):
+        google_directory.list_groups(max_results=10)
 
 
 def test_list_groups_concatenates_pages(directory_client):

--- a/app/tests/modules/provisioning/test_provisioning_groups.py
+++ b/app/tests/modules/provisioning/test_provisioning_groups.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from modules.provisioning import groups
 
 
@@ -170,6 +172,11 @@ def test_get_groups_from_integration_filters_returns_subset(
     mock_aws_list_groups_with_memberships.assert_called_once_with(groups_filters=[])
 
     assert not mock_google_list_groups_with_members.called
+
+
+def test_get_groups_from_integration_rejects_return_dataframe():
+    with pytest.raises(TypeError):
+        groups.get_groups_from_integration("google_groups", return_dataframe=True)
 
 
 @patch("modules.provisioning.groups.logger")

--- a/backlog/tasks/task-25.1.4 - Migrate-legacy-modules-Directory-consumers-off-integrations-google_workspace-google_directory.py.md
+++ b/backlog/tasks/task-25.1.4 - Migrate-legacy-modules-Directory-consumers-off-integrations-google_workspace-google_directory.py.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:33'
-updated_date: '2026-09-01 15:35'
+updated_date: '2026-09-01 19:51'
 labels:
   - clients
   - phase-3
@@ -31,10 +31,113 @@ Slice 4 of TASK-25.1. A SEPARATE consumer path from TASK-22.4 (which only covers
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py, and modules/reports/google_groups.py no longer import integrations.google_workspace.google_directory's execute_google_api_call-backed calls; each is wired onto TASK-22.4's factory + classify_google_error (or the DirectoryService Protocol, whichever is decided at implementation time)
-- [ ] #2 All 4 consumers behave identically for their Directory-related calls (existing tests pass, behavior-neutral)
-- [ ] #3 integrations/google_workspace/google_directory.py (the non-facade, non-_next original) has zero remaining production consumers once this slice lands, or is itself migrated onto the same factory+classify pattern if a shared implementation is chosen
+- [ ] #1 integrations/google_workspace/google_directory.py's list_users, list_groups and list_group_members no longer call execute_google_api_call; they route through TASK-22.4's get_admin_directory_service factory plus classify_google_error/execute_google_api_request, so modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py and modules/reports/google_groups.py no longer reach any dispatcher-backed Directory call
+- [ ] #2 All 4 consumers behave identically for their Directory-related calls (existing tests pass, behavior-neutral); they keep their current google_directory imports, and the only consumer edit is deleting the unreachable return_dataframe branch in modules/provisioning/groups.py - the DirectoryService/DirectoryProvider Protocol route is rejected because it returns canonical dataclasses that drop the raw Google fields these modules consume
+- [ ] #3 integrations/google_workspace/google_directory.py is itself migrated onto the factory+classify pattern and is pruned from app/bin/baselines/sdk_typing_antipatterns.txt; zero execute_google_api_call occurrences remain in that file
+- [ ] #4 get_user, get_group and add_users_to_group (zero production consumers, grep-verified) are deleted together with their tests rather than migrated, while list_groups_with_members and get_members_details are left untouched and their existing tests pass unchanged
+- [ ] #5 The dead pandas DataFrame path is removed end to end: get_groups_from_integration's return_dataframe parameter and both of its branches, google_directory.convert_google_groups_members_to_dataframe, identity_store.convert_aws_groups_members_to_dataframe, and the now-unused pandas imports in both integrations modules; repo-wide grep for return_dataframe and both convert_*_to_dataframe symbols returns zero, and pandas remains a dependency only for its live consumer modules/aws/spending.py
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+DECISION (resolves the open doubt this task flagged for implementation-time review)
+
+Option A chosen: migrate integrations/google_workspace/google_directory.py ITSELF onto TASK-22.4's get_admin_directory_service factory + classify_google_error/execute_google_api_request (AC#3's second branch), mirroring the shipped TASK-25.1.1/25.1.2/25.1.3 pattern for calendar/meet/docs/sheets. The four legacy modules/ consumers keep their existing google_directory imports; only one of them (modules/provisioning/groups.py) is edited at all, and only to delete the dead return_dataframe branch (step 5).
+
+Option B (route the 4 modules through infrastructure/directory's DirectoryProvider / DirectoryService Protocol) is rejected as incompatible with AC#2 (behaviour-neutral), on evidence:
+- DirectoryProvider returns canonical frozen dataclasses inside OperationResult (DirectoryUser/DirectoryGroup/DirectoryMember, infrastructure/directory/models.py). Those drop the raw Google fields these consumers require: directMembersCount, description, primaryEmail, name.givenName/name.familyName and member status - consumed by get_members_details and by log_groups' members_display_key="primaryEmail" lookup in modules/provisioning/groups.py.
+- Signature/semantic mismatches: DirectoryProvider.list_users(query="", limit=100) caps results, while google_directory.list_users() lists all users (maxResults=500, paginated); DirectoryProvider.list_groups(query) REQUIRES a query and applies managed-group domain/prefix normalisation plus enforce_managed_group_email rejection (infrastructure/directory/google.py:158-201, 294-330), which would silently filter or reject groups the legacy report path expects.
+- GoogleDirectoryProvider has no equivalent of list_groups_with_members.
+Converting these 4 modules onto the Provider is therefore a semantic rewrite of legacy code already slated for deletion by the modules-strangler (TASK-37..41), not this slice's behaviour-neutral migration. Recorded here so implementation does not re-litigate it.
+
+CODEBASE FINDINGS (fresh grep, 2026-09-01)
+Directory call sites in the 4 consumers: modules/permissions/handler.py:15 and :32 (list_group_members); modules/provisioning/users.py:26 (list_users); modules/provisioning/groups.py:53 (list_groups_with_members) and :58 (convert_google_groups_members_to_dataframe); modules/reports/google_groups.py:47 (list_groups) and :61 (list_group_members). No other production file imports google_directory (infrastructure/operations/classifiers.py:278 is a docstring example naming a function that does not exist in this module).
+Zero production consumers, grep-verified: get_user (google_directory.py:16), get_group (:127), add_users_to_group (:155) - referenced only by tests/integrations/google_workspace/test_google_directory.py.
+DEAD PANDAS PATH, grep-verified: convert_google_groups_members_to_dataframe has exactly one call site (modules/provisioning/groups.py:58) and it is UNREACHABLE - it is gated by get_groups_from_integration's return_dataframe parameter, and no caller anywhere passes return_dataframe=True. The four production callers are modules/aws/groups.py:108 and modules/aws/identity_center.py:56 and :69 (plus users.py's separate entry point); none passes it, and no test passes it either. The same is true of its AWS twin integrations/aws/identity_store.py::convert_aws_groups_members_to_dataframe (groups.py:72), which has zero tests. Additional evidence the path is abandoned: modules/provisioning/groups.py builds groups_dataframe BEFORE applying post_processing_filters and then returns it (groups.py:90), so the dataframe branch has always ignored post-processing filtering - a latent bug nobody hit because the branch never runs.
+
+STEPS
+
+1. app/integrations/google_workspace/google_directory.py - module header.
+   - Remove "from integrations.google_workspace import google_service" and the "handle_google_api_errors = google_service.handle_google_api_errors" alias.
+   - Add "from integrations.google_workspace import client as google_service_client" (sibling naming convention: sheets.py:5, google_calendar.py:8).
+   - Keep the module-level constant but source it directly: GOOGLE_WORKSPACE_CUSTOMER_ID = get_google_workspace_settings().GOOGLE_WORKSPACE_CUSTOMER_ID, via "from infrastructure.configuration.integrations.google import get_google_workspace_settings". Same import-time evaluation as today (google_service.py:33 does exactly this), so the existing @patch("...google_directory.GOOGLE_WORKSPACE_CUSTOMER_ID") tests keep working unchanged.
+   - Add scope constants mirroring SHEETS_SCOPES/CALENDAR_SCOPES:
+     DIRECTORY_USER_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
+     DIRECTORY_GROUP_READONLY_SCOPES = ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
+   - Remove "import pandas as pd" (dead after step 5). Keep the structlog / utils.filters / retry_request imports (used by the untouched composition functions). Replace convert_string_to_camel_case with convert_kwargs_to_camel_case (see step 3).
+
+2. Add a module-private pagination helper (deliberately NOT a new shared primitive in client.py, so TASK-25.1.6's tolerated-deviation surface does not grow):
+
+   def _list_all(resource, response_key: str, **list_kwargs) -> list[dict]:
+       items: list[dict] = []
+       request = resource.list(**list_kwargs)
+       while request is not None:
+           response = google_service_client.execute_google_api_request(request)
+           items.extend(response.get(response_key, []))
+           request = resource.list_next(request, response)
+       return items
+
+   This reproduces google_service.execute_google_api_call's paginate=True branch exactly (google_service.py:216-223: accumulate results.get(<last resource-path segment>, []), advance via <method>_next(request, results)) and mirrors the shipped, already-reviewed infrastructure/directory/google.py::_paginate (lines 80-98) for the same API surface, where "resource" is likewise typed loosely. Do NOT add num_retries= : execute_google_api_request calls bare .execute() and the dispatcher did too; adding SDK-native retry here is TASK-25.1.6's call, not a behaviour-neutral slice's.
+   Stub verification already done against .venv googleapiclient-stubs/_apis/admin/directory_v1/resources.pyi: UsersResource.list_next (:819), GroupsResource.list_next (:352), MembersResource.list_next (:387) all exist, and every list() accepts **kwargs: typing.Any so fields= passes; orderBy is a Literal that accepts the "email" literal we pass.
+
+3. Convert the three list functions, each keeping its current public signature so no consumer signature changes:
+   - list_users(customer=None, **kwargs): delegated = kwargs.pop("delegated_user_email", None); service = google_service_client.get_admin_directory_service(scopes=DIRECTORY_USER_READONLY_SCOPES, delegated_user_email=delegated); return _list_all(service.users(), "users", customer=customer or GOOGLE_WORKSPACE_CUSTOMER_ID, maxResults=500, orderBy="email", **convert_kwargs_to_camel_case(kwargs)).
+   - list_groups(customer=None, **kwargs): same shape on service.groups(), response key "groups", maxResults=200, orderBy="email", scopes DIRECTORY_GROUP_READONLY_SCOPES.
+   - list_group_members(group_key, fields=None, **kwargs): scopes DIRECTORY_GROUP_READONLY_SCOPES; _list_all(service.members(), "members", groupKey=group_key, maxResults=200, fields=fields, **convert_kwargs_to_camel_case(kwargs)).
+   - Drop every @handle_google_api_errors decorator. Errors now log once (google_api_request_failed, emitted by execute_google_api_request) and propagate, classified by classify_google_error - identical to the sibling slices.
+   - Keep convert_kwargs_to_camel_case on residual kwargs to preserve today's dispatcher-side snake_case-to-camelCase conversion (google_service.py:212). Parity choice, flagged as doubt (a).
+
+4. Delete the three zero-production-consumer functions and their tests: get_user (:16), get_group (:127), add_users_to_group (:155). Deleting rather than migrating keeps the slice subtractive and matches the sprint precedent for zero-consumer surfaces (gmail.py in TASK-25.1.1, sqs.py in TASK-25.2.3, identity_store_next in TASK-23). This also retires the only Directory-related entry in google_service.handle_google_api_errors' non_critical_errors table ("get_user": ["timed out"]) - but leave google_service.py itself untouched, it is still used by google_drive.py (TASK-25.1.5).
+
+5. Delete the dead return_dataframe / pandas-conversion capability outright (HUMAN-DIRECTED 2026-09-01; the DataFrame flattening was an early data-cleanup accelerator superseded by the Directory API's own fields= partial-response projection, which list_groups_with_members already uses). It is unreachable end to end, so this is subtractive, not a behaviour change:
+   - integrations/google_workspace/google_directory.py: delete convert_google_groups_members_to_dataframe (:269-309) and the now-unused "import pandas as pd" (:3).
+   - modules/provisioning/groups.py: delete the return_dataframe parameter and its docstring line, the "groups_dataframe = None" initialiser (:45), both "if return_dataframe:" branches (:57-58 Google, :71-72 AWS), and change the final "return groups_dataframe if groups_dataframe is not None else groups" (:90) to "return groups". This is the only edit any of the 4 named consumer modules receives.
+   - integrations/aws/identity_store.py: delete convert_aws_groups_members_to_dataframe (:383-420) and its "import pandas as pd" (:3), which the previous bullet orphans. Grep-verified: zero other call sites, zero tests. See doubt (f) - this one line-item crosses into the AWS vendor package (TASK-25.2.4 territory); it is included here because leaving a newly-orphaned dead function behind is worse than the small boundary crossing, but the reviewer can veto it and it will be filed as a follow-up instead.
+   - pandas stays a project dependency: modules/aws/spending.py is a genuine, live pandas consumer (spending.py:5, 50-54, 80-81, 125-153) and is untouched.
+
+6. Leave untouched, explicitly out of scope (they contain no dispatcher calls): list_groups_with_members and get_members_details. They are business logic living inside a vendor package (an outbound-clients.md deviation), and list_groups_with_members calls integrations/utils/api.py::retry_request, a time.sleep retry loop that violates outbound-clients.md's "no hand-rolled retry loops in app/integrations/" check. Both problems are pre-existing, not introduced here - see open questions.
+
+7. Prune "integrations/google_workspace/google_directory.py" from app/bin/baselines/sdk_typing_antipatterns.txt (mirrors 25.1.1/25.1.2/25.1.3; the checker only ratchets down).
+
+8. Rework app/tests/integrations/google_workspace/test_google_directory.py:
+   - Delete the 5 tests covering the removed functions (currently at lines 11, 211, 228, 236, 245).
+   - Rewrite the 6 dispatcher-patching tests (list_users x2, list_groups x2, list_group_members x2) to patch google_directory.google_service_client.get_admin_directory_service, returning a MagicMock service whose .users()/.groups()/.members().list(...) yields a request mock and whose list_next returns None after the first page. Preserve every existing assertion on returned shape; assert the exact .list(**kwargs) call args (customer/maxResults/orderBy/groupKey/fields) plus the scopes and delegated_user_email passed to the factory (the delegation assertions the dispatcher-based tests already made, relocated to the factory boundary).
+   - Add coverage the dispatcher-based tests never had: (a) multi-page pagination - list_next returns a second request once then None, result is both pages concatenated; (b) a page missing the response key contributes nothing (matches results.get(resource, [])); (c) failure path - HttpError raised by .execute() propagates out of each of the 3 functions, proving decorator removal.
+   - test_list_groups_with_members_filtered_dataframe (:509): drop its dataframe half (the convert_... call and the DataFrame/columns assertions) and keep the groups_filters assertions, renaming it accordingly - it is currently the only test asserting that path; also remove the file's now-unused "import pandas as pd" (:5).
+   - The remaining 8 list_groups_with_members / get_members_details tests patch google_directory.list_groups / list_users / retry_request / filters.filter_by_condition directly and MUST pass unchanged - that is the regression proof for step 6.
+
+9. app/tests/unit/integrations/google_workspace/test_client.py: expect no change - get_admin_directory_service already has dedicated coverage (test_client.py:88 and :125) from TASK-22.4. Only extend it if a parametrized factory case is found to omit it.
+
+10. Consumer test files: tests/modules/permissions/test_handler.py and tests/modules/provisioning/test_provisioning_users.py patch at the modules.<x>.google_directory.<fn> boundary and require zero edits. tests/modules/provisioning/test_provisioning_groups.py: verify none of its 8 tests passes return_dataframe (grep-confirmed today: none does), so it should also need zero edits after step 5 - if any assertion depends on the removed parameter, adjust minimally. modules/reports/google_groups.py has NO test file - record in Notes that its two Directory call sites (list_groups(), list_group_members(...)) have no automated regression coverage before or after this change; behaviour-neutrality there rests on step 3's signature/return-shape preservation alone.
+
+11. Re-run repo checks: grep for execute_google_api_call in google_directory.py (expect zero); grep for convert_google_groups_members_to_dataframe / convert_aws_groups_members_to_dataframe / return_dataframe repo-wide (expect zero); python3 bin/check_sdk_typing.py; python3 bin/check_deprecated_infra_client_imports.py; bin/generate_client_usage_matrix.sh.
+
+AC-TO-STEP-TO-TEST
+- AC#1 (consumers no longer reach execute_google_api_call-backed calls; wired onto TASK-22.4's factory + classify_google_error) -> Steps 1-4 via Option A. Verified by: zero execute_google_api_call occurrences in google_directory.py; step 8 tests; the consumer test files green.
+- AC#2 (all 4 consumers behave identically) -> Steps 3 and 6 (signature/return-shape parity, composition functions untouched) + Step 10 (consumer test files green) + the explicit no-coverage note for modules/reports/google_groups.py. The step 5 edit to modules/provisioning/groups.py removes only an unreachable branch, so observable behaviour is unchanged.
+- AC#3 (google_directory.py migrated onto the same factory+classify pattern) -> Steps 1-4 and 7.
+- AC#4 (dead surfaces deleted, composition helpers untouched) -> Steps 4, 5 and 6, verified by the greps in step 11 and the unchanged composition tests in step 8.
+
+TEST MATRIX
+Happy path: list_users / list_groups / list_group_members return the same aggregated list shape as today from a mocked Resource chain. Pagination: single page (list_next -> None); two pages (concatenated); a page missing the response key (skipped). Delegation and scopes: default (no delegated_user_email -> factory called with None) and explicit override, per function. Params: customer default vs explicit; exact maxResults/orderBy/fields/groupKey call kwargs; residual snake_case kwargs arrive camelCased. Error propagation: HttpError raised by .execute() propagates for all 3 functions. Deletion proof: repo-wide grep for the removed symbols returns zero. Regression: the remaining list_groups_with_members / get_members_details tests, tests/modules/permissions/test_handler.py, tests/modules/provisioning/test_provisioning_users.py, tests/modules/provisioning/test_provisioning_groups.py (all 8 get_groups_from_integration tests must stay green after the return_dataframe parameter is removed).
+Commands: cd app && uv run pytest tests/integrations/google_workspace tests/unit/integrations/google_workspace tests/modules/permissions tests/modules/provisioning tests/unit/modules/aws -v; then make test (use the Makefile split, not the single-process whole-tree run, which has pre-existing cross-directory-pollution failures); uv run ruff check .; uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' - note the pre-existing whole-tree error baseline; the bar is zero errors naming the touched files.
+
+ASSUMPTIONS AND DOUBTS
+(a) camelCase parity: step 3 keeps convert_kwargs_to_camel_case on residual kwargs to match the dispatcher. No production caller passes snake_case today (only query and fields), so dropping it would also be safe and simpler. One line either way - confirm with the reviewer.
+(b) Unsupported-parameter behaviour change (intentional, matches the sibling slices): the dispatcher silently dropped kwargs that its docstring-scraping get_google_api_command_parameters did not recognise, logging a warning; after migration an unknown kwarg reaches googleapiclient and raises TypeError. No production caller passes one (all 4 consumers read), so this is latent-only.
+(c) fields plus pagination: list_groups_with_members passes fields="groups(email, name, directMembersCount, description)" and fields="members(email, role, type, status)", which exclude nextPageToken from the response, so list_next returns None after page one - pagination is effectively disabled on those calls TODAY and stays disabled after migration. Preserved deliberately; do NOT "fix" it in this slice, it would change how many groups/members the provisioning and report paths see.
+(d) Deleting get_user/get_group/add_users_to_group (step 4) goes beyond the task's literal wording. If the reviewer prefers keeping them, migrate them instead onto service.users().get(userKey=...) / service.groups().get(groupKey=...) through execute_google_api_request (about 20 extra production LOC plus 3 rewritten tests), and note that get_user's current "timed out" swallow-and-return-None behaviour would be lost either way.
+(e) No num_retries= is added (step 2) even though outbound-clients.md names it as the Google SDK-native retry primitive - consistent with the shipped sibling slices; it belongs to TASK-25.1.6.
+(f) Step 5's third bullet deletes integrations/aws/identity_store.py::convert_aws_groups_members_to_dataframe, which is in TASK-25.2.4's vendor package rather than this slice's. It is a pure deletion of a function that step 5's second bullet orphans, with zero call sites and zero tests. Reviewer may veto; the alternative is leaving it dead in-tree and filing a one-line follow-up.
+(g) NOT documented in decisions/: a repo-wide grep of decisions/*.md finds no mention of pandas, DataFrame, or the Directory API's fields= projection at all. The "use the Google client's built-in features instead of DataFrame flattening" rationale for step 5 is therefore an undocumented convention, not a citable decision record. If it should be durable guidance, it needs a line in a decision record - flagged for the reviewer rather than assumed.
+
+BLAST RADIUS AND ROLLBACK
+Production files changed: 3 (integrations/google_workspace/google_directory.py - migrated; modules/provisioning/groups.py and integrations/aws/identity_store.py - pure deletions) plus one guardrail baseline line. Zero changes to modules/permissions/handler.py, modules/provisioning/users.py, modules/reports/google_groups.py, client.py, google_service.py, or infrastructure/directory/**. Reachable surfaces: the provisioning Slack command paths, the Google Groups report command, and the permissions authorizer check - every new failure mode is "a Directory call raises instead of being swallowed", already the sprint-wide accepted change; the step 5 deletions remove only unreachable code. Rollback is a single revert.
+
+SIZE GATE VERDICT
+Fits one PR: roughly 120-150 changed production LOC in 1 file plus about 90 deleted LOC across 2 more files (all subtractive), 1 baseline line, 1 test file reworked (about 5 tests deleted, 6 rewritten, 6 added, 1 trimmed). Deletion-heavy slices do not trip the gate the way net-new-logic slices do. No decomposition required.
+<!-- SECTION:PLAN:END -->
 
 ## Comments
 
@@ -43,5 +146,15 @@ author: task-planner
 created: 2026-09-01 15:35
 ---
 TRACKING NOTE (2026-09-01, task-planner): TASK-25.1.1 introduces a shared integrations/google_workspace/client.py::execute_google_api_request(request) helper (try/except + classify_google_error + log + raise) as a deliberate, TEMPORARY deviation from outbound-clients.md's exact vendor-package export contract, tracked by TASK-25.1.6. This slice reuses TASK-22.4's AdminDirectoryResource factory + classify_google_error, so it may not touch execute_google_api_request at all -- if it does (or introduces an equivalent for these 4 legacy consumers), update TASK-25.1.6's description/references with the exact files and call sites added here, so its eventual inline-vs-formalize decision is made against the full call-site inventory, not just TASK-25.1.1's.
+---
+
+created: 2026-09-01 19:42
+---
+PLANNED 2026-09-01 (task-planner). Open doubt resolved in the plan: Option A (migrate google_directory.py in place onto TASK-22.4's get_admin_directory_service + execute_google_api_request/classify_google_error), NOT the DirectoryProvider Protocol route - evidence and rejected-option rationale are in the plan's DECISION section. Consequence: the 4 named consumer modules get zero code edits, so the task title reads slightly off versus what the PR will actually touch (one integrations file plus one guardrail baseline line). ACs bulk-replaced (4, was 3) to record that decision and to add the dead-function deletion. TWO PRE-EXISTING VIOLATIONS FOUND AND DELIBERATELY NOT FIXED HERE, no task covers either today (grep of backlog/ for retry_request and utils/api.py: zero hits): (1) list_groups_with_members / get_members_details / convert_google_groups_members_to_dataframe are business logic inside a vendor package, which decisions/outbound-clients.md forbids; (2) integrations/utils/api.py::retry_request is a time.sleep retry loop called from list_groups_with_members, which trips outbound-clients.md's Checks line 'no time.sleep/tenacity/backoff retry loops in app/integrations/'. Both are behaviour-changing to fix and would blow this slice's behaviour-neutral framing - recommend filing a follow-up task rather than folding them in; flagged for the human reviewer to confirm.
+---
+
+created: 2026-09-01 19:51
+---
+SCOPE ADJUSTMENT 2026-09-01 (human-directed): drop the pandas DataFrame conversion. Verified it is DEAD END TO END, not merely unused: convert_google_groups_members_to_dataframe has exactly one call site (modules/provisioning/groups.py:58) gated by get_groups_from_integration's return_dataframe parameter, and NO caller anywhere passes return_dataframe=True - the production callers are modules/aws/groups.py:108 and modules/aws/identity_center.py:56 and :69, none of which passes it, and no test does either. Extra evidence the branch was abandoned: groups.py builds the dataframe BEFORE applying post_processing_filters and then returns it (groups.py:90), so it has always silently ignored post-processing filtering. Removing the parameter also orphans the AWS twin integrations/aws/identity_store.py::convert_aws_groups_members_to_dataframe (zero other call sites, zero tests), so the plan deletes both plus their pandas imports - flagged as doubt (f) since the AWS one crosses into TASK-25.2.4's vendor package and the reviewer may prefer a separate follow-up. pandas stays a project dependency: modules/aws/spending.py is a genuine live consumer. ACs bulk-replaced (5, was 4); AC#2 now admits the one consumer edit this creates in modules/provisioning/groups.py. CORRECTION TO THE STATED RATIONALE: a repo-wide grep of decisions/*.md finds NO mention of pandas, DataFrame, or the Google client's fields= partial-response projection - the 'use the built-in API client features instead' guidance is not currently written down anywhere. Recorded as plan doubt (g); if it should be durable it needs a line in a decision record.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.4 - Migrate-legacy-modules-Directory-consumers-off-integrations-google_workspace-google_directory.py.md
+++ b/backlog/tasks/task-25.1.4 - Migrate-legacy-modules-Directory-consumers-off-integrations-google_workspace-google_directory.py.md
@@ -3,10 +3,11 @@ id: TASK-25.1.4
 title: >-
   Migrate legacy modules/ Directory consumers off
   integrations/google_workspace/google_directory.py
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-31 18:33'
-updated_date: '2026-09-01 19:51'
+updated_date: '2026-09-01 21:17'
 labels:
   - clients
   - phase-3
@@ -31,11 +32,11 @@ Slice 4 of TASK-25.1. A SEPARATE consumer path from TASK-22.4 (which only covers
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 integrations/google_workspace/google_directory.py's list_users, list_groups and list_group_members no longer call execute_google_api_call; they route through TASK-22.4's get_admin_directory_service factory plus classify_google_error/execute_google_api_request, so modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py and modules/reports/google_groups.py no longer reach any dispatcher-backed Directory call
-- [ ] #2 All 4 consumers behave identically for their Directory-related calls (existing tests pass, behavior-neutral); they keep their current google_directory imports, and the only consumer edit is deleting the unreachable return_dataframe branch in modules/provisioning/groups.py - the DirectoryService/DirectoryProvider Protocol route is rejected because it returns canonical dataclasses that drop the raw Google fields these modules consume
-- [ ] #3 integrations/google_workspace/google_directory.py is itself migrated onto the factory+classify pattern and is pruned from app/bin/baselines/sdk_typing_antipatterns.txt; zero execute_google_api_call occurrences remain in that file
-- [ ] #4 get_user, get_group and add_users_to_group (zero production consumers, grep-verified) are deleted together with their tests rather than migrated, while list_groups_with_members and get_members_details are left untouched and their existing tests pass unchanged
-- [ ] #5 The dead pandas DataFrame path is removed end to end: get_groups_from_integration's return_dataframe parameter and both of its branches, google_directory.convert_google_groups_members_to_dataframe, identity_store.convert_aws_groups_members_to_dataframe, and the now-unused pandas imports in both integrations modules; repo-wide grep for return_dataframe and both convert_*_to_dataframe symbols returns zero, and pandas remains a dependency only for its live consumer modules/aws/spending.py
+- [x] #1 integrations/google_workspace/google_directory.py's list_users, list_groups and list_group_members no longer call execute_google_api_call; they route through TASK-22.4's get_admin_directory_service factory plus classify_google_error/execute_google_api_request, so modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py and modules/reports/google_groups.py no longer reach any dispatcher-backed Directory call
+- [x] #2 All 4 consumers behave identically for their Directory-related calls (existing tests pass, behavior-neutral); they keep their current google_directory imports, and the only consumer edit is deleting the unreachable return_dataframe branch in modules/provisioning/groups.py - the DirectoryService/DirectoryProvider Protocol route is rejected because it returns canonical dataclasses that drop the raw Google fields these modules consume
+- [x] #3 integrations/google_workspace/google_directory.py is itself migrated onto the factory+classify pattern and is pruned from app/bin/baselines/sdk_typing_antipatterns.txt; zero execute_google_api_call occurrences remain in that file
+- [x] #4 get_user, get_group and add_users_to_group (zero production consumers, grep-verified) are deleted together with their tests rather than migrated, while list_groups_with_members and get_members_details are left untouched and their existing tests pass unchanged
+- [x] #5 The dead pandas DataFrame path is removed end to end: get_groups_from_integration's return_dataframe parameter and both of its branches, google_directory.convert_google_groups_members_to_dataframe, identity_store.convert_aws_groups_members_to_dataframe, and the now-unused pandas imports in both integrations modules; repo-wide grep for return_dataframe and both convert_*_to_dataframe symbols returns zero, and pandas remains a dependency only for its live consumer modules/aws/spending.py
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -138,6 +139,22 @@ Production files changed: 3 (integrations/google_workspace/google_directory.py -
 SIZE GATE VERDICT
 Fits one PR: roughly 120-150 changed production LOC in 1 file plus about 90 deleted LOC across 2 more files (all subtractive), 1 baseline line, 1 test file reworked (about 5 tests deleted, 6 rewritten, 6 added, 1 trimmed). Deletion-heavy slices do not trip the gate the way net-new-logic slices do. No decomposition required.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Migrated google_directory.py off execute_google_api_call onto get_admin_directory_service and execute_google_api_request with pagination helper _list_all. Removed zero-consumer functions get_user, get_group, add_users_to_group and convert_google_groups_members_to_dataframe. Removed dead return_dataframe parameter and branches from modules/provisioning/groups.py and orphaned convert_aws_groups_members_to_dataframe from identity_store.py. Pruned google_directory.py from sdk_typing_antipatterns.txt. All unit and integration tests pass green, lint and mypy checks pass. DoD items left for human verification: code review and merge approval.
+
+FOLLOW-ON 2026-09-01 (human-directed, post-implementation): resolved plan doubt (a) in the opposite direction and went further. The original slice kept `**kwargs` + `convert_kwargs_to_camel_case` and passed a `dict[str, Any]` into `_list_all(resource, ...)` with `resource` un-annotated -- so every `.list(**list_kwargs)` was typed `Any` and the googleapiclient-stubs adopted in TASK-70/22.4 bought this module nothing, contradicting decisions/sdk-typing.md item 3 ('calls ... directly with real method/parameter/return-shape completion AND checking').
+
+Changes: (1) integrations/google_workspace/google_directory.py -- `list_users`/`list_groups`/`list_group_members` now take explicit typed parameters (customer/query/fields/delegated_user_email; group_key/fields/delegated_user_email) instead of `**kwargs`; `convert_kwargs_to_camel_case` is gone from this module; page sizes are named constants (_USERS_PAGE_SIZE=500, _GROUPS_PAGE_SIZE=200, _MEMBERS_PAGE_SIZE=200); `_list_all` became `_collect_pages(resource, request, response_key)` which takes the ALREADY-BUILT request, so the `.list(...)` call itself stays at the call site and is stub-checked. (2) infrastructure/directory/google.py -- `_paginate` had the identical untyped hole (`resource: Any`, `list_kwargs: dict[str, Any]`); it now takes the built request too, and all four call sites (list_users, get_group_members, list_groups x2 branches, get_user_groups) build their request via a typed resource local.
+
+Behaviour parity: googleapiclient/discovery.py:1108-1112 deletes None-valued kwargs before building the request, so always passing `query=None`/`fields=None` is identical to omitting them. Verified typing now bites -- a probe passing orderBy='not-a-valid-literal' and maxResults='two-hundred' produces mypy arg-type errors that the previous dict-splat swallowed. Unknown parameter NAMES still pass mypy (stubs end in `**kwargs: typing.Any`) but now raise TypeError at the SDK, covered by a new test.
+
+Tests: test_google_directory.py list-call assertions extended with query=None/fields=None; `test_list_groups_converts_residual_kwargs_to_camel_case` replaced by `test_list_groups_forwards_query_and_fields_verbatim` + `test_list_groups_rejects_unsupported_keyword`. tests/unit/infrastructure/directory/test_google.py needed no edits. `make test` green; ruff and mypy clean on the touched files.
+
+Scope note: infrastructure/directory/google.py was explicitly out of scope in the original plan ('zero changes to ... infrastructure/directory/**'). Included on human direction because it carried the same defect on the same API surface; reviewer may split it out.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
+++ b/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-01 15:31'
-updated_date: '2026-09-01 19:47'
+updated_date: '2026-09-01 21:21'
 labels:
   - clients
   - phase-3
@@ -20,8 +20,11 @@ dependencies:
   - TASK-25.1.5
 references:
   - decisions/outbound-clients.md
+  - decisions/sdk-typing.md
   - app/integrations/google_workspace/client.py
   - app/integrations/google_workspace/google_docs.py
+  - app/integrations/google_workspace/google_directory.py
+  - app/infrastructure/directory/google.py
   - app/packages/incident_draft/adapters/google_docs.py
 parent_task_id: TASK-25.1
 priority: medium
@@ -36,6 +39,8 @@ decisions/outbound-clients.md's Checks require each vendor package to export exa
 CORRECTION (2026-09-01): this task's original framing — "decide between (a) inline per-adapter or (b) keep execute_google_api_request as a permanent, formalized shared primitive" — was inaccurate and is replaced. decisions/outbound-clients.md already decided the target shape (one adaptation tier: clients raise, adapters classify). execute_google_api_request performing classification inside the vendor package is a real, currently-necessary deviation from that decision, not a genuinely open two-way choice. It is tolerated only because today's actual Google Workspace call sites have no compliant adapter tier to inline the try/except into: TASK-25.1.1/.2's consumers are legacy app/modules/incident/*.py files with zero error handling of their own, plus app/packages/incident_draft/adapters/google_docs.py — a real packages/<feature>/adapters/ file (per decisions/feature-packages.md) that itself performs no try/except/classify today either.
 
 Reconciliation must correct this deviation, not ratify it as permanent. Once all of TASK-25.1's children (Calendar/Meet, Docs, Sheets, legacy Directory consumers, Drive) are Done and the full execute_google_api_request call-site inventory is known, this task's job is to: (1) inline try/except + classify_google_error directly at every call site that already lives in a real packages/<feature>/adapters/ or infrastructure/ file, deleting that call site's dependency on execute_google_api_request; (2) for every remaining call site that is legacy app/modules/* code with no adapter tier, file (or point at) the follow-up work that migrates it onto a real per-feature adapter — this may itself need its own decomposition, since building a first adapter for app/modules/incident's Google Docs/Drive/Calendar usage is new architecture, not a mechanical inline; (3) delete execute_google_api_request from client.py entirely once no call site depends on it. Keeping it as a permanent vendor-package export is not an acceptable resolution of this task.
+
+SCOPE ADDITION (2026-09-01, human-directed): (4) investigate and resolve DUPLICATED CONCERNS between the vendor modules and their infrastructure/ or packages/ counterparts on the same API surface — the shared-helper question above is only one symptom of a broader "two implementations of the same boundary" problem. The named, confirmed example is app/integrations/google_workspace/google_directory.py versus app/infrastructure/directory/google.py::GoogleDirectoryProvider: both build the SAME Admin Directory Resource from the SAME factory (integrations.google_workspace.client.get_admin_directory_service), both hardcode the same OAuth readonly scope strings, both resolve the same GOOGLE_WORKSPACE_CUSTOMER_ID, both implement a near-identical list/list_next pagination loop, and both cover the same three calls (users.list, groups.list, members.list) — differing only in that the provider classifies into OperationResult + typed dataclasses while the vendor module raises + returns raw dicts. The split is legacy-vs-target, not a real separation: google_directory.py exists only for its four legacy app/modules/* consumers (permissions/handler.py, provisioning/users.py, provisioning/groups.py, reports/google_groups.py) while GoogleDirectoryProvider already serves app/packages/access. Under decisions/outbound-clients.md ("one adaptation tier") and decisions/sdk-typing.md (one construction path per vendor) exactly one of these should survive. This is an INVESTIGATE-AND-DECOMPOSE item, not something to implement inside this task; it is deliberately out of scope for TASK-25.1.4, which migrated google_directory.py in place and explicitly rejected the DirectoryProvider route to keep that slice behaviour-neutral. NOTE: the task title now under-describes this scope.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -43,6 +48,8 @@ Reconciliation must correct this deviation, not ratify it as permanent. Once all
 - [ ] #1 The full execute_google_api_request call-site inventory across TASK-25.1.1/.2/.3/.4/.5 is enumerated, naming which call sites already live in a real packages/<feature>/adapters/ or infrastructure/ file vs. which are legacy app/modules/* code with no adapter tier
 - [ ] #2 Every call site already in a real packages/<feature>/adapters/ or infrastructure/ file has its own inline try/except + classify_google_error + raise, and no longer depends on execute_google_api_request
 - [ ] #3 Every remaining legacy app/modules/* call site either has its own real per-feature adapter built and inlined, or a follow-up task migrating it there is filed/linked here; execute_google_api_request is deleted from client.py once zero call sites depend on it
+- [ ] #4 Duplicated-concern inventory produced for the Google Workspace surface: for each vendor module in app/integrations/google_workspace/, its infrastructure/ or packages/ counterpart (if any) is named, the overlapping API calls and duplicated mechanics (service construction, scopes, customer id, pagination, retry, error handling) are listed, and a single survivor is chosen per surface with the losing side's consumers enumerated
+- [ ] #5 The google_directory.py vs infrastructure/directory/google.py::GoogleDirectoryProvider duplication specifically has a written decision (which survives, how the four legacy app/modules/* consumers move, what happens to list_groups_with_members/get_members_details and their time.sleep retry_request loop) and follow-up subtasks filed for the migration; no implementation is done inside this task
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -102,5 +109,27 @@ TASK-25.1.3 (Sheets) implemented 2026-09-01: appended its 5 execute_google_api_r
 created: 2026-09-01 19:42
 ---
 CALL-SITE INVENTORY UPDATE from TASK-25.1.4 planning (2026-09-01, per the tracking note on that task): TASK-25.1.4 DOES reuse integrations/google_workspace/client.py::execute_google_api_request. Its planned new call sites are inside integrations/google_workspace/google_directory.py, all funnelled through one module-private pagination helper _list_all(resource, response_key, **list_kwargs) that calls execute_google_api_request once per page, used by list_users, list_groups and list_group_members. No new shared primitive is added to client.py by that slice, so this task's deviation surface does not grow beyond the existing helper. Two additional items for this task's reconciliation, found while planning 25.1.4 and deliberately left in place there: (a) google_directory.py's list_groups_with_members / get_members_details / convert_google_groups_members_to_dataframe are business logic inside a vendor package, which decisions/outbound-clients.md forbids - they need a home outside integrations/ (or to die with the modules-strangler); (b) integrations/utils/api.py::retry_request, called from list_groups_with_members, is a time.sleep retry loop inside app/integrations/ and directly trips outbound-clients.md's Checks line, the correct replacement being the SDK-native num_retries= argument that execute_google_api_request currently does not pass.
+---
+
+author: @me
+created: 2026-09-01 21:21
+---
+DUPLICATED-CONCERNS EVIDENCE (2026-09-01, human-directed after TASK-25.1.4 implementation). Scope of this task widened via description item (4) + AC#4/#5. Concrete side-by-side for the named example:
+
+SAME construction path — app/integrations/google_workspace/google_directory.py calls integrations.google_workspace.client.get_admin_directory_service() directly; app/infrastructure/directory/factory.py:55 injects that SAME function into GoogleDirectoryProvider as its get_service callable. One factory, two consumers that then diverge.
+
+SAME hardcoded inputs — scopes: google_directory.py holds DIRECTORY_USER_READONLY_SCOPES / DIRECTORY_GROUP_READONLY_SCOPES module constants; google.py inlines the identical .../admin.directory.user.readonly and .../admin.directory.group.readonly literals per method. Customer id: google_directory.py reads get_google_workspace_settings().GOOGLE_WORKSPACE_CUSTOMER_ID at import time into a module constant; google.py receives the same value as constructor arg self._customer_id (factory.py:61).
+
+SAME pagination mechanic — google_directory.py::_collect_pages and google.py::_paginate are now structurally identical loops (list_next until None, response.get(key, [])). They differ only in that _paginate passes num_retries=_NUM_RETRIES to .execute() and google_directory.py does not — i.e. the vendor module is the one MISSING outbound-clients.md's SDK-native retry, while still carrying the forbidden time.sleep loop (integrations/utils/api.py::retry_request) in list_groups_with_members.
+
+SAME API calls, different return contract — users.list / groups.list / members.list are called from both files. google_directory.list_users/list_groups/list_group_members raise and return raw list[dict]; provider.list_users/list_groups/get_group_members classify via classify_google_error into OperationResult and translate into DirectoryUser/DirectoryGroup/DirectoryMember dataclasses. The provider is the shape decisions/sdk-typing.md item 3 asks for.
+
+WORSE-DUPLICATE case — google_directory.list_groups_with_members loops groups and calls list_group_members once per group behind retry_request (time.sleep). infrastructure/directory/google.py::get_group_members_batch already does the same job in ONE batched Directory request via client.execute_batch_request. The legacy path is not just duplicated, it is the inferior of the two.
+
+CONSUMER SPLIT (the reason both still exist) — google_directory.py: modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py (via list_groups_with_members), modules/reports/google_groups.py. GoogleDirectoryProvider: packages/access/catalog/service.py, packages/access/sync/desired_state.py, modules/dev/google.py. Purely legacy-vs-target; no capability justifies keeping two.
+
+LIKELY RESOLUTION (to be confirmed by whoever plans this, not decided here): GoogleDirectoryProvider survives; the four legacy consumers move onto the DirectoryProvider Protocol; google_directory.py's three list functions are deleted; list_groups_with_members/get_members_details either die or are rebuilt on get_group_members_batch outside integrations/ (they are business logic in a vendor package, already flagged in the 2026-09-01 19:42 comment). That also retires this surface's dependency on execute_google_api_request, which is AC#2/#3's job — the two threads converge. Sizing: this is multi-PR work (4 consumer modules, 2 of which have thin or no coverage — modules/reports/google_groups.py has NO test file at all per TASK-25.1.4 notes), so run it through the implementation-planning size gate and decompose before writing code.
+
+NOT DONE HERE and explicitly out of scope of TASK-25.1.4.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
+++ b/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
@@ -6,11 +6,12 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-01 15:31'
-updated_date: '2026-09-01 18:56'
+updated_date: '2026-09-01 19:47'
 labels:
   - clients
   - phase-3
   - cleanup
+milestone: m-3
 dependencies:
   - TASK-25.1.1
   - TASK-25.1.2
@@ -96,5 +97,10 @@ author: implementation
 created: 2026-09-01 18:56
 ---
 TASK-25.1.3 (Sheets) implemented 2026-09-01: appended its 5 execute_google_api_request call sites to the inventory in Notes. Two things for whoever picks this task up: (1) modules/reports/google_groups.py and modules/aws/spending.py have ZERO test coverage of their Sheets call sites, so any error-handling change there is unguarded and needs characterization tests written first; (2) the accumulated inventory (.1/.2/.3 reported, .4/.5 outstanding) already exceeds a single reviewable PR — this task should be decomposed into per-adapter / per-legacy-feature-area subtasks plus a final helper-deletion task before any code is written.
+---
+
+created: 2026-09-01 19:42
+---
+CALL-SITE INVENTORY UPDATE from TASK-25.1.4 planning (2026-09-01, per the tracking note on that task): TASK-25.1.4 DOES reuse integrations/google_workspace/client.py::execute_google_api_request. Its planned new call sites are inside integrations/google_workspace/google_directory.py, all funnelled through one module-private pagination helper _list_all(resource, response_key, **list_kwargs) that calls execute_google_api_request once per page, used by list_users, list_groups and list_group_members. No new shared primitive is added to client.py by that slice, so this task's deviation surface does not grow beyond the existing helper. Two additional items for this task's reconciliation, found while planning 25.1.4 and deliberately left in place there: (a) google_directory.py's list_groups_with_members / get_members_details / convert_google_groups_members_to_dataframe are business logic inside a vendor package, which decisions/outbound-clients.md forbids - they need a home outside integrations/ (or to die with the modules-strangler); (b) integrations/utils/api.py::retry_request, called from list_groups_with_members, is a time.sleep retry loop inside app/integrations/ and directly trips outbound-clients.md's Checks line, the correct replacement being the SDK-native num_retries= argument that execute_google_api_request currently does not pass.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-73 - Incident-status-update-from-the-information-modal-never-reaches-the-incident-spreadsheet.md
+++ b/backlog/tasks/task-73 - Incident-status-update-from-the-information-modal-never-reaches-the-incident-spreadsheet.md
@@ -1,0 +1,92 @@
+---
+id: TASK-73
+title: >-
+  Incident status update from the information modal never reaches the incident
+  spreadsheet
+status: To Do
+assignee: []
+created_date: '2026-09-01 19:28'
+updated_date: '2026-09-01 19:28'
+labels:
+  - bug
+  - incident
+  - sheets
+dependencies: []
+references:
+  - decisions/outbound-clients.md
+  - app/modules/incident/incident_folder.py
+  - app/modules/incident/information_update.py
+  - app/modules/incident/incident_status.py
+priority: medium
+ordinal: 129000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Changing an incident's status from the incident-information modal never updates the incident Google Sheet. The DynamoDB record and the incident document are updated, no exception is raised, and nothing is logged - so the failure is completely silent and looks like a Sheets API problem.
+
+ROOT CAUSE (investigated 2026-09-01 while validating TASK-25.1.3; NOT caused by that migration)
+
+The incident list spreadsheet stores the channel column in slug form. Confirmed against the live sheet:
+
+    ['2026-09-01', 'testing new sheets api', 'Site reliability engineering', 'In Progress', '#2026-09-01-testing-new-sheets-api']
+
+incident_folder.update_spreadsheet_incident_status matches rows with `if channel_name in row` - exact element membership against that slug form.
+
+- modules/incident/incident_status.py:57 normalizes first: update_spreadsheet_incident_status(incident_folder.return_channel_name(channel_name), status) -> "#slug" -> matches.
+- modules/incident/information_update.py:311 (handle_update_field_submission) passes the raw value: update_spreadsheet_incident_status(channel_name, value), where incident_data["channel_name"] is the Slack channel name ("incident-2026-09-01-..." / "incident-dev-...") -> never matches any row -> the loop falls through and returns False.
+
+Secondary defect: the not-found branch of update_spreadsheet_incident_status returns False with no log line, so the miss is unobservable. Every other failure branch in that function logs update_incident_spreadsheet_error.
+
+RULED OUT - the TASK-25.1.3 Sheets migration is behaviour-equivalent (verified live, read-only):
+- get_values old dispatcher vs new factory path returned identical payloads (467 rows, old == new).
+- batch_update_values old vs new build an identical request URI and JSON body.
+- fields=None / range=None are stripped by googleapiclient.discovery.createMethod before the request, exactly as the old filtered_params logic did.
+git log also shows information_update.py's call site unchanged since well before that branch.
+
+Note: the SlackApiError "views.update ... not_found" seen in the same log run is a separate, unrelated issue - body["view"]["root_view_id"] is stale because Slack tears down the modal stack on view_submission.
+
+PROPOSED FIX (not urgent - see deferral note)
+
+Normalize inside the domain function rather than at each call site. return_channel_name is idempotent ("#foo" has no incident- prefix, returned unchanged), so this fixes information_update.py without changing incident_status.py behaviour:
+
+    sheet_name = "Sheet1"
+    # Sheet stores the slug form (#slug), callers may pass the Slack channel name.
+    search_value = return_channel_name(channel_name)
+    ...
+    for i, row in enumerate(values):
+        if search_value in row:
+            ...
+    logger.warning(
+        "update_incident_spreadsheet_error",
+        channel=channel_name,
+        search_value=search_value,
+        status=status,
+        error="Channel not found in the sheet",
+    )
+    return False
+
+Tests to add in app/tests/modules/incident/test_incident_folder.py: raw "incident-dev-foo" resolves to the "#foo" row and issues the batch_update_values call; already-normalized "#foo" still matches (no regression for incident_status.py); a miss logs the warning and returns False.
+
+DEFERRAL RATIONALE
+
+This is deliberately not being fixed inside the TASK-25.1.3 PR, to keep that migration behaviour-neutral. It may also not be worth fixing in this shape at all: the spreadsheet is currently treated as a source of truth keyed by a fuzzy substring/membership match on a human-editable column, which is inherently flaky and risky. The intended direction is a proper DB backend as the source of truth with the spreadsheet demoted to a read-only dashboard/export. If that migration lands first, this lookup path disappears rather than being repaired. Decide between the two-line fix above and waiting for the DB-backed rewrite before scheduling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 update_spreadsheet_incident_status matches the sheet row when called with a raw Slack channel name (incident-foo / incident-dev-foo) as well as with an already-normalized #foo, and issues the batch_update_values call
+- [ ] #2 A channel-not-found miss in update_spreadsheet_incident_status emits an update_incident_spreadsheet_error warning log instead of returning False silently
+- [ ] #3 Regression tests in app/tests/modules/incident/test_incident_folder.py cover raw-name match, normalized-name match, and the not-found warning path
+- [ ] #4 A decision is recorded (comment or decision record) on whether this lookup path is repaired as-is or removed by moving the source of truth to a DB backend with the spreadsheet demoted to a dashboard
+<!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-01 19:28
+---
+Discovered while validating TASK-25.1.3 (Sheets migration off execute_google_api_call). Explicitly NOT a regression from that PR: get_values old-vs-new returned identical live payloads (467 rows, old == new) and batch_update_values old-vs-new build an identical request URI and JSON body; googleapiclient strips None kwargs exactly as the old filtered_params logic did. Left out of that PR to keep the migration behaviour-neutral.
+---
+<!-- COMMENTS:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request refactors how Google Workspace and AWS group/user data is retrieved and processed, focusing on simplifying API pagination, removing DataFrame conversion utilities, and cleaning up related code paths. The changes improve type safety, reduce unnecessary dependencies, and streamline the integration interfaces.

**Google Directory Integration Refactor:**

- Rewrote Google Directory API pagination to accept pre-built requests, improving type safety and making the code more explicit and maintainable. (`app/infrastructure/directory/google.py` [[1]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cL84-R99) [[2]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cL396-R407) [[3]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR456-R460) [[4]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR752) [[5]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cL753-R770) [[6]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR826-R830)
- Refactored `app/integrations/google_workspace/google_directory.py` to remove DataFrame-related code and pandas dependency, and to use a new, explicit pagination helper for all list operations. (`app/integrations/google_workspace/google_directory.py` [[1]](diffhunk://#diff-2ac0c9ae3f5a0e44fe4a8345310be7e3b560141179f4e8e4e4a7b3da1c5e7523L3-R132) [[2]](diffhunk://#diff-2ac0c9ae3f5a0e44fe4a8345310be7e3b560141179f4e8e4e4a7b3da1c5e7523L267-L309)

**AWS Identity Store Integration Cleanup:**

- Removed the `convert_aws_groups_members_to_dataframe` function and the pandas import, eliminating DataFrame conversion utilities from the AWS integration. (`app/integrations/aws/identity_store.py` [[1]](diffhunk://#diff-685a6a4daa0f776bde753ec9e392444825f57657841b6e2b9c9159fbbc690fd7L3) [[2]](diffhunk://#diff-685a6a4daa0f776bde753ec9e392444825f57657841b6e2b9c9159fbbc690fd7L381-L420)
- Added a test to ensure the DataFrame conversion function is no longer present. (`app/tests/integrations/aws/test_identity_store.py` [app/tests/integrations/aws/test_identity_store.pyR888-R891](diffhunk://#diff-5f4300ec85345fbd5df7c6ebb89e2b0f52d9c4a52c4a72bd380615f6f9dce93eR888-R891))

**Provisioning Module Simplification:**

- Removed the `return_dataframe` parameter and related logic from `get_groups_from_integration`, so group data is always returned as a list of dictionaries, not as a DataFrame. (`app/modules/provisioning/groups.py` [[1]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL15) [[2]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL27) [[3]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL45) [[4]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL57-L58) [[5]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL71-L72) [[6]](diffhunk://#diff-10c06cdf84bb8a8592199bccde5127afe03da70df23c42408fa6fe89efe085bcL90-R83)

These changes collectively improve code clarity, maintainability, and type safety, and remove unnecessary dependencies and features that are no longer required.