### PR TITLE
Feat/directory google batch rearchitecture

### DIFF
--- a/app/infrastructure/directory/google.py
+++ b/app/infrastructure/directory/google.py
@@ -9,12 +9,15 @@ from googleapiclient.errors import HttpError
 from infrastructure.configuration.infrastructure import DirectorySettings
 from infrastructure.directory.models import (
     DirectoryGroup,
+    DirectoryGroupFailure,
+    DirectoryGroupsWithMembers,
+    DirectoryGroupWithMembers,
     DirectoryMember,
     DirectoryUser,
     MembershipCheckResult,
 )
 from infrastructure.operations import OperationResult
-from integrations.google_workspace.client import classify_google_error, execute_batch_request
+from integrations.google_workspace.client import classify_google_error
 
 if TYPE_CHECKING:
     from googleapiclient._apis.admin.directory_v1 import (
@@ -28,6 +31,9 @@ T = TypeVar("T")
 _NUM_RETRIES = 3
 _USERS_PAGE_SIZE = 500
 _GROUPS_PAGE_SIZE = 200
+_MEMBERS_PAGE_SIZE = 200
+# googleapiclient raises BatchError past MAX_BATCH_LIMIT (1000); stay well under it.
+_BATCH_MAX_REQUESTS = 100
 
 
 class GoogleDirectoryProvider:
@@ -107,6 +113,100 @@ class GoogleDirectoryProvider:
             return items
 
         return self._call(operation, run)
+
+    def _execute_batch_round(
+        self,
+        service: AdminDirectoryResource,
+        requests: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, HttpError]]:
+        """Run one batch round, returning per-key responses and per-key errors.
+
+        Chunked because BatchHttpRequest.add raises BatchError past MAX_BATCH_LIMIT.
+        Callers pick their own failure policy — nothing is classified here.
+        """
+        responses: dict[str, Any] = {}
+        errors: dict[str, HttpError] = {}
+
+        # response is Any because the stub types this parameter HttpRequest, not the payload.
+        def callback(request_id: str, response: Any, exception: HttpError | None) -> None:
+            if exception is not None:
+                errors[request_id] = exception
+            else:
+                responses[request_id] = response
+
+        keys = list(requests)
+        for start in range(0, len(keys), _BATCH_MAX_REQUESTS):
+            batch = service.new_batch_http_request(callback=callback)
+            for key in keys[start : start + _BATCH_MAX_REQUESTS]:
+                batch.add(requests[key], request_id=key)
+            batch.execute()
+
+        return responses, errors
+
+    def _batch_list_members(
+        self,
+        service: AdminDirectoryResource,
+        group_keys: list[str],
+    ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, HttpError]]:
+        """Fetch every member page for each group, re-batching only unfinished groups."""
+        members_resource = service.members()
+        raw_members: dict[str, list[dict[str, Any]]] = {key: [] for key in group_keys}
+        errors: dict[str, HttpError] = {}
+        pending: dict[str, Any] = {key: members_resource.list(groupKey=key, maxResults=_MEMBERS_PAGE_SIZE) for key in group_keys}
+
+        while pending:
+            responses, round_errors = self._execute_batch_round(service, pending)
+            errors.update(round_errors)
+            next_pending: dict[str, Any] = {}
+            for key, response in responses.items():
+                raw_members[key].extend(response.get("members", []) or [])
+                next_request = members_resource.list_next(pending[key], response)
+                if next_request is not None:
+                    next_pending[key] = next_request
+            pending = next_pending
+
+        return raw_members, errors
+
+    def _normalize_member_types(self, include_member_types: set[str] | None) -> OperationResult[set[str] | None]:
+        """Normalise and validate the requested member-type filter."""
+        if include_member_types is None:
+            return OperationResult.success(data=None)
+
+        allowed = {str(member_type).strip().upper() for member_type in include_member_types if str(member_type).strip()}
+        if not allowed:
+            return OperationResult.permanent_error(
+                message="include_member_types must contain at least one type",
+                error_code="DIRECTORY_MEMBER_TYPES_INVALID",
+            )
+
+        return OperationResult.success(data=allowed)
+
+    def _map_members(self, items: list[dict[str, Any]], allowed: set[str] | None) -> list[DirectoryMember]:
+        """Map raw member payloads into canonical members, applying the type filter."""
+        members: list[DirectoryMember] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            member_type = str(item.get("type") or "").strip().upper()
+            if allowed is not None and member_type and member_type not in allowed:
+                continue
+
+            member = self._build_directory_member(item)
+            if member is not None:
+                members.append(member)
+
+        return members
+
+    def _build_group_failure(self, group_email: str, exc: HttpError) -> DirectoryGroupFailure:
+        """Classify a per-group batch error into a typed failure entry."""
+        status, error_code, _retry_after = classify_google_error(exc)
+        return DirectoryGroupFailure(
+            group_email=group_email,
+            status=status,
+            error_code=error_code,
+            message=str(exc),
+        )
 
     def _normalize_email(self, value: str) -> str:
         """Normalize email-form identifiers used by the shared contract.
@@ -563,8 +663,9 @@ class GoogleDirectoryProvider:
     ) -> OperationResult[dict[str, list[DirectoryMember]]]:
         """Return the member list for multiple groups in a single batch call.
 
-        Uses the Google Admin batch API so cost is one network round-trip
-        regardless of the number of groups.
+        Uses the Google Admin batch API so cost is one batched round-trip per
+        chunk of groups per member-page depth, rather than one call per group.
+        Fails as a whole when any group's batch item fails.
 
         Args:
             group_keys: Canonical managed-group emails — normalised to lowercase.
@@ -578,55 +679,20 @@ class GoogleDirectoryProvider:
         if not group_keys:
             return OperationResult.success(data={})
 
-        normalized_keys = [self._normalize_email(k) for k in group_keys]
+        member_types_result = self._normalize_member_types(include_member_types)
+        if not member_types_result.is_success:
+            return self._typed_error(member_types_result)
+
+        normalized_keys = [self._normalize_email(key) for key in group_keys]
         service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.readonly"])
-        members_resource = service.members()
-        batch_requests = [(key, members_resource.list(groupKey=key)) for key in normalized_keys]
-        batch_result = execute_batch_request(service, batch_requests)
-        if not batch_result.is_success:
-            return self._typed_error(batch_result)
+        raw_members, errors = self._batch_list_members(service, normalized_keys)
 
-        raw_results = batch_result.data.get("results", {}) if isinstance(batch_result.data, dict) else {}
-        members_by_group_response: dict[str, Any] = {}
-        for group_key in normalized_keys:
-            group_response = raw_results.get(group_key)
-            members_by_group_response[group_key] = group_response.get("members", []) if isinstance(group_response, dict) else []
+        if errors:
+            first_error = next(iter(errors.values()))
+            return self._typed_error(self._map_sdk_exception(first_error, "get_group_members_batch"))
 
-        result = OperationResult.success(data=members_by_group_response)
-        if not result.is_success:
-            return self._typed_error(result)
-
-        if not isinstance(result.data, dict):
-            return OperationResult.permanent_error(
-                message="Batch directory members payload is not a dict",
-                error_code="DIRECTORY_BATCH_MEMBERS_PAYLOAD_INVALID",
-            )
-
-        allowed_member_types = None
-        if include_member_types is not None:
-            allowed_member_types = {str(t).strip().upper() for t in include_member_types if str(t).strip()}
-            if not allowed_member_types:
-                return OperationResult.permanent_error(
-                    message="include_member_types must contain at least one type",
-                    error_code="DIRECTORY_MEMBER_TYPES_INVALID",
-                )
-
-        batch_members: dict[str, list[DirectoryMember]] = {}
-        for group_key, raw_members in result.data.items():
-            members: list[DirectoryMember] = []
-            if isinstance(raw_members, list):
-                for item in raw_members:
-                    if not isinstance(item, dict):
-                        continue
-                    member_type = str(item.get("type") or "").strip().upper()
-                    if allowed_member_types is not None and member_type and member_type not in allowed_member_types:
-                        continue
-                    member = self._build_directory_member(item)
-                    if member is not None:
-                        members.append(member)
-            batch_members[group_key] = members
-
-        return OperationResult.success(data=batch_members)
+        allowed = member_types_result.data
+        return OperationResult.success(data={key: self._map_members(items, allowed) for key, items in raw_members.items()})
 
     def get_group(self, group_key: str) -> OperationResult[DirectoryGroup]:
         """Return a canonical managed group by key.
@@ -909,6 +975,72 @@ class GoogleDirectoryProvider:
         )
 
         return OperationResult.success(data=groups[:limit] if limit is not None else groups)
+
+    def list_groups_with_members(
+        self,
+        query: str = "",
+        limit: int | None = None,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult[DirectoryGroupsWithMembers]:
+        """List groups together with their members in one batched composition.
+
+        Groups whose members could not be fetched are returned in ``failures``
+        rather than failing the whole result; groups with zero members are
+        included.
+
+        Args:
+            query: Google Admin Directory search clause(s), as for ``list_groups``.
+            limit: Maximum number of groups to return, or None for all groups.
+            include_member_types: Optional set of member types to include
+                (for example ``{"USER"}``). Defaults to no filtering.
+
+        Returns:
+            OperationResult: success with the DirectoryGroupsWithMembers payload.
+        """
+        groups_result = self.list_groups(query=query, limit=limit)
+        if not groups_result.is_success:
+            return self._typed_error(groups_result)
+
+        if not groups_result.data:
+            return OperationResult.success(data=DirectoryGroupsWithMembers())
+
+        member_types_result = self._normalize_member_types(include_member_types)
+        if not member_types_result.is_success:
+            return self._typed_error(member_types_result)
+
+        allowed = member_types_result.data
+        group_by_email = {group.group_email: group for group in groups_result.data}
+
+        service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.member.readonly"])
+        raw_members, errors = self._batch_list_members(service, list(group_by_email))
+
+        groups_with_members: list[DirectoryGroupWithMembers] = []
+        failures: list[DirectoryGroupFailure] = []
+        for group_email, group in group_by_email.items():
+            error = errors.get(group_email)
+            if error is not None:
+                failures.append(self._build_group_failure(group_email, error))
+                continue
+
+            groups_with_members.append(
+                DirectoryGroupWithMembers(
+                    group=group,
+                    members=tuple(self._map_members(raw_members.get(group_email, []), allowed)),
+                )
+            )
+
+        self._logger.info(
+            "directory_groups_with_members_listed",
+            returned=len(groups_with_members),
+            failed=len(failures),
+        )
+
+        return OperationResult.success(
+            data=DirectoryGroupsWithMembers(
+                groups=tuple(groups_with_members),
+                failures=tuple(failures),
+            )
+        )
 
     def get_user_groups(self, user_email: str) -> OperationResult[list[DirectoryGroup]]:
         """Return all managed groups the user is a direct member of.

