### PR TITLE
Feat/increase google workspace tests coverage pre migration

### DIFF
--- a/app/tests/unit/modules/aws/test_spending_handler.py
+++ b/app/tests/unit/modules/aws/test_spending_handler.py
@@ -134,6 +134,67 @@ def test_should_skip_update_when_spreadsheet_id_not_set(mock_sheets):
 
 
 @pytest.mark.unit
+@patch("modules.aws.spending.sheets")
+def test_should_send_header_row_followed_by_dataframe_rows_to_sheets(mock_sheets):
+    """Test the exact values matrix crossing the Sheets boundary."""
+    # Arrange
+    df = pd.DataFrame({"Account": ["123456789012", "210987654321"], "Cost": [100.00, 250.50]})
+
+    # Act
+    spending.update_spending_data(df, spreadsheet_id="test_sheet_id")
+
+    # Assert
+    call_kwargs = mock_sheets.batch_update_values.call_args[1]
+    assert call_kwargs["values"] == [
+        ["Account", "Cost"],
+        ["123456789012", 100.00],
+        ["210987654321", 250.50],
+    ]
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.sheets")
+def test_should_send_header_row_only_when_dataframe_has_no_rows(mock_sheets):
+    """Test that an empty but columned DataFrame sends just the header."""
+    # Arrange
+    df = pd.DataFrame(columns=["Account", "Cost"])
+
+    # Act
+    spending.update_spending_data(df, spreadsheet_id="test_sheet_id")
+
+    # Assert
+    call_kwargs = mock_sheets.batch_update_values.call_args[1]
+    assert call_kwargs["values"] == [["Account", "Cost"]]
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.sheets")
+def test_should_skip_update_when_spreadsheet_id_is_empty_string(mock_sheets):
+    """Test that update is skipped when the spreadsheet ID is an empty string."""
+    # Arrange
+    df = pd.DataFrame({"Account": ["123456789012"], "Cost": [100.00]})
+
+    # Act
+    spending.update_spending_data(df, spreadsheet_id="")
+
+    # Assert
+    mock_sheets.batch_update_values.assert_not_called()
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.sheets")
+def test_should_propagate_error_when_sheets_update_fails(mock_sheets):
+    """Test that a failing Sheets write propagates out of update_spending_data."""
+    # Arrange
+    df = pd.DataFrame({"Account": ["123456789012"], "Cost": [100.00]})
+    mock_sheets.batch_update_values.side_effect = RuntimeError("sheets down")
+
+    # Act / Assert
+    with pytest.raises(RuntimeError):
+        spending.update_spending_data(df, spreadsheet_id="test_sheet_id")
+
+
+@pytest.mark.unit
 @patch("modules.aws.spending.generate_spending_data")
 @patch("modules.aws.spending.update_spending_data")
 def test_should_execute_and_update_spending_job_successfully(mock_update, mock_generate):

