### PR TITLE
Fix/access sync directory batch failure

### DIFF
--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -116,7 +116,14 @@ class DirectoryMembershipBuilder:
         self,
         effective: EffectivePlatformPolicy,
     ) -> OperationResult[DesiredPlatformState]:
-        """Batch-read authn and entitlement groups into platform-shaped state."""
+        """Batch-read authn and entitlement groups into platform-shaped state.
+
+        Any IDP failure is propagated as an error result: a caller must never be
+        able to mistake an unreachable directory for "these entitlements have no
+        members", since reconciliation removes memberships absent from the
+        desired state.  The single exception is a ``NOT_FOUND`` on a rule's own
+        group, which is legitimate absence and skips only that entitlement.
+        """
         log = logger.bind(platform=effective.platform)
 
         authn_group_result = self._directory.get_group(effective.authn_group_slug)
@@ -145,6 +152,13 @@ class DirectoryMembershipBuilder:
         email_to_rule: dict[str, EntitlementRule] = {}
         for rule in effective.sync_managed_rules():
             group_result = self._directory.get_group(rule.group_slug)
+            if not group_result.is_success and group_result.status != OperationStatus.NOT_FOUND:
+                return OperationResult.error(
+                    group_result.status,
+                    message=group_result.message,
+                    error_code=group_result.error_code,
+                    retry_after=group_result.retry_after,
+                )
             if not group_result.is_success or not group_result.data:
                 log.warning(
                     "build_desired_state_group_not_found",
@@ -166,14 +180,19 @@ class DirectoryMembershipBuilder:
                     "build_desired_state_batch_members_failed",
                     error=batch_result.message,
                 )
-            else:
-                for group_email, members in (batch_result.data or {}).items():
-                    matched_rule = email_to_rule.get(group_email)
-                    if matched_rule is None:
-                        continue
-                    desired_members_by_entitlement.setdefault(matched_rule.entitlement_id, set()).update(
-                        member.email.lower() for member in members if member.email.lower() in desired_users
-                    )
+                return OperationResult.error(
+                    batch_result.status,
+                    message=batch_result.message,
+                    error_code=batch_result.error_code,
+                    retry_after=batch_result.retry_after,
+                )
+            for group_email, members in (batch_result.data or {}).items():
+                matched_rule = email_to_rule.get(group_email)
+                if matched_rule is None:
+                    continue
+                desired_members_by_entitlement.setdefault(matched_rule.entitlement_id, set()).update(
+                    member.email.lower() for member in members if member.email.lower() in desired_users
+                )
 
         return OperationResult.success(
             data=DesiredPlatformState(

--- a/app/tests/integration/packages/access/sync/conftest.py
+++ b/app/tests/integration/packages/access/sync/conftest.py
@@ -110,11 +110,15 @@ class FakeDirectory:
         transitive_membership_slugs: set[str] | None = None,
         user_direct_group_slugs: set[str] | None = None,
         group_members: dict[str, list[str]] | None = None,
+        batch_members_result: OperationResult | None = None,
+        group_result_by_slug: dict[str, OperationResult] | None = None,
     ) -> None:
         self._discovered: set[str] = discovered_slugs or set()
         self._transitive: set[str] = transitive_membership_slugs or set()
         self._direct: set[str] = user_direct_group_slugs or set()
         self._members: dict[str, list[str]] = group_members or {}
+        self._batch_members_result = batch_members_result
+        self._group_result_by_slug: dict[str, OperationResult] = group_result_by_slug or {}
 
     def _make_group(self, slug: str) -> DirectoryGroup:
         return DirectoryGroup(
@@ -124,8 +128,10 @@ class FakeDirectory:
         )
 
     def get_group(self, slug: str) -> OperationResult:
-        # Groups always exist in the IDP directory; only membership is configurable.
-        # The membership question is answered by check_membership / get_user_groups.
+        # Groups always exist in the IDP directory unless a per-slug result is injected;
+        # the membership question is answered by check_membership / get_user_groups.
+        if slug in self._group_result_by_slug:
+            return self._group_result_by_slug[slug]
         return OperationResult.success(data=self._make_group(slug))
 
     def check_membership(self, group_email: str, user_email: str) -> OperationResult:
@@ -158,6 +164,8 @@ class FakeDirectory:
         group_emails: list[str],
         include_member_types: set[str] | None = None,
     ) -> OperationResult:
+        if self._batch_members_result is not None:
+            return self._batch_members_result
         result = {}
         for group_email in group_emails:
             slug = group_email.split("@")[0]

