### PR TITLE
Fix/google sheets unquoted range

### DIFF
--- a/app/modules/reports/google_groups.py
+++ b/app/modules/reports/google_groups.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 from datetime import datetime
 
@@ -13,6 +14,27 @@ from integrations.google_workspace import (
 FOLDER_REPORTS_GOOGLE_GROUPS = get_google_resources_config().google_groups_reports_folder_id
 
 logger = get_logger()
+
+_SHEET_TITLE_MAX_LENGTH = 50
+_SHEET_TITLE_DIGEST_LENGTH = 6
+
+
+def _sheet_title(group_name: str) -> str:
+    """Derive a bounded, collision-safe sheet title from a group display name."""
+    # Apostrophes are stripped so no title can carry the A1 quote character.
+    sanitised = group_name.replace("'", "")
+    if sanitised == group_name and len(sanitised) <= _SHEET_TITLE_MAX_LENGTH:
+        return sanitised
+    # sha256, never the salted builtin hash(), so titles are stable across processes.
+    digest = hashlib.sha256(group_name.encode("utf-8")).hexdigest()[:_SHEET_TITLE_DIGEST_LENGTH]
+    keep = _SHEET_TITLE_MAX_LENGTH - _SHEET_TITLE_DIGEST_LENGTH - 1
+    return f"{sanitised[:keep]}-{digest}"
+
+
+def _a1_range(sheet_title: str, cell: str = "") -> str:
+    """Quote a sheet title for A1 notation, doubling any embedded single quote."""
+    quoted = "'{}'".format(sheet_title.replace("'", "''"))
+    return f"{quoted}!{cell}" if cell else quoted
 
 
 def generate_report(args, respond):
@@ -63,13 +85,11 @@ def generate_group_members_report(args, respond):
         groups_with_members.append(group)
 
     for group in groups_with_members:
-        group_sheet_name = f"{group['name']}"
-        log.info("processing_group_sheet", group=group_sheet_name)
-        if len(group_sheet_name) > 50:
-            group_sheet_name = group_sheet_name[:50]
+        sheet_title = _sheet_title(group["name"])
+        log.info("processing_group_sheet", group=sheet_title)
 
         try:
-            sheet = sheets.get_sheet(file["id"], group_sheet_name)
+            sheet = sheets.get_sheet(file["id"], _a1_range(sheet_title))
         except Exception:
             sheet = None
         if sheet:
@@ -81,7 +101,7 @@ def generate_group_members_report(args, respond):
                         {
                             "addSheet": {
                                 "properties": {
-                                    "title": group_sheet_name,
+                                    "title": sheet_title,
                                 }
                             }
                         }
@@ -89,21 +109,20 @@ def generate_group_members_report(args, respond):
                 }
                 sheet = sheets.batch_update(file["id"], request)
                 if sheet:
-                    log.info("sheet_created", sheet=group_sheet_name)
+                    log.info("sheet_created", sheet=sheet_title)
             except Exception as e:
                 log.error("sheet_creation_failed", error=str(e))
 
-        values = [["Group Name", group_sheet_name], ["Email", "Role"]]
-        group_sheet_name = f"{group_sheet_name}!A1"
+        values = [["Group Name", sheet_title], ["Email", "Role"]]
         for member in group["members"]:
             values.append([member["email"], member["role"]])
         updated_sheet = sheets.batch_update_values(
             file["id"],
-            group_sheet_name,
+            _a1_range(sheet_title, "A1"),
             values,
         )
         if updated_sheet:
-            log.info("sheet_updated", sheet=group_sheet_name)
+            log.info("sheet_updated", sheet=sheet_title)
 
         time.sleep(1.1)
 

--- a/app/tests/unit/modules/reports/test_google_groups_report.py
+++ b/app/tests/unit/modules/reports/test_google_groups_report.py
@@ -1,14 +1,15 @@
 """Characterization tests for the Google Groups members report.
 
 These tests pin the behaviour the module has today, including its rough edges
-(blanket excepts, unquoted A1 ranges). They are a change detector, not an
-endorsement.
+(blanket excepts). They are a change detector, not an endorsement. A1 ranges
+and derived sheet titles are asserted at their TASK-25.1.6.12 target shape.
 
 Stub strategy: the vendor modules are patched as bound in the module under test
 by a single fixture, and every boundary assertion goes through an accessor
 helper so the seam can be moved in one place.
 """
 
+import hashlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -28,6 +29,24 @@ _MSG_SUCCESS = "Google Groups Members report generated."
 
 _FOLDER_ID = "FOLDER1"
 _FILE_ID = "FILE1"
+
+_TITLE_MAX_LENGTH = 50
+_TITLE_DIGEST_LENGTH = 6
+
+
+def _expected_title(group_name: str) -> str:
+    """Expected sheet title, derived here independently of the module under test."""
+    sanitised = group_name.replace("'", "")
+    if sanitised == group_name and len(sanitised) <= _TITLE_MAX_LENGTH:
+        return sanitised
+    digest = hashlib.sha256(group_name.encode("utf-8")).hexdigest()[:_TITLE_DIGEST_LENGTH]
+    keep = _TITLE_MAX_LENGTH - _TITLE_DIGEST_LENGTH - 1
+    return f"{sanitised[:keep]}-{digest}"
+
+
+def _expected_range(sheet_title: str, cell: str = "") -> str:
+    quoted = "'{}'".format(sheet_title.replace("'", "''"))
+    return f"{quoted}!{cell}" if cell else quoted
 
 
 def _member(email: str, role: str) -> dict[str, str]:
@@ -144,7 +163,7 @@ class TestGenerateGroupMembersReportBehaviour:
         google_groups.generate_group_members_report([], report_deps.respond)
 
         assert _members_requested(report_deps) == ["one@test.com"]
-        assert [write[1] for write in _sheet_writes(report_deps)] == ["GroupOne!A1"]
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["'GroupOne'!A1"]
 
     def test_should_respond_no_groups_after_creating_the_file_when_all_groups_excluded(self, report_deps):
         report_deps.directory.list_groups.return_value = [_group("AWS-Admins", "aws@test.com")]
@@ -155,16 +174,18 @@ class TestGenerateGroupMembersReportBehaviour:
         assert len(_file_created(report_deps)) == 1
         assert _sheet_writes(report_deps) == []
 
-    def test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range(self, report_deps):
+    def test_should_derive_a_bounded_sheet_title_for_an_overlong_group_name(self, report_deps):
         long_name = "G" * 60
         report_deps.directory.list_groups.return_value = [_group(long_name, "long@test.com")]
 
         google_groups.generate_group_members_report([], report_deps.respond)
 
-        truncated = "G" * 50
+        expected = _expected_title(long_name)
+        assert len(expected) == 50
         _, cell_range, values = _sheet_writes(report_deps)[0]
-        assert cell_range == f"{truncated}!A1"
-        assert values[0] == ["Group Name", truncated]
+        assert cell_range == _expected_range(expected, "A1")
+        assert values[0] == ["Group Name", expected]
+        assert [created[1] for created in _sheets_created(report_deps)] == [expected]
 
     def test_should_write_header_rows_followed_by_members_in_order(self, report_deps):
         report_deps.directory.list_groups.return_value = [_group("GroupOne", "one@test.com")]