--- a/app/tests/unit/modules/reports/test_google_groups_report.py
+++ b/app/tests/unit/modules/reports/test_google_groups_report.py
@@ -1,0 +1,317 @@
+"""Characterization tests for the Google Groups members report.
+
+These tests pin the behaviour the module has today, including its rough edges
+(blanket excepts, unquoted A1 ranges). They are a change detector, not an
+endorsement.
+
+Stub strategy: the vendor modules are patched as bound in the module under test
+by a single fixture, and every boundary assertion goes through an accessor
+helper so the seam can be moved in one place.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
+
+from modules.reports import google_groups
+
+_DIRECTORY = "modules.reports.google_groups.google_directory"
+_DRIVE = "modules.reports.google_groups.google_drive"
+_SHEETS = "modules.reports.google_groups.sheets"
+_SLEEP = "modules.reports.google_groups.time.sleep"
+
+_MSG_FOLDER_UNSET = "Google Drive folder for reports not set."
+_MSG_NO_GROUPS = "No groups found."
+_MSG_SUCCESS = "Google Groups Members report generated."
+
+_FOLDER_ID = "FOLDER1"
+_FILE_ID = "FILE1"
+
+
+def _member(email: str, role: str) -> dict[str, str]:
+    return {"email": email, "role": role}
+
+
+def _group(name: str, email: str) -> dict[str, str]:
+    return {"name": name, "email": email}
+
+
+def _file_lookup(deps) -> tuple[str, str]:
+    """Name and folder id handed to the Drive file lookup."""
+    call = deps.drive.find_files_by_name.call_args
+    return (call.args[0], call.args[1])
+
+
+def _file_created(deps) -> list[tuple[str, str, str]]:
+    """Filename, folder id and mime kind of every Drive file creation."""
+    return [(call.args[0], call.args[1], call.args[2]) for call in deps.drive.create_file.call_args_list]
+
+
+def _groups_listed(deps) -> int:
+    return deps.directory.list_groups.call_count
+
+
+def _members_requested(deps) -> list[str]:
+    """Group keys passed to the Directory member lookup, in call order."""
+    return [call.args[0] for call in deps.directory.list_group_members.call_args_list]
+
+
+def _sheets_read(deps) -> list[tuple[str, str]]:
+    """Spreadsheet id and range of every Sheets read."""
+    return [(call.args[0], call.args[1]) for call in deps.sheets.get_sheet.call_args_list]
+
+
+def _sheets_created(deps) -> list[tuple[str, str]]:
+    """Spreadsheet id and addSheet title of every sheet creation."""
+    return [
+        (call.args[0], call.args[1]["requests"][0]["addSheet"]["properties"]["title"])
+        for call in deps.sheets.batch_update.call_args_list
+    ]
+
+
+def _sheet_create_requests(deps) -> list[dict]:
+    return [call.args[1] for call in deps.sheets.batch_update.call_args_list]
+
+
+def _sheet_writes(deps) -> list[tuple[str, str, list[list[str]]]]:
+    """Spreadsheet id, range and values matrix of every Sheets write."""
+    return [(call.args[0], call.args[1], call.args[2]) for call in deps.sheets.batch_update_values.call_args_list]
+
+
+def _sleep_delays(deps) -> list[float]:
+    return [call.args[0] for call in deps.sleep.call_args_list]
+
+
+@pytest.fixture
+def report_deps():
+    """Single owner of every patch and default return value for this module."""
+    with (
+        patch(_DIRECTORY) as directory,
+        patch(_DRIVE) as drive,
+        patch(_SHEETS) as sheets,
+        patch(_SLEEP) as sleep,
+        patch.object(google_groups, "FOLDER_REPORTS_GOOGLE_GROUPS", _FOLDER_ID),
+    ):
+        drive.find_files_by_name.return_value = []
+        drive.create_file.return_value = {"id": _FILE_ID}
+        directory.list_groups.return_value = [
+            _group("GroupOne", "one@test.com"),
+            _group("GroupTwo", "two@test.com"),
+        ]
+        directory.list_group_members.return_value = [
+            _member("member1@test.com", "MEMBER"),
+            _member("member2@test.com", "OWNER"),
+        ]
+        # explicit falsy read so the addSheet branch is exercised by default
+        sheets.get_sheet.return_value = {}
+        sheets.batch_update.return_value = {}
+        sheets.batch_update_values.return_value = {}
+        yield SimpleNamespace(
+            directory=directory,
+            drive=drive,
+            sheets=sheets,
+            sleep=sleep,
+            respond=MagicMock(),
+        )
+
+
+@pytest.mark.unit
+class TestGenerateGroupMembersReportBehaviour:
+    """What the module computes and emits; must survive the adapter migrations."""
+
+    def test_should_respond_and_stop_when_reports_folder_is_unset(self, report_deps):
+        with patch.object(google_groups, "FOLDER_REPORTS_GOOGLE_GROUPS", ""):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        report_deps.respond.assert_called_once_with(_MSG_FOLDER_UNSET)
+        assert report_deps.drive.mock_calls == []
+        assert report_deps.directory.mock_calls == []
+        assert report_deps.sheets.mock_calls == []
+
+    def test_should_respond_with_success_when_report_is_generated(self, report_deps):
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        report_deps.respond.assert_called_once_with(_MSG_SUCCESS)
+
+    def test_should_exclude_groups_whose_name_contains_aws_prefix(self, report_deps):
+        report_deps.directory.list_groups.return_value = [
+            _group("AWS-Admins", "aws@test.com"),
+            _group("GroupOne", "one@test.com"),
+        ]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _members_requested(report_deps) == ["one@test.com"]
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["GroupOne!A1"]
+
+    def test_should_respond_no_groups_after_creating_the_file_when_all_groups_excluded(self, report_deps):
+        report_deps.directory.list_groups.return_value = [_group("AWS-Admins", "aws@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        report_deps.respond.assert_called_once_with(_MSG_NO_GROUPS)
+        assert len(_file_created(report_deps)) == 1
+        assert _sheet_writes(report_deps) == []
+
+    def test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range(self, report_deps):
+        long_name = "G" * 60
+        report_deps.directory.list_groups.return_value = [_group(long_name, "long@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        truncated = "G" * 50
+        _, cell_range, values = _sheet_writes(report_deps)[0]
+        assert cell_range == f"{truncated}!A1"
+        assert values[0] == ["Group Name", truncated]
+
+    def test_should_write_header_rows_followed_by_members_in_order(self, report_deps):
+        report_deps.directory.list_groups.return_value = [_group("GroupOne", "one@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        _, _, values = _sheet_writes(report_deps)[0]
+        assert values == [
+            ["Group Name", "GroupOne"],
+            ["Email", "Role"],
+            ["member1@test.com", "MEMBER"],
+            ["member2@test.com", "OWNER"],
+        ]
+
+    def test_should_pause_once_per_surviving_group(self, report_deps):
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _sleep_delays(report_deps) == [1.1, 1.1]
+
+    def test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges(self, report_deps):
+        # Pinned, not endorsed: unquoted A1 ranges are the defect TASK-25.1.6.12 fixes.
+        report_deps.directory.list_groups.return_value = [_group("SRE Team", "sre@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _sheets_read(report_deps) == [(_FILE_ID, "SRE Team")]
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["SRE Team!A1"]
+
+
+@pytest.mark.unit
+class TestGenerateGroupMembersReportBoundary:
+    """Arguments handed to the vendor modules; translated when the seam moves."""
+
+    @freeze_time("2026-05-04")
+    def test_should_look_up_a_date_derived_filename_in_the_reports_folder(self, report_deps):
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _file_lookup(report_deps) == ("groups_report_2026-05-04", _FOLDER_ID)
+
+    def test_should_create_a_spreadsheet_when_no_file_is_found(self, report_deps):
+        with freeze_time("2026-05-04"):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _file_created(report_deps) == [("groups_report_2026-05-04", _FOLDER_ID, "spreadsheet")]
+
+    def test_should_reuse_the_existing_file_id_without_creating_a_spreadsheet(self, report_deps):
+        report_deps.drive.find_files_by_name.return_value = [{"id": "EXISTING1"}, {"id": "OTHER1"}]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _file_created(report_deps) == []
+        assert {write[0] for write in _sheet_writes(report_deps)} == {"EXISTING1"}
+        assert {read[0] for read in _sheets_read(report_deps)} == {"EXISTING1"}
+
+    def test_should_list_groups_once_and_request_members_per_group_email(self, report_deps):
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _groups_listed(report_deps) == 1
+        report_deps.directory.list_groups.assert_called_once_with()
+        assert _members_requested(report_deps) == ["one@test.com", "two@test.com"]
+
+    def test_should_read_and_create_sheets_with_the_group_sheet_name(self, report_deps):
+        report_deps.directory.list_groups.return_value = [_group("GroupOne", "one@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _sheets_read(report_deps) == [(_FILE_ID, "GroupOne")]
+        assert _sheet_create_requests(report_deps) == [{"requests": [{"addSheet": {"properties": {"title": "GroupOne"}}}]}]
+
+    def test_should_write_values_positionally_with_file_id_and_range(self, report_deps):
+        report_deps.directory.list_groups.return_value = [_group("GroupOne", "one@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        spreadsheet_id, cell_range, values = _sheet_writes(report_deps)[0]
+        assert spreadsheet_id == _FILE_ID
+        assert cell_range == "GroupOne!A1"
+        assert values[1] == ["Email", "Role"]
+
+
+@pytest.mark.unit
+class TestGenerateGroupMembersReportFailureModes:
+    """Failure and partial-result behaviour as it stands today."""
+
+    def test_should_swallow_a_failing_sheet_read_and_fall_back_to_creating_the_sheet(self, report_deps):
+        report_deps.sheets.get_sheet.side_effect = RuntimeError("boom")
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert [created[1] for created in _sheets_created(report_deps)] == ["GroupOne", "GroupTwo"]
+        report_deps.respond.assert_called_once_with(_MSG_SUCCESS)
+
+    def test_should_skip_sheet_creation_when_the_sheet_already_exists(self, report_deps):
+        report_deps.sheets.get_sheet.return_value = {"sheets": [{"properties": {"title": "GroupOne"}}]}
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _sheets_created(report_deps) == []
+        assert len(_sheet_writes(report_deps)) == 2
+
+    def test_should_swallow_a_failing_sheet_creation_and_still_write_values(self, report_deps):
+        report_deps.sheets.batch_update.side_effect = RuntimeError("boom")
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert len(_sheet_writes(report_deps)) == 2
+        report_deps.respond.assert_called_once_with(_MSG_SUCCESS)
+
+    def test_should_propagate_a_failing_drive_lookup_before_any_other_call(self, report_deps):
+        report_deps.drive.find_files_by_name.side_effect = RuntimeError("drive down")
+
+        with pytest.raises(RuntimeError):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        report_deps.respond.assert_not_called()
+        assert _file_created(report_deps) == []
+        assert _groups_listed(report_deps) == 0
+        assert _sheet_writes(report_deps) == []
+
+    def test_should_propagate_a_failing_group_listing_after_the_file_was_created(self, report_deps):
+        report_deps.directory.list_groups.side_effect = RuntimeError("directory down")
+
+        with pytest.raises(RuntimeError):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert len(_file_created(report_deps)) == 1
+        report_deps.respond.assert_not_called()
+        assert _sheet_writes(report_deps) == []
+
+    def test_should_propagate_a_mid_loop_member_failure_before_any_sheet_is_written(self, report_deps):
+        report_deps.directory.list_group_members.side_effect = [
+            [_member("member1@test.com", "MEMBER")],
+            RuntimeError("members down"),
+        ]
+
+        with pytest.raises(RuntimeError):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert _members_requested(report_deps) == ["one@test.com", "two@test.com"]
+        assert _sheet_writes(report_deps) == []
+        report_deps.respond.assert_not_called()
+
+    def test_should_propagate_a_mid_loop_write_failure_leaving_the_first_sheet_written(self, report_deps):
+        report_deps.sheets.batch_update_values.side_effect = [{}, RuntimeError("bad range")]
+
+        with pytest.raises(RuntimeError):
+            google_groups.generate_group_members_report([], report_deps.respond)
+
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["GroupOne!A1", "GroupTwo!A1"]
+        report_deps.respond.assert_not_called()

--- a/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
+++ b/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-01 15:31'
-updated_date: '2026-09-02 16:38'
+updated_date: '2026-09-02 18:54'
 labels:
   - clients
   - phase-3
@@ -55,8 +55,9 @@ FOUR LIVE DEVIATIONS TO CLOSE.
 
 DIRECTORY DUPLICATION - DECIDED (2026-09-02, human). infrastructure/directory/{provider,google,factory}.py::DirectoryProvider / GoogleDirectoryProvider IS THE WAY FORWARD. It survives; integrations/google_workspace/google_directory.py is deleted; the four legacy app/modules/* consumers (permissions/handler.py, provisioning/users.py, provisioning/groups.py, reports/google_groups.py) migrate onto the DirectoryProvider Protocol. This closes the duplicated-boundary investigation recorded in this task's 2026-09-01 comment - both sides build the same Resource from the same factory, hardcode the same scopes, resolve the same customer id and run structurally identical pagination, and the provider is additionally the better of the two (get_group_members_batch does in one batched request what the legacy path does in N behind time.sleep retries). No further analysis is required; the work is migration, owned by TASK-25.1.6.3/.4/.5.
 
-DECOMPOSED (2026-09-02) - this task is now a coordinator and contains NO implementation. Eleven children, ordered:
+DECOMPOSED (2026-09-02) - this task is now a coordinator and contains NO implementation. Twelve children, ordered:
 - TASK-25.1.6.1 - characterization tests for the untested call sites (GATE; modules/reports/google_groups.py has no test file, modules/aws/spending.py has no Sheets coverage).
+- TASK-25.1.6.12 - fix the unquoted A1 sheet-name range in modules/reports/google_groups.py (BUG, found while planning .1; blocks .10 so the Sheets migration repoints correct code rather than carrying a live defect across the seam).
 - TASK-25.1.6.2 - relocate the pure-domain helpers out of integrations/google_workspace (independent, can run first).
 - TASK-25.1.6.3 - close the DirectoryProvider capability gaps (unbounded list-users, unbounded list-groups, silent group dropping, batched groups-with-members).
 - TASK-25.1.6.4 - migrate permissions/handler.py, provisioning/users.py and reports/google_groups.py Directory calls onto DirectoryProvider.
@@ -68,12 +69,12 @@ DECOMPOSED (2026-09-02) - this task is now a coordinator and contains NO impleme
 - TASK-25.1.6.10 - move the Sheets call sites onto adapters, carrying the caller-specific parse-range rule across.
 - TASK-25.1.6.11 - delete execute_google_api_request, resolve execute_batch_request, add a CI guardrail against the vendor package regrowing.
 
-This task closes when all eleven are Done. Its own remaining direct work is nil.
+This task closes when all twelve are Done. Its own remaining direct work is nil.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All eleven children (TASK-25.1.6.1 through .11) are Done
+- [ ] #1 All twelve children (TASK-25.1.6.1 through .12) are Done
 - [ ] #2 app/integrations/google_workspace/ contains only client.py (per-API stub-typed factories plus classify_google_error) and settings; the six per-method mirror modules and google_service.py no longer exist
 - [ ] #3 Every Google Workspace call site in the repo lives in a packages/<feature>/adapters/ file or an infrastructure/ capability, builds its Resource from a client.py factory, performs its own try/except plus classify_google_error, and returns typed domain values rather than raw SDK dicts
 - [ ] #4 The Directory duplication is resolved as decided: GoogleDirectoryProvider survives, integrations/google_workspace/google_directory.py is deleted, and all four legacy app/modules/* consumers use the DirectoryProvider Protocol
@@ -223,5 +224,19 @@ Neither site uses execute_google_api_request or a google_drive passthrough any m
 Reusable test helper left behind for TASK-25.1.6.6's Docs half, in app/tests/unit/packages/incident_draft/test_incident_draft_adapter.py:
   _drive_resource_fake(*, copy_response=None, copy_error=None, get_response=None, get_error=None) -> MagicMock
 plus an autouse `drive_service` fixture patching packages.incident_draft.adapters.google_docs.google_workspace_client and a _copy_request(drive_service) accessor. Reuse these rather than reinventing the Resource mock chain.
+---
+
+author: @task-planner
+created: 2026-09-02 18:54
+---
+TWELFTH CHILD ADDED 2026-09-02 (task-planner, human-approved). TASK-25.1.6.12 - "Fix the unquoted A1 sheet-name range in the Google Groups members report" - was found while planning TASK-25.1.6.1 and is a genuine production bug, not refactor work.
+
+WHY IT IS A CHILD OF THIS COORDINATOR RATHER THAN A LOOSE TASK. It was surfaced by this decomposition, it sits in a file three other children touch (modules/reports/google_groups.py: Directory sites in .4, Drive sites in .8, Sheets sites in .10), and TASK-25.1.6.10 now depends on it. Making it a child adds no extra blocking, since .10 was already a child and already gates on it.
+
+WHY IT IS NOT FOLDED INTO .10, WHICH OWNS THAT CALL SITE. The implementation-planning size gate separates mechanical migration diffs (reviewed for completeness) from behaviour diffs (reviewed for correctness). Folding a user-facing bug fix into a seam migration makes both harder to review, and would leave a live defect in place until a Medium-priority downstream slice ships.
+
+DEPENDENCY WIRING APPLIED: .12 depends on .1 (the characterization gate pins todays unquoted output as a defect probe that .12 then flips); .10 now depends on TASK-25.1.6.7 AND TASK-25.1.6.12. Ordinal 132500 places it immediately after the gate task. AC#1 and the Description child list were updated from eleven to twelve; the other six acceptance criteria are unchanged, re-emitted only because the CLI replaces the set as a whole.
+
+SCOPE FENCE BETWEEN .12 AND .10, recorded on both: .12 quotes the sheet name in the batch_update_values range and the get_sheet ranges through one shared helper and makes 50-char truncation collision-safe. It does NOT touch the two blanket excepts (.10 AC#3 owns those), does NOT add skip-instead-of-abort resilience around batch_update_values (left to .10, which is rewriting that error handling anyway), and migrates nothing.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
+++ b/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
@@ -3,10 +3,11 @@ id: TASK-25.1.6.1
 title: >-
   Add characterization tests for the untested Google Workspace call sites before
   any adapter work
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@me'
 created_date: '2026-09-02 14:58'
-updated_date: '2026-09-02 18:54'
+updated_date: '2026-09-02 19:17'
 labels:
   - clients
   - phase-3
@@ -40,13 +41,13 @@ Write characterization tests FIRST that pin today's observable behaviour, includ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 app/tests/unit/modules/reports/test_google_groups_report.py exists (unit layer per decisions/testing.md, NOT the legacy app/tests/modules tree) and pins today request arguments at all seven Google call sites in app/modules/reports/google_groups.py: google_drive.find_files_by_name, google_drive.create_file, google_directory.list_groups, google_directory.list_group_members, sheets.get_sheet, sheets.batch_update (the addSheet request) and sheets.batch_update_values
-- [ ] #2 Assertions are split into a BEHAVIOUR group (what the module computes and emits: respond strings for the unset-folder, no-groups and success branches; the AWS- name exclusion; the 50-character sheet-name truncation; the {name}!A1 range; the header-plus-members values matrix) and a BOUNDARY group (arguments handed to the vendor modules), so later slices can translate the boundary group while the behaviour group must keep passing unchanged
-- [ ] #3 Failure and partial-result paths are pinned for google_groups.py, not just happy paths: the blanket except around sheets.get_sheet yielding sheet=None and the addSheet fallback; a raising sheets.batch_update being swallowed while batch_update_values still runs; a raising Drive or Directory call propagating uncaught; and the observable partial state after a mid-loop failure (file already created, N sheets already written)
-- [ ] #4 app/tests/unit/modules/aws/test_spending_handler.py is EXTENDED (not duplicated) to close its real gap: the exact values matrix crossing sheets.batch_update_values (header row plus DataFrame rows), the empty-DataFrame case, spreadsheet_id="" skipping the call, and a raising Sheets call propagating out of update_spending_data
-- [ ] #5 Tests obey decisions/testing.md: marked unit, deterministic (freezegun for the date-derived filename, time.sleep patched so the per-group 1.1s pause does not enter the runtime budget), no network, and no docstring references to task ids or plan steps
-- [ ] #6 No production file is modified by this task (git diff touches app/tests/** only)
-- [ ] #7 Seam-churn control is implemented so the three sibling rewires are cheap: ONE fixture owns all patching, no test reads mock.call_args directly (all assertions go through named accessor helpers that normalise the seam), and the three respond() message literals live in single module-level constants
+- [x] #1 app/tests/unit/modules/reports/test_google_groups_report.py exists (unit layer per decisions/testing.md, NOT the legacy app/tests/modules tree) and pins today request arguments at all seven Google call sites in app/modules/reports/google_groups.py: google_drive.find_files_by_name, google_drive.create_file, google_directory.list_groups, google_directory.list_group_members, sheets.get_sheet, sheets.batch_update (the addSheet request) and sheets.batch_update_values
+- [x] #2 Assertions are split into a BEHAVIOUR group (what the module computes and emits: respond strings for the unset-folder, no-groups and success branches; the AWS- name exclusion; the 50-character sheet-name truncation; the {name}!A1 range; the header-plus-members values matrix) and a BOUNDARY group (arguments handed to the vendor modules), so later slices can translate the boundary group while the behaviour group must keep passing unchanged
+- [x] #3 Failure and partial-result paths are pinned for google_groups.py, not just happy paths: the blanket except around sheets.get_sheet yielding sheet=None and the addSheet fallback; a raising sheets.batch_update being swallowed while batch_update_values still runs; a raising Drive or Directory call propagating uncaught; and the observable partial state after a mid-loop failure (file already created, N sheets already written)
+- [x] #4 app/tests/unit/modules/aws/test_spending_handler.py is EXTENDED (not duplicated) to close its real gap: the exact values matrix crossing sheets.batch_update_values (header row plus DataFrame rows), the empty-DataFrame case, spreadsheet_id="" skipping the call, and a raising Sheets call propagating out of update_spending_data
+- [x] #5 Tests obey decisions/testing.md: marked unit, deterministic (freezegun for the date-derived filename, time.sleep patched so the per-group 1.1s pause does not enter the runtime budget), no network, and no docstring references to task ids or plan steps
+- [x] #6 No production file is modified by this task (git diff touches app/tests/** only)
+- [x] #7 Seam-churn control is implemented so the three sibling rewires are cheap: ONE fixture owns all patching, no test reads mock.call_args directly (all assertions go through named accessor helpers that normalise the seam), and the three respond() message literals live in single module-level constants
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -290,6 +291,37 @@ nothing else. No terraform, CI, settings or migration ordering.
 SIZE GATE VERDICT: FITS ONE PR. Production diff is 0 files / 0 LOC, one subsystem (tests), no
 mechanical-plus-behaviour mixing, revert-safe. No decomposition required.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED 2026-09-02. Tests-only, as specified; zero production files touched.
+
+WHAT LANDED
+- app/tests/unit/modules/reports/__init__.py (empty) and app/tests/unit/modules/reports/test_google_groups_report.py (~310 LOC, 21 tests). Collection is clean with an __init__.py only in reports/, matching the sibling child packages; the plan's fallback was not needed.
+- app/tests/unit/modules/aws/test_spending_handler.py extended with 4 appended tests (values matrix, header-only empty DataFrame, spreadsheet_id='' skip, RuntimeError propagation). Existing tests untouched.
+
+STRUCTURE (AC#2, AC#7)
+Three classes: TestGenerateGroupMembersReportBehaviour (8 tests, must survive .4/.8/.10 unchanged), TestGenerateGroupMembersReportBoundary (5 tests, translated when the seam moves), TestGenerateGroupMembersReportFailureModes (7 tests). One report_deps fixture owns every patch (google_directory, google_drive, sheets, time.sleep, FOLDER_REPORTS_GOOGLE_GROUPS) and every default return; no test patches anything itself except the unset-folder test, which must override the constant. Boundary reads go through seven accessors: _file_lookup, _file_created, _groups_listed, _members_requested, _sheets_read, _sheets_created/_sheet_create_requests, _sheet_writes (plus _sleep_delays). No test in the report file reads mock.call_args directly. Three respond() literals are module constants _MSG_FOLDER_UNSET / _MSG_NO_GROUPS / _MSG_SUCCESS, asserted with assert_called_once_with.
+
+DEVIATIONS FROM THE PLAN
+1. The plan listed five accessors; seven were written. _file_created was split out of _file_lookup because the create-before-empty-check ordering wart needs a call-list, not a single call; _sheets_created (title only) and _sheet_create_requests (full request dict) were split because the behaviour group wants the title while the boundary group must pin the exact addSheet dict.
+2. The spending extension keeps that file's existing house style (module-level @patch decorators, direct call_args reads) rather than the accessor pattern. Plan step 3 forbade restructuring the existing tests, and a lone Sheets call site does not carry the seam-churn cost the report file does. AC#7's accessor requirement is satisfied where it was scoped: the report file.
+
+DEFECT PROBE PINNED, NOT FIXED (AC#6)
+test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges asserts today's UNQUOTED 'SRE Team!A1' range and 'SRE Team' get_sheet range, with a one-line comment marking it pinned-not-endorsed and naming TASK-25.1.6.12. TASK-25.1.6.12 AC#5 flips exactly this assertion. test_should_propagate_a_mid_loop_write_failure_leaving_the_first_sheet_written pins the abort-with-no-respond shape that defect takes in production.
+
+TEST EVIDENCE
+- uv run pytest tests/unit/modules/reports tests/unit/modules/aws/test_spending_handler.py -q --durations=5 -> 32 passed in 1.56s; slowest 0.11s (freeze_time). time.sleep is patched, so the 1.1s per-group pause never enters the budget.
+- uv run ruff check . -> All checks passed.
+- uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' -> 94 pre-existing errors in 31 files, all on main before this branch; zero in tests/unit/modules/reports or tests/unit/modules/aws (verified by grep).
+- Full suite green (make test, run by the human 2026-09-02).
+- git status confirms exactly three paths, all under app/tests/**.
+
+LEFT FOR HUMAN VERIFICATION
+- That the pinned behaviours are an accurate record rather than an endorsement: the blanket excepts, file-created-before-the-empty-groups-check, the 1.1s sleep, the unquoted A1 range and the 50-char truncation are all deliberately locked in as-is.
+- Plan step 5 (re-confirm the pre-registered comments on TASK-25.1.6.4, .8 and .10 name the right file path, class names and accessor helpers) is a post-merge action and has not been done; note the two extra accessors above when doing it.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
+++ b/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 14:58'
+updated_date: '2026-09-02 18:54'
 labels:
   - clients
   - phase-3
@@ -39,8 +40,313 @@ Write characterization tests FIRST that pin today's observable behaviour, includ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 app/tests/modules/reports/test_google_groups.py exists and covers every Google call site in app/modules/reports/google_groups.py: the Directory list_groups/list_group_members pair, the sheets.get_sheet call including its blanket-except fallback to None, and the Drive find_files_by_name/create_file calls
-- [ ] #2 app/modules/aws/spending.py's Sheets call sites have characterization coverage asserting today's request arguments and returned shape
-- [ ] #3 Failure paths are pinned, not just happy paths: for each file, a raising SDK call is exercised and the test asserts today's actual observable outcome (swallowed to None, propagated, or partial result), so a later behaviour change is visible as a test diff rather than a silent regression
-- [ ] #4 No production file is modified by this task (git diff touches app/tests/** only)
+- [ ] #1 app/tests/unit/modules/reports/test_google_groups_report.py exists (unit layer per decisions/testing.md, NOT the legacy app/tests/modules tree) and pins today request arguments at all seven Google call sites in app/modules/reports/google_groups.py: google_drive.find_files_by_name, google_drive.create_file, google_directory.list_groups, google_directory.list_group_members, sheets.get_sheet, sheets.batch_update (the addSheet request) and sheets.batch_update_values
+- [ ] #2 Assertions are split into a BEHAVIOUR group (what the module computes and emits: respond strings for the unset-folder, no-groups and success branches; the AWS- name exclusion; the 50-character sheet-name truncation; the {name}!A1 range; the header-plus-members values matrix) and a BOUNDARY group (arguments handed to the vendor modules), so later slices can translate the boundary group while the behaviour group must keep passing unchanged
+- [ ] #3 Failure and partial-result paths are pinned for google_groups.py, not just happy paths: the blanket except around sheets.get_sheet yielding sheet=None and the addSheet fallback; a raising sheets.batch_update being swallowed while batch_update_values still runs; a raising Drive or Directory call propagating uncaught; and the observable partial state after a mid-loop failure (file already created, N sheets already written)
+- [ ] #4 app/tests/unit/modules/aws/test_spending_handler.py is EXTENDED (not duplicated) to close its real gap: the exact values matrix crossing sheets.batch_update_values (header row plus DataFrame rows), the empty-DataFrame case, spreadsheet_id="" skipping the call, and a raising Sheets call propagating out of update_spending_data
+- [ ] #5 Tests obey decisions/testing.md: marked unit, deterministic (freezegun for the date-derived filename, time.sleep patched so the per-group 1.1s pause does not enter the runtime budget), no network, and no docstring references to task ids or plan steps
+- [ ] #6 No production file is modified by this task (git diff touches app/tests/** only)
+- [ ] #7 Seam-churn control is implemented so the three sibling rewires are cheap: ONE fixture owns all patching, no test reads mock.call_args directly (all assertions go through named accessor helpers that normalise the seam), and the three respond() message literals live in single module-level constants
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+GROUNDING (2026-09-02, verified against current code, not the task prose alone)
+
+SUBJECT 1 -- app/modules/reports/google_groups.py (107 LOC). No test file exists anywhere for it
+(find app/tests -path "*reports*" returns zero). Reached from modules/reports/core.py:42, the
+/sre reports google-groups-members Slack command. Seven Google call sites:
+  :37  google_drive.find_files_by_name(filename, FOLDER_REPORTS_GOOGLE_GROUPS)
+  :41  google_drive.create_file(filename, FOLDER_REPORTS_GOOGLE_GROUPS, "spreadsheet")
+  :47  google_directory.list_groups()
+  :61  google_directory.list_group_members(group["email"])
+  :72  sheets.get_sheet(file["id"], group_sheet_name)          <- wrapped in blanket except -> None
+  :90  sheets.batch_update(file["id"], {"requests":[{"addSheet":...}]})  <- except Exception -> log only
+  :100 sheets.batch_update_values(file["id"], f"{name}!A1", values)
+Control flow worth pinning, in order: falsy folder -> respond + return before any Google call;
+filename is date-derived; file is created BEFORE the empty-groups check, so a run with zero groups
+still creates a spreadsheet; groups whose "name" contains "AWS-" are filtered out; member collection
+completes for ALL groups before ANY sheet write begins; sheet name truncated to 50 chars and reused
+both as the "Group Name" cell and as the "{name}!A1" range; time.sleep(1.1) per group.
+
+SUBJECT 2 -- app/modules/aws/spending.py. Exactly ONE Sheets call site: :190
+sheets.batch_update_values(spreadsheetId=..., cell_range="Sheet1", values=..., valueInputOption=...)
+inside update_spending_data. Contrary to the task description, this is NOT uncovered:
+app/tests/unit/modules/aws/test_spending_handler.py:102-133 already asserts spreadsheetId,
+cell_range, valueInputOption and the skip-when-id-falsy branch (TASK-25.1.3 notes looked at
+app/tests/modules/aws/, which does not exist). Real gap: the values matrix crossing the boundary is
+never asserted, and there is no failure-path coverage. See the AC-corrections comment on this task.
+
+SUSPECTED PRODUCTION DEFECT FOUND WHILE PLANNING -- PINNED HERE, FIXED ELSEWHERE
+google_groups.py:97 builds an A1 range by interpolating a Google Group DISPLAY NAME straight into
+f"{group_sheet_name}!A1" with no quoting, and :72 passes the same bare name as get_sheet ranges=.
+Google Sheets A1 notation requires a sheet name containing spaces or special characters to be
+wrapped in single quotes (with embedded quotes doubled); unquoted, the API rejects the request with
+400 "Unable to parse range". Group display names routinely contain spaces. Corroborating evidence,
+not speculation: (a) every OTHER range in this repo is a hardcoded space-free literal --
+incident_folder.py:271 "Sheet1!A:A", :305 "Sheet1", :318 f"{sheet_name}!D{i+1}" over a "Sheet1"
+literal, spending.py:192 "Sheet1" -- so this is the only user-controlled sheet name in an A1 range
+repo-wide; (b) TASK-25.1.3 relocated a live "Unable to parse range" swallow for the incidents sheet,
+so this app demonstrably hits that exact error class; (c) tests/factories/google.py emits space-free
+names like "group-name1", so any test built on the factory would never surface it.
+Likely observable impact: get_sheet 400s and is swallowed by the blanket except -> sheet=None -> the
+addSheet path runs -> if the sheet already exists that 400s too and is swallowed -> batch_update_values
+400s and PROPAGATES, because nothing wraps it. The Slack command then dies with no respond() at all.
+NOT FIXED IN THIS TASK (this is a tests-only gate; AC#6 forbids production edits). This task PINS
+todays unquoted behaviour so the defect is visible and the fix is a two-assertion diff. See the
+comment on this task for the proposed fix task and its ordering ahead of TASK-25.1.6.10.
+
+PLACEMENT AND TOOLING
+- app/tests/modules/ is the legacy tree; decisions/testing.md mandates unit/integration/smoke, and
+  every maintained module test lives under app/tests/unit/modules/<area>/. New file goes to
+  app/tests/unit/modules/reports/.
+- app/tests/unit/modules/ has NO __init__.py while each child dir (aws, incident, role, ...) does.
+  Mirror that: add app/tests/unit/modules/reports/__init__.py only. Do NOT add one to the parent --
+  it would change package naming for the existing sibling test packages.
+- No pytest-mock in this repo. Use unittest.mock.patch, matching test_spending_handler.py house
+  style. freezegun==1.5.5 is available and is the blessed clock tool per decisions/testing.md.
+
+MOCK SEAM -- deliberate, and the thing the later slices inherit
+Patch the VENDOR MODULE OBJECTS as bound in the module under test:
+  patch("modules.reports.google_groups.google_directory" / ".google_drive" / ".sheets")
+  patch("modules.aws.spending.sheets")
+That is todays real boundary, so it is what can pin todays request arguments. It is explicitly NOT
+the target seam: TASK-25.1.6.4 replaces the Directory calls with DirectoryProvider, .8 with an
+incident Drive adapter, .10 with a Sheets adapter. MagicMock module doubles rather than Protocol
+fakes -- decisions/testing.md last-choice double -- ACCEPTED BY THE HUMAN 2026-09-02 for this task,
+on the grounds that the subjects are legacy app/modules/* whose collaborators are plain function
+modules with no Protocol, and inventing one would mean building the very adapters the sibling slices
+exist to build.
+
+SEAM-CHURN CONTROL -- the design constraint that decides what .4/.8/.10 cost
+Three sibling slices will each rewire this one file. Write it so each rewire is a handful of edits,
+not a rewrite. Follow the precedent TASK-25.1.5.1 set with _drive_resource_fake plus its
+_copy_request accessor, which its own notes credit with making TASK-25.1.6.6 cheap.
+1. ONE fixture owns all patching (report_deps). No test patches anything itself. That fixture is the
+   single rewire point per sibling.
+2. NO test reads mock.call_args directly. Every assertion goes through a small set of ACCESSOR
+   HELPERS that normalise the seam into repo-local shapes:
+     _file_lookup(deps)      -> tuple[str, str]                  (name, folder_id)
+     _groups_listed(deps)    -> int                              (call count; args are seam-shaped)
+     _members_requested(deps)-> list[str]                        (group keys, in order)
+     _sheet_writes(deps)     -> list[tuple[str, str, list[list]]] (spreadsheet_id, range, values)
+     _sheets_created(deps)   -> list[tuple[str, str]]            (spreadsheet_id, addSheet title)
+   When .4 swaps Directory for DirectoryProvider only _groups_listed/_members_requested change; when
+   .8 swaps Drive only _file_lookup changes; when .10 swaps Sheets only _sheet_writes/_sheets_created
+   change. The ~12 behaviour assertions do not move. Without accessors each sibling rewrites ~15
+   assertion sites and has to re-judge each one against its "pass unchanged or name the change" AC.
+3. Message literals get ONE indirection: module-level _MSG_FOLDER_UNSET / _MSG_NO_GROUPS /
+   _MSG_SUCCESS. Assert respond.assert_called_once_with(_MSG_SUCCESS) -- exact, because the message
+   is the ONLY thing distinguishing the no-groups branch from the success branch, so substring or
+   assert_called matching would let a branch swap pass silently and the gate would stop gating. A
+   cosmetic reword then costs one line, not N.
+4. Keep the BOUNDARY group thin and never restate a fact the BEHAVIOUR group already asserts. The
+   boundary group is the disposable half; duplication there is duplicated migration cost.
+5. Do not parametrize across the seam. Explicit tests translate; parametrized ones have to be
+   untangled first.
+
+ORDERED STEPS
+
+1. Create app/tests/unit/modules/reports/__init__.py (empty).
+
+2. Create app/tests/unit/modules/reports/test_google_groups_report.py.
+   Module-level patch-target constants (_DIRECTORY/_DRIVE/_SHEETS/_SLEEP), the three _MSG_ constants,
+   the five accessor helpers above, and ONE shared fixture report_deps which: patches the three
+   vendor modules plus time.sleep; monkeypatches FOLDER_REPORTS_GOOGLE_GROUPS to "FOLDER1"; and
+   installs explicit defaults -- find_files_by_name -> [], create_file -> {"id": "FILE1"},
+   list_groups -> two plain group dicts with name/email, list_group_members -> two member dicts with
+   email/role, get_sheet -> {} (an EXPLICIT falsy dict; a bare MagicMock return is truthy and would
+   silently skip the addSheet branch), batch_update -> {}, batch_update_values -> {}. Yield a simple
+   namespace plus a MagicMock respond. The fixture is the single place any test overrides a value.
+
+   class TestGenerateGroupMembersReportBehaviour  (must survive .4/.8/.10 unchanged)
+     - unset folder: do NOT use the fixture patch of the constant; assert respond receives
+       _MSG_FOLDER_UNSET and that all three vendor mocks recorded zero calls.
+     - success: respond called once with _MSG_SUCCESS.
+     - a group whose name contains "AWS-" is excluded: no sheet write for it.
+     - list_groups returns only excluded groups (or []): respond receives _MSG_NO_GROUPS AND
+       create_file was still called first -- pins the create-before-check ordering wart.
+     - a 60-character group name is truncated to 50 in BOTH the "Group Name" values row and the
+       "{name}!A1" range.
+     - values matrix equals [["Group Name", name], ["Email", "Role"], [m.email, m.role], ...] in
+       member order.
+     - time.sleep called once per surviving group with 1.1.
+     - GROUP NAME CONTAINING A SPACE (the defect probe): a group named "SRE Team" produces range
+       "SRE Team!A1" and get_sheet ranges "SRE Team" -- UNQUOTED, as today. One short comment marks
+       this as pinned-not-endorsed and points at the fix task. This is the assertion the fix task
+       flips to "\x27SRE Team\x27!A1".
+
+   class TestGenerateGroupMembersReportBoundary  (translated by .4/.8/.10)
+     - under freeze_time("2026-05-04"), _file_lookup is ("groups_report_2026-05-04", "FOLDER1").
+     - no existing file -> create_file(filename, "FOLDER1", "spreadsheet"); existing file ->
+       create_file NOT called and files[0]["id"] is the spreadsheet id used by every later Sheets call.
+     - list_groups called once with no arguments; list_group_members called once per surviving group
+       with that group email, positionally.
+     - get_sheet(file_id, sheet_name) positional; batch_update(file_id, exact addSheet request dict);
+       batch_update_values(file_id, range, values) positional.
+
+   class TestGenerateGroupMembersReportFailureModes
+     - get_sheet raises RuntimeError -> swallowed by the blanket except, sheet is None, addSheet IS
+       called, run completes with _MSG_SUCCESS.
+     - get_sheet returns a truthy dict -> batch_update NOT called.
+     - batch_update raises -> swallowed, the values write still happens, run completes.
+     - find_files_by_name raises -> propagates (pytest.raises); respond never called; no Directory or
+       Sheets call made.
+     - list_groups raises -> propagates; create_file had ALREADY run (partial side effect pinned).
+     - list_group_members raises on the second group -> propagates; ZERO sheet writes (member
+       collection precedes all writes) -- todays partial state is "file created, no sheets".
+     - batch_update_values raises on the second group -> propagates with NO respond() at all; the
+       FIRST group sheet was already written. This is the exact shape the suspected A1-quoting defect
+       takes in production, so it doubles as that defects regression guard.
+
+3. Extend app/tests/unit/modules/aws/test_spending_handler.py. Do not restructure or rename the
+   existing four tests; append:
+     - exact values payload: a two-row DataFrame -> call_kwargs["values"] == [columns, row0, row1]
+       with the DataFrame own value types.
+     - an empty-but-columned DataFrame -> values == [columns] only.
+     - spreadsheet_id="" (the value SPENDING_SHEET_ID actually holds under test) also skips the call
+       -- the existing test only covers None.
+     - batch_update_values side_effect RuntimeError -> propagates out of update_spending_data
+       (no try/except exists today).
+   Do NOT add a test asserting execute_spending_data_update_job reaches Sheets: it passes the
+   def-time-bound default, and :136-167 already pin that delegation with update_spending_data patched.
+
+4. Validate: cd app && uv run pytest tests/unit/modules/reports tests/unit/modules/aws/test_spending_handler.py -q --durations=10
+   (confirms collection works for the new package and that the unit budget holds), then
+   uv run ruff check . ; uv run mypy . --exclude "(?:^|/)\.venv(?:/|$)" ;
+   uv run pytest tests --ignore=tests/smoke.
+
+5. After merge, confirm the pre-registered comments on TASK-25.1.6.4, .8 and .10 still name the
+   correct file paths, class names and accessor helper names; correct them if implementation deviated.
+
+AC TRACEABILITY
+- AC#1 -> steps 1-2, class TestGenerateGroupMembersReportBoundary (all seven sites).
+- AC#2 -> step 2 class split (Behaviour vs Boundary) and step 3 additions.
+- AC#3 -> step 2 class TestGenerateGroupMembersReportFailureModes (seven cases, two partial-state).
+- AC#4 -> step 3.
+- AC#5 -> the shared fixture (time.sleep patch), freeze_time on the filename test, pytest.mark.unit
+  on every test, and step 4 --durations check; docstrings describe behaviour and stub strategy only.
+- AC#6 -> nothing outside app/tests/** is touched; verified by git diff --stat at review time.
+- AC#7 -> the SEAM-CHURN CONTROL section: one fixture, five accessors, three message constants, no
+  direct call_args reads.
+
+TEST MATRIX
+| Case | File | Class | Asserts |
+| happy: full report | test_google_groups_report.py | Behaviour | _MSG_SUCCESS, one write per group |
+| boundary: folder unset | same | Behaviour | early respond, zero Google calls |
+| boundary: no groups after filter | same | Behaviour | _MSG_NO_GROUPS AND file already created |
+| boundary: 60-char name | same | Behaviour | 50-char truncation in cell and range |
+| boundary: name with a space | same | Behaviour | unquoted "SRE Team!A1" (defect probe) |
+| boundary: existing file found | same | Boundary | create_file not called, files[0] id reused |
+| boundary: date-derived filename | same | Boundary | freeze_time, exact _file_lookup |
+| failure: get_sheet raises | same | FailureModes | swallowed -> addSheet path -> run completes |
+| failure: batch_update raises | same | FailureModes | swallowed -> values write still happens |
+| failure: Drive list raises | same | FailureModes | propagates, no respond, no downstream calls |
+| failure: Directory list raises | same | FailureModes | propagates, file already created |
+| partial: members raises on group 2 | same | FailureModes | propagates, zero writes |
+| partial: values write raises on group 2 | same | FailureModes | propagates, no respond, one write done |
+| happy: values matrix | test_spending_handler.py | (appended) | [columns, row0, row1] |
+| boundary: empty DataFrame | same | (appended) | [columns] only |
+| boundary: spreadsheet_id="" | same | (appended) | no Sheets call |
+| failure: Sheets raises | same | (appended) | propagates out of update_spending_data |
+
+ASSUMPTIONS AND DOUBTS
+- Assumes app/tests/unit/modules/ intentionally lacks __init__.py while its children have one, and
+  that adding one only to reports/ collects cleanly. VERIFY by actually running step 4 rather than
+  assuming; if collection complains about a duplicate basename, fall back to no __init__.py.
+- RESOLVED (human, 2026-09-02): MagicMock module doubles are accepted here; do not spend the task
+  inventing Protocol fakes.
+- RESOLVED: the exact respond() strings ARE part of the contract, because the message is the only
+  observable that distinguishes the branches. Centralised behind three constants so a reword is one
+  line -- see SEAM-CHURN CONTROL item 3.
+- RESOLVED: group["name"] raising KeyError on a name-less group is NOT pinned. groups.list is called
+  with no fields projection, and the Directory API always returns name/email on a group resource, so
+  this is a crash on impossible input rather than a designed behaviour. The name-shaped defect worth
+  covering turned out to be the A1 quoting one above, which IS pinned.
+- The A1-quoting defect is assessed from the Sheets A1 notation rules plus the in-repo corroboration
+  listed under SUSPECTED PRODUCTION DEFECT; it is NOT confirmed against live Google here. Confirming
+  it is the first step of the fix task, not of this one. Pinning todays unquoted output is correct
+  either way: if Google turns out to be lenient the pinned assertion is simply an accurate record.
+- These tests deliberately encode behaviour that is WRONG (blanket except, create-file-before-empty-
+  check, 1.1s sleep, unquoted A1 range, def-time-bound spreadsheet default). They are a change
+  detector, not an endorsement. The correct response to a red characterization test in .4/.8/.10 is
+  often to update it and say why.
+
+FOLLOW-UPS NOTED, NOT FIXED (tests-only task)
+1. spending.update_spending_data binds spreadsheet_id=SPENDING_SHEET_ID at import time, freezing the
+   sheet id at process start. Registered by comment on TASK-25.1.6.10, which owns that call site.
+2. The A1-quoting defect above, plus its two neighbours found with it: the 50-char truncation can
+   collide two group names onto one sheet title (second silently overwrites the first, and the
+   duplicate-title addSheet 400 is swallowed), and nothing wraps batch_update_values so one bad group
+   aborts the whole report with no user feedback. Proposed as its own task ahead of TASK-25.1.6.10 --
+   see the comment on this task; awaiting human approval to create.
+
+BLAST RADIUS AND ROLLBACK
+Zero production LOC, zero production files. Two test files (one new ~400-450 LOC, one extended ~+70)
+plus one empty __init__.py. Nothing ships behaviour; a single git revert removes the guard and
+nothing else. No terraform, CI, settings or migration ordering.
+
+SIZE GATE VERDICT: FITS ONE PR. Production diff is 0 files / 0 LOC, one subsystem (tests), no
+mechanical-plus-behaviour mixing, revert-safe. No decomposition required.
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-02 17:14
+---
+AC CORRECTIONS 2026-09-02 (task-planner), after grounding the task against current code. Three of the four ACs carried inaccurate premises; recording the replacement explicitly rather than quietly reshaping them.
+
+1. AC#1 TEST PATH WAS WRONG FOR THIS REPO. It named app/tests/modules/reports/test_google_groups.py. app/tests/modules/ is the LEGACY tree; decisions/testing.md mandates one tree with unit/integration/smoke layers, and every maintained module test lives under app/tests/unit/modules/<area>/ (atip, aws, incident, role, secret, sre). Corrected to app/tests/unit/modules/reports/test_google_groups_report.py.
+
+2. AC#1 CALL-SITE LIST WAS INCOMPLETE. It named five sites. grep -n on app/modules/reports/google_groups.py shows SEVEN: google_drive.find_files_by_name:37, google_drive.create_file:41, google_directory.list_groups:47, google_directory.list_group_members:61, sheets.get_sheet:72, sheets.batch_update:90 (the addSheet request), sheets.batch_update_values:100. The two missing ones are Sheets writes that TASK-25.1.6.10 will migrate, so leaving them unpinned would defeat the point of this gate.
+
+3. AC#2 PREMISE WAS PARTLY WRONG. The task says modules/aws/spending.py has no coverage of its Sheets call sites, citing TASK-25.1.3 notes. It has exactly ONE Sheets call site (sheets.batch_update_values:190 in update_spending_data), and app/tests/unit/modules/aws/test_spending_handler.py:102-133 ALREADY asserts spreadsheetId, cell_range and valueInputOption plus the skip-when-no-id branch. TASK-25.1.3 notes looked at app/tests/modules/aws/ (which does not exist) rather than app/tests/unit/modules/aws/. The genuine gap is narrower: the values matrix that actually crosses the boundary (header row plus DataFrame rows) is never asserted, and there is no failure-path coverage. AC#2 narrowed to that gap, and the work extends the existing file rather than creating a duplicate one.
+
+4. AC#2/#3 gained an explicit BEHAVIOUR vs BOUNDARY split (new AC#2). Characterization tests here have two jobs with different lifetimes: assertions about what the module computes and emits must survive every TASK-25.1.6 slice unchanged, while assertions about the vendor-call arguments will legitimately be TRANSLATED when the seam moves to DirectoryProvider (TASK-25.1.6.4), the Drive adapter (.8) and the Sheets adapter (.10). Splitting them into labelled groups is what makes those siblings ACs (characterization tests pass unchanged, or each intentional change is named) checkable rather than a judgement call.
+
+Nothing was removed from scope; AC#4 (no production file modified) is unchanged and renumbered.
+---
+
+author: @task-planner
+created: 2026-09-02 18:48
+---
+SUSPECTED PRODUCTION DEFECT FOUND WHILE PLANNING (2026-09-02, task-planner). Raised for a decision rather than folded into this task, because this is a tests-only gate and AC#6 forbids production edits.
+
+THE DEFECT. app/modules/reports/google_groups.py:97 builds an A1 range by interpolating a Google Group DISPLAY NAME straight into f"{group_sheet_name}!A1" with no quoting, and :72 passes the same bare name as get_sheet ranges=. Google Sheets A1 notation requires a sheet name containing spaces or special characters to be wrapped in single quotes (embedded quotes doubled); unquoted, the API rejects it with 400 "Unable to parse range". Google Group display names routinely contain spaces.
+
+WHY THIS IS NOT SPECULATION.
+(a) It is the ONLY user-controlled sheet name in an A1 range repo-wide. Every other range is a hardcoded, space-free literal: incident_folder.py:271 "Sheet1!A:A", :305 "Sheet1", :318 f"{sheet_name}!D{i+1}" over a "Sheet1" literal, spending.py:192 "Sheet1".
+(b) TASK-25.1.3 relocated a live "Unable to parse range" swallow for the incidents sheet, so this application demonstrably hits that exact error class in production.
+(c) tests/factories/google.py emits space-free names ("group-name1"), so any test built naively on the factory would never surface it -- which is likely why it has survived.
+
+LIKELY PRODUCTION SHAPE. get_sheet 400s and is swallowed by the blanket except -> sheet=None -> the addSheet path runs -> if that sheet already exists the addSheet 400s too and is swallowed by the second except -> batch_update_values 400s and PROPAGATES, because nothing wraps it. The /sre reports google-groups-members command then dies at the first affected group with no respond() at all: the user sees nothing. The two blanket excepts are actively masking the diagnosis.
+
+TWO NEIGHBOURS FOUND WITH IT, same function, same fix window:
+- The 50-character truncation at :69-70 can collide two different group names onto one sheet title. The second groups write then silently overwrites the first, and the duplicate-title addSheet 400 is swallowed.
+- Nothing wraps batch_update_values, so a single bad group aborts the entire report rather than being skipped and reported.
+
+RECOMMENDATION -- three options considered.
+A. Fix it inside this task. REJECTED: destroys the purpose of a characterization gate, breaks AC#6, and mixes a behaviour change into the guard PR.
+B. Hand it to TASK-25.1.6.10, which owns this call site. REJECTED as the primary route: .10 is Medium and downstream, so the bug lives on; and it would mix a behaviour fix into a migration PR, which the implementation-planning size gate explicitly separates (mechanical diffs are reviewed for completeness, behaviour diffs for correctness).
+C. RECOMMENDED: a small standalone fix task, dependency-ordered AFTER this one and BEFORE TASK-25.1.6.10. Its first step is to confirm the behaviour against the Sheets API (docs plus a targeted check) rather than assume it. Scope: quote the sheet name in both the range and the ranges argument, make truncation collision-safe, and decide whether a failed group should skip-and-report instead of aborting. Estimated production diff well under 50 LOC in one file, one subsystem, trivially revertible.
+
+WHAT THIS TASK DOES ABOUT IT NOW. The plan adds a defect probe to TestGenerateGroupMembersReportBehaviour: a group named "SRE Team" is asserted to produce the unquoted range "SRE Team!A1" today, marked pinned-not-endorsed. The fix task then flips exactly that assertion. The mid-loop batch_update_values failure test in TestGenerateGroupMembersReportFailureModes already pins the abort-with-no-respond shape, so it doubles as the regression guard.
+
+AWAITING HUMAN APPROVAL to create the fix task with --dep TASK-25.1.6.1 --parent TASK-25.1.6 and to add it as a dependency of TASK-25.1.6.10.
+---
+
+author: @task-planner
+created: 2026-09-02 18:54
+---
+APPROVED AND CREATED 2026-09-02 (human). The fix task proposed in the previous comment now exists as TASK-25.1.6.12 - "Fix the unquoted A1 sheet-name range in the Google Groups members report" (type bug, High, milestone m-3, parent TASK-25.1.6, ordinal 132500).
+
+WIRING APPLIED: TASK-25.1.6.12 depends on THIS task, and TASK-25.1.6.10 now depends on TASK-25.1.6.7 AND TASK-25.1.6.12. The coordinator TASK-25.1.6 was updated from eleven children to twelve (AC#1 and the Description child list).
+
+WHAT THIS MEANS FOR THIS TASK: nothing changes in its scope. It stays tests-only and AC#6 still forbids production edits. The defect probe in TestGenerateGroupMembersReportBehaviour must still pin todays UNQUOTED range ("SRE Team!A1"), because TASK-25.1.6.12 depends on this task landing first and its AC#5 is defined as flipping exactly that one assertion. Do not pre-emptively assert the quoted form.
+
+Resolves the "awaiting human approval to create" note in FOLLOW-UPS item 2 of the implementation plan.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.10 - Move-the-Sheets-call-sites-onto-adapters-and-carry-across-the-parse-range-business-rule.md
+++ b/backlog/tasks/task-25.1.6.10 - Move-the-Sheets-call-sites-onto-adapters-and-carry-across-the-parse-range-business-rule.md
@@ -6,12 +6,14 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:03'
+updated_date: '2026-09-02 18:52'
 labels:
   - clients
   - phase-3
 milestone: m-3
 dependencies:
   - TASK-25.1.6.7
+  - TASK-25.1.6.12
 references:
   - decisions/outbound-clients.md
   - decisions/sdk-typing.md
@@ -49,3 +51,34 @@ NOTE: app/tests/integrations/google_workspace/test_sheets.py:250 contains a hasa
 - [ ] #5 app/integrations/google_workspace/sheets.py is deleted with its test file, grep-verified zero references repo-wide outside backlog/ and tmp/
 - [ ] #6 After this task, grep for execute_google_api_call repo-wide matches only bin/check_sdk_typing.py's own detection regex
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-02 17:17
+---
+PRE-REGISTERED BY TASK-25.1.6.1 PLANNING (2026-09-02, task-planner). Three items land in your scope.
+
+1. CORRECTION TO YOUR PREMISE FOR modules/aws/spending.py. Your description says it "has no coverage of its Sheets sites at all". It has exactly ONE Sheets call site (sheets.batch_update_values:190 in update_spending_data) and app/tests/unit/modules/aws/test_spending_handler.py:102-133 already asserts spreadsheetId, cell_range, valueInputOption and the skip-when-id-falsy branch. TASK-25.1.3 notes looked at app/tests/modules/aws/, which does not exist. TASK-25.1.6.1 extends that existing file rather than creating a new one; it adds the exact values matrix (header row plus DataFrame rows), the empty-DataFrame case, spreadsheet_id="" skipping the call, and a raising Sheets call propagating out of update_spending_data (there is no try/except today). Your AC#4 should be read against that file, in place.
+
+2. WHAT GUARDS modules/reports/google_groups.py Sheets sites. New file app/tests/unit/modules/reports/test_google_groups_report.py (unit tree, per the AC correction on TASK-25.1.6.1). TestGenerateGroupMembersReportBoundary pins all three Sheets calls positionally: get_sheet(file_id, sheet_name), batch_update(file_id, exact addSheet request dict), batch_update_values(file_id, "{name}!A1", values). TestGenerateGroupMembersReportBehaviour pins the 50-character sheet-name truncation applied to BOTH the "Group Name" cell and the range, and the exact values matrix. Those behaviour assertions must survive your migration.
+
+Your AC#3 targets the blanket "except Exception: sheet = None". The characterization tests pin its consequences precisely, so you can see what you are changing: get_sheet raising is swallowed, sheet becomes None, the addSheet batch_update path runs, and the report still completes with its success respond(). A separate test pins that a raising batch_update is ALSO swallowed (logged only) while batch_update_values still runs. Replacing either with classification-based handling is an intentional behaviour change to name in your notes.
+
+3. FOLLOW-UP REGISTERED HERE, FOUND WHILE PLANNING TASK-25.1.6.1, NOT FIXED THERE (tests-only task). modules/aws/spending.py::update_spending_data declares spreadsheet_id=SPENDING_SHEET_ID as a DEFAULT ARGUMENT, evaluated at import time. The sheet id is therefore frozen at process start and unaffected by any later config resolution, and patching the module attribute in tests does not change it (which is why every test must pass spreadsheet_id explicitly). execute_spending_data_update_job calls update_spending_data(spending_data) with no id, so it always uses that frozen value. You own this call site -- fix it when you migrate it (read the config inside the function, or take the id from the adapter/settings slice) rather than carrying the import-time binding across.
+---
+
+author: @task-planner
+created: 2026-09-02 18:52
+---
+DEPENDENCY ADDED 2026-09-02 (task-planner): now also depends on TASK-25.1.6.12, the A1 sheet-name quoting fix in modules/reports/google_groups.py, which was found while planning TASK-25.1.6.1. It lands before this migration so you repoint already-correct range construction rather than carrying a live defect across a seam change.
+
+WHAT .12 DELIBERATELY LEAVES FOR YOU, so the two tasks do not collide:
+- The blanket "except Exception: sheet = None" around get_sheet and the blanket except around the addSheet batch_update are UNTOUCHED by .12. Your AC#3 still owns replacing them with classification-based handling.
+- Resilience around batch_update_values is also left to you. Today nothing wraps it, so one failing group aborts the whole report with no respond() at all. Quoting removes the main cause of that abort but not the fragility; when you rewrite this function error handling, decide explicitly whether a failing group should be skipped and reported rather than aborting the run, and record the decision.
+- .12 migrates nothing. Both Sheets call sites in that file are still on integrations.google_workspace.sheets when you pick this up.
+
+WHAT CHANGES UNDER YOU: the range handed to batch_update_values and the ranges handed to get_sheet will be single-quoted (with embedded quotes doubled) through one shared helper, and sheet-title truncation will be collision-safe. TASK-25.1.6.1 defect-probe test asserts the quoted form by then, so treat the quoted range as the expected input shape for your adapter method.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
+++ b/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
@@ -1,0 +1,57 @@
+---
+id: TASK-25.1.6.12
+title: Fix the unquoted A1 sheet-name range in the Google Groups members report
+status: To Do
+assignee: []
+created_date: '2026-09-02 18:52'
+labels:
+  - reports
+  - phase-3
+milestone: m-3
+dependencies:
+  - TASK-25.1.6.1
+references:
+  - app/modules/reports/google_groups.py
+  - decisions/testing.md
+  - 'https://developers.google.com/workspace/sheets/api/guides/concepts'
+parent_task_id: TASK-25.1.6
+priority: high
+type: bug
+ordinal: 132500
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while planning TASK-25.1.6.1 (see the SUSPECTED PRODUCTION DEFECT comment on that task for the full evidence). Split out as its own task rather than folded into a characterization gate or a migration PR, so a behaviour fix is reviewed as a behaviour fix.
+
+THE DEFECT. app/modules/reports/google_groups.py:97 builds an A1 range by interpolating a Google Group DISPLAY NAME straight into f"{group_sheet_name}!A1" with no quoting, and :72 passes the same bare name as the get_sheet ranges argument. Google Sheets A1 notation requires a sheet name containing spaces or special characters to be wrapped in single quotes, with any embedded single quote doubled. Unquoted, the API rejects the request with 400 "Unable to parse range". Google Group display names routinely contain spaces.
+
+EVIDENCE THAT THIS IS REAL, NOT SPECULATION.
+(a) It is the only user-controlled sheet name in an A1 range repo-wide. Every other range is a hardcoded, space-free literal: incident_folder.py:271 Sheet1!A:A, :305 Sheet1, :318 an f-string over a Sheet1 literal, spending.py:192 Sheet1.
+(b) TASK-25.1.3 relocated a live "Unable to parse range" swallow for the incidents sheet, so this application demonstrably hits that exact error class in production.
+(c) tests/factories/google.py emits space-free names like group-name1, so tests built on the factory never surface it, which is likely why it survived.
+
+LIKELY PRODUCTION SHAPE. get_sheet 400s and is swallowed by the blanket except, so sheet becomes None; the addSheet path then runs; if the sheet already exists that 400s too and is swallowed by the second except; finally batch_update_values 400s and PROPAGATES, because nothing wraps it. The /sre reports google-groups-members Slack command dies at the first affected group with no respond() at all, so the user sees nothing. The two blanket excepts are actively masking the diagnosis.
+
+SECOND DEFECT, SAME FIX WINDOW. The 50-character truncation at :69-70 can collide two different group names onto one sheet title. The second group write then silently overwrites the first, and the resulting duplicate-title addSheet 400 is swallowed too.
+
+VERIFY BEFORE CHANGING. The first step is to confirm the quoting rule and the exact failure against the Sheets API documentation and a targeted check, not to assume it. Quoting is valid A1 notation whether or not the API is lenient, so the fix is safe either way, but the task notes must record what was actually confirmed.
+
+EXPLICITLY OUT OF SCOPE, to avoid colliding with TASK-25.1.6.10.
+- Do NOT touch the blanket "except Exception: sheet = None" around get_sheet or the blanket except around the addSheet batch_update. TASK-25.1.6.10 AC#3 owns replacing those with classification-based handling.
+- Do NOT add resilience around batch_update_values so that one bad group is skipped instead of aborting the report. Quoting removes the main cause of that abort; the remaining resilience question belongs with TASK-25.1.6.10, which is rewriting the error handling in this function anyway. It is registered there by comment.
+- Do NOT migrate any call site onto an adapter. This task leaves the seam exactly where it is.
+
+GUARDED BY TASK-25.1.6.1, which is a hard dependency. That task pins todays unquoted output in a named defect probe (a group called SRE Team producing an unquoted range) plus a failure test covering the abort-with-no-respond shape. This fix flips that probe assertion; nothing else in that file should need to change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The quoting rule and the failure mode are confirmed against the Sheets A1 notation documentation before any production edit, and the task notes record what was verified and how
+- [ ] #2 The A1 range passed to sheets.batch_update_values wraps the sheet name in single quotes with embedded single quotes doubled, so a group named with spaces, a leading digit or an apostrophe produces a valid range
+- [ ] #3 The ranges argument passed to sheets.get_sheet is quoted by the same rule and through the same single helper, so the two call sites cannot drift apart
+- [ ] #4 Sheet-title truncation is collision-safe: two group names sharing their first 50 characters no longer resolve to the same sheet title, and a test covers the collision case
+- [ ] #5 TASK-25.1.6.1 defect-probe assertion is updated from the unquoted range to the quoted one, and no other assertion in app/tests/unit/modules/reports/test_google_groups_report.py needs to change
+- [ ] #6 The blanket excepts around get_sheet and the addSheet batch_update are untouched, and no call site is migrated onto an adapter, leaving TASK-25.1.6.10 scope intact
+<!-- AC:END -->

--- a/backlog/tasks/task-25.1.6.4 - Migrate-permissions-provisioning-users-and-reports-Directory-call-sites-onto-DirectoryProvider.md
+++ b/backlog/tasks/task-25.1.6.4 - Migrate-permissions-provisioning-users-and-reports-Directory-call-sites-onto-DirectoryProvider.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:00'
+updated_date: '2026-09-02 17:16'
 labels:
   - clients
   - phase-3
@@ -53,3 +54,22 @@ GUARDED BY: TASK-25.1.6.1's characterization tests, which must be in place for m
 - [ ] #6 TASK-25.1.6.1's characterization tests for modules/reports/google_groups.py pass unchanged, or every intentional behaviour change is named in the task notes
 - [ ] #7 integrations/google_workspace/google_directory.py still exists after this task (TASK-25.1.6.5 deletes it) but has exactly one remaining production consumer: modules/provisioning/groups.py
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-02 17:16
+---
+PRE-REGISTERED BY TASK-25.1.6.1 PLANNING (2026-09-02, task-planner). Your AC#6 says "TASK-25.1.6.1 characterization tests for modules/reports/google_groups.py pass unchanged, or every intentional behaviour change is named in the task notes". Here is what you will actually be looking at.
+
+FILE: app/tests/unit/modules/reports/test_google_groups_report.py (NOT app/tests/modules/... -- TASK-25.1.6.1 AC#1 was corrected to the unit tree per decisions/testing.md).
+
+STRUCTURE: three classes, deliberately split by lifetime.
+- TestGenerateGroupMembersReportBehaviour -- respond strings, the AWS- name exclusion, sheet-name truncation, values matrix, control flow. These MUST keep passing after your migration; if one goes red, you changed observable behaviour.
+- TestGenerateGroupMembersReportBoundary -- the arguments handed to google_directory.list_groups()/list_group_members(). These are EXPECTED to be translated by you, not deleted: the seam moves from patch("modules.reports.google_groups.google_directory") to a DirectoryProvider double obtained via get_directory_provider(). Translating them is normal; silently dropping them is not.
+- TestGenerateGroupMembersReportFailureModes -- includes two cases that are directly your problem: (a) list_groups raising propagates uncaught today and create_file has ALREADY run, so a failed Directory call leaves an empty spreadsheet behind; (b) list_group_members raising on the second group propagates with ZERO sheet writes done. Under OperationResult these exceptions no longer cross the boundary, so both of these tests WILL need rewriting -- that rewrite is your AC#4 error-branch handling, and the notes must name it.
+
+ALSO INHERITED: the tests monkeypatch modules.reports.google_groups.FOLDER_REPORTS_GOOGLE_GROUPS because GOOGLE_RESOURCES is not in the pytest env block, and they patch time.sleep (the module sleeps 1.1s per group). Keep both when you rework them.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.8 - Move-modules-incident-and-jobs-Drive-call-sites-onto-the-incident-Drive-adapter-and-retire-the-folder-display-shim.md
+++ b/backlog/tasks/task-25.1.6.8 - Move-modules-incident-and-jobs-Drive-call-sites-onto-the-incident-Drive-adapter-and-retire-the-folder-display-shim.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:02'
+updated_date: '2026-09-02 17:16'
 labels:
   - clients
   - phase-3
@@ -48,3 +49,23 @@ SIZE: this touches eight consumer files plus the adapter and is the most likely 
 - [ ] #6 modules/reports/google_groups.py's Drive call sites are migrated and TASK-25.1.6.1's characterization tests for that file pass, or each intentional change is named in the notes
 - [ ] #7 Pagination behaviour established by TASK-25.1.5 (list_next drained to exhaustion, nextPageToken in the projection) is preserved through the move, proven by a multi-page test at the adapter boundary
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-02 17:16
+---
+PRE-REGISTERED BY TASK-25.1.6.1 PLANNING (2026-09-02, task-planner). Your AC#6 depends on TASK-25.1.6.1 characterization tests for modules/reports/google_groups.py. What lands:
+
+FILE: app/tests/unit/modules/reports/test_google_groups_report.py (unit tree, per the AC correction on TASK-25.1.6.1 -- not app/tests/modules/).
+
+WHAT COVERS YOUR TWO DRIVE SITES: TestGenerateGroupMembersReportBoundary pins google_drive.find_files_by_name("groups_report_<YYYY-MM-DD>", folder_id) under freeze_time, google_drive.create_file(filename, folder_id, "spreadsheet") when the lookup returns [], and create_file NOT being called plus files[0]["id"] being reused as the spreadsheet id when it returns a hit. Those assertions are yours to TRANSLATE onto the incident Drive adapter seam, not to delete.
+
+TWO THINGS THE TESTS DELIBERATELY PIN THAT YOU MAY WANT TO CHANGE -- if you do, name it in your notes:
+- The spreadsheet is created BEFORE the empty-groups check, so a run with zero groups still leaves an empty spreadsheet in Drive. TestGenerateGroupMembersReportBehaviour asserts that ordering explicitly.
+- find_files_by_name raising propagates uncaught out of generate_group_members_report today, with respond() never called. TestGenerateGroupMembersReportFailureModes asserts that. Once the adapter classifies into OperationResult that exception stops crossing the boundary, so this test will need rewriting -- that is an intentional change, not a regression.
+
+NOTE ON create_file: the file_type-to-mimeType map and its ValueError live in google_drive.create_file and your AC#2 moves them into the adapter. The reports call passes the literal "spreadsheet"; the characterization tests assert the string that is passed, not the mimeType, so the map move is invisible to them.
+---
+<!-- COMMENTS:END -->


### PR DESCRIPTION
# Summary | Résumé

Adds characterization tests for the Google Workspace call sites in `app/modules/reports/google_groups.py` and `app/modules/aws/spending.py` ahead of the vendor-mirror retirement (TASK-25.1.6). Tests only — no production code changes.

`google_groups.py` had no test file at all, and every sibling slice under TASK-25.1.6 will change the error-handling shape of exactly these call sites. This pins today's observable behaviour first so those migrations are guarded.

## Changes

- **New** `app/tests/unit/modules/reports/test_google_groups_report.py` (21 tests) covering all seven Google call sites, split into three classes:
  - `Behaviour` — respond strings, `AWS-` exclusion, 50-char sheet-name truncation, values matrix, per-group pause. Must survive the adapter migrations unchanged.
  - `Boundary` — arguments handed to the vendor modules. Expected to be *translated* when the seam moves to adapters.
  - `FailureModes` — the blanket excepts, propagation paths, and partial state after a mid-loop failure.
- **Extended** `app/tests/unit/modules/aws/test_spending_handler.py` (+4 tests): the exact values matrix crossing `batch_update_values`, empty-DataFrame, `spreadsheet_id=""` skip, and error propagation. Existing tests untouched.
- Task metadata updated.

## Notes for reviewers

- **These tests deliberately encode behaviour that is wrong.** They are a change detector, not an endorsement. Locked in as-is: the two blanket excepts, the spreadsheet being created *before* the empty-groups check, the 1.1s sleep, and the unquoted A1 range.
- **One test pins a suspected production defect.** `test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges` asserts today's unquoted `"SRE Team!A1"`. Group display names routinely contain spaces, and Sheets A1 notation requires quoting — this likely 400s in production and dies with no user feedback. TASK-25.1.6.12 owns the fix and flips exactly that assertion; it is *not* fixed here.
- **Seam-churn control** is the main design constraint: one fixture owns all patching, no test reads `call_args` directly, and the three `respond()` literals are module constants — so each of the three sibling rewires is a handful of edits rather than a rewrite.

## Validation

`ruff` clean; `mypy` clean on touched files (94 errors pre-exist on `main`); 32/32 targeted tests pass; full suite green.