--- a/app/tests/integration/packages/access/sync/test_desired_state.py
+++ b/app/tests/integration/packages/access/sync/test_desired_state.py
@@ -26,10 +26,20 @@ Scenarios covered:
   A5  User is in authn but get_user_groups returns a group that is NOT
       in the effective policy (e.g. a foreign-platform group).
       Required entitlements must remain empty.
+
+  B1  Platform-state build happy path.
+
+  B2  IDP batch-membership failure must propagate, never surface as a
+      success carrying an empty desired membership map (TASK-77).
+
+  B3  A per-rule NOT_FOUND group lookup remains a legitimate skip.
+
+  B4  A per-rule non-NOT_FOUND group lookup failure must propagate.
 """
 
 import pytest
 
+from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig as AccessSyncRuntimeConfig
 from packages.access.common.config import PlatformPolicy
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
@@ -282,3 +292,156 @@ def test_should_not_include_entitlement_for_group_outside_effective_policy():
     assert result.is_success
     assert result.data.user_should_exist is True
     assert result.data.required_entitlements == []
+
+
+# ---------------------------------------------------------------------------
+# B: build_platform_state_from_effective
+# ---------------------------------------------------------------------------
+
+
+def _make_platform_builder_and_effective(
+    *,
+    discovered_slugs: set,
+    group_members: dict | None = None,
+    batch_members_result: OperationResult | None = None,
+    group_result_by_slug: dict | None = None,
+    platform: str = "aws",
+) -> tuple:
+    """Return (DirectoryMembershipBuilder, EffectivePlatformPolicy) for platform builds."""
+    config = AccessSyncRuntimeConfig(
+        dir_prefix="sg",
+        platforms={
+            platform: PlatformPolicy(
+                authn_token="authn",
+                authn_removal_mode="delete",
+                mode_overrides={},
+            )
+        },
+    )
+    directory = FakeDirectory(
+        discovered_slugs=discovered_slugs,
+        group_members=group_members or {},
+        batch_members_result=batch_members_result,
+        group_result_by_slug=group_result_by_slug,
+    )
+    builder = DirectoryMembershipBuilder(directory)
+    effective = resolve_effective_policy(config, platform, discovered_slugs)
+    return builder, effective
+
+
+@pytest.mark.integration
+def test_should_build_platform_state_from_authn_and_entitlement_groups():
+    """Happy path: desired members are authn members present in each entitlement group."""
+    # Arrange
+    builder, effective = _make_platform_builder_and_effective(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly"},
+        group_members={
+            "sg-aws-authn": ["alice@example.com", "bob@example.com"],
+            "sg-aws-admin": ["alice@example.com", "ghost@example.com"],
+            "sg-aws-readonly": ["bob@example.com"],
+        },
+    )
+
+    # Act
+    result = builder.build_platform_state_from_effective(effective)
+
+    # Assert
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.desired_users == {"alice@example.com", "bob@example.com"}
+    assert result.data.desired_members_by_entitlement == {
+        "admin": {"alice@example.com"},
+        "readonly": {"bob@example.com"},
+    }
+    assert result.data.entitlement_slug_by_id == {
+        "admin": "sg-aws-admin",
+        "readonly": "sg-aws-readonly",
+    }
+
+
+@pytest.mark.integration
+def test_should_propagate_error_when_batch_members_fetch_fails():
+    """A failing get_group_members_batch must not surface as success with empty members."""
+    # Arrange
+    builder, effective = _make_platform_builder_and_effective(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly"},
+        group_members={
+            "sg-aws-authn": ["alice@example.com"],
+            "sg-aws-admin": ["alice@example.com"],
+        },
+        batch_members_result=OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            message="rate limited",
+            error_code="429",
+            retry_after=30,
+        ),
+    )
+
+    # Act
+    result = builder.build_platform_state_from_effective(effective)
+
+    # Assert
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "429"
+    assert result.retry_after == 30
+    assert result.data is None
+
+
+@pytest.mark.integration
+def test_should_skip_entitlement_when_group_not_found():
+    """NOT_FOUND on a rule's group is legitimate absence: skip only that entitlement."""
+    # Arrange
+    builder, effective = _make_platform_builder_and_effective(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly"},
+        group_members={
+            "sg-aws-authn": ["alice@example.com", "bob@example.com"],
+            "sg-aws-readonly": ["bob@example.com"],
+        },
+        group_result_by_slug={
+            "sg-aws-admin": OperationResult.error(
+                OperationStatus.NOT_FOUND,
+                message="group not found",
+                error_code="GROUP_NOT_FOUND",
+            )
+        },
+    )
+
+    # Act
+    result = builder.build_platform_state_from_effective(effective)
+
+    # Assert
+    assert result.is_success
+    assert result.data is not None
+    assert "admin" not in result.data.desired_members_by_entitlement
+    assert result.data.desired_members_by_entitlement["readonly"] == {"bob@example.com"}
+
+
+@pytest.mark.integration
+def test_should_propagate_error_when_group_lookup_transiently_fails():
+    """A non-NOT_FOUND per-rule failure must fail the whole build, not skip the rule."""
+    # Arrange
+    builder, effective = _make_platform_builder_and_effective(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly"},
+        group_members={
+            "sg-aws-authn": ["alice@example.com", "bob@example.com"],
+            "sg-aws-readonly": ["bob@example.com"],
+        },
+        group_result_by_slug={
+            "sg-aws-admin": OperationResult.error(
+                OperationStatus.TRANSIENT_ERROR,
+                message="backend error",
+                error_code="503",
+                retry_after=15,
+            )
+        },
+    )
+
+    # Act
+    result = builder.build_platform_state_from_effective(effective)
+
+    # Assert
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "503"
+    assert result.data is None