--- a/app/infrastructure/directory/models.py
+++ b/app/infrastructure/directory/models.py
@@ -2,10 +2,15 @@
 
 from dataclasses import dataclass
 
+from infrastructure.operations.status import OperationStatus
+
 __all__ = [
     "DirectoryUser",
     "DirectoryMember",
     "DirectoryGroup",
+    "DirectoryGroupWithMembers",
+    "DirectoryGroupFailure",
+    "DirectoryGroupsWithMembers",
     "MembershipCheckResult",
 ]
 
@@ -45,6 +50,36 @@ class DirectoryGroup:
     name: str | None = None
     description: str | None = None
     provider: str | None = None
+
+
+@dataclass(frozen=True)
+class DirectoryGroupWithMembers:
+    """Canonical group paired with its resolved members."""
+
+    group: DirectoryGroup
+    members: tuple[DirectoryMember, ...] = ()
+
+
+@dataclass(frozen=True)
+class DirectoryGroupFailure:
+    """Per-group failure carried inside a successful composition result."""
+
+    group_email: str
+    status: OperationStatus
+    error_code: str | None
+    message: str
+
+
+@dataclass(frozen=True)
+class DirectoryGroupsWithMembers:
+    """Groups-with-members composition payload.
+
+    Per-group failures live here rather than in the result status because the
+    OperationStatus set is closed (decisions/operation-result.md).
+    """
+
+    groups: tuple[DirectoryGroupWithMembers, ...] = ()
+    failures: tuple[DirectoryGroupFailure, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/app/infrastructure/directory/provider.py
+++ b/app/infrastructure/directory/provider.py
@@ -4,6 +4,7 @@ from typing import Protocol, runtime_checkable
 
 from infrastructure.directory.models import (
     DirectoryGroup,
+    DirectoryGroupsWithMembers,
     DirectoryMember,
     DirectoryUser,
     MembershipCheckResult,
@@ -158,6 +159,32 @@ class DirectoryProvider(Protocol):
 
         Returns:
             OperationResult: success with the matching DirectoryGroup list.
+        """
+        ...
+
+    def list_groups_with_members(
+        self,
+        query: str = "",
+        limit: int | None = None,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult[DirectoryGroupsWithMembers]:
+        """List groups together with their members in one composition.
+
+        Implementors should use a provider-native batch API so the cost stays
+        proportional to the number of member pages rather than the number of
+        groups.  Groups whose members could not be fetched are returned in
+        ``failures`` rather than failing the whole result, because the
+        OperationStatus set is closed (decisions/operation-result.md).  Groups
+        with zero members are included.
+
+        Args:
+            query: Provider-agnostic query expression, as for ``list_groups``.
+            limit: Maximum number of groups to return, or None for all groups.
+            include_member_types: Optional set of member types to include
+                (for example ``{"USER"}``). If not provided, return all types.
+
+        Returns:
+            OperationResult: success with the DirectoryGroupsWithMembers payload.
         """
         ...
 

--- a/app/tests/unit/infrastructure/directory/test_google.py
+++ b/app/tests/unit/infrastructure/directory/test_google.py
@@ -9,6 +9,8 @@ import pytest
 from googleapiclient.errors import HttpError
 from structlog.testing import capture_logs
 
+from infrastructure.directory import google as google_module
+from infrastructure.directory import models as directory_models
 from infrastructure.directory.google import GoogleDirectoryProvider
 from infrastructure.directory.models import (
     DirectoryGroup,
@@ -18,6 +20,10 @@ from infrastructure.directory.models import (
 )
 from infrastructure.directory.provider import DirectoryProvider
 from infrastructure.operations.status import OperationStatus
+
+# Contract values asserted by the batch tests; the provider owns the constants.
+_MEMBERS_PAGE_SIZE = 200
+_BATCH_MAX_REQUESTS = 100
 
 
 def _request(payload: Any) -> MagicMock:
@@ -48,32 +54,72 @@ def _install_pages(resource: MagicMock, response_key: str, pages: list[list[Any]
     return requests
 
 
-def _install_fake_batch(service: MagicMock, responses: dict[str, Any]) -> None:
-    """Configure new_batch_http_request to synchronously invoke callback per added request.
+def _install_paged_batch(
+    service: MagicMock,
+    pages_by_key: dict[str, list[list[dict[str, Any]]]],
+    errors_by_key: dict[str, Exception] | None = None,
+) -> list[list[str]]:
+    """Wire members.list/list_next plus a batch double that pages per group key.
 
-    Requests whose request_id is missing from responses invoke the callback
-    with an exception, mirroring a per-item Admin SDK batch failure.
+    ``pages_by_key`` maps a group key to its ordered member pages, so a key with
+    more than one page proves the provider re-batches until the pages are
+    exhausted. Returns the per-``new_batch_http_request``-call list of added
+    request ids, which tests assert on to prove chunking and re-batching.
     """
+    errors = errors_by_key or {}
+    rounds: list[list[str]] = []
+    members_resource = service.members.return_value
+
+    requests_by_key: dict[str, list[MagicMock]] = {}
+    payload_by_request: dict[int, dict[str, Any]] = {}
+    position_by_request: dict[int, tuple[str, int]] = {}
+
+    for key in {**pages_by_key, **dict.fromkeys(errors, [[]])}:
+        pages = pages_by_key.get(key) or [[]]
+        page_requests: list[MagicMock] = []
+        for index, page in enumerate(pages):
+            request = MagicMock(name=f"{key}-page-{index}")
+            payload: dict[str, Any] = {"members": page}
+            if index + 1 < len(pages):
+                payload["nextPageToken"] = f"{key}-token-{index}"
+            payload_by_request[id(request)] = payload
+            position_by_request[id(request)] = (key, index)
+            page_requests.append(request)
+        requests_by_key[key] = page_requests
+
+    members_resource.list.side_effect = lambda groupKey, **_kwargs: requests_by_key[groupKey][0]
+
+    def list_next(previous_request: MagicMock, _previous_response: Any) -> MagicMock | None:
+        key, index = position_by_request[id(previous_request)]
+        page_requests = requests_by_key[key]
+        return page_requests[index + 1] if index + 1 < len(page_requests) else None
+
+    members_resource.list_next.side_effect = list_next
 
     def new_batch_http_request(callback):
-        added: list[tuple[str, Any]] = []
+        added: list[tuple[str, MagicMock]] = []
+        round_ids: list[str] = []
+        rounds.append(round_ids)
         batch = MagicMock()
 
         def add(request, request_id):
             added.append((request_id, request))
+            round_ids.append(request_id)
 
-        def execute(**kwargs):
-            for request_id, _request_obj in added:
-                if request_id in responses:
-                    callback(request_id, responses[request_id], None)
+        def execute(**_kwargs):
+            for request_id, request in added:
+                error = errors.get(request_id)
+                if error is not None:
+                    callback(request_id, None, error)
                 else:
-                    callback(request_id, None, RuntimeError(f"missing response for {request_id}"))
+                    callback(request_id, payload_by_request[id(request)], None)
 
         batch.add.side_effect = add
         batch.execute.side_effect = execute
         return batch
 
     service.new_batch_http_request.side_effect = new_batch_http_request
+    return rounds
 
 
 @pytest.fixture
@@ -1283,15 +1329,11 @@ class TestDirectoryProviderProtocolSignatures:
 class TestGetGroupMembersBatch:
     def test_returns_members_for_each_group(self, provider, google_service):
         # Arrange
-        _install_fake_batch(
+        _install_paged_batch(
             google_service,
             {
-                "sg-aws-admin@example.com": {
-                    "members": [{"email": "alice@example.com", "type": "USER", "id": "m1"}],
-                },
-                "sg-aws-read@example.com": {
-                    "members": [{"email": "bob@example.com", "type": "USER", "id": "m2"}],
-                },
+                "sg-aws-admin@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]],
+                "sg-aws-read@example.com": [[{"email": "bob@example.com", "type": "USER", "id": "m2"}]],
             },
         )
 
@@ -1321,32 +1363,17 @@ class TestGetGroupMembersBatch:
         assert result.data == {}
         google_service.new_batch_http_request.assert_not_called()
 
-    def test_propagates_batch_failure(self, provider, google_service):
-        # Arrange
-        _install_fake_batch(google_service, {})
-
-        # Act
-        result = provider.get_group_members_batch(["sg-aws-admin@example.com"])
-
-        # Assert
-        assert not result.is_success
-        assert result.status == OperationStatus.PERMANENT_ERROR
-
     def test_filters_to_requested_member_types(self, provider, google_service):
         # Arrange
-        _install_fake_batch(
+        _install_paged_batch(
             google_service,
             {
-                "sg-aws-admin@example.com": {
-                    "members": [
+                "sg-aws-admin@example.com": [
+                    [
                         {"email": "alice@example.com", "type": "USER", "id": "m1"},
-                        {
-                            "email": "nested-group@example.com",
-                            "type": "GROUP",
-                            "id": "m2",
-                        },
-                    ],
-                },
+                        {"email": "nested-group@example.com", "type": "GROUP", "id": "m2"},
+                    ]
+                ],
             },
         )
 
@@ -1362,12 +1389,367 @@ class TestGetGroupMembersBatch:
         assert len(members) == 1
         assert members[0].email == "alice@example.com"
 
+    def test_empty_member_types_returns_error_without_issuing_a_request(self, provider, google_service):
+        # Arrange
+        _install_paged_batch(google_service, {"sg-aws-admin@example.com": [[]]})
+
+        # Act
+        result = provider.get_group_members_batch(["sg-aws-admin@example.com"], include_member_types=set())
+
+        # Assert
+        assert not result.is_success
+        assert result.error_code == "DIRECTORY_MEMBER_TYPES_INVALID"
+        google_service.new_batch_http_request.assert_not_called()
+
     def test_normalises_group_keys_to_lowercase(self, provider, google_service):
         # Arrange
-        _install_fake_batch(google_service, {"sg-aws-admin@example.com": {"members": []}})
+        _install_paged_batch(google_service, {"sg-aws-admin@example.com": [[]]})
 
         # Act
         provider.get_group_members_batch(["SG-AWS-Admin@EXAMPLE.COM"])
 
         # Assert
-        google_service.members.return_value.list.assert_called_once_with(groupKey="sg-aws-admin@example.com")
+        google_service.members.return_value.list.assert_called_once_with(
+            groupKey="sg-aws-admin@example.com",
+            maxResults=_MEMBERS_PAGE_SIZE,
+        )
+
+    def test_batched_list_requests_use_the_members_page_size(self, provider, google_service):
+        # Arrange
+        _install_paged_batch(
+            google_service,
+            {"sg-a@example.com": [[]], "sg-b@example.com": [[]]},
+        )
+
+        # Act
+        provider.get_group_members_batch(["sg-a@example.com", "sg-b@example.com"])
+
+        # Assert
+        page_sizes = {call.kwargs["maxResults"] for call in google_service.members.return_value.list.call_args_list}
+        assert page_sizes == {_MEMBERS_PAGE_SIZE}
+
+    def test_vendor_batch_helper_is_not_imported(self):
+        # Assert
+        assert not hasattr(google_module, "execute_batch_request")
+
+    def test_surfaces_per_key_response_and_error(self, provider, google_service):
+        # Arrange
+        _install_paged_batch(
+            google_service,
+            {"sg-a@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]]},
+            errors_by_key={"sg-b@example.com": _http_error(429)},
+        )
+        members_resource = google_service.members()
+        requests = {
+            key: members_resource.list(groupKey=key, maxResults=_MEMBERS_PAGE_SIZE)
+            for key in ("sg-a@example.com", "sg-b@example.com")
+        }
+
+        # Act
+        responses, errors = provider._execute_batch_round(google_service, requests)
+
+        # Assert
+        assert responses["sg-a@example.com"]["members"][0]["email"] == "alice@example.com"
+        assert "sg-b@example.com" not in responses
+        assert isinstance(errors["sg-b@example.com"], HttpError)
+        assert "sg-a@example.com" not in errors
+
+    def test_paginates_members_across_batch_rounds(self, provider, google_service):
+        # Arrange
+        _install_paged_batch(
+            google_service,
+            {
+                "sg-aws-admin@example.com": [
+                    [{"email": "alice@example.com", "type": "USER", "id": "m1"}],
+                    [{"email": "bob@example.com", "type": "USER", "id": "m2"}],
+                ]
+            },
+        )
+
+        # Act
+        result = provider.get_group_members_batch(["sg-aws-admin@example.com"])
+
+        # Assert
+        assert result.is_success
+        assert [member.email for member in result.data["sg-aws-admin@example.com"]] == [
+            "alice@example.com",
+            "bob@example.com",
+        ]
+
+    def test_second_round_rebatches_only_unfinished_groups(self, provider, google_service):
+        # Arrange
+        rounds = _install_paged_batch(
+            google_service,
+            {
+                "sg-paged@example.com": [
+                    [{"email": "alice@example.com", "type": "USER", "id": "m1"}],
+                    [{"email": "bob@example.com", "type": "USER", "id": "m2"}],
+                ],
+                "sg-done@example.com": [[{"email": "carol@example.com", "type": "USER", "id": "m3"}]],
+            },
+        )
+
+        # Act
+        result = provider.get_group_members_batch(["sg-paged@example.com", "sg-done@example.com"])
+
+        # Assert
+        assert result.is_success
+        assert len(rounds) == 2
+        assert set(rounds[0]) == {"sg-paged@example.com", "sg-done@example.com"}
+        assert rounds[1] == ["sg-paged@example.com"]
+
+    def test_chunks_batch_rounds_at_the_request_limit(self, provider, google_service):
+        # Arrange
+        group_keys = [f"sg-{index}@example.com" for index in range(150)]
+        rounds = _install_paged_batch(
+            google_service,
+            {key: [[{"email": f"user-{key}", "type": "USER", "id": key}]] for key in group_keys},
+        )
+
+        # Act
+        result = provider.get_group_members_batch(group_keys)
+
+        # Assert
+        assert result.is_success
+        assert len(rounds) == 2
+        assert [len(round_ids) for round_ids in rounds] == [_BATCH_MAX_REQUESTS, 50]
+        assert set(result.data.keys()) == set(group_keys)
+
+    def test_one_failing_group_fails_the_whole_batch_with_a_classified_status(self, provider, google_service):
+        # Arrange
+        _install_paged_batch(
+            google_service,
+            {"sg-ok@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]]},
+            errors_by_key={"sg-bad@example.com": _http_error(429)},
+        )
+
+        # Act
+        result = provider.get_group_members_batch(["sg-ok@example.com", "sg-bad@example.com"])
+
+        # Assert
+        assert not result.is_success
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "429"
+
+    def test_signature_is_unchanged(self):
+        # Assert
+        parameters = signature(GoogleDirectoryProvider.get_group_members_batch).parameters
+        assert list(parameters) == ["self", "group_keys", "include_member_types"]
+        assert parameters["include_member_types"].default is None
+
+
+class TestListGroupsWithMembers:
+    @staticmethod
+    def _install_groups(google_service, emails: list[str]) -> None:
+        """Wire groups.list to return one canonical group per email."""
+        google_service.groups.return_value.list.return_value = _request(
+            {"groups": [{"email": email, "id": f"group-{index}", "name": email} for index, email in enumerate(emails)]}
+        )
+
+    def test_protocol_declares_the_composition(self):
+        # Assert
+        parameters = signature(DirectoryProvider.list_groups_with_members).parameters
+        assert list(parameters) == ["self", "query", "limit", "include_member_types"]
+        assert parameters["query"].default == ""
+        assert parameters["limit"].default is None
+        assert parameters["include_member_types"].default is None
+
+    def test_returns_typed_groups_with_members(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-a@example.com", "sg-b@example.com"])
+        _install_paged_batch(
+            google_service,
+            {
+                "sg-a@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]],
+                "sg-b@example.com": [[{"email": "bob@example.com", "type": "USER", "id": "m2"}]],
+            },
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        payload = result.data
+        assert isinstance(payload, directory_models.DirectoryGroupsWithMembers)
+        assert payload.failures == ()
+        assert isinstance(payload.groups, tuple)
+        by_email = {entry.group.group_email: entry for entry in payload.groups}
+        assert set(by_email) == {"sg-a@example.com", "sg-b@example.com"}
+        entry = by_email["sg-a@example.com"]
+        assert isinstance(entry, directory_models.DirectoryGroupWithMembers)
+        assert isinstance(entry.group, DirectoryGroup)
+        assert entry.members == (
+            DirectoryMember(
+                email="alice@example.com",
+                membership_id="m1",
+                provider_user_id="m1",
+                member_type="USER",
+                role=None,
+                provider="google",
+            ),
+        )
+
+    def test_issues_one_batched_round_trip_per_page_depth(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-a@example.com", "sg-b@example.com"])
+        rounds = _install_paged_batch(
+            google_service,
+            {"sg-a@example.com": [[]], "sg-b@example.com": [[]]},
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert len(rounds) == 1
+        assert set(rounds[0]) == {"sg-a@example.com", "sg-b@example.com"}
+
+    def test_group_requiring_a_second_page_returns_every_member_in_order(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-a@example.com"])
+        _install_paged_batch(
+            google_service,
+            {
+                "sg-a@example.com": [
+                    [{"email": "alice@example.com", "type": "USER", "id": "m1"}],
+                    [{"email": "bob@example.com", "type": "USER", "id": "m2"}],
+                ]
+            },
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert [member.email for member in result.data.groups[0].members] == [
+            "alice@example.com",
+            "bob@example.com",
+        ]
+
+    def test_failed_group_is_carried_in_failures_with_classified_status(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-ok@example.com", "sg-bad@example.com"])
+        _install_paged_batch(
+            google_service,
+            {"sg-ok@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]]},
+            errors_by_key={"sg-bad@example.com": _http_error(429)},
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        payload = result.data
+        assert [entry.group.group_email for entry in payload.groups] == ["sg-ok@example.com"]
+        assert len(payload.failures) == 1
+        failure = payload.failures[0]
+        assert isinstance(failure, directory_models.DirectoryGroupFailure)
+        assert failure.group_email == "sg-bad@example.com"
+        assert failure.status == OperationStatus.TRANSIENT_ERROR
+        assert failure.error_code == "429"
+        assert failure.message
+
+    def test_unmapped_per_group_http_error_propagates(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-bad@example.com"])
+        _install_paged_batch(
+            google_service,
+            {},
+            errors_by_key={"sg-bad@example.com": _http_error(400)},
+        )
+
+        # Act / Assert
+        with pytest.raises(HttpError):
+            provider.list_groups_with_members()
+
+    def test_empty_group_list_returns_empty_payload_without_batching(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, [])
+        _install_paged_batch(google_service, {})
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert result.data.groups == ()
+        assert result.data.failures == ()
+        google_service.new_batch_http_request.assert_not_called()
+
+    def test_group_set_spanning_more_than_one_chunk_is_merged(self, provider, google_service):
+        # Arrange
+        emails = [f"sg-{index}@example.com" for index in range(150)]
+        self._install_groups(google_service, emails)
+        rounds = _install_paged_batch(
+            google_service,
+            {email: [[{"email": f"user-{email}", "type": "USER", "id": email}]] for email in emails},
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert len(rounds) == 2
+        assert [len(round_ids) for round_ids in rounds] == [_BATCH_MAX_REQUESTS, 50]
+        assert {entry.group.group_email for entry in result.data.groups} == set(emails)
+
+    def test_zero_member_group_is_included(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-empty@example.com"])
+        _install_paged_batch(google_service, {"sg-empty@example.com": [[]]})
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert len(result.data.groups) == 1
+        assert result.data.groups[0].group.group_email == "sg-empty@example.com"
+        assert result.data.groups[0].members == ()
+
+    def test_members_are_not_merged_with_user_records(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-a@example.com"])
+        _install_paged_batch(
+            google_service,
+            {"sg-a@example.com": [[{"email": "alice@example.com", "type": "USER", "id": "m1"}]]},
+        )
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert result.is_success
+        assert all(isinstance(member, DirectoryMember) for member in result.data.groups[0].members)
+        google_service.users.assert_not_called()
+
+    def test_propagates_list_groups_error_without_batching(self, provider, google_service):
+        # Arrange
+        google_service.groups.return_value.list.return_value.execute.side_effect = _http_error(503)
+        _install_paged_batch(google_service, {})
+
+        # Act
+        result = provider.list_groups_with_members()
+
+        # Assert
+        assert not result.is_success
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        google_service.new_batch_http_request.assert_not_called()
+
+    def test_empty_member_types_returns_error_without_batching(self, provider, google_service):
+        # Arrange
+        self._install_groups(google_service, ["sg-a@example.com"])
+        _install_paged_batch(google_service, {"sg-a@example.com": [[]]})
+
+        # Act
+        result = provider.list_groups_with_members(include_member_types=set())
+
+        # Assert
+        assert not result.is_success
+        assert result.error_code == "DIRECTORY_MEMBER_TYPES_INVALID"
+        google_service.new_batch_http_request.assert_not_called()

--- a/app/tests/unit/infrastructure/directory/test_google.py
+++ b/app/tests/unit/infrastructure/directory/test_google.py
@@ -1583,7 +1583,7 @@ class TestListGroupsWithMembers:
             DirectoryMember(
                 email="alice@example.com",
                 membership_id="m1",
-                provider_user_id="m1",
+                provider_user_id=None,
                 member_type="USER",
                 role=None,
                 provider="google",

--- a/backlog/tasks/task-25.1.6.11 - Delete-execute_google_api_request-and-enforce-the-Google-Workspace-vendor-export-contract.md
+++ b/backlog/tasks/task-25.1.6.11 - Delete-execute_google_api_request-and-enforce-the-Google-Workspace-vendor-export-contract.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:04'
-updated_date: '2026-09-03 18:02'
+updated_date: '2026-09-03 20:08'
 labels:
   - clients
   - phase-3
@@ -67,5 +67,17 @@ GREP-CONFIRMED 2026-09-03: execute_batch_request has exactly one consumer repo-w
 So once TASK-25.1.6.3.1 merges, your item collapses from a design decision to a straight deletion of a zero-consumer function plus its tests. No amendment to decisions/outbound-clients.md is needed - the deviation is removed rather than legalised. Note TASK-25.1.6.3.1 deliberately LEAVES the dead function in place rather than deleting it, because its AC#7 confines that PR's diff to app/infrastructure/directory/**; the deletion is yours.
 
 Worth folding into your AC#7 CI guardrail: a vendor package exporting an OperationResult-returning orchestration helper is exactly the regrowth shape the guardrail should catch, since decisions/outbound-clients.md says app/integrations/<vendor>/ provides exactly factories, classify_<vendor>_error and settings.
+---
+
+author: @task-planner
+created: 2026-09-03 20:08
+---
+TWO RESIDUALS ADDED TO YOUR SWEEP 2026-09-03 (task-planner, human-approved while planning TASK-25.1.6.3.1). Both are inside app/infrastructure/directory/google.py, deliberately left there because fixing them in TASK-25.1.6.3.1 would have mixed a mechanical refactor of out-of-scope methods into a behaviour PR (implementation-planning size-gate trigger #3).
+
+R1. DUPLICATED MEMBER MAPPING. TASK-25.1.6.3.1 extracts _normalize_member_types and _map_members and uses them from the batch path and the new groups-with-members composition, but leaves get_group_members (today google.py:499-557) with its own inline copy of the same type-filter + _build_directory_member loop. Three call sites, two implementations. Collapsing it is a pure refactor with no behaviour change.
+
+R2. INCONSISTENT OAUTH SCOPE FOR THE SAME CALL. get_group_members and the new composition request https://www.googleapis.com/auth/admin.directory.group.member.readonly; get_group_members_batch requests the broader https://www.googleapis.com/auth/admin.directory.group.readonly (today google.py:583). Same underlying members.list call, two scopes. TASK-25.1.6.3.1's AC#3 forbade changing it (it is a live path used by packages/access/sync/desired_state.py:160 and an OAuth scope change is not a no-op). Converging on the narrower member.readonly scope is safe - the delegation grant demonstrably exists, since get_group_members uses it in production - but it deserves its own small PR.
+
+ALSO CONFIRMING YOUR AC#2: after TASK-25.1.6.3.1 merges, integrations/google_workspace/client.py::execute_batch_request has ZERO consumers repo-wide and is a straight delete. The 'relocated to the provider' branch of your AC#2 is satisfied and no amendment to decisions/outbound-clients.md is needed. One thing to carry into the PR description when you delete it: the provider's replacement does NOT reproduce execute_batch_request's blanket PERMANENT_ERROR/BATCH_ERRORS - it classifies per-item HttpErrors via classify_google_error, which is why the vendor helper could not simply move.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.3 - Close-the-DirectoryProvider-capability-gaps-that-block-the-legacy-Directory-consumers.md
+++ b/backlog/tasks/task-25.1.6.3 - Close-the-DirectoryProvider-capability-gaps-that-block-the-legacy-Directory-consumers.md
@@ -3,11 +3,11 @@ id: TASK-25.1.6.3
 title: >-
   Make DirectoryProvider list-all generic and unbounded, and close the mapping
   gaps blocking the legacy consumers
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-02 15:00'
-updated_date: '2026-09-03 18:41'
+updated_date: '2026-09-03 20:22'
 labels:
   - clients
   - phase-3

--- a/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
+++ b/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
@@ -3,11 +3,11 @@ id: TASK-25.1.6.3.1
 title: >-
   Rearchitect Directory batch orchestration into the provider and add a
   paginated groups-with-members composition
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-03 17:57'
-updated_date: '2026-09-03 20:35'
+updated_date: '2026-09-03 20:42'
 labels:
   - architecture
 milestone: m-3

--- a/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
+++ b/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
@@ -3,10 +3,11 @@ id: TASK-25.1.6.3.1
 title: >-
   Rearchitect Directory batch orchestration into the provider and add a
   paginated groups-with-members composition
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-03 17:57'
-updated_date: '2026-09-03 20:09'
+updated_date: '2026-09-03 20:35'
 labels:
   - architecture
 milestone: m-3
@@ -59,15 +60,15 @@ OUT OF SCOPE: repointing any consumer; modifying integrations/google_workspace/*
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GoogleDirectoryProvider performs its own batch orchestration via service.new_batch_http_request and no longer imports or calls integrations.google_workspace.client.execute_batch_request; the helper surfaces per-key responses and per-key exceptions rather than collapsing them
-- [ ] #2 get_group_members_batch paginates across batch rounds: a test with a group whose first batched response carries a nextPageToken proves every page is returned, and a test proves only the unfinished groups are re-batched
-- [ ] #3 get_group_members_batch keeps its existing signature and its all-or-nothing error contract; its failure status is now classified by classify_google_error rather than the blanket PERMANENT_ERROR/BATCH_ERRORS the vendor helper hardcoded; packages/access/** is not modified and its existing tests pass unchanged
-- [ ] #4 A groups-with-members composition exists on DirectoryProvider and GoogleDirectoryProvider, is built on the batched helper (one batched round-trip per chunk of at most _BATCH_MAX_REQUESTS groups per page depth, not one request per group), and returns typed frozen dataclasses
-- [ ] #5 Per-group failures are carried inside the composition's success payload as typed values with a classified status and error_code - no new OperationStatus member is introduced (decisions/operation-result.md status set is closed)
-- [ ] #6 Composition tests cover: multi-group success, a per-group failure inside the batch, a group requiring a second page, an empty group list, and a group set spanning more than one batch chunk
-- [ ] #7 The composition contains no consumer business logic - no groups_filters, no user-record merging, no dataframe conversion, and zero-member groups are returned rather than dropped - and git diff touches app/infrastructure/directory/** and its tests only
-- [ ] #8 Batch rounds are chunked at _BATCH_MAX_REQUESTS=100 so a group set larger than googleapiclient's MAX_BATCH_LIMIT never raises the unclassifiable BatchError; a test with more than one chunk's worth of groups proves multiple batch requests are issued and all results merged
-- [ ] #9 Batched members.list requests pass maxResults=_MEMBERS_PAGE_SIZE (200), matching the legacy google_directory.py page size
+- [x] #1 GoogleDirectoryProvider performs its own batch orchestration via service.new_batch_http_request and no longer imports or calls integrations.google_workspace.client.execute_batch_request; the helper surfaces per-key responses and per-key exceptions rather than collapsing them
+- [x] #2 get_group_members_batch paginates across batch rounds: a test with a group whose first batched response carries a nextPageToken proves every page is returned, and a test proves only the unfinished groups are re-batched
+- [x] #3 get_group_members_batch keeps its existing signature and its all-or-nothing error contract; its failure status is now classified by classify_google_error rather than the blanket PERMANENT_ERROR/BATCH_ERRORS the vendor helper hardcoded; packages/access/** is not modified and its existing tests pass unchanged
+- [x] #4 A groups-with-members composition exists on DirectoryProvider and GoogleDirectoryProvider, is built on the batched helper (one batched round-trip per chunk of at most _BATCH_MAX_REQUESTS groups per page depth, not one request per group), and returns typed frozen dataclasses
+- [x] #5 Per-group failures are carried inside the composition's success payload as typed values with a classified status and error_code - no new OperationStatus member is introduced (decisions/operation-result.md status set is closed)
+- [x] #6 Composition tests cover: multi-group success, a per-group failure inside the batch, a group requiring a second page, an empty group list, and a group set spanning more than one batch chunk
+- [x] #7 The composition contains no consumer business logic - no groups_filters, no user-record merging, no dataframe conversion, and zero-member groups are returned rather than dropped - and git diff touches app/infrastructure/directory/** and its tests only
+- [x] #8 Batch rounds are chunked at _BATCH_MAX_REQUESTS=100 so a group set larger than googleapiclient's MAX_BATCH_LIMIT never raises the unclassifiable BatchError; a test with more than one chunk's worth of groups proves multiple batch requests are issued and all results merged
+- [x] #9 Batched members.list requests pass maxResults=_MEMBERS_PAGE_SIZE (200), matching the legacy google_directory.py page size
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -407,6 +408,27 @@ the three dataclasses are net-new with zero production callers until TASK-25.1.6
 anything. No config prerequisite, no deploy ordering constraint, no data migration, no OAuth scope change.
 A single git revert fully restores prior behaviour; the only thing lost on revert is the truncation fix.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED 2026-09-03 on feat/directory_google_batch_rearchitecture. Plan followed as written; no deviations except the one noted below.
+
+CHANGES
+- infrastructure/directory/models.py: added DirectoryGroupWithMembers, DirectoryGroupFailure, DirectoryGroupsWithMembers (frozen, tuple-valued) + OperationStatus import; __all__ updated.
+- infrastructure/directory/provider.py: DirectoryProvider gains list_groups_with_members(query, limit, include_member_types).
+- infrastructure/directory/google.py: dropped the execute_batch_request import; added _MEMBERS_PAGE_SIZE=200 and _BATCH_MAX_REQUESTS=100; added _execute_batch_round (chunked, per-key responses + per-key HttpErrors, callback response param annotated Any per the stub bug), _batch_list_members (re-batches only groups whose list_next yields another page), _normalize_member_types, _map_members, _build_group_failure; rebuilt get_group_members_batch on those (signature unchanged, all-or-nothing kept, member-type validation now runs before any request, failure status classified by classify_google_error); added list_groups_with_members composition (list_groups -> chunked batch -> typed payload, per-group failures in the payload, zero-member groups included, emits directory_groups_with_members_listed).
+
+TEST EVIDENCE
+- tests/unit/infrastructure/directory: 99 passed (all TestGetGroupMembersBatch + TestListGroupsWithMembers cases from the pre-authored matrix).
+- Full gates: ruff clean; mypy reports zero errors in infrastructure/directory/** (the 95 remaining errors are pre-existing legacy modules/**); pytest tests --ignore=tests/smoke: 3221 passed, 5 failed.
+- The 5 full-suite failures are PRE-EXISTING ORDER-DEPENDENT FLAKES, not regressions: 3 in tests/modules/webhooks/test_webhooks_aws_sns.py (untouched subsystem) and 2 Slice A capture_logs assertions in TestListGroups (list_groups is unmodified by this task). All 5 pass when their files are run together or alone; they only fail under the full-suite ordering.
+- grep execute_batch_request over infrastructure/ and packages/: zero hits (client.py definition left dead for TASK-25.1.6.11). packages/access/** untouched.
+
+ONE TEST CORRECTION: the pre-authored TestListGroupsWithMembers::test_returns_typed_groups_with_members expected DirectoryMember(provider_user_id='m1'). _build_directory_member sets provider_user_id=None and 13 existing assertions depend on that; making the composition differ would either fork member mapping or change get_group_members, both out of scope. Expectation corrected to None. Flagging in case the intent was actually to start populating provider_user_id from the Google member id - that would be its own task.
+
+LEFT FOR HUMAN VERIFICATION: the assumption that no live group currently exceeds one member page (plan assumption 3) - check desired_state sync logs for member counts on a page boundary before merge; if one exists this PR fixes a live truncation bug worth calling out in the PR description. Residuals R1/R2/R3 remain for TASK-25.1.6.11 as planned.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
+++ b/backlog/tasks/task-25.1.6.3.1 - Rearchitect-Directory-batch-orchestration-into-the-provider-and-add-a-paginated-groups-with-members-composition.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 17:57'
+updated_date: '2026-09-03 20:09'
 labels:
   - architecture
 milestone: m-3
@@ -60,9 +61,385 @@ OUT OF SCOPE: repointing any consumer; modifying integrations/google_workspace/*
 <!-- AC:BEGIN -->
 - [ ] #1 GoogleDirectoryProvider performs its own batch orchestration via service.new_batch_http_request and no longer imports or calls integrations.google_workspace.client.execute_batch_request; the helper surfaces per-key responses and per-key exceptions rather than collapsing them
 - [ ] #2 get_group_members_batch paginates across batch rounds: a test with a group whose first batched response carries a nextPageToken proves every page is returned, and a test proves only the unfinished groups are re-batched
-- [ ] #3 get_group_members_batch keeps its existing signature and all-or-nothing error contract; packages/access/** is not modified and its existing tests pass unchanged
-- [ ] #4 A groups-with-members composition exists on DirectoryProvider and GoogleDirectoryProvider, is built on the batched helper (one batched round-trip per page depth, not one request per group), and returns typed frozen dataclasses
+- [ ] #3 get_group_members_batch keeps its existing signature and its all-or-nothing error contract; its failure status is now classified by classify_google_error rather than the blanket PERMANENT_ERROR/BATCH_ERRORS the vendor helper hardcoded; packages/access/** is not modified and its existing tests pass unchanged
+- [ ] #4 A groups-with-members composition exists on DirectoryProvider and GoogleDirectoryProvider, is built on the batched helper (one batched round-trip per chunk of at most _BATCH_MAX_REQUESTS groups per page depth, not one request per group), and returns typed frozen dataclasses
 - [ ] #5 Per-group failures are carried inside the composition's success payload as typed values with a classified status and error_code - no new OperationStatus member is introduced (decisions/operation-result.md status set is closed)
-- [ ] #6 Composition tests cover: multi-group success, a per-group failure inside the batch, a group requiring a second page, and an empty group list
-- [ ] #7 The composition contains no consumer business logic - no groups_filters, no user-record merging, no dataframe conversion - and git diff touches app/infrastructure/directory/** and its tests only
+- [ ] #6 Composition tests cover: multi-group success, a per-group failure inside the batch, a group requiring a second page, an empty group list, and a group set spanning more than one batch chunk
+- [ ] #7 The composition contains no consumer business logic - no groups_filters, no user-record merging, no dataframe conversion, and zero-member groups are returned rather than dropped - and git diff touches app/infrastructure/directory/** and its tests only
+- [ ] #8 Batch rounds are chunked at _BATCH_MAX_REQUESTS=100 so a group set larger than googleapiclient's MAX_BATCH_LIMIT never raises the unclassifiable BatchError; a test with more than one chunk's worth of groups proves multiple batch requests are issued and all results merged
+- [ ] #9 Batched members.list requests pass maxResults=_MEMBERS_PAGE_SIZE (200), matching the legacy google_directory.py page size
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+GROUNDING (read 2026-09-03 against main @ e625b638, after Slice A merged as PR #1437)
+
+Slice A is MERGED. models.py already carries DirectoryUser.given_name/family_name; google.py already
+has _build_group / _build_managed_group, _extract_name_parts, _USERS_PAGE_SIZE=500, _GROUPS_PAGE_SIZE=200,
+and list_users/list_groups take limit: int | None = None. This slice builds on that, unchanged.
+
+CALL SITES THIS SLICE TOUCHES (enumerated, not assumed):
+- app/infrastructure/directory/google.py:17   -> import of execute_batch_request (REMOVED here)
+- app/infrastructure/directory/google.py:559-629 -> get_group_members_batch (REBUILT here)
+- app/infrastructure/directory/provider.py:184-205 -> get_group_members_batch protocol entry (untouched)
+- app/infrastructure/directory/models.py -> gains 3 dataclasses
+- app/integrations/google_workspace/client.py:170-199 -> execute_batch_request (NOT touched; left dead for TASK-25.1.6.11)
+- app/packages/access/sync/desired_state.py:160 -> only consumer of get_group_members_batch (NOT touched)
+
+STUB FACTS VERIFIED EMPIRICALLY WITH MYPY (not assumed; probe run and deleted 2026-09-03):
+- DirectoryResource.new_batch_http_request is typed (googleapiclient-stubs _apis/admin/directory_v1/resources.pyi:877)
+  and returns googleapiclient.http.BatchHttpRequest.
+- STUB INACCURACY, MUST BE HANDLED: the stub declares the callback as
+  Callable[[str, googleapiclient.http.HttpRequest, HttpError | None], Any] - the middle parameter is typed
+  HttpRequest even though at runtime it is the DESERIALISED RESPONSE. Annotating the callback's response
+  parameter as the Members TypedDict FAILS mypy with arg-type. The response parameter MUST be annotated
+  Any (exactly as client.py:175 does today). Do not "fix" this; it is a stub bug, not a code bug.
+- BatchHttpRequest.add(request, callback=None, request_id=None) and BatchHttpRequest.execute(http=None)
+  type-check as used. NOTE: batch execute takes NO num_retries - the batch path has no SDK-native retry,
+  unlike _paginate. Named delta, not fixed here.
+- members_resource.list_next(previous_request, previous_response) is typed
+  (MembersHttpRequest, Members) -> MembersHttpRequest | None. This is the paging mechanism to use; it
+  returns None when the response carries no nextPageToken, so no manual token handling is needed.
+- MembersHttpRequest.execute(num_retries=...) -> Members; Members["nextPageToken"] is str | None.
+- googleapiclient/http.py:71 MAX_BATCH_LIMIT = 1000 and http.py:1440 raises BatchError past it.
+  BatchError is NOT an HttpError, so classify_google_error re-raises it: an unchunked batch over a
+  >1000-group domain would CRASH. Slice A made list_groups unbounded, so the new composition can reach
+  that. Chunking is therefore required by this slice, not optional (HUMAN-APPROVED 2026-09-03).
+
+HUMAN DECISIONS TAKEN DURING PLANNING (2026-09-03):
+D1. Chunk batch rounds at _BATCH_MAX_REQUESTS = 100 (Google's Admin SDK batch guidance), well under
+    MAX_BATCH_LIMIT. Forces the AC#4 wording amendment recorded in the comment on this task.
+D2. get_group_members_batch stays all-or-nothing, but its failure status is now CLASSIFIED by
+    classify_google_error (429/503 -> TRANSIENT_ERROR with retry_after, 404 -> NOT_FOUND) instead of the
+    blanket PERMANENT_ERROR / "BATCH_ERRORS" that execute_batch_request hardcoded. That is the whole point
+    of moving classification to the adapter per decisions/outbound-clients.md. No consumer impact today:
+    desired_state.py:163 only reads is_success. Comment left on TASK-77.
+D3. The batched members.list requests pass maxResults=_MEMBERS_PAGE_SIZE = 200, matching legacy
+    google_directory.py:18. Human direction: fix things as they come while migrating toward
+    decisions/layers.md, keeping siblings informed.
+D4. Composition name, signature and dataclasses accepted as proposed (Step 1 / Step 5 below).
+    Groups with ZERO members are INCLUDED. Legacy list_groups_with_members dropped them
+    (integrations/google_workspace/google_directory.py:187-190) - that filtering is consumer business
+    logic and belongs to TASK-25.1.6.5 per scope item (e). Comment left on .5.
+
+---------------------------------------------------------------------------
+STEP 1 - models.py: three frozen dataclasses for the composition [AC#4, AC#5]
+
+Add to app/infrastructure/directory/models.py (and to __all__):
+
+    @dataclass(frozen=True)
+    class DirectoryGroupWithMembers:
+        group: DirectoryGroup
+        members: tuple[DirectoryMember, ...] = ()
+
+    @dataclass(frozen=True)
+    class DirectoryGroupFailure:
+        group_email: str
+        status: OperationStatus
+        error_code: str | None
+        message: str
+
+    @dataclass(frozen=True)
+    class DirectoryGroupsWithMembers:
+        groups: tuple[DirectoryGroupWithMembers, ...] = ()
+        failures: tuple[DirectoryGroupFailure, ...] = ()
+
+Tuples, not lists, so frozen means frozen. This adds the file's first import:
+`from infrastructure.operations.status import OperationStatus`. That is legal - decisions/layers.md
+declares infrastructure/operations/ a shared kernel importable from any tier - and it is what
+decisions/operation-result.md's closed status set forces: partial batch outcomes must be expressed in
+the typed payload, never as a new OperationStatus member.
+Per decisions/type-model-boundaries: frozen dataclasses, because these are canonical internal entities,
+not I/O boundary models.
+
+STEP 2 - google.py: _execute_batch_round, the chunked per-key batch primitive [AC#1, AC#8]
+
+Add constants next to the existing page-size constants:
+    _MEMBERS_PAGE_SIZE = 200      # matches legacy google_directory.py:18
+    _BATCH_MAX_REQUESTS = 100     # googleapiclient MAX_BATCH_LIMIT is 1000; stay well under it
+
+Add:
+
+    def _execute_batch_round(
+        self,
+        service: AdminDirectoryResource,
+        requests: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, HttpError]]:
+        """Run one batch round, returning per-key responses and per-key errors.
+
+        Chunked because BatchHttpRequest.add raises BatchError past MAX_BATCH_LIMIT.
+        """
+        responses: dict[str, Any] = {}
+        errors: dict[str, HttpError] = {}
+
+        def callback(request_id: str, response: Any, exception: HttpError | None) -> None:
+            if exception is not None:
+                errors[request_id] = exception
+            else:
+                responses[request_id] = response
+
+        keys = list(requests)
+        for start in range(0, len(keys), _BATCH_MAX_REQUESTS):
+            batch = service.new_batch_http_request(callback=callback)
+            for key in keys[start : start + _BATCH_MAX_REQUESTS]:
+                batch.add(requests[key], request_id=key)
+            batch.execute()
+        return responses, errors
+
+`response: Any` is MANDATORY - see the stub inaccuracy in GROUNDING. This helper does NOT return
+OperationResult and does NOT classify: it hands raw responses and raw HttpErrors back so each caller
+picks its own failure policy (AC#1). That is the behaviour execute_batch_request could not express.
+
+STEP 3 - google.py: _batch_list_members, paginated across batch rounds [AC#2, AC#9]
+
+    def _batch_list_members(
+        self,
+        service: AdminDirectoryResource,
+        group_keys: list[str],
+    ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, HttpError]]:
+        """Fetch every member page for each group, re-batching only unfinished groups."""
+        members_resource = service.members()
+        raw_members: dict[str, list[dict[str, Any]]] = {key: [] for key in group_keys}
+        errors: dict[str, HttpError] = {}
+        pending: dict[str, Any] = {
+            key: members_resource.list(groupKey=key, maxResults=_MEMBERS_PAGE_SIZE)
+            for key in group_keys
+        }
+        while pending:
+            responses, round_errors = self._execute_batch_round(service, pending)
+            errors.update(round_errors)
+            next_pending: dict[str, Any] = {}
+            for key, response in responses.items():
+                raw_members[key].extend(response.get("members", []) or [])
+                next_request = members_resource.list_next(pending[key], response)
+                if next_request is not None:
+                    next_pending[key] = next_request
+            pending = next_pending
+        return raw_members, errors
+
+Termination: a key leaves `pending` when it errored (absent from responses) or when list_next returns
+None. Same mechanic as the existing _paginate (google.py:78-101); no extra round cap is added, to stay
+consistent with it. This closes the silent-truncation defect (fact 2 in the description) which today
+also affects packages/access/sync/desired_state.py:160.
+
+STEP 4 - google.py: rebuild get_group_members_batch on the new helpers [AC#1, AC#2, AC#3, AC#9]
+
+Add two small private helpers, used by Step 4 and Step 5 (two call sites justify them):
+
+    def _normalize_member_types(self, include_member_types: set[str] | None) -> OperationResult[set[str] | None]
+        -> returns success(None) when the argument is None; success(set) otherwise; and
+           permanent_error("include_member_types must contain at least one type",
+           "DIRECTORY_MEMBER_TYPES_INVALID") when the normalised set is empty. Same message and error
+           code as today - no new error codes are introduced anywhere in this slice.
+
+    def _map_members(self, items: list[dict[str, Any]], allowed: set[str] | None) -> list[DirectoryMember]
+        -> the existing type-filter + _build_directory_member loop from google.py:614-627, extracted verbatim.
+
+Rewrite get_group_members_batch's body (signature and return type UNCHANGED):
+  1. empty group_keys -> success({}) (unchanged; keeps test_returns_empty_dict_for_empty_input green).
+  2. validate include_member_types via _normalize_member_types BEFORE issuing any request. Today the
+     validation runs AFTER the batch call (google.py:605-612), so an invalid argument burns a round-trip.
+     Same returned result, no wasted call. Named as a deliberate ordering change.
+  3. normalise keys, build the service with the CURRENT scope
+     "https://www.googleapis.com/auth/admin.directory.group.readonly" (google.py:583) - unchanged, see
+     RESIDUALS.
+  4. raw_members, errors = self._batch_list_members(service, normalized_keys)
+  5. if errors: classify the FIRST error via self._map_sdk_exception(first_error, "get_group_members_batch")
+     and return it through _typed_error. All-or-nothing preserved (AC#3); status fidelity gained (D2).
+  6. otherwise success({key: self._map_members(raw, allowed) for key, raw in raw_members.items()}).
+Delete the `from integrations.google_workspace.client import ... execute_batch_request` half of the
+import at google.py:17, keeping classify_google_error.
+
+STEP 5 - provider.py + google.py: the groups-with-members composition [AC#4, AC#5, AC#6, AC#7]
+
+provider.py - add to the DirectoryProvider Protocol, after list_groups:
+
+    def list_groups_with_members(
+        self,
+        query: str = "",
+        limit: int | None = None,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult[DirectoryGroupsWithMembers]: ...
+
+Docstring states: implementors SHOULD use a provider-native batch API; groups whose members could not be
+fetched are returned in `failures`, not as an error status, because decisions/operation-result.md's status
+set is closed; groups with zero members ARE included.
+
+google.py - implement:
+  1. groups_result = self.list_groups(query=query, limit=limit); on failure return _typed_error.
+     This deliberately reuses Slice A's generic/managed branch (empty query -> _build_group,
+     non-empty -> _build_managed_group) rather than duplicating mapping.
+  2. empty group list -> success(DirectoryGroupsWithMembers()) WITHOUT building a service or a batch.
+  3. _normalize_member_types(include_member_types); on failure return _typed_error.
+  4. group_by_email = {group.group_email: group for group in groups}  (dict keying collapses duplicate
+     emails; the Directory API cannot return two groups with the same primary email, and the managed
+     mapper already canonicalises aliases - noted, not defended against).
+  5. service = self._get_service(["https://www.googleapis.com/auth/admin.directory.group.member.readonly"])
+     - the same least-privilege scope get_group_members uses (google.py:521).
+  6. raw_members, errors = self._batch_list_members(service, list(group_by_email))
+  7. groups tuple = one DirectoryGroupWithMembers per email NOT in errors, members mapped via _map_members.
+     failures tuple = one DirectoryGroupFailure per errored email, built by a small
+     _build_group_failure(group_email, exc) that calls classify_google_error(exc) for status/error_code
+     and str(exc) for message.
+  8. emit `directory_groups_with_members_listed` with returned/failed counts, matching the observability
+     shape Slice A added to list_groups.
+NOTE (deliberate, per decisions/outbound-clients.md): classify_google_error RE-RAISES unmapped HttpError
+statuses (client.py:145). A per-group 400 therefore propagates out of the composition rather than becoming
+a DirectoryGroupFailure. That is correct - an unexpected status is a bug, not an outcome - and it is
+covered by a test.
+NOTE (AC#7): no groups_filters, no user-record merging, no dataframe conversion. Verified by reading
+integrations/google_workspace/google_directory.py:135-200: the legacy behaviours this slice does NOT
+reproduce are (a) filters.filter_by_condition over raw dicts, (b) get_members_details merging whole user
+records into members, (c) dropping zero-member groups, (d) the fields= projection to
+{id, email, name, directMembersCount, description}. All four are TASK-25.1.6.5's.
+
+---------------------------------------------------------------------------
+VALIDATION: cd app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' && uv run ruff check . &&
+uv run pytest tests --ignore=tests/smoke. Run after Step 4 and after Step 5.
+Plus: grep -rn "execute_batch_request" app/infrastructure app/packages -> expect zero.
+Plus: git diff --name-only -> expect only app/infrastructure/directory/{models,provider,google}.py and
+app/tests/unit/infrastructure/directory/test_google.py.
+
+AC TRACEABILITY
+AC#1 provider owns batch orchestration, per-key responses + exceptions -> Steps 2,4 ->
+     TestGetGroupMembersBatch::test_vendor_batch_helper_is_not_imported +
+     ::test_surfaces_per_key_response_and_error
+AC#2 paginates across rounds, re-batches only unfinished groups -> Step 3 ->
+     ::test_paginates_members_across_batch_rounds + ::test_second_round_rebatches_only_unfinished_groups
+AC#3 signature + all-or-nothing preserved, packages/access untouched -> Step 4 ->
+     ::test_signature_is_unchanged + ::test_one_failing_group_fails_the_whole_batch +
+     the 5 existing TestGetGroupMembersBatch tests + tests/unit/packages/access/** green unmodified
+AC#4 composition exists, batched, typed dataclasses -> Steps 1,5 ->
+     TestListGroupsWithMembers::test_returns_typed_groups_with_members +
+     ::test_issues_one_batched_round_trip_per_page_depth
+AC#5 per-group failures inside the success payload, no new status -> Steps 1,5 ->
+     ::test_failed_group_is_carried_in_failures_with_classified_status
+AC#6 composition test coverage -> Step 5 -> the five named TestListGroupsWithMembers cases below
+AC#7 no consumer business logic, diff scope -> Step 5 -> ::test_zero_member_group_is_included +
+     ::test_members_are_not_merged_with_user_records + git diff --name-only
+AC#8 chunking -> Step 2 -> ::test_chunks_batch_rounds_at_the_request_limit
+AC#9 maxResults on batched members.list -> Steps 3,4 -> ::test_batched_list_requests_page_size
+
+TEST MATRIX
+All in app/tests/unit/infrastructure/directory/test_google.py (existing file, existing feature-prefixed
+name; unit layer per decisions/testing.md - no network, no real time, MagicMock only for the Admin SDK
+Resource, which is never the subject under test).
+
+HARNESS WORK FIRST: the current _install_fake_batch (test_google.py:51-76) maps request_id -> a single
+response and ignores request identity, so it cannot express pagination. Replace it with
+_install_paged_batch(service, pages_by_key, errors_by_key=None) which:
+  - wires service.members().list(groupKey=key, maxResults=...) to return a distinct per-key page-0 request,
+  - wires service.members().list_next(prev_request, response) to return the next page request for that key
+    or None when exhausted,
+  - wires service.new_batch_http_request(callback) to a batch double that records added request_ids and,
+    on execute(), invokes callback(request_id, page_payload, None) or callback(request_id, None, HttpError)
+    for keys in errors_by_key,
+  - records the added-request_id list PER new_batch_http_request call so tests can assert chunking and
+    re-batching.
+The five existing TestGetGroupMembersBatch tests are migrated onto it; only
+test_normalises_group_keys_to_lowercase (test_google.py:1370) changes assertion, gaining
+maxResults=_MEMBERS_PAGE_SIZE (AC#9), and test_propagates_batch_failure becomes
+test_one_failing_group_fails_the_whole_batch asserting a CLASSIFIED status (D2).
+
+Happy path:
+  - multi-group batch returns every group's members (existing, migrated)
+  - composition returns one DirectoryGroupWithMembers per group with mapped DirectoryMember tuples
+Boundary:
+  - group with a second page: both pages' members present, in order
+  - two groups, one needing a second page: round 2's batch contains ONLY that group's request_id
+  - 150 group keys: new_batch_http_request called twice for round 1 and all 150 results merged
+  - empty group_keys / empty group list: success, new_batch_http_request never called
+  - group with zero members: present in `groups` with an empty members tuple
+  - include_member_types={"USER"} filters GROUP members out (existing, migrated)
+  - include_member_types=set(): DIRECTORY_MEMBER_TYPES_INVALID and NO API call issued
+Failure:
+  - one group's batch item returns HttpError(429): get_group_members_batch -> TRANSIENT_ERROR
+    (all-or-nothing); composition -> success with that group in `failures`, status TRANSIENT_ERROR,
+    error_code "429", and the other group still in `groups`
+  - list_groups fails: composition returns the typed error and issues no batch
+  - one group's batch item returns HttpError(400) (unmapped): the exception propagates out of the
+    composition rather than being swallowed
+Regression:
+  - tests/unit/packages/access/** and tests/integration/packages/access/** pass unmodified (AC#3 proof)
+  - the partial DirectoryProvider fakes at tests/integration/packages/access/sync/conftest.py:156 and
+    tests/unit/packages/access/sync/test_application.py:275 keep working: Protocol growth is structural,
+    pyproject.toml excludes ^tests/ from mypy, and the only isinstance(..., DirectoryProvider) checks
+    (tests/unit/infrastructure/directory/test_factory.py:43,:93) target GoogleDirectoryProvider, which
+    will implement the new method.
+
+ASSUMPTIONS AND DOUBTS
+1. VERIFIED, not assumed: execute_batch_request has exactly one consumer repo-wide (google.py:17, :585).
+   Re-verify with `grep -rn execute_batch_request app/` before merge; expect only client.py after this PR.
+2. VERIFIED, not assumed: the stub types every surface used here, and the callback response parameter must
+   be Any (mypy probe, see GROUNDING). No Any-laundering beyond that one stub-forced annotation and the
+   raw-payload dicts, which are the same shape _paginate already returns.
+3. ASSUMED: no deployed environment has a Google group whose members exceed one page today, so the
+   pagination fix cannot regress packages/access - it can only ever return MORE members. Verify by reading
+   the desired_state sync logs for member counts equal to a page boundary before merge; if one is found it
+   is a live bug this PR fixes, worth calling out in the PR description.
+4. ASSUMED: the service account's domain-wide delegation already grants
+   admin.directory.group.member.readonly. VERIFIED indirectly - get_group_members (google.py:521) uses it
+   in production today. The composition uses the same scope, so no delegation change is required.
+5. ASSUMED: BatchHttpRequest invokes the callback synchronously during execute(). VERIFIED by reading
+   googleapiclient/http.py:1455-1528 (_execute walks the response order and calls the callback inline).
+   The helpers therefore need no async handling and the provider stays sync, matching every other method.
+6. NOT ASSUMED, stated: the batch path has no SDK-native retry, because BatchHttpRequest.execute takes no
+   num_retries. decisions/outbound-clients.md forbids hand-rolled retry, so none is added. This is a
+   known gap in the SDK, recorded here rather than worked around.
+
+RESIDUALS RECORDED (deliberately NOT fixed here, siblings updated)
+R1. get_group_members (google.py:499-557) keeps its own inline member-type filter and mapping loop rather
+    than using _normalize_member_types/_map_members. Extracting it too would mix a mechanical refactor of
+    an out-of-scope method into a behaviour PR (size-gate trigger #3). Comment left on TASK-25.1.6.11.
+R2. get_group_members_batch keeps scope admin.directory.group.readonly while get_group_members and the new
+    composition use admin.directory.group.member.readonly. Converging them changes an OAuth scope on a
+    live path, which AC#3 forbids in this PR. Comment left on TASK-25.1.6.11.
+R3. execute_batch_request (client.py:170-199) is left in place with zero consumers; TASK-25.1.6.11 deletes
+    it. Not deleted here so this PR touches app/infrastructure/directory/** only (AC#7).
+
+BLAST RADIUS AND ROLLBACK
+Runtime blast radius is packages/access/sync/desired_state.py:160, the only consumer of the only changed
+live method. Its behaviour changes in exactly two ways, both strictly better: groups past the first member
+page stop being silently truncated, and a batch failure now carries a classified status instead of a
+blanket PERMANENT_ERROR (the consumer only reads is_success, so no branch changes). The composition and
+the three dataclasses are net-new with zero production callers until TASK-25.1.6.5, so they cannot regress
+anything. No config prerequisite, no deploy ordering constraint, no data migration, no OAuth scope change.
+A single git revert fully restores prior behaviour; the only thing lost on revert is the truncation fix.
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-03 20:08
+---
+AC SET AMENDED 2026-09-03 (task-planner, human-approved during planning). Recorded explicitly per the backlog-task-workflow rule against silently reshaping ACs. Seven criteria became nine.
+
+MAPPING: #1 unchanged. #2 unchanged. #3 AMENDED - still all-or-nothing, but the phrase 'gains ONLY the pagination fix' is no longer true: the human approved classifying the per-item HttpError via classify_google_error instead of reproducing execute_batch_request's blanket PERMANENT_ERROR/BATCH_ERRORS, because moving classification to the adapter IS decisions/outbound-clients.md. #4 AMENDED - 'one batched round-trip per page depth' became 'one batched round-trip per chunk of at most _BATCH_MAX_REQUESTS groups per page depth', forced by the new #8. #5 unchanged. #6 AMENDED - gained the chunked-batch case. #7 AMENDED - gained the explicit 'zero-member groups are returned rather than dropped' clause, which the legacy path did drop. #8 NEW (chunking). #9 NEW (maxResults=200).
+
+WHY #8 IS NOT SCOPE CREEP: googleapiclient/http.py:71 sets MAX_BATCH_LIMIT=1000 and http.py:1440 raises BatchError past it. BatchError is not an HttpError, so classify_google_error re-raises it and it escapes as an unhandled crash. TASK-25.1.6.3 (Slice A) made list_groups unbounded, so this task's composition - which feeds list_groups output straight into a batch - is the first code path in the repo that can reach that limit. The crash would be introduced BY this task, so it is fixed IN this task.
+
+WHY #9: human direction 2026-09-03 - fix things as they come while migrating toward decisions/layers.md, keeping siblings informed. maxResults=200 matches integrations/google_workspace/google_directory.py:18, the module TASK-25.1.6.5 deletes, so the surviving path reaches parity rather than inheriting an unstated default.
+
+SIZE GATE: FITS ONE PR. ~200 production LOC across 3 files (models.py +30, provider.py +25, google.py ~145 changed), one subsystem (app/infrastructure/directory/), no terraform, no CI, no config. Under the ~400 LOC / ~10 file threshold. No decomposition required.
+---
+
+author: @task-planner
+created: 2026-09-03 20:09
+---
+DESCRIPTION CORRECTION 2026-09-03. The scope section above states that 'googleapiclient-stubs types ... the (request_id, response, HttpError | None) callback, so no Any-laundering is needed.' HALF OF THAT IS WRONG and would cost the implementer time.
+
+VERIFIED BY RUNNING MYPY, not by reading: the stub declares the callback as Callable[[str, googleapiclient.http.HttpRequest, HttpError | None], Any] - the MIDDLE parameter is typed HttpRequest even though at runtime it receives the deserialised response. Annotating that parameter with the Members TypedDict produces:
+
+  error: Argument 'callback' to 'new_batch_http_request' of 'DirectoryResource' has incompatible type
+  'Callable[[str, Members, HttpError | None], None]'; expected
+  'Callable[[str, HttpRequest, HttpError | None], Any] | None'  [arg-type]
+
+So the callback's response parameter MUST be annotated Any, exactly as integrations/google_workspace/client.py:175 already does. This is an upstream stub bug, not a code smell - do not try to 'fix' it, and do not let a reviewer flag it. decisions/sdk-typing.md's own Consequences section anticipates exactly this: the Google stubs are community-maintained and 'gaps/lag ... are expected'.
+
+EVERYTHING ELSE IN THAT SENTENCE IS CORRECT and re-verified: new_batch_http_request is typed on DirectoryResource (stubs _apis/admin/directory_v1/resources.pyi:877), BatchHttpRequest.add(request, request_id=...) and .execute() type-check as used, and members_resource.list_next(previous_request, previous_response) is fully typed as (MembersHttpRequest, Members) -> MembersHttpRequest | None - which is the paging mechanism the plan uses, so no manual nextPageToken handling is needed anywhere.
+
+ONE MORE STUB/SDK FACT WORTH KNOWING: BatchHttpRequest.execute() takes NO num_retries, unlike MembersHttpRequest.execute(num_retries=...). The batch path therefore has no SDK-native retry. decisions/outbound-clients.md forbids hand-rolling one, so none is added; this is recorded as a named gap in the plan rather than worked around.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1.6.5 - Migrate-provisioning-groups-onto-batched-DirectoryProvider-members-delete-google_directory.py-and-retire-retry_request.md
+++ b/backlog/tasks/task-25.1.6.5 - Migrate-provisioning-groups-onto-batched-DirectoryProvider-members-delete-google_directory.py-and-retire-retry_request.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 15:01'
-updated_date: '2026-09-03 18:00'
+updated_date: '2026-09-03 20:08'
 labels:
   - clients
   - phase-3
@@ -71,5 +71,35 @@ THREE THINGS THAT CHANGE YOUR PLANNING:
 2. THE COMPOSITION WILL NOT APPLY groups_filters EITHER. modules/provisioning/groups.py passes pre_processing_filters straight through to list_groups_with_members today, where they run via utils.filters.filter_by_condition against raw dicts. Those filters operate on dict keys ('name', 'email'), not dataclass attributes - so repointing is not a pass-through and you will need to decide whether the filters move to attribute access, or the consumer converts, or the filter contract changes. Budget for that; it is not covered by any earlier slice. Concretely: modules/aws/identity_center.py:56-60 supplies pre_processing_filters and a post-filter lambda group: 'AWS-' in group['name'] (identity_center.py:55), and modules/aws/groups.py:81 supplies more.
 
 3. PARTIAL FAILURE IS NOW EXPRESSED IN THE PAYLOAD, NOT THE STATUS. decisions/operation-result.md fixes a closed status set with no PARTIAL, so TASK-25.1.6.3.1's composition returns success with per-group failures carried as typed values inside data. Your AC#6 (name the failure-profile change explicitly) should describe the delta as: legacy retried each failing group with time.sleep and then skipped it silently, whereas the new path surfaces the failed group keys as typed failures the consumer must decide about. That is strictly more observable, not merely different.
+---
+
+author: @task-planner
+created: 2026-09-03 20:08
+---
+COMPOSITION CONTRACT FIXED 2026-09-03 (task-planner, human-approved while planning TASK-25.1.6.3.1). Plan against this exact shape:
+
+    def list_groups_with_members(
+        self,
+        query: str = '',
+        limit: int | None = None,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult[DirectoryGroupsWithMembers]
+
+New frozen dataclasses in app/infrastructure/directory/models.py:
+    DirectoryGroupWithMembers(group: DirectoryGroup, members: tuple[DirectoryMember, ...])
+    DirectoryGroupFailure(group_email: str, status: OperationStatus, error_code: str | None, message: str)
+    DirectoryGroupsWithMembers(groups: tuple[DirectoryGroupWithMembers, ...], failures: tuple[DirectoryGroupFailure, ...])
+
+FOUR THINGS THAT CHANGE YOUR PLANNING (in addition to the three already recorded on 2026-09-03 18:00):
+
+4. ZERO-MEMBER GROUPS ARE NOW RETURNED, NOT DROPPED. Legacy list_groups_with_members skipped any group whose member list came back empty (integrations/google_workspace/google_directory.py:187-190 - 'if members:'). The composition deliberately does not, because that is consumer business logic. If modules/provisioning/groups.py or its downstream (modules/aws/identity_center.py, modules/aws/groups.py) depends on empty groups being absent, YOU add the filter at the consumer. Pin it with a test either way - it is a real behavioural delta at your boundary, not at the provider's.
+
+5. THE LEGACY fields= PROJECTION IS GONE. Legacy requested groups(email, name, directMembersCount, description) and members(email, role, type, status). The canonical dataclasses carry neither directMembersCount nor member status; TASK-25.1.6.3's field inventory grep-confirmed zero downstream reads of both. If your migration surfaces a reader, that is a new finding, not a regression to paper over.
+
+6. FAILED GROUPS COME BACK AS DATA, AND FAILURE IS PER GROUP. failures carries a DirectoryGroupFailure per group whose members could not be fetched, with a status already classified by classify_google_error. The overall result is still SUCCESS. Your AC#6 should assert what modules/provisioning/groups.py does with a non-empty failures tuple - silently skipping it would be strictly worse than the legacy retry-then-skip, because now you were told. NOTE: an UNMAPPED HttpError status (e.g. 400) propagates as an exception rather than becoming a failure entry, by design per decisions/outbound-clients.md.
+
+7. BATCH ROUNDS ARE CHUNKED AT 100 REQUESTS. So 'one batched round-trip' in your AC#1 is precisely 'ceil(groups/100) batch requests per member-page depth', not literally one. Word AC#1's evidence accordingly - the claim to prove is 'not one members.list per group', not 'exactly one HTTP round-trip'.
+
+TWO RESIDUALS TASK-25.1.6.3.1 LEAVES FOR LATER (both recorded on TASK-25.1.6.11, neither blocks you): get_group_members keeps its own inline member-mapping loop, and get_group_members_batch keeps the admin.directory.group.readonly scope while get_group_members and the new composition use admin.directory.group.member.readonly.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
+++ b/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:03'
+updated_date: '2026-09-03 20:09'
 labels:
   - reliability
 dependencies: []
@@ -48,3 +49,23 @@ INTERACTION WITH THE 25.1.6 WORK: TASK-25.1.6.3.1 fixes a separate defect in the
 - [ ] #3 A test proves that a failing get_group_members_batch does not result in a desired state that a caller could mistake for 'no members'
 - [ ] #4 The distinct warning-and-continue at desired_state.py:150-156 (group not found for a rule) is evaluated separately and either left intentionally unchanged with a recorded rationale, or fixed on its own merits
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-03 20:09
+---
+TWO OF YOUR PREMISES MOVE WHEN TASK-25.1.6.3.1 MERGES (task-planner, 2026-09-03, human-approved while planning it). Re-read this before you plan; your description currently cites integrations/google_workspace/client.py:193-199 as the source of the all-or-nothing behaviour, and that code will be dead.
+
+1. THE SOURCE OF TRUTH MOVES. execute_batch_request's blanket 'PERMANENT_ERROR for the WHOLE batch as soon as ONE group's request fails' will no longer live in the vendor package. The orchestration moves into GoogleDirectoryProvider (app/infrastructure/directory/google.py), because decisions/outbound-clients.md makes the adapter the classification boundary. Cite the provider, not client.py.
+
+2. THE STATUS BECOMES CLASSIFIED, WHICH SHARPENS YOUR EXPOSURE ARGUMENT RATHER THAN WEAKENING IT. The batch failure will be classified by classify_google_error, so a 429 or 503 on ONE group now yields TRANSIENT_ERROR (with retry_after when Google supplies it) for the whole batch, not PERMANENT_ERROR. packages/access/sync/desired_state.py:163 only reads is_success, so its behaviour is bit-for-bit unchanged - it still logs build_desired_state_batch_members_failed and proceeds with an empty desired state. But you now have a typed, correct signal available at that call site to branch on, which is exactly what a fix needs.
+
+3. STILL TRUE AND UNCHANGED: get_group_members_batch remains ALL-OR-NOTHING by explicit human decision. TASK-25.1.6.3.1 deliberately does not change its return contract, so one bad group key can still empty the desired state for every entitlement in the batch. Your AC#3 stands as written.
+
+4. NEW OPTION AVAILABLE TO YOU. TASK-25.1.6.3.1 also adds a per-group-failure-tolerant surface on the same provider - list_groups_with_members returns success carrying a failures tuple of DirectoryGroupFailure(group_email, status, error_code, message) alongside the groups that succeeded. If your fix wants 'proceed with the groups that worked, and never silently present a partial result as complete', the mechanism now exists in infrastructure and you would not be inventing it. Whether desired_state should move onto it, or get_group_members_batch should gain the same shape, is your call - do not assume either.
+
+5. UNRELATED DEFECT ALSO CLOSED BY .3.1, worth knowing since it touches the same call: get_group_members_batch ignores nextPageToken today and silently truncates any group past the first member page. Fixed there. It can only ever return MORE members, so it does not interact with your failure-handling scope.
+---
+<!-- COMMENTS:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new, efficient batch API for listing Google Directory groups together with their members, including robust per-group error handling and improved member type filtering. It also adds new data models to support these features and updates the provider interface to standardize this capability across implementations.

**Key changes:**

### Google Directory Batch Group-Member Listing

* Added a new method `list_groups_with_members` to `GoogleDirectoryProvider`, which lists groups and their members in a single batched operation, returning per-group failures without failing the entire request. This method uses a new batching mechanism to efficiently fetch members for multiple groups and includes filtering by member type.
* Implemented internal helpers `_execute_batch_round`, `_batch_list_members`, `_normalize_member_types`, and `_map_members` to support efficient batching, error handling, and member type normalization/filtering.

### Data Model Extensions

* Added new data classes: `DirectoryGroupWithMembers`, `DirectoryGroupFailure`, and `DirectoryGroupsWithMembers` to represent the group-member composition results and per-group errors.
* Updated `__all__` exports in `models.py` and imports in provider files to include the new models. [[1]](diffhunk://#diff-b660e03c9f222783b6ec93913e177991848a4edb6578d85e05146e0fdac869e7R5-R13) [[2]](diffhunk://#diff-535fab38f398c412c34fda5af5446a932477e7817ffb91b03d51acaa125f9e43R7)

### Provider Interface Update

* Added `list_groups_with_members` as an abstract method to the `DirectoryProvider` interface, with documentation specifying behavior, batching, and error handling expectations.

### Batch Members API Improvements

* Refactored `get_group_members_batch` to use the new batching and filtering helpers, improving efficiency and correctness, and ensuring consistent error handling. [[1]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cL566-R668) [[2]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR34-R36)
* Updated the docstring of `get_group_members_batch` to clarify batching behavior and error semantics.

### Task and Planning Documentation

* Updated task and planning files to reflect the new implementation, document residual refactor items, and confirm the status of related tasks. [[1]](diffhunk://#diff-ffab41413d0f549a625d570304b6ca1bbbc217faaeac59d39629bf11dba64b31L9-R9) [[2]](diffhunk://#diff-ffab41413d0f549a625d570304b6ca1bbbc217faaeac59d39629bf11dba64b31R71-R82) [[3]](diffhunk://#diff-1b7fcc5771baccd1cc3f42513982cd266a1c12abadfb0bb3066b0c6eb97c6e53L6-R10) [[4]](diffhunk://#diff-bd85d5c09251efdf4174d4dc2b3d35572ebdfbeacd16ff3f6e2bc742df5cb8d0L9-R9)