@@ -184,14 +205,64 @@ class TestGenerateGroupMembersReportBehaviour:
 
         assert _sleep_delays(report_deps) == [1.1, 1.1]
 
-    def test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges(self, report_deps):
-        # Pinned, not endorsed: unquoted A1 ranges are the defect TASK-25.1.6.12 fixes.
+    def test_should_quote_sheet_names_containing_spaces_in_ranges(self, report_deps):
         report_deps.directory.list_groups.return_value = [_group("SRE Team", "sre@test.com")]
 
         google_groups.generate_group_members_report([], report_deps.respond)
 
-        assert _sheets_read(report_deps) == [(_FILE_ID, "SRE Team")]
-        assert [write[1] for write in _sheet_writes(report_deps)] == ["SRE Team!A1"]
+        assert _sheets_read(report_deps) == [(_FILE_ID, "'SRE Team'")]
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["'SRE Team'!A1"]
+        # Quoting belongs to the range only; the sheet title itself stays bare.
+        assert [created[1] for created in _sheets_created(report_deps)] == ["SRE Team"]
+
+    def test_should_strip_apostrophes_from_the_title_google_receives(self, report_deps):
+        report_deps.directory.list_groups.return_value = [_group("Jon's Team", "jon@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        expected = _expected_title("Jon's Team")
+        assert "'" not in expected
+        assert [created[1] for created in _sheets_created(report_deps)] == [expected]
+        _, cell_range, values = _sheet_writes(report_deps)[0]
+        assert values[0] == ["Group Name", expected]
+        assert cell_range == f"'{expected}'!A1"
+
+    def test_should_derive_distinct_titles_for_group_names_sharing_a_fifty_character_prefix(self, report_deps):
+        shared = "P" * 55
+        report_deps.directory.list_groups.return_value = [
+            _group(f"{shared}-alpha", "alpha@test.com"),
+            _group(f"{shared}-beta", "beta@test.com"),
+        ]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        titles = [created[1] for created in _sheets_created(report_deps)]
+        ranges = [write[1] for write in _sheet_writes(report_deps)]
+        assert len(set(titles)) == 2
+        assert len(set(ranges)) == 2
+
+    def test_should_derive_distinct_titles_when_apostrophe_removal_would_collide(self, report_deps):
+        report_deps.directory.list_groups.return_value = [
+            _group("Jon's Team", "jon@test.com"),
+            _group("Jons Team", "jons@test.com"),
+        ]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        titles = [created[1] for created in _sheets_created(report_deps)]
+        assert len(set(titles)) == 2
+
+    def test_should_derive_the_same_title_on_every_run_for_the_same_group_name(self, report_deps):
+        # Same-process double invocation: PYTHONHASHSEED is fixed within one process,
+        # so this guards against a per-run derivation, not against the salted builtin hash().
+        report_deps.directory.list_groups.return_value = [_group("G" * 60, "long@test.com")]
+
+        google_groups.generate_group_members_report([], report_deps.respond)
+        google_groups.generate_group_members_report([], report_deps.respond)
+
+        ranges = [write[1] for write in _sheet_writes(report_deps)]
+        assert len(ranges) == 2
+        assert ranges[0] == ranges[1]
 
 
 @pytest.mark.unit
@@ -231,7 +302,7 @@ class TestGenerateGroupMembersReportBoundary:
 
         google_groups.generate_group_members_report([], report_deps.respond)
 
-        assert _sheets_read(report_deps) == [(_FILE_ID, "GroupOne")]
+        assert _sheets_read(report_deps) == [(_FILE_ID, "'GroupOne'")]
         assert _sheet_create_requests(report_deps) == [{"requests": [{"addSheet": {"properties": {"title": "GroupOne"}}}]}]
 
     def test_should_write_values_positionally_with_file_id_and_range(self, report_deps):
@@ -241,7 +312,7 @@ class TestGenerateGroupMembersReportBoundary:
 
         spreadsheet_id, cell_range, values = _sheet_writes(report_deps)[0]
         assert spreadsheet_id == _FILE_ID
-        assert cell_range == "GroupOne!A1"
+        assert cell_range == "'GroupOne'!A1"
         assert values[1] == ["Email", "Role"]
 
 
@@ -313,5 +384,5 @@ class TestGenerateGroupMembersReportFailureModes:
         with pytest.raises(RuntimeError):
             google_groups.generate_group_members_report([], report_deps.respond)
 
-        assert [write[1] for write in _sheet_writes(report_deps)] == ["GroupOne!A1", "GroupTwo!A1"]
+        assert [write[1] for write in _sheet_writes(report_deps)] == ["'GroupOne'!A1", "'GroupTwo'!A1"]
         report_deps.respond.assert_not_called()

--- a/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
+++ b/backlog/tasks/task-25.1.6.1 - Add-characterization-tests-for-the-untested-Google-Workspace-call-sites-before-any-adapter-work.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - '@me'
 created_date: '2026-09-02 14:58'
-updated_date: '2026-09-02 19:17'
+updated_date: '2026-09-02 19:40'
 labels:
   - clients
   - phase-3
@@ -380,5 +380,21 @@ WIRING APPLIED: TASK-25.1.6.12 depends on THIS task, and TASK-25.1.6.10 now depe
 WHAT THIS MEANS FOR THIS TASK: nothing changes in its scope. It stays tests-only and AC#6 still forbids production edits. The defect probe in TestGenerateGroupMembersReportBehaviour must still pin todays UNQUOTED range ("SRE Team!A1"), because TASK-25.1.6.12 depends on this task landing first and its AC#5 is defined as flipping exactly that one assertion. Do not pre-emptively assert the quoted form.
 
 Resolves the "awaiting human approval to create" note in FOLLOW-UPS item 2 of the implementation plan.
+---
+
+created: 2026-09-02 19:40
+---
+DEFECT PROBE IS BEING FLIPPED 2026-09-02 (task-planner, while planning TASK-25.1.6.12). This task stays Done; recording what .12 does to the harness it shipped, so the "Behaviour class must survive the adapter migrations unchanged" framing in its Notes is amended once, deliberately, rather than eroding quietly.
+
+SIX ASSERTIONS IN test_google_groups_report.py CHANGE, all of them A1-range or derived-title shaped, none of them behaviour-shaped:
+- test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges -> renamed test_should_quote_sheet_names_containing_spaces_in_ranges; "SRE Team!A1" becomes "'SRE Team'!A1" and the read range becomes "'SRE Team'". This is the flip .12 AC#6 exists for, exactly as pre-registered.
+- test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range -> renamed test_should_derive_a_bounded_sheet_title_for_an_overlong_group_name; the 60-G name no longer yields 50 Gs but 43 Gs plus a hyphen plus a 6-hex sha256 prefix, because .12 also makes truncation collision-safe.
+- test_should_exclude_groups_whose_name_contains_aws_prefix, test_should_read_and_create_sheets_with_the_group_sheet_name, test_should_write_values_positionally_with_file_id_and_range and test_should_propagate_a_mid_loop_write_failure_leaving_the_first_sheet_written each gain quotes on their range strings, because .12 quotes UNCONDITIONALLY rather than only when the name looks special.
+
+WHY UNCONDITIONAL, since it costs four more assertion edits than the minimum: googleapiclient and its stubs provide no A1 helper at all (the sheets/v4 stub types the parameter as plain str), the Sheets docs document `'Sheet1'` as the PRECISE sheet reference while bare `Sheet1` can resolve to a named range instead, and gspread's absolute_range_name quotes every name unconditionally and doubles embedded quotes. A conditional "does this need quoting" predicate would have been our own guess at Google's unenumerated special-character set.
+
+WHAT DOES NOT CHANGE, and this is the part that keeps this task's guarantee intact: the three respond-message constants and their assertions, the values-matrix ordering test, the sleep test, the file lookup and creation tests, the list-groups call-count test, all seven accessors, the report_deps fixture, and the addSheet request title assertion (a sheet title is a literal title, not A1 notation, so it stays bare "GroupOne"). The spending_handler additions are untouched entirely.
+
+The pinned-not-endorsed comment naming TASK-25.1.6.12 is removed by .12 along with the assertion it guarded, which is the intended lifecycle for a defect probe.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.10 - Move-the-Sheets-call-sites-onto-adapters-and-carry-across-the-parse-range-business-rule.md
+++ b/backlog/tasks/task-25.1.6.10 - Move-the-Sheets-call-sites-onto-adapters-and-carry-across-the-parse-range-business-rule.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:03'
-updated_date: '2026-09-02 18:52'
+updated_date: '2026-09-02 19:47'
 labels:
   - clients
   - phase-3
@@ -80,5 +80,29 @@ WHAT .12 DELIBERATELY LEAVES FOR YOU, so the two tasks do not collide:
 - .12 migrates nothing. Both Sheets call sites in that file are still on integrations.google_workspace.sheets when you pick this up.
 
 WHAT CHANGES UNDER YOU: the range handed to batch_update_values and the ranges handed to get_sheet will be single-quoted (with embedded quotes doubled) through one shared helper, and sheet-title truncation will be collision-safe. TASK-25.1.6.1 defect-probe test asserts the quoted form by then, so treat the quoted range as the expected input shape for your adapter method.
+---
+
+created: 2026-09-02 19:40
+---
+REGISTERED FROM TASK-25.1.6.12 PLANNING 2026-09-02 (task-planner). Three things land in this task's scope when .12 ships. .10 already depends on .12, so nothing new blocks here.
+
+1. TWO HELPERS TRAVEL WITH THE CALL SITE, they do not get re-inlined and they do not move into integrations/. TASK-25.1.6.12 adds `_sheet_title(group_name) -> str` and `_a1_range(sheet_title, cell="") -> str` as module-private helpers in app/modules/reports/google_groups.py. When .10 moves the Sheets call sites onto an adapter, both must move with them into the adapter (or into a shared A1 utility outside the vendor package). Putting A1 range formatting into integrations/google_workspace/sheets.py would be a NEW instance of exactly the business-logic-in-the-vendor-package deviation that TASK-25.1.6 exists to close - do not "helpfully" push it down a layer. _a1_range implements gspread's absolute_range_name semantics: unconditional single quotes, embedded quotes doubled. _sheet_title strips apostrophes and appends a deterministic sha256-derived suffix whenever the title had to be derived (over 50 chars, or an apostrophe removed). Never swap that sha256 for the builtin hash(); str.__hash__ is salted per process, so the sheet title would change on every container restart.
+
+2. THE BOUNDARY ASSERTIONS .10 WILL BE TRANSLATING HAVE MOVED. In app/tests/unit/modules/reports/test_google_groups_report.py, every A1 range assertion becomes the quoted form ("'GroupOne'!A1", "'SRE Team'!A1", read range "'GroupOne'"), while the addSheet request title assertion stays BARE ("GroupOne") - a sheet title is a literal title, not A1 notation. Two tests are renamed: test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range becomes test_should_derive_a_bounded_sheet_title_for_an_overlong_group_name, and test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges becomes test_should_quote_sheet_names_containing_spaces_in_ranges. Four tests are added (apostrophe handling, two collision cases, determinism across two invocations). The respond-message, values-matrix, call-count and call-ordering assertions are untouched, so .10's "characterization tests pass unchanged or each change is named" bar is unaffected by .12.
+
+3. WHAT .12 DELIBERATELY LEFT FOR THIS TASK, unchanged from the existing scope fence: the blanket "except Exception: sheet = None" around get_sheet and the blanket except around the addSheet batch_update are still there for .10 AC#3 to replace with classify_google_error-based handling; and batch_update_values is still unwrapped, so one bad group still aborts the whole report with no respond() to the user. Quoting removes the main CAUSE of that abort but not the fragility - skip-and-report resilience remains .10's call, since .10 is rewriting that error handling anyway.
+
+ONE OPEN QUESTION HANDED OVER RATHER THAN DECIDED IN .12: the Group Name cell (:96 today) carries the DERIVED sheet title, so for an overlong or apostrophe-bearing group the human-readable cell now shows a hash suffix. Putting the full group["name"] in that cell and keeping the derived value only for the title and the range would be strictly more useful, but it is an unrequested behaviour change. If it is not taken as a two-line follow-up before .10, fold it in here.
+---
+
+created: 2026-09-02 19:47
+---
+FORWARD NOTE FROM TASK-25.1.6.12's APPROVAL 2026-09-02 (human). TASK-25.1.6.12 is approved as planned, with an attached instruction to reassess its fix once app/modules/reports/google_groups.py's consumer moves to the app/packages/<feature>/ architecture. That migration has no owning task today, so the note is registered here as the nearest downstream owner of this call site.
+
+Two items to carry, extending the earlier "the two helpers travel with the call site" comment on this task:
+
+1. In the package endstate, _a1_range and _sheet_title belong in the feature's Sheets adapter under app/packages/<feature>/adapters/, next to the try/except plus classify_google_error boundary this task builds. _a1_range is the piece worth lifting to a shared primitive if a second feature ever needs A1 quoting; _sheet_title is report-specific domain logic and stays with the feature. Neither goes into app/integrations/google_workspace/ at any point.
+
+2. The 50-character bound, the sha256 suffix and the apostrophe strip all exist because a user-controlled Google Group display name is being used as a sheet identifier. A feature package with a real domain type for a group could carry a stable identifier separately from the display label, removing the need for the suffix and freeing the Group Name cell to show the full untruncated name. That is the same open question already flagged on this task; it resolves cleanly at the package boundary rather than in a legacy module.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
+++ b/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
@@ -4,6 +4,7 @@ title: Fix the unquoted A1 sheet-name range in the Google Groups members report
 status: To Do
 assignee: []
 created_date: '2026-09-02 18:52'
+updated_date: '2026-09-02 19:45'
 labels:
   - reports
   - phase-3
@@ -12,8 +13,10 @@ dependencies:
   - TASK-25.1.6.1
 references:
   - app/modules/reports/google_groups.py
+  - app/tests/unit/modules/reports/test_google_groups_report.py
   - decisions/testing.md
   - 'https://developers.google.com/workspace/sheets/api/guides/concepts'
+  - 'https://github.com/burnash/gspread/blob/master/gspread/utils.py'
 parent_task_id: TASK-25.1.6
 priority: high
 type: bug
@@ -48,10 +51,258 @@ GUARDED BY TASK-25.1.6.1, which is a hard dependency. That task pins todays unqu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The quoting rule and the failure mode are confirmed against the Sheets A1 notation documentation before any production edit, and the task notes record what was verified and how
+- [ ] #1 The quoting rule and the failure mode are confirmed before any production edit, and the task notes record what was verified and how
 - [ ] #2 The A1 range passed to sheets.batch_update_values wraps the sheet name in single quotes with embedded single quotes doubled, so a group named with spaces, a leading digit or an apostrophe produces a valid range
 - [ ] #3 The ranges argument passed to sheets.get_sheet is quoted by the same rule and through the same single helper, so the two call sites cannot drift apart
-- [ ] #4 Sheet-title truncation is collision-safe: two group names sharing their first 50 characters no longer resolve to the same sheet title, and a test covers the collision case
-- [ ] #5 TASK-25.1.6.1 defect-probe assertion is updated from the unquoted range to the quoted one, and no other assertion in app/tests/unit/modules/reports/test_google_groups_report.py needs to change
-- [ ] #6 The blanket excepts around get_sheet and the addSheet batch_update are untouched, and no call site is migrated onto an adapter, leaving TASK-25.1.6.10 scope intact
+- [ ] #4 The derived sheet title has apostrophes removed, so no title Google receives can contain the A1 quote character; the addSheet title and the Group Name cell carry that same derived title unquoted
+- [ ] #5 Derived sheet titles are collision-safe and deterministic across processes: two group names that would reduce to the same title, whether by length truncation or by apostrophe removal, resolve to different titles, and the same group name resolves to the same title on every run
+- [ ] #6 The characterization tests are updated only where an A1 range or a derived sheet title is asserted, each change is named in the task notes, and the assertions about respond messages, the values matrix, call counts and call ordering are untouched
+- [ ] #7 The blanket excepts around get_sheet and the addSheet batch_update are untouched, and no call site is migrated onto an adapter, leaving TASK-25.1.6.10 scope intact
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+VERIFICATION DONE AT PLANNING TIME (AC#1 evidence; re-record in Notes at implementation time)
+
+1. The SDK gives you nothing. Confirmed against the installed packages, not from memory:
+   .venv/.../googleapiclient-stubs/_apis/sheets/v4/resources.pyi types the parameters as
+   `range: str` and `ranges: str | _list[str] | None`. There is no A1 builder, quoter or
+   escaper anywhere in googleapiclient or its stubs. A1 quoting is 100 percent caller-side
+   responsibility, so "use the SDK helper" is not an available option here.
+
+2. Google states the requirement but not the escape. The Sheets API concepts page says
+   verbatim: "Single quotes are required for sheet names with spaces or special characters",
+   and gives `'My Custom Sheet'!A:A`. It also says `'A1'` refers to a SHEET named A1 while
+   bare `A1` refers to a CELL, and that with a named range called Sheet1, bare `Sheet1`
+   resolves to the named range while `'Sheet1'` resolves to the sheet. So quoting is not
+   merely tolerated on names that do not need it, it is the more precise reference form.
+   The same page then writes `'Jon's_Data'!A1:D5` with the embedded apostrophe NOT doubled,
+   which contradicts the standard escape. Google's own docs are internally inconsistent on
+   exactly the apostrophe case, which is why item 3 matters.
+
+3. gspread settles both questions empirically. burnash/gspread is the de facto Python Sheets
+   client and drives every one of its values calls through one helper:
+       def absolute_range_name(sheet_name, range_name=None):
+           sheet_name = "'{}'".format(sheet_name.replace("'", "''"))
+           return "{}!{}".format(sheet_name, range_name) if range_name else sheet_name
+   Its doctests pin `absolute_range_name("Sheet1", "A1") == "'Sheet1'!A1"` (quoted even for
+   a plain alphanumeric name) and `absolute_range_name("Sheet'1") == "'Sheet''1'"` (doubling).
+   Its parser is the mirror image: SHEET_TITLE_RE = r"'((?:[^']|'')+)'!|([^!]+)!" and
+   extract_title_from_range does .replace("''", "'"). A widely used library quoting
+   unconditionally against live Google is stronger evidence than the docs example.
+
+CONCLUSION, answering the nuance that we quote nothing today: unconditional quoting is the
+safe direction, not the risky one. It cannot break a name that works unquoted (the quoted
+form is documented as the sheet reference), it fixes every name that is broken today, and it
+avoids inventing a "does this name need quoting" predicate, which would be a guess since
+Google never enumerates its special characters. Conditional quoting is rejected.
+
+TARGET SHAPE, app/modules/reports/google_groups.py
+
+The root cause is one variable doing two jobs: `group_sheet_name` holds the sheet TITLE at
+:72 and :84 and :96, then is reassigned to an A1 RANGE at :97. Split it, and put each job
+behind its own helper.
+
+Two module-private helpers, added above generate_report:
+
+    _SHEET_TITLE_MAX_LENGTH = 50
+    _SHEET_TITLE_DIGEST_LENGTH = 6
+
+    def _sheet_title(group_name: str) -> str:
+        # Apostrophes are stripped so no title can contain the A1 quote character.
+        sanitised = group_name.replace("'", "")
+        if sanitised == group_name and len(sanitised) <= _SHEET_TITLE_MAX_LENGTH:
+            return sanitised
+        digest = hashlib.sha256(group_name.encode("utf-8")).hexdigest()[:_SHEET_TITLE_DIGEST_LENGTH]
+        keep = _SHEET_TITLE_MAX_LENGTH - _SHEET_TITLE_DIGEST_LENGTH - 1
+        return f"{sanitised[:keep]}-{digest}"
+
+    def _a1_range(sheet_title: str, cell: str = "") -> str:
+        quoted = "'{}'".format(sheet_title.replace("'", "''"))
+        return f"{quoted}!{cell}" if cell else quoted
+
+Notes on the design, so review does not have to reconstruct it:
+- hashlib.sha256, never the builtin hash(). str.__hash__ is salted per process
+  (PYTHONHASHSEED), so a builtin-hash suffix would give a different sheet title on every
+  container restart and the report would silently create duplicate sheets. sha256 is also
+  what keeps ruff's S rules quiet; md5/sha1 would trip S324.
+- The suffix fires only when the title actually had to be derived (too long, or an
+  apostrophe removed). A short apostrophe-free name is returned byte for byte as today, so
+  the common path is untouched and most characterization assertions are unaffected.
+- _a1_range keeps the doubling even though _sheet_title now guarantees no apostrophe
+  reaches it. That is deliberate: it makes _a1_range a correct general A1 quoter matching
+  gspread's semantics, so a future caller that passes a raw name is still safe. It is one
+  .replace, and it is the behaviour AC#2 asks for.
+
+Call-site rewiring inside the group loop (today's :66-106):
+  - `sheet_title = _sheet_title(group["name"])`, replacing the f-string plus the
+    len>50 truncate block at :66-70.
+  - `log.info("processing_group_sheet", group=sheet_title)` unchanged in intent.
+  - `sheets.get_sheet(file["id"], _a1_range(sheet_title))` at :72.
+  - addSheet properties title stays `sheet_title`, UNQUOTED. A sheet title is a literal
+    title, not A1 notation; quoting it would create a sheet whose name literally contains
+    apostrophes.
+  - `values = [["Group Name", sheet_title], ["Email", "Role"]]` unchanged in intent.
+  - `sheets.batch_update_values(file["id"], _a1_range(sheet_title, "A1"), values)`,
+    replacing the `group_sheet_name = f"{group_sheet_name}!A1"` reassignment at :97.
+  - `log.info("sheet_updated", sheet=sheet_title)` now logs the title rather than the
+    range, a side effect of removing the variable reuse. No test asserts it.
+
+No other line in the file changes. `import hashlib` is the only new import.
+
+ORDERED STEPS
+
+1. Re-run the two verification checks above and write the result into the task Notes
+   (AC#1): the stub signatures from the installed venv, the concepts-page quotes including
+   the inconsistent apostrophe example, and gspread's absolute_range_name plus its two
+   doctests. Do not skip this because the plan already records it; AC#1 asks for what was
+   verified at implementation time.
+2. Update the tests first (they are the specification here, and TASK-25.1.6.1 already shipped
+   the harness). In app/tests/unit/modules/reports/test_google_groups_report.py, change
+   exactly these six assertions and add four:
+   CHANGED
+     a. TestGenerateGroupMembersReportBehaviour::test_should_exclude_groups_whose_name_
+        contains_aws_prefix -- write range "GroupOne!A1" becomes "'GroupOne'!A1".
+     b. ...::test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range --
+        rename to test_should_derive_a_bounded_sheet_title_for_an_overlong_group_name; the
+        60-G name now yields a 50-char title of 43 Gs, a hyphen and the 6-hex sha256 prefix
+        of the full name; assert cell_range == _a1_range(expected_title, "A1") shape and
+        values[0] == ["Group Name", expected_title]. Compute the digest in the test with
+        hashlib rather than hardcoding a hex literal.
+     c. ...::test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges -- rename to
+        test_should_quote_sheet_names_containing_spaces_in_ranges; the defect probe flips:
+        _sheets_read == [(_FILE_ID, "'SRE Team'")] and write range "'SRE Team'!A1". Drop the
+        pinned-not-endorsed comment. Add to this test that the addSheet title is still the
+        bare "SRE Team", which is the assertion that proves quoting was applied at the range
+        and only at the range.
+     d. TestGenerateGroupMembersReportBoundary::test_should_read_and_create_sheets_with_the_
+        group_sheet_name -- read range becomes "'GroupOne'"; the _sheet_create_requests
+        assertion stays exactly as it is, title "GroupOne".
+     e. ...::test_should_write_values_positionally_with_file_id_and_range -- cell_range
+        becomes "'GroupOne'!A1".
+     f. TestGenerateGroupMembersReportFailureModes::test_should_propagate_a_mid_loop_write_
+        failure_leaving_the_first_sheet_written -- ranges become ["'GroupOne'!A1",
+        "'GroupTwo'!A1"].
+   ADDED (all pytest.mark.unit, all through the existing report_deps fixture and accessors)
+     g. Behaviour: a group named "Jon's Team" produces addSheet title "Jons Team", cell
+        value "Jons Team", and range "'Jons Team'!A1" -- the apostrophe never reaches Google
+        in either position. Because the title was derived, it also carries the digest
+        suffix; assert the exact string the helper produces.
+     h. Behaviour: two groups whose names share their first 50 characters produce two
+        DIFFERENT sheet titles and two different write ranges (AC#5 collision case).
+     i. Behaviour: "Jon's Team" and "Jons Team" as two groups in one run also produce two
+        different titles (the apostrophe-removal collision case).
+     j. Determinism: invoke generate_group_members_report twice with the same overlong group
+        and assert the two runs produced identical write ranges. This is the regression
+        guard against anyone swapping sha256 for the builtin hash(); it must be a
+        same-process double invocation, since PYTHONHASHSEED is fixed within one process --
+        state that limitation in the test docstring rather than pretending it proves more.
+   UNTOUCHED, and verify at review that they are: the three respond-message assertions, the
+   values-matrix ordering test, the sleep test, the file lookup and creation tests, the
+   list-groups call-count test and all seven failure-mode behaviours other than (f).
+3. Implement the two helpers and rewire the six usages of group_sheet_name as described in
+   TARGET SHAPE. Do not touch anything else in the file.
+4. Validate: cd app && uv run pytest tests/unit/modules/reports -q, then uv run ruff check .,
+   then uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' confirming zero errors mention
+   modules/reports or tests/unit/modules/reports (the repo carries a ~94-error pre-existing
+   mypy baseline; do not read a green whole-tree run as the bar), then the Makefile split
+   make test-new and make test-legacy rather than a single whole-tree pytest run.
+5. Write the Notes: the AC#1 verification record, and the explicit list of the six changed
+   plus four added test assertions, satisfying AC#6's "each change is named".
+6. Post-merge, update the two pre-registered sibling comments if implementation deviated
+   from the helper names _sheet_title and _a1_range.
+
+AC TRACEABILITY
+- AC#1 -> step 1, plus the VERIFICATION DONE section above.
+- AC#2 -> _a1_range's doubling, exercised by step 2 items c, g.
+- AC#3 -> both call sites go through _a1_range; step 2 items c, d assert the get_sheet side.
+- AC#4 -> _sheet_title's apostrophe strip; step 2 item g asserts title, cell and range together.
+- AC#5 -> _sheet_title's sha256 suffix; step 2 items b, h, i, j.
+- AC#6 -> step 2's explicit changed/added/untouched split, recorded in Notes at step 5.
+- AC#7 -> step 3's "do not touch anything else"; verified by git diff at review.
+
+TEST MATRIX
+| Case | Class | Asserts |
+| plain name quoted | Behaviour | 'GroupOne'!A1 write, 'GroupOne' read, GroupOne addSheet title |
+| name with a space | Behaviour | 'SRE Team'!A1 write, bare SRE Team addSheet title |
+| overlong name | Behaviour | 43 chars + hyphen + 6 hex, same title in cell and range |
+| name with an apostrophe | Behaviour | apostrophe absent from title and cell, range quoted |
+| 50-char prefix collision | Behaviour | two distinct titles, two distinct ranges |
+| apostrophe collision | Behaviour | two distinct titles |
+| determinism across runs | Behaviour | two invocations, identical ranges |
+| mid-loop write failure | FailureModes | quoted ranges, still propagates, still no respond |
+
+ASSUMPTIONS AND DOUBTS
+- RESOLVED by research, was the plan's main open question: quote unconditionally. Evidence in
+  VERIFICATION DONE items 1-3. Conditional quoting is rejected because the predicate would be
+  a guess about Google's unenumerated special-character set.
+- RESOLVED by the human: strip apostrophes from derived titles rather than rely solely on
+  doubling. The doubling in _a1_range is retained anyway as the correct general primitive.
+  A reviewer who considers that redundant can delete the .replace in _a1_range without
+  changing observable behaviour, since no title can reach it with an apostrophe -- flagging
+  this explicitly rather than defending it as load-bearing.
+- NOT A CONCERN, verified: the derived-title change cannot orphan existing production sheets.
+  The spreadsheet filename is date-derived (groups_report_YYYY-MM-DD at :35), so a new file is
+  created each day and sheets are created fresh inside it. Within a day, re-running resolves
+  to the same file and the same deterministic titles.
+- OPEN, for the reviewer, deliberately not decided here: the Group Name cell at :96 carries
+  the DERIVED title, so for an overlong or apostrophe-bearing group the human-readable cell
+  now shows a hash suffix, which is worse to read than today's plain truncation. Putting the
+  FULL group["name"] in that cell and keeping the derived value only for the sheet title and
+  the range would be strictly more useful, but it is a behaviour change nobody asked for and
+  it would change one more characterization assertion. Left as-is; say yes and it is a
+  two-line follow-up.
+- NOT VERIFIED, and cannot be from here: that a group display name containing an apostrophe
+  actually exists in the tenant. The fix is correct regardless.
+- The 50-character bound is inherited, not chosen. Google Sheets allows longer titles; the
+  plan keeps 50 because widening it is out of scope and would change more assertions.
+
+BLAST RADIUS AND ROLLBACK
+One production file, app/modules/reports/google_groups.py: two new helpers, two constants,
+one new import, and six rewired usages inside one loop. Roughly 25 to 35 production LOC.
+One test file. No settings, terraform, CI, dependency or migration-ordering change. The only
+consumer is the /sre reports google-groups-members Slack command. A single git revert restores
+today's behaviour, and the TASK-25.1.6.1 harness would then go red on the six assertions,
+which is the intended signal.
+
+SIZE GATE VERDICT: FITS ONE PR. One production file, one subsystem, well under the 400 LOC
+and 10 file thresholds, no mechanical migration mixed in with the behaviour change (that
+separation is exactly why this task exists apart from TASK-25.1.6.10). No decomposition.
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-02 19:39
+---
+AC SET REPLACED 2026-09-02 (task-planner, human-directed research outcome). Recording the replacement explicitly per the backlog-task-workflow rule against silently reshaping ACs. Six criteria became seven; nothing was dropped from scope.
+
+WHY. The human asked that the quoting strategy be settled by researching the Google Python client and its stubs rather than by picking the option with the smallest test diff, and separately chose to strip apostrophes from derived sheet titles. Both answers changed what the ACs need to say.
+
+WHAT THE RESEARCH FOUND. (1) googleapiclient and googleapiclient-stubs offer NO A1 helper at all - the installed sheets/v4 stub types the parameters as plain `range: str` / `ranges: str | list[str] | None`, so quoting is entirely caller-side and there is no SDK primitive to defer to. (2) The Sheets concepts page requires quotes for names with spaces or special characters, documents `'Sheet1'` as the precise sheet reference (bare `Sheet1` can resolve to a named range instead), and then writes `'Jon's_Data'!A1:D5` WITHOUT doubling the embedded apostrophe - Google's own docs are inconsistent on exactly the apostrophe case. (3) gspread, the de facto Python Sheets client, resolves both: absolute_range_name() quotes UNCONDITIONALLY and doubles embedded quotes, with doctests pinning "'Sheet1'!A1" for a plain alphanumeric name and "'Sheet''1'" for an apostrophe, and its parser mirrors that with `'((?:[^']|'')+)'!` plus .replace("''", "'"). A library doing this against live Google at scale outweighs the docs example.
+
+SO: quote unconditionally. The nuance that we quote nothing today cuts toward unconditional, not away from it - the quoted form is the documented sheet reference, so it cannot break a name that works unquoted, while a conditional predicate would be our own guess at Google's unenumerated special-character set.
+
+CHANGES, criterion by criterion.
+- #1 unchanged in substance; dropped the phrase "against the Sheets A1 notation documentation" because the decisive evidence turned out to be the SDK stubs and gspread, not the docs alone.
+- #2 and #3 unchanged.
+- #4 NEW: derived sheet titles have apostrophes removed, and the addSheet title plus the Group Name cell carry that same derived title unquoted. This is the human's decision, and it also pins the thing that is easy to get wrong - a sheet title is a literal title, not A1 notation, so quoting it would create a sheet whose name contains apostrophes.
+- #5 was the old #4 (collision-safe truncation), WIDENED. Apostrophe removal is a second way two different group names can collapse onto one title, so the criterion now covers both causes, and it adds the determinism requirement: the same group name must resolve to the same title on every run. That rules out the builtin hash(), which is salted per process and would silently produce a different sheet title after every container restart.
+- #6 REPLACED the old #5. The old text said the defect-probe assertion flips and "no other assertion needs to change". That is not achievable and was written before the research: unconditional quoting changes six range assertions, and the collision-safe title changes the truncation assertion. The new text draws the honest line - only A1-range and derived-title assertions change, each one is named in the Notes, and the respond messages, values matrix, call counts and call ordering stay untouched. That is still a checkable bar, and it is the bar that actually protects TASK-25.1.6.4/.8/.10.
+- #7 was the old #6, unchanged.
+---
+
+created: 2026-09-02 19:45
+---
+PLAN APPROVED AS IS 2026-09-02 (human). Unconditional quoting, apostrophe-stripped derived titles, sha256-suffixed collision safety, and the replaced seven-criterion AC set all stand as written. Ready for tests-creation / implementation; status stays To Do until that work starts.
+
+REASSESSMENT NOTE ATTACHED BY THE SAME APPROVAL. Revisit this fix when app/modules/reports/google_groups.py's consumer moves to the app/packages/<feature>/ architecture. Two things change shape at that point and neither is in scope now:
+
+1. WHERE THE HELPERS LIVE. _sheet_title and _a1_range are module-private in a legacy app/modules/ file today purely because that is where the call site is. In the package world the natural home is the feature's Sheets adapter under app/packages/<feature>/adapters/, alongside the try/except plus classify_google_error boundary. If a second feature ever needs A1 quoting, _a1_range is the shared primitive to lift; _sheet_title is report-specific domain logic and should stay with the feature. Neither ever belongs in app/integrations/google_workspace/ - that is the deviation TASK-25.1.6 exists to close.
+
+2. WHETHER THE DERIVED TITLE IS STILL THE RIGHT MODEL. The 50-character bound, the hash suffix and the apostrophe strip are all compensations for using a user-controlled display name as a sheet identifier. A feature package with a real domain type for a group could carry a stable identifier separately from the display label, which would make the suffix unnecessary and would let the Group Name cell show the full untruncated name - the open question already flagged in the plan and registered on TASK-25.1.6.10.
+
+No task owns the reports-to-package migration today (grep of backlog/ finds none), so this is recorded here and on TASK-25.1.6.10 rather than filed as work. Whoever picks up that migration should read this before re-deriving the quoting rules from scratch; the evidence set (no A1 helper in googleapiclient or its stubs, the Sheets concepts page, gspread's absolute_range_name) is in this task's plan and references.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
+++ b/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-25.1.6.12
 title: Fix the unquoted A1 sheet-name range in the Google Groups members report
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-02 18:52'
-updated_date: '2026-09-02 19:59'
+updated_date: '2026-09-02 20:00'
 labels:
   - reports
   - phase-3

--- a/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
+++ b/backlog/tasks/task-25.1.6.12 - Fix-the-unquoted-A1-sheet-name-range-in-the-Google-Groups-members-report.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-25.1.6.12
 title: Fix the unquoted A1 sheet-name range in the Google Groups members report
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-02 18:52'
-updated_date: '2026-09-02 19:45'
+updated_date: '2026-09-02 19:59'
 labels:
   - reports
   - phase-3
@@ -51,13 +52,13 @@ GUARDED BY TASK-25.1.6.1, which is a hard dependency. That task pins todays unqu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The quoting rule and the failure mode are confirmed before any production edit, and the task notes record what was verified and how
-- [ ] #2 The A1 range passed to sheets.batch_update_values wraps the sheet name in single quotes with embedded single quotes doubled, so a group named with spaces, a leading digit or an apostrophe produces a valid range
-- [ ] #3 The ranges argument passed to sheets.get_sheet is quoted by the same rule and through the same single helper, so the two call sites cannot drift apart
-- [ ] #4 The derived sheet title has apostrophes removed, so no title Google receives can contain the A1 quote character; the addSheet title and the Group Name cell carry that same derived title unquoted
-- [ ] #5 Derived sheet titles are collision-safe and deterministic across processes: two group names that would reduce to the same title, whether by length truncation or by apostrophe removal, resolve to different titles, and the same group name resolves to the same title on every run
-- [ ] #6 The characterization tests are updated only where an A1 range or a derived sheet title is asserted, each change is named in the task notes, and the assertions about respond messages, the values matrix, call counts and call ordering are untouched
-- [ ] #7 The blanket excepts around get_sheet and the addSheet batch_update are untouched, and no call site is migrated onto an adapter, leaving TASK-25.1.6.10 scope intact
+- [x] #1 The quoting rule and the failure mode are confirmed before any production edit, and the task notes record what was verified and how
+- [x] #2 The A1 range passed to sheets.batch_update_values wraps the sheet name in single quotes with embedded single quotes doubled, so a group named with spaces, a leading digit or an apostrophe produces a valid range
+- [x] #3 The ranges argument passed to sheets.get_sheet is quoted by the same rule and through the same single helper, so the two call sites cannot drift apart
+- [x] #4 The derived sheet title has apostrophes removed, so no title Google receives can contain the A1 quote character; the addSheet title and the Group Name cell carry that same derived title unquoted
+- [x] #5 Derived sheet titles are collision-safe and deterministic across processes: two group names that would reduce to the same title, whether by length truncation or by apostrophe removal, resolve to different titles, and the same group name resolves to the same title on every run
+- [x] #6 The characterization tests are updated only where an A1 range or a derived sheet title is asserted, each change is named in the task notes, and the assertions about respond messages, the values matrix, call counts and call ordering are untouched
+- [x] #7 The blanket excepts around get_sheet and the addSheet batch_update are untouched, and no call site is migrated onto an adapter, leaving TASK-25.1.6.10 scope intact
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -270,6 +271,108 @@ SIZE GATE VERDICT: FITS ONE PR. One production file, one subsystem, well under t
 and 10 file thresholds, no mechanical migration mixed in with the behaviour change (that
 separation is exactly why this task exists apart from TASK-25.1.6.10). No decomposition.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED as planned. One production file changed: app/modules/reports/google_groups.py.
+
+AC#1 VERIFICATION RECORD (re-run at implementation time, 2026-09-02)
+- Installed stubs, .venv/lib/python3.14/site-packages/googleapiclient-stubs/_apis/sheets/v4/resources.pyi:
+  values().get/update type the parameter as `range: str` (line ~133) and spreadsheets().get types
+  `ranges: str | _list[str] | None = ...` (line ~186). Confirmed by grep against the installed venv,
+  not from memory. There is no A1 builder, quoter or escaper anywhere in googleapiclient or its stubs,
+  so quoting is entirely caller-side. "Defer to an SDK helper" is not an available option.
+- Sheets API concepts page: "Single quotes are required for sheet names with spaces or special
+  characters" ('My Custom Sheet'!A:A); 'Sheet1' is the precise SHEET reference while bare Sheet1 can
+  resolve to a named range. The same page writes 'Jon's_Data'!A1:D5 with the apostrophe NOT doubled,
+  i.e. Google's docs are internally inconsistent on exactly the apostrophe case.
+- gspread (not installed in this venv; evidence is the upstream source cited in the task references)
+  settles it: absolute_range_name() quotes UNCONDITIONALLY and doubles embedded quotes, doctests pin
+  "'Sheet1'!A1" and "'Sheet''1'", and its parser mirrors that with '((?:[^']|'')+)'! plus
+  .replace("''", "'").
+- CONCLUSION UNCHANGED: quote unconditionally. Not verified and not verifiable from here: that a live
+  400 "Unable to parse range" occurs for a specific tenant group name. The fix is valid A1 notation
+  either way.
+
+PRODUCTION CHANGE
+- New import: hashlib. New constants _SHEET_TITLE_MAX_LENGTH = 50, _SHEET_TITLE_DIGEST_LENGTH = 6.
+- New module-private _sheet_title(group_name): strips apostrophes; returns the name byte-for-byte when
+  it was already apostrophe-free and <= 50 chars; otherwise truncates to 43 and appends "-" plus the
+  6-hex sha256 prefix of the FULL original name. sha256 not builtin hash(), which is PYTHONHASHSEED
+  salted and would yield a different title after every container restart.
+- New module-private _a1_range(sheet_title, cell=""): wraps in single quotes, doubling embedded quotes,
+  and appends "!<cell>" when a cell is given.
+- Rewired the six uses of the old dual-purpose group_sheet_name variable: title derivation replaces the
+  f-string + len>50 truncate block; get_sheet takes _a1_range(sheet_title); the addSheet properties
+  title and the "Group Name" cell carry the bare derived title; batch_update_values takes
+  _a1_range(sheet_title, "A1"), replacing the in-place reassignment to an A1 range. sheet_updated now
+  logs the title rather than the range (no test asserts it).
+
+AC#7 HELD: both blanket excepts are byte-identical to before; no call site moved onto an adapter.
+TASK-25.1.6.10 scope intact.
+
+AC#6 TEST DELTA, app/tests/unit/modules/reports/test_google_groups_report.py
+CHANGED (6, all A1-range or derived-title assertions only)
+ 1. Behaviour::test_should_exclude_groups_whose_name_contains_aws_prefix - write range
+    "GroupOne!A1" -> "'GroupOne'!A1".
+ 2. Behaviour::test_should_truncate_sheet_name_to_fifty_characters_in_cell_and_range renamed to
+    test_should_derive_a_bounded_sheet_title_for_an_overlong_group_name - 60-G name now yields
+    43 Gs + "-" + 6 hex; digest computed in-test with hashlib, not hardcoded.
+ 3. Behaviour::test_should_leave_sheet_names_containing_spaces_unquoted_in_ranges renamed to
+    test_should_quote_sheet_names_containing_spaces_in_ranges - the defect probe flips to
+    read (_FILE_ID, "'SRE Team'") and write "'SRE Team'!A1", plus a new assertion that the addSheet
+    title is still the bare "SRE Team". Pinned-not-endorsed comment dropped.
+ 4. Boundary::test_should_read_and_create_sheets_with_the_group_sheet_name - read range -> "'GroupOne'";
+    _sheet_create_requests assertion unchanged, title still "GroupOne".
+ 5. Boundary::test_should_write_values_positionally_with_file_id_and_range - "'GroupOne'!A1".
+ 6. FailureModes::test_should_propagate_a_mid_loop_write_failure_leaving_the_first_sheet_written -
+    ranges -> ["'GroupOne'!A1", "'GroupTwo'!A1"].
+ADDED (4)
+ 7. test_should_strip_apostrophes_from_the_title_google_receives - "Jon's Team": apostrophe absent from
+    addSheet title and from the Group Name cell, range quoted.
+ 8. test_should_derive_distinct_titles_for_group_names_sharing_a_fifty_character_prefix - AC#5 length
+    collision: two distinct titles and two distinct ranges.
+ 9. test_should_derive_distinct_titles_when_apostrophe_removal_would_collide - "Jon's Team" vs
+    "Jons Team" resolve to two distinct titles.
+10. test_should_derive_the_same_title_on_every_run_for_the_same_group_name - same-process double
+    invocation yields identical ranges. Docstring states the limitation: PYTHONHASHSEED is fixed within
+    one process, so this guards against a per-run derivation, not against the salted builtin hash().
+UNTOUCHED as required: the three respond-message assertions, the values-matrix ordering test, the sleep
+test, the file lookup/creation/reuse tests, the list-groups call-count test, and the six failure-mode
+behaviours other than item 6.
+
+TEST EVIDENCE
+- uv run pytest tests/unit/modules/reports -q: 25 passed.
+- uv run ruff check .: All checks passed.
+- uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)': zero errors matching reports/google_groups (grep -c
+  returned 0). The repo carries a pre-existing ~94-error baseline elsewhere; that baseline is unchanged.
+- make test (whole suite, run manually by the human): green.
+
+LEFT FOR HUMAN VERIFICATION / DoD
+- Reviewer confirmation via git diff that AC#7 holds (excepts untouched, no adapter migration).
+- The plan's OPEN question, deliberately not decided: the "Group Name" cell now shows the DERIVED title,
+  so for an overlong or apostrophe-bearing group it carries a hash suffix, which reads worse than
+  today's plain truncation. Putting the full group["name"] in that cell while keeping the derived value
+  for the sheet title and range is a two-line follow-up if wanted; it is registered on TASK-25.1.6.10.
+- Post-merge, update the two pre-registered sibling comments if reviewers rename _sheet_title/_a1_range.
+- No behaviour confirmed against live Google; this was not exercised against the real Sheets API.
+
+CLARIFICATION ON THE gspread EVIDENCE (added after review, to prevent confusion in this codebase)
+gspread is a THIRD-PARTY, community-maintained Sheets client (burnash/gspread). It is NOT the Google
+Python API client (google-api-python-client / googleapiclient) and NOT googleapiclient-stubs. This
+repository does NOT depend on gspread, does not import it, and this task adds no such dependency; it
+is not installed in the venv. It was cited purely as CORROBORATING PRIOR ART for the A1 quoting rule -
+a widely used library that quotes unconditionally and doubles embedded quotes against live Google -
+because the official Google documentation is self-contradictory on the apostrophe case and the
+official client we DO use exposes no A1 helper at all.
+
+The binding evidence for our implementation is therefore: (1) the installed googleapiclient-stubs
+signatures showing `range: str` / `ranges: str | list[str] | None`, i.e. no SDK-side quoting exists,
+and (2) the Sheets API concepts page requiring single quotes. gspread's absolute_range_name() is
+referenced as a sanity check on the escape form only. Our _a1_range() is our own implementation in
+app/modules/reports/google_groups.py; it is not copied from, vendored from, or coupled to gspread.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces two key helpers to ensure Google Sheets sheet titles are bounded, collision-safe, and that all A1 notation ranges are correctly quoted, addressing defects and preparing for future adapter migration. It updates both the implementation in `google_groups.py` and the corresponding characterization tests to assert the new behaviors, including deterministic, collision-resistant sheet title derivation and robust, unconditional quoting for A1 ranges.

**Key changes:**

**Sheet title derivation and A1 range quoting:**
- Added `_sheet_title(group_name)` to generate a sanitized, max-50-character sheet title with apostrophe removal and a deterministic sha256 suffix if needed, ensuring collision safety and stability across runs. (`app/modules/reports/google_groups.py`)
- Added `_a1_range(sheet_title, cell="")` to unconditionally single-quote sheet titles (doubling embedded quotes) for A1 notation, matching gspread and Google Sheets documentation. (`app/modules/reports/google_groups.py`)

**Integration with report generation:**
- Updated all usages in `generate_group_members_report` to use `_sheet_title` for sheet creation and `_a1_range` for all A1 range references, replacing previous ad-hoc truncation and unquoted usage. (`app/modules/reports/google_groups.py`) [[1]](diffhunk://#diff-d4c7fc68458f8f9f9f08673eee6694c229e1814e4452375cbe875a276d6f1111L66-R92) [[2]](diffhunk://#diff-d4c7fc68458f8f9f9f08673eee6694c229e1814e4452375cbe875a276d6f1111L84-R125)

**Characterization tests:**
- Refactored and expanded tests to assert the new quoting and title derivation logic, including:
  - Renamed and updated tests for overlong names, names with spaces, and apostrophes.
  - Added tests for collision resistance, determinism, and correct quoting in all relevant places.
  - Updated all assertions to expect quoted ranges and derived titles, not just bare names. (`app/tests/unit/modules/reports/test_google_groups_report.py`) [[1]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adR33-R50) [[2]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL147-R166) [[3]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL158-R188) [[4]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL187-R265) [[5]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL234-R305) [[6]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL244-R315) [[7]](diffhunk://#diff-1de79a50d767ffd3c6b03f9b975424a8941fb7992c8cf42f80092ff52ab5f4adL316-R387)

**Documentation and task tracking:**
- Updated task documentation to record the rationale, test assertion changes, and future migration instructions, ensuring that the new helpers and their placement are clear for downstream work. (`backlog/tasks/task-25.1.6.1...md`, `backlog/tasks/task-25.1.6.10...md`) [[1]](diffhunk://#diff-7b31059cfea5dbfc4472b506e774935fbb391d11654c45a176cc54581ac6b215R384-R399) [[2]](diffhunk://#diff-2fdf3b0b342d458975c97d611a8e8b49217bd862193a07811e55bafb27c51f9dR84-R107)

These changes make the sheet title and range handling robust, deterministic, and ready for adapter migration, while maintaining full test coverage and clear documentation of the new behaviors.