--- a/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
+++ b/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
@@ -3,13 +3,14 @@ id: TASK-77
 title: >-
   Review access sync treating a Directory batch failure as a warning and
   proceeding with empty desired state
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-03 18:03'
-updated_date: '2026-09-04 12:54'
+updated_date: '2026-09-04 12:55'
 labels:
   - reliability
+milestone: m-3
 dependencies: []
 references:
   - decisions/operation-result.md

--- a/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
+++ b/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
@@ -3,10 +3,11 @@ id: TASK-77
 title: >-
   Review access sync treating a Directory batch failure as a warning and
   proceeding with empty desired state
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-03 18:03'
-updated_date: '2026-09-04 12:39'
+updated_date: '2026-09-04 12:54'
 labels:
   - reliability
 dependencies: []
@@ -44,11 +45,11 @@ INTERACTION WITH THE 25.1.6 WORK: TASK-25.1.6.3.1 fixes a separate defect in the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 It is determined and recorded in the task notes whether any consumer of DesiredPlatformState acts destructively on an empty desired_members_by_entitlement, citing the exact reconciliation call sites read
-- [ ] #2 If an existing guard prevents destructive action, a regression test pins it and this task closes with that evidence; if no guard exists, the IDP failure is propagated rather than swallowed at desired_state.py:163
-- [ ] #3 A test proves that a failing get_group_members_batch does not result in a desired state that a caller could mistake for 'no members'
-- [ ] #4 The distinct warning-and-continue at desired_state.py:150-156 (group not found for a rule) is evaluated separately and either left intentionally unchanged with a recorded rationale, or fixed on its own merits
-- [ ] #5 When a per-rule get_group call fails with a non-NOT_FOUND status (TRANSIENT_ERROR, UNAUTHORIZED, or any other classified failure), build_platform_state_from_effective propagates that failure instead of silently excluding the entitlement; a NOT_FOUND result continues to be treated as legitimate absence (skip only that one entitlement), each branch covered by its own test
+- [x] #1 It is determined and recorded in the task notes whether any consumer of DesiredPlatformState acts destructively on an empty desired_members_by_entitlement, citing the exact reconciliation call sites read
+- [x] #2 If an existing guard prevents destructive action, a regression test pins it and this task closes with that evidence; if no guard exists, the IDP failure is propagated rather than swallowed at desired_state.py:163
+- [x] #3 A test proves that a failing get_group_members_batch does not result in a desired state that a caller could mistake for 'no members'
+- [x] #4 The distinct warning-and-continue at desired_state.py:150-156 (group not found for a rule) is evaluated separately and either left intentionally unchanged with a recorded rationale, or fixed on its own merits
+- [x] #5 When a per-rule get_group call fails with a non-NOT_FOUND status (TRANSIENT_ERROR, UNAUTHORIZED, or any other classified failure), build_platform_state_from_effective propagates that failure instead of silently excluding the entitlement; a NOT_FOUND result continues to be treated as legitimate absence (skip only that one entitlement), each branch covered by its own test
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -160,6 +161,26 @@ ASSUMPTIONS / OPEN QUESTIONS FOR REVIEWER
 BLAST RADIUS / ROLLBACK
 Blast radius: single method's failure-handling in `packages/access/sync/desired_state.py`, consumed only by `AccessSyncApplicationService.sync_platform`. No schema, API, or adapter changes. Behaviourally, IDP outages during platform sync now correctly abort the sync run (surfacing as a sync_platform error, already logged/dispatched via SYNC_FAILED-equivalent handling in application.py) instead of silently reconciling against an empty desired state. Rollback is a straight revert of the one file + its tests; no data migration or dual-write concerns.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED (implementation agent, 2026-09-04). Production change confined to app/packages/access/sync/desired_state.py:build_platform_state_from_effective.
+
+AC#1 — NO GUARD EXISTS; the swallowed batch failure is genuinely destructive. Call sites read end to end: packages/access/sync/application.py:237-239 (sync_platform aborts on 'not desired_result.is_success' — the only guard, and it never fired because desired_state.py masked the failure as success); adapters/aws_identity_center.py:908-923 (_build_canonical_platform_state seeds desired_members_by_entitlement from policy rules, then overlays desired data — an empty overlay is indistinguishable from legitimate emptiness); aws_identity_center.py:1094-1096 (managed_entitlement_ids taken from canonical desired keys, so CURRENT members are still fetched for every managed entitlement); policies.py:293-320 (PlatformReconciliationPlanner: members_to_remove = current_members - desired_members, i.e. ALL current members when desired is empty). Non-dry-run then executes that plan.
+
+AC#2/#3 — get_group_members_batch failure now returns OperationResult.error propagating status, message, error_code and retry_after instead of logging a warning and falling through. The existing warning log is retained for operator visibility. application.py:237 needed no change; it now aborts correctly.
+
+AC#4/#5 — the per-rule get_group loop now branches on status: a non-NOT_FOUND failure propagates and fails the whole build; NOT_FOUND (and the pre-existing success-but-no-data edge case) still logs build_desired_state_group_not_found and skips only that entitlement.
+
+TEST EVIDENCE — new section B in app/tests/integration/packages/access/sync/test_desired_state.py (this method had zero coverage before): test_should_build_platform_state_from_authn_and_entitlement_groups (happy-path regression), test_should_propagate_error_when_batch_members_fetch_fails (AC#2/#3: TRANSIENT_ERROR, error_code 429, retry_after 30, data is None), test_should_skip_entitlement_when_group_not_found (AC#5 NOT_FOUND branch), test_should_propagate_error_when_group_lookup_transiently_fails (AC#5 non-NOT_FOUND branch). FakeDirectory in that package's conftest.py gained optional batch_members_result and group_result_by_slug injection, defaulting to prior always-succeed behaviour so every pre-existing test is untouched and still green.
+
+VALIDATION — 'make test' green. Targeted run: tests/integration/packages/access/sync + tests/unit/packages/access = 316 passed. ruff check clean. mypy reports only pre-existing repo-wide errors; none in the touched files.
+
+NOT DONE HERE — the partial-tolerant list_groups_with_members 'failures' composition was deliberately not adopted (see plan's considered-and-rejected). discover_group_slugs' identical swallow-on-failure shape remains open as TASK-78.
+
+LEFT FOR HUMAN VERIFICATION — DoD sign-off and moving this task to Done; also confirm the operational consequence is acceptable: an IDP outage during platform sync now aborts the sync run (surfaced as a sync_platform error) rather than silently reconciling against an empty desired state.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
+++ b/backlog/tasks/task-77 - Review-access-sync-treating-a-Directory-batch-failure-as-a-warning-and-proceeding-with-empty-desired-state.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:03'
-updated_date: '2026-09-03 20:09'
+updated_date: '2026-09-04 12:39'
 labels:
   - reliability
 dependencies: []
@@ -48,7 +48,118 @@ INTERACTION WITH THE 25.1.6 WORK: TASK-25.1.6.3.1 fixes a separate defect in the
 - [ ] #2 If an existing guard prevents destructive action, a regression test pins it and this task closes with that evidence; if no guard exists, the IDP failure is propagated rather than swallowed at desired_state.py:163
 - [ ] #3 A test proves that a failing get_group_members_batch does not result in a desired state that a caller could mistake for 'no members'
 - [ ] #4 The distinct warning-and-continue at desired_state.py:150-156 (group not found for a rule) is evaluated separately and either left intentionally unchanged with a recorded rationale, or fixed on its own merits
+- [ ] #5 When a per-rule get_group call fails with a non-NOT_FOUND status (TRANSIENT_ERROR, UNAUTHORIZED, or any other classified failure), build_platform_state_from_effective propagates that failure instead of silently excluding the entitlement; a NOT_FOUND result continues to be treated as legitimate absence (skip only that one entitlement), each branch covered by its own test
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+RESEARCH SUMMARY (grounded, current code — TASK-25.1.6.3.1 is Done and already merged, so this plan cites the current provider code, not the retired vendor dispatcher)
+
+AC#1 verdict: NO GUARD EXISTS. The batch failure is destructive, confirmed end-to-end:
+- packages/access/sync/desired_state.py:160-175 (build_platform_state_from_effective) — on get_group_members_batch failure, logs a warning and falls through, returning OperationResult.success with desired_members_by_entitlement={}.
+- packages/access/sync/application.py:237-239 (sync_platform) — DOES correctly abort when `not desired_result.is_success`. This is the only existing guard, and it never fires for this bug because desired_state.py masks the failure as success.
+- packages/access/sync/adapters/aws_identity_center.py:908-923 (_build_canonical_platform_state) — unconditionally seeds `desired_members_by_entitlement = {canonical_id: set() for canonical_id in canonical_id_by_slug.values()}` for EVERY canonical entitlement derived from policy rules, THEN overlays the incoming desired_state data. A swallowed batch failure is indistinguishable from a legitimately-empty result at this point.
+- aws_identity_center.py:1094-1096 (_build_current_platform_state call) — `managed_entitlement_ids=set(canonical_desired.desired_members_by_entitlement.keys())` is populated from policy rules regardless of batch success, so CURRENT members ARE fetched for every managed entitlement even when desired is empty.
+- policies.py:293-320 (PlatformReconciliationPlanner.plan_platform_actions) — for every entitlement_id, `members_to_remove = current_members - desired_members`; when desired_members is empty, members_to_remove == ALL current_members. Every user in every managed AWS group is planned for `remove_entitlement`.
+- Non-dry-run path executes this plan via `_execute_planned_actions` (aws_identity_center.py ~1130-1140). Confirmed destructive, not theoretical: a single transient Directory error empties every managed group platform-wide.
+
+AC#4 verdict (human-confirmed 2026-09-04): FIX IT. The per-rule `get_group` loop at desired_state.py:150-156 conflates a true NOT_FOUND (legitimate — group deleted/renamed) with any other failure status (TRANSIENT_ERROR, UNAUTHORIZED, or any other classified failure) by checking only `is_success`. classify_google_error (integrations/google_workspace/client.py:126-147) already distinguishes these; `get_group`'s OperationResult carries `.status` correctly classified. Only NOT_FOUND is safe to silently skip; anything else must propagate, mirroring the batch fix (AC#5, added to this task).
+
+CONSIDERED AND REJECTED: adopting DirectoryProvider.list_groups_with_members's partial-tolerant `failures` composition (added by TASK-25.1.6.3.1) inside desired_state.py, instead of propagating. Rejected because get_group_members_batch's all-or-nothing contract is an explicit, separate human decision (TASK-25.1.6.3.1's scope note c) that this task must not silently relitigate — AC#2's own wording ("propagate the failure rather than swallow it") already picks the minimal, safe fix. Moving to the partial-tolerant composition would be a materially larger behavioural change (silently proceeding on partial data) than this bug-fix task's scope; if wanted later, it is its own decision with its own review, not a byproduct of this fix.
+
+RELATED FINDING OUT OF SCOPE — filed as TASK-78: a third, separate code path (`discover_group_slugs`, called from `application.py:112`'s `_resolve`, on `list_groups` failure) silently returns an empty group-slug set BEFORE `build_platform_state_from_effective` ever runs, reaching the identical destructive blast radius through effective-policy resolution rather than through either call site this task's ACs cite. Not fixed here — it needs a signature change reviewed for both `sync_user` and `sync_platform` callers, a wider blast radius than this task's contained change.
+
+IMPLEMENTATION STEPS (single PR; touches only app/packages/access/sync/desired_state.py production code + its test double/tests — one subsystem, small diff, no decomposition needed)
+
+STEP 1 — desired_state.py:160-175, propagate the batch failure [AC#2, AC#3]
+Replace:
+    if not batch_result.is_success:
+        log.warning("build_desired_state_batch_members_failed", error=batch_result.message)
+    else:
+        for group_email, members in (batch_result.data or {}).items():
+            ...
+with an early return on failure (mirroring the existing authn_members_result pattern at line ~134) and de-indent the population loop to run unconditionally on success:
+    if not batch_result.is_success:
+        return OperationResult.error(
+            batch_result.status,
+            message=batch_result.message,
+            error_code=batch_result.error_code,
+            retry_after=batch_result.retry_after,
+        )
+    for group_email, members in (batch_result.data or {}).items():
+        matched_rule = email_to_rule.get(group_email)
+        if matched_rule is None:
+            continue
+        desired_members_by_entitlement.setdefault(matched_rule.entitlement_id, set()).update(
+            member.email.lower() for member in members if member.email.lower() in desired_users
+        )
+No changes needed in application.py or aws_identity_center.py — application.py's existing `if not desired_result.is_success: return desired_result` (line 237) already aborts correctly once this returns an error.
+
+STEP 2 — desired_state.py:150-156, distinguish NOT_FOUND from other failures [AC#4, AC#5]
+Replace:
+    for rule in effective.sync_managed_rules():
+        group_result = self._directory.get_group(rule.group_slug)
+        if not group_result.is_success or not group_result.data:
+            log.warning("build_desired_state_group_not_found", group_slug=rule.group_slug)
+            continue
+        email_to_rule[group_result.data.group_email] = rule
+with:
+    for rule in effective.sync_managed_rules():
+        group_result = self._directory.get_group(rule.group_slug)
+        if not group_result.is_success:
+            if group_result.status != OperationStatus.NOT_FOUND:
+                return OperationResult.error(
+                    group_result.status,
+                    message=group_result.message,
+                    error_code=group_result.error_code,
+                    retry_after=group_result.retry_after,
+                )
+            log.warning("build_desired_state_group_not_found", group_slug=rule.group_slug)
+            continue
+        if not group_result.data:
+            log.warning("build_desired_state_group_not_found", group_slug=rule.group_slug)
+            continue
+        email_to_rule[group_result.data.group_email] = rule
+(OperationStatus is already imported in this file.) The success-but-no-data branch is preserved unchanged (existing edge-case behaviour, not part of this task's finding).
+
+STEP 3 — update docstrings [housekeeping, not a separate AC]
+Update `build_platform_state_from_effective`'s one-line docstring to state the propagate-on-failure contract explicitly, and correct `discover_group_slugs`'s docstring is NOT touched (out of scope — that non-fatal design is TASK-78's subject, not this task's).
+
+STEP 4 — test infrastructure: app/tests/integration/packages/access/sync/conftest.py's FakeDirectory [enables AC#3, AC#5 tests]
+FakeDirectory currently always returns OperationResult.success for get_group and get_group_members_batch — there is no way to inject a failure today, and build_platform_state_from_effective has ZERO existing test coverage (happy or unhappy path). Extend the constructor with two optional injectable failure overrides, defaulting to current always-succeed behaviour so every existing test is unaffected:
+    def __init__(self, ..., batch_members_result: OperationResult | None = None, group_result_by_slug: dict[str, OperationResult] | None = None) -> None:
+- `get_group_members_batch` returns `self._batch_members_result` when set, else current behaviour.
+- `get_group(slug)` returns `self._group_result_by_slug[slug]` when the slug is a key, else current behaviour (always success).
+
+STEP 5 — tests in app/tests/integration/packages/access/sync/test_desired_state.py [AC#3, AC#5]
+Add a new section for `build_platform_state_from_effective` (none exists today):
+- test_should_build_platform_state_happy_path: baseline regression proving the untouched success path still works after Step 1/2's restructuring (no existing test covers this method at all).
+- test_should_propagate_error_when_batch_members_fetch_fails: FakeDirectory with `batch_members_result=OperationResult.error(OperationStatus.TRANSIENT_ERROR, message="rate limited", error_code="429", retry_after=30)`; assert `not result.is_success`, `result.status == OperationStatus.TRANSIENT_ERROR`, `result.retry_after == 30`, and that no success-with-empty-membership result is produced.
+- test_should_skip_entitlement_when_group_not_found: FakeDirectory with one rule's group_result_by_slug entry = `OperationResult.error(OperationStatus.NOT_FOUND, ...)`; assert the build still succeeds, that entitlement is absent from desired_members_by_entitlement, other entitlements are unaffected (documents the still-legitimate NOT_FOUND skip).
+- test_should_propagate_error_when_group_lookup_transiently_fails: FakeDirectory with one rule's group_result_by_slug entry = `OperationResult.error(OperationStatus.TRANSIENT_ERROR, ...)`; assert the WHOLE build_platform_state_from_effective call fails with that status (does not silently exclude just that entitlement).
+
+VALIDATION
+cd app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' && uv run ruff check . && uv run pytest tests --ignore=tests/smoke
+Plus: `git diff --name-only` → expect only app/packages/access/sync/desired_state.py, app/tests/integration/packages/access/sync/conftest.py, app/tests/integration/packages/access/sync/test_desired_state.py.
+Plus: run the full app/tests/unit/packages/access/sync/** and app/tests/integration/packages/access/sync/** suites explicitly and confirm all pre-existing tests remain green unmodified (proves Step 1/2 are pure restructuring for the success path).
+
+AC TRACEABILITY
+AC#1 (destructive-consumer determination) → recorded above, citing aws_identity_center.py:908-923, 1094-1096, policies.py:293-320, application.py:237-239 — no test required, evidentiary record only.
+AC#2 (propagate batch failure) → Step 1 → test_should_propagate_error_when_batch_members_fetch_fails.
+AC#3 (test proves no mistakable empty-success) → Step 5 → test_should_propagate_error_when_batch_members_fetch_fails.
+AC#4 (evaluate group-not-found separately) → recorded above (human-confirmed: fix it) → Step 2.
+AC#5 (NOT_FOUND vs other-failure branches) → Step 2 → test_should_skip_entitlement_when_group_not_found + test_should_propagate_error_when_group_lookup_transiently_fails.
+
+ASSUMPTIONS / OPEN QUESTIONS FOR REVIEWER
+1. Confirmed with the human during planning (2026-09-04): AC#4 is fixed (NOT_FOUND vs other-status branching), not left as a documented no-op. Recorded as AC#5.
+2. TASK-78 was filed to carry the discover_group_slugs finding (a third, separate path to the same destructive shape) since it is out of this task's cited scope and needs its own signature-change review — not blocking this task.
+3. This task's fix intentionally does NOT adopt list_groups_with_members's partial-tolerant `failures` composition — see "considered and rejected" above. Flagging in case the reviewer expected that mechanism to be used instead.
+4. batch_result.retry_after propagation is new (the sibling authn_members_result early-return at desired_state.py:~134 does not propagate retry_after) — a minor, targeted improvement scoped to the code this task touches, not a blanket fix of that sibling line.
+
+BLAST RADIUS / ROLLBACK
+Blast radius: single method's failure-handling in `packages/access/sync/desired_state.py`, consumed only by `AccessSyncApplicationService.sync_platform`. No schema, API, or adapter changes. Behaviourally, IDP outages during platform sync now correctly abort the sync run (surfacing as a sync_platform error, already logged/dispatched via SYNC_FAILED-equivalent handling in application.py) instead of silently reconciling against an empty desired state. Rollback is a straight revert of the one file + its tests; no data migration or dual-write concerns.
+<!-- SECTION:PLAN:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
+++ b/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
@@ -1,0 +1,41 @@
+---
+id: TASK-78
+title: >-
+  Review access sync discover_group_slugs IDP failure silently emptying
+  effective policy before reconciliation
+status: To Do
+assignee: []
+created_date: '2026-09-04 12:38'
+labels:
+  - reliability
+dependencies: []
+references:
+  - decisions/operation-result.md
+  - decisions/reliability.md
+  - app/packages/access/sync/desired_state.py
+  - app/packages/access/sync/application.py
+priority: high
+type: bug
+ordinal: 147000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Raised 2026-09-04 (task-planner, human-directed) while planning TASK-77. Same destructive blast radius as TASK-77 (a Directory failure silently producing an empty desired state that a platform-sync reconciler cannot distinguish from a legitimate 'no managed groups' state, which per TASK-77's confirmed finding at packages/access/sync/adapters/aws_identity_center.py's _build_canonical_platform_state + _build_current_platform_state + policies.py PlatformReconciliationPlanner.plan_platform_actions plans removal of every user from every currently-managed group), reached via a THIRD, separate code path that TASK-77's acceptance criteria do not cite and its fix does not cover.
+
+THE PATH. app/packages/access/sync/application.py:112 (AccessSyncApplicationService._resolve, called by both sync_user and sync_platform) calls self._membership_builder.discover_group_slugs(self._config, platform) BEFORE resolve_effective_policy(...). desired_state.py's discover_group_slugs (around line 186) queries self._directory.list_groups(query=prefix); on failure it logs discover_groups_failed and returns an empty set -- by its own docstring, deliberately non-fatal: 'Returns an empty set on IDP failure (non-fatal; the coordinator proceeds with an empty rule set).'
+
+WHY THIS MATTERS. An empty discovered-slugs set flows into resolve_effective_policy(config, platform, discovered=set()), which then has zero sync_managed_rules for that platform. build_platform_state_from_effective (once TASK-77 lands) will see email_to_rule stay empty and skip the batch call entirely -- there is no IDP failure at that point to propagate, because the empty state was manufactured one level up, before build_platform_state_from_effective ever ran. TASK-77's fix (propagate get_group / get_group_members_batch failures) does not and cannot catch this: the failure already happened and was silently absorbed inside discover_group_slugs.
+
+WHAT THIS TASK MUST DETERMINE: whether 'proceed with an empty rule set' on a list_groups outage was a deliberate product decision (e.g. discovery is expected to be best-effort because policy is re-resolved every run and a transient miss is tolerable) or an oversight of the same shape TASK-77 just fixed. If it is the same defect class, the fix likely needs to propagate the list_groups failure out of discover_group_slugs (or out of _resolve) rather than defaulting to set() -- but note _resolve()'s current return contract for discover_group_slugs is a bare set[str], not an OperationResult, so the fix may need a signature change reviewed for both sync_user and sync_platform callers, which is a wider blast radius than TASK-77's contained change and should be scoped/estimated on its own.
+
+Do not assume TASK-77's fix pattern transfers directly -- confirm the actual call contract and both call sites (sync_user single-user path and sync_platform batch path) before proposing a fix shape.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 It is determined and recorded whether discover_group_slugs' empty-set-on-IDP-failure fallback was a deliberate product decision or an oversight, citing the exact reasoning
+- [ ] #2 If it is the same defect class as TASK-77, a fix is proposed that propagates the list_groups failure to both sync_user and sync_platform callers without silently emptying effective policy, with the signature change reviewed for both call sites
+- [ ] #3 A test proves that a list_groups failure during group discovery does not result in a platform sync that treats the platform as having zero managed groups
+<!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request improves error handling and test coverage in the platform state synchronization logic. The main focus is to ensure that failures in directory lookups or batch membership fetches are correctly propagated as errors, rather than being silently treated as empty results, which could lead to incorrect removal of entitlements. The changes also add comprehensive integration tests to cover these scenarios.

**Error Handling Improvements:**

* Updated `build_platform_state_from_effective` in `desired_state.py` to propagate any IDP failure as an error result, except for a `NOT_FOUND` on a rule's own group, which is treated as a legitimate absence and only skips that entitlement. Now, both per-group and batch membership failures will cause the operation to fail, preventing silent data loss. [[1]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L119-R126) [[2]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59R155-R161) [[3]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L169-R188)

**Test Enhancements:**

* Extended the `FakeDirectory` test double in `conftest.py` to allow injection of per-group and batch membership errors, enabling more precise simulation of directory failures during tests. [[1]](diffhunk://#diff-384a0de4d5456504c8d30cfbc9c15750dd602ba707733fc546c65c5253bc9bf7R113-R121) [[2]](diffhunk://#diff-384a0de4d5456504c8d30cfbc9c15750dd602ba707733fc546c65c5253bc9bf7L127-R134) [[3]](diffhunk://#diff-384a0de4d5456504c8d30cfbc9c15750dd602ba707733fc546c65c5253bc9bf7R167-R168)
* Added new integration tests in `test_desired_state.py` to verify: 
  - The happy path for building platform state,
  - That batch membership failures are propagated as errors (TASK-77),
  - That `NOT_FOUND` group lookups are treated as legitimate skips,
  - That other group lookup failures cause the entire operation to fail. [[1]](diffhunk://#diff-a287c6ab9dd8b1b96cc07af295d44e0b01fd6b5b22e2da50ba4fb58eef1cfd71R29-R42) [[2]](diffhunk://#diff-a287c6ab9dd8b1b96cc07af295d44e0b01fd6b5b22e2da50ba4fb58eef1cfd71R295-R447)

**Documentation and Task Tracking:**

* Marked TASK-77 as complete, reflecting that the issue of treating batch failures as warnings (instead of errors) has been resolved.