### PR TITLE
Fix/access sync directory groups slugs

### DIFF
--- a/app/packages/access/sync/application.py
+++ b/app/packages/access/sync/application.py
@@ -109,8 +109,10 @@ class AccessSyncApplicationService:
                     error_code="ADAPTER_NOT_FOUND",
                 ),
             )
-        discovered = self._membership_builder.discover_group_slugs(self._config, platform)
-        effective = resolve_effective_policy(self._config, platform, discovered)
+        discovered_result = self._membership_builder.discover_group_slugs(self._config, platform)
+        if not discovered_result.is_success:
+            return None, None, discovered_result
+        effective = resolve_effective_policy(self._config, platform, discovered_result.data or set())
         return adapter, effective, None
 
     def _persist(

--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -9,7 +9,8 @@ The coordinator resolves effective policy once per run via
 ``build_user_state_from_effective`` (single-user) or
 ``build_platform_state_from_effective`` (batch reconciliation).  Discovery
 of IDP groups is handled by ``discover_group_slugs`` which queries the
-directory with the platform prefix and returns matching slugs.
+directory with the platform prefix and returns matching slugs, propagating
+any directory failure to the caller.
 """
 
 from typing import TYPE_CHECKING
@@ -206,12 +207,14 @@ class DirectoryMembershipBuilder:
         self,
         config: AccessRuntimeConfig,
         platform: str,
-    ) -> set[str]:
+    ) -> OperationResult[set[str]]:
         """Discover IDP group slugs for a platform by querying with the platform prefix.
 
         Uses ``config.group_prefix(platform)`` as the query and filters results
-        to slugs that start with that prefix.  Returns an empty set on IDP
-        failure (non-fatal; the coordinator proceeds with an empty rule set).
+        to slugs that start with that prefix.  An IDP failure is propagated as
+        an error result: a caller must never be able to mistake an unreachable
+        directory for "this platform declares no managed groups", since an
+        empty rule set silently disables entitlement enforcement.
         """
         prefix = config.group_prefix(platform)
         log = logger.bind(platform=platform, group_prefix=prefix)
@@ -221,7 +224,12 @@ class DirectoryMembershipBuilder:
                 "discover_groups_failed",
                 error=list_result.message,
             )
-            return set()
+            return OperationResult.error(
+                list_result.status,
+                message=list_result.message,
+                error_code=list_result.error_code,
+                retry_after=list_result.retry_after,
+            )
 
         groups = list_result.data if isinstance(list_result.data, list) else []
         discovered = {
@@ -236,7 +244,7 @@ class DirectoryMembershipBuilder:
             discovered_count=len(discovered),
             discovered_group_slugs=sorted(discovered),
         )
-        return discovered
+        return OperationResult.success(data=discovered)
 
     def _check_group_membership(
         self,

--- a/app/tests/integration/packages/access/sync/conftest.py
+++ b/app/tests/integration/packages/access/sync/conftest.py
@@ -112,6 +112,7 @@ class FakeDirectory:
         group_members: dict[str, list[str]] | None = None,
         batch_members_result: OperationResult | None = None,
         group_result_by_slug: dict[str, OperationResult] | None = None,
+        list_groups_result: OperationResult | None = None,
     ) -> None:
         self._discovered: set[str] = discovered_slugs or set()
         self._transitive: set[str] = transitive_membership_slugs or set()
@@ -119,6 +120,7 @@ class FakeDirectory:
         self._members: dict[str, list[str]] = group_members or {}
         self._batch_members_result = batch_members_result
         self._group_result_by_slug: dict[str, OperationResult] = group_result_by_slug or {}
+        self._list_groups_result = list_groups_result
 
     def _make_group(self, slug: str) -> DirectoryGroup:
         return DirectoryGroup(
@@ -174,6 +176,8 @@ class FakeDirectory:
         return OperationResult.success(data=result)
 
     def list_groups(self, query: str = "") -> OperationResult:
+        if self._list_groups_result is not None:
+            return self._list_groups_result
         matching = [self._make_group(slug) for slug in self._discovered if not query or slug.startswith(query)]
         return OperationResult.success(data=matching)
 

--- a/app/tests/integration/packages/access/sync/test_desired_state.py
+++ b/app/tests/integration/packages/access/sync/test_desired_state.py
@@ -35,6 +35,12 @@ Scenarios covered:
   B3  A per-rule NOT_FOUND group lookup remains a legitimate skip.
 
   B4  A per-rule non-NOT_FOUND group lookup failure must propagate.
+
+  C1  Group discovery returns the platform-prefixed slugs and filters out
+      foreign-platform groups.
+
+  C2  An IDP failure during group discovery must propagate, never surface
+      as a success carrying an empty slug set (TASK-78).
 """
 
 import pytest
@@ -444,4 +450,74 @@ def test_should_propagate_error_when_group_lookup_transiently_fails():
     assert not result.is_success
     assert result.status == OperationStatus.TRANSIENT_ERROR
     assert result.error_code == "503"
+    assert result.data is None
+
+
+# ---------------------------------------------------------------------------
+# C: discover_group_slugs
+# ---------------------------------------------------------------------------
+
+
+def _make_discovery_builder(
+    *,
+    discovered_slugs: set,
+    list_groups_result: OperationResult | None = None,
+    platform: str = "aws",
+) -> tuple:
+    """Return (DirectoryMembershipBuilder, AccessSyncRuntimeConfig) for discovery."""
+    config = AccessSyncRuntimeConfig(
+        dir_prefix="sg",
+        platforms={
+            platform: PlatformPolicy(
+                authn_token="authn",
+                authn_removal_mode="delete",
+                mode_overrides={},
+            )
+        },
+    )
+    directory = FakeDirectory(
+        discovered_slugs=discovered_slugs,
+        list_groups_result=list_groups_result,
+    )
+    return DirectoryMembershipBuilder(directory), config
+
+
+@pytest.mark.integration
+def test_should_discover_matching_group_slugs():
+    """Happy path: prefixed slugs are returned, non-matching slugs filtered out."""
+    # Arrange
+    builder, config = _make_discovery_builder(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly", "sg-gcp-viewer"},
+    )
+
+    # Act
+    result = builder.discover_group_slugs(config, "aws")
+
+    # Assert
+    assert result.is_success
+    assert result.data == {"sg-aws-admin", "sg-aws-readonly"}
+
+
+@pytest.mark.integration
+def test_should_propagate_error_when_group_discovery_fails():
+    """A failing list_groups must not surface as success with an empty slug set."""
+    # Arrange
+    builder, config = _make_discovery_builder(
+        discovered_slugs={"sg-aws-admin"},
+        list_groups_result=OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            message="rate limited",
+            error_code="429",
+            retry_after=30,
+        ),
+    )
+
+    # Act
+    result = builder.discover_group_slugs(config, "aws")
+
+    # Assert
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "429"
+    assert result.retry_after == 30
     assert result.data is None

--- a/app/tests/unit/packages/access/sync/test_application.py
+++ b/app/tests/unit/packages/access/sync/test_application.py
@@ -6,6 +6,8 @@ Covers:
   F-03  POLICY_NOT_FOUND and ADAPTER_NOT_FOUND errors surface correctly
   F-04  dry_run returns planned actions without executing them
   F-05  UNSUPPORTED_OPERATION from adapter sets requires_manual_action
+  F-06  A group-discovery IDP failure aborts sync instead of syncing an
+        empty rule set (TASK-78)
 """
 
 from typing import Any
@@ -219,11 +221,13 @@ class FakeDirectory:
         is_member: bool = True,
         groups: set[str] | None = None,
         user_group_slugs: set[str] | None = None,
+        list_groups_result: OperationResult | None = None,
     ) -> None:
         self._is_member = is_member
         self._per_group: dict[str, bool] = {}
         self._groups: set[str] = groups or set()
         self._user_group_slugs: set[str] | None = user_group_slugs
+        self._list_groups_result = list_groups_result
 
     def set_membership(self, group_slug: str, value: bool) -> None:
         self._per_group[group_slug] = value
@@ -287,6 +291,8 @@ class FakeDirectory:
         return OperationResult.success(data=mapping)
 
     def list_groups(self, query: str = "") -> OperationResult:
+        if self._list_groups_result is not None:
+            return self._list_groups_result
         matching = [
             DirectoryGroup(
                 group_email=f"{slug}@example.com",
@@ -307,6 +313,7 @@ def make_coordinator(
     user_exists: bool = True,
     adapter: FakeAdapter | None = None,
     discovered_groups: set[str] | None = None,
+    list_groups_result: OperationResult | None = None,
 ) -> tuple:
     if adapter is None:
         adapter = FakeAdapter(current_entitlement_ids=current_ids or set(), user_exists=user_exists)
@@ -325,6 +332,7 @@ def make_coordinator(
         is_member=is_member,
         groups=discovered_groups or set(),
         user_group_slugs=user_group_slugs,
+        list_groups_result=list_groups_result,
     )
     directory_provider: Any = directory
     coordinator = AccessSyncApplicationService(
@@ -461,3 +469,42 @@ def test_sync_platform_unknown_platform_returns_error():
     result = coordinator.sync_platform("nonexistent")
     assert not result.is_success
     assert result.error_code == "POLICY_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# F-06 Group-discovery IDP failure aborts sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sync_user_propagates_error_when_group_discovery_fails():
+    coordinator, adapter = make_coordinator(
+        discovered_groups={"sg-aws-admin"},
+        list_groups_result=OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            message="rate limited",
+            error_code="429",
+        ),
+    )
+    result = coordinator.sync_user("alice@example.com", "aws")
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "429"
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
+def test_sync_platform_propagates_error_when_group_discovery_fails():
+    coordinator, adapter = make_coordinator(
+        discovered_groups={"sg-aws-admin"},
+        list_groups_result=OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            message="rate limited",
+            error_code="429",
+        ),
+    )
+    result = coordinator.sync_platform("aws")
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "429"
+    assert adapter.calls == []

--- a/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
+++ b/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
@@ -3,13 +3,14 @@ id: TASK-78
 title: >-
   Review access sync discover_group_slugs IDP failure silently emptying
   effective policy before reconciliation
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-04 12:38'
 updated_date: '2026-09-04 13:37'
 labels:
   - reliability
+milestone: m-3
 dependencies: []
 references:
   - decisions/operation-result.md

--- a/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
+++ b/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
@@ -3,10 +3,11 @@ id: TASK-78
 title: >-
   Review access sync discover_group_slugs IDP failure silently emptying
   effective policy before reconciliation
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-04 12:38'
-updated_date: '2026-09-04 13:14'
+updated_date: '2026-09-04 13:37'
 labels:
   - reliability
 dependencies: []
@@ -36,9 +37,9 @@ Do not assume TASK-77's fix pattern transfers directly -- confirm the actual cal
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 It is determined and recorded whether discover_group_slugs' empty-set-on-IDP-failure fallback was a deliberate product decision or an oversight, citing the exact reasoning
-- [ ] #2 If it is the same defect class as TASK-77, a fix is proposed that propagates the list_groups failure to both sync_user and sync_platform callers without silently emptying effective policy, with the signature change reviewed for both call sites
-- [ ] #3 A test proves that a list_groups failure during group discovery does not result in a platform sync that treats the platform as having zero managed groups
+- [x] #1 It is determined and recorded whether discover_group_slugs' empty-set-on-IDP-failure fallback was a deliberate product decision or an oversight, citing the exact reasoning
+- [x] #2 If it is the same defect class as TASK-77, a fix is proposed that propagates the list_groups failure to both sync_user and sync_platform callers without silently emptying effective policy, with the signature change reviewed for both call sites
+- [x] #3 A test proves that a list_groups failure during group discovery does not result in a platform sync that treats the platform as having zero managed groups
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -106,3 +107,23 @@ ASSUMPTIONS / OPEN QUESTIONS FOR REVIEWER
 BLAST RADIUS / ROLLBACK
 Blast radius: discover_group_slugs()'s failure handling in packages/access/sync/desired_state.py, and _resolve()'s handling of that result in packages/access/sync/application.py -- consumed only by AccessSyncApplicationService.sync_user() and .sync_platform(). No schema, API, or adapter changes. Behaviourally, an IDP outage during group discovery now correctly aborts sync_user/sync_platform (surfacing as an error result, already logged/dispatched via existing error-handling paths) instead of silently proceeding with an effective policy that has zero entitlement rules for that platform. Rollback is a straight revert of the two production files + their tests; no data migration or dual-write concerns.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED (2026-09-04).
+
+AC#1 verdict: OVERSIGHT, same defect class as TASK-77. DirectoryMembershipBuilder's own class docstring states all public methods return OperationResult; discover_group_slugs was the sole violator. list_groups already distinguishes a zero-match query (success with data=[]) from a classified failure, so the empty-set fallback conflated 'IDP outage' with 'platform declares zero groups' -- exactly the ambiguity decisions/operation-result.md exists to prevent. Blast-radius correction from the plan stands: actual effect was silent SKIP of entitlement grant/revoke enforcement (stale access persists, new access not granted), not active mass removal, because plan_actions' removal branch requires ent_id in sync_managed_by_id which is empty when rules are empty.
+
+AC#2 changes (production, 2 files):
+- packages/access/sync/desired_state.py: discover_group_slugs now returns OperationResult[set[str]]; on list_groups failure it keeps the discover_groups_failed warning and returns OperationResult.error propagating status/message/error_code/retry_after; success wraps the discovered set. Method and module docstrings updated to the propagate-on-failure contract.
+- packages/access/sync/application.py: _resolve() returns (None, None, discovered_result) when discovery fails, else resolves effective policy from discovered_result.data. No changes needed in sync_user()/sync_platform() -- both already short-circuit on the shared error tuple, confirming the single choke point reviewed for both call sites.
+
+AC#3 test evidence (test scaffolding was already present on the branch):
+- tests/integration/packages/access/sync/test_desired_state.py section C: test_should_discover_matching_group_slugs (happy path, prefix filtering) and test_should_propagate_error_when_group_discovery_fails (TRANSIENT_ERROR/429/retry_after=30 propagated, data is None).
+- tests/unit/packages/access/sync/test_application.py: sync_user and sync_platform discovery-failure tests assert an error result and that the adapter is never invoked -- proving no sync proceeds as if the platform had zero managed groups.
+
+VALIDATION: mypy on both changed files -> no new errors (only pre-existing integrations/slack/help.py:125). ruff check . -> All checks passed. Targeted access sync suites: 181 passed. Full 'make test' run by the human -> all green.
+
+FOR HUMAN VERIFICATION (DoD): review the behaviour change that an IDP list_groups outage now aborts sync_user/sync_platform with an error result (surfaced through existing error dispatch/logging) instead of silently no-op'ing enforcement; confirm alerting/runbook expectations for that new error path.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
+++ b/backlog/tasks/task-78 - Review-access-sync-discover_group_slugs-IDP-failure-silently-emptying-effective-policy-before-reconciliation.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-04 12:38'
+updated_date: '2026-09-04 13:14'
 labels:
   - reliability
 dependencies: []
@@ -39,3 +40,69 @@ Do not assume TASK-77's fix pattern transfers directly -- confirm the actual cal
 - [ ] #2 If it is the same defect class as TASK-77, a fix is proposed that propagates the list_groups failure to both sync_user and sync_platform callers without silently emptying effective policy, with the signature change reviewed for both call sites
 - [ ] #3 A test proves that a list_groups failure during group discovery does not result in a platform sync that treats the platform as having zero managed groups
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+RESEARCH SUMMARY (grounded, current code)
+
+CONFIRMED CALL CONTRACT. Only one call site exists: application.py:112, AccessSyncApplicationService._resolve(), called identically by both sync_user() and sync_platform() via the shared (adapter, effective, error) tuple contract. discover_group_slugs() currently returns a bare set[str] and swallows list_groups() failures internally (desired_state.py ~186-207), violating DirectoryMembershipBuilder's own class docstring, which states "All public methods return OperationResult so callers can handle IDP failures through the standard result contract without catching exceptions." It is the only public method on this class that does not.
+
+AC#1 VERDICT (human-confirmed 2026-09-04): OVERSIGHT, same defect class as TASK-77. Evidence: (1) list_groups (infrastructure/directory/google.py:865-) already distinguishes a genuine IDP failure from a legitimate zero-match query -- a zero-match query returns OperationResult.success(data=[]), and is_success is False only for a classified error via classify_google_error. So the empty-set fallback in discover_group_slugs conflates "outage" with "this platform legitimately declares zero groups", which is exactly the ambiguity operation-result.md's envelope exists to prevent. (2) The class's own docstring contract (above) is violated only by this method. (3) TASK-77 already fixed the identical swallow-on-failure shape one level down in the same file/class.
+
+BLAST-RADIUS CORRECTION (human-confirmed 2026-09-04): TASK-78's filed description claims "same destructive blast radius as TASK-77 -- plans removal of every user from every currently-managed group." Tracing the actual downstream effect through PolicyEngine.plan_actions (policies.py:209-278) and the AWS adapter shows this is NOT accurate. When discover_group_slugs silently returns an empty set, resolve_effective_policy() produces an EMPTY entitlement_rules list (not just empty membership data, unlike TASK-77's bug, which left rules populated and only emptied membership data). plan_actions' removal branch only fires for an entitlement id that IS in sync_managed_by_id (built from those same, now-empty, rules) -- `if ent_id in sync_managed_by_id and ent_id not in desired_ids`. With sync_managed_by_id empty, NO removals are planned for any currently-held entitlement, in either sync_user or sync_platform (aws_identity_center.py: canonical_id_by_slug is built from context.entitlement_rules, also empty, so managed_entitlement_ids is empty and _build_current_platform_state skips list_members_for_groups entirely).
+
+ACTUAL EFFECT: entitlement grant/revoke enforcement for the platform is silently SKIPPED ENTIRELY for the duration of the outage -- stale access persists (a user who should lose a group membership does not), and new access is not granted -- while authn-driven user lifecycle (provision/disable/delete) is UNAFFECTED because it does not depend on discovered rules. This is a real defect (an outage is indistinguishable from "zero declared groups", silently disabling drift correction for as long as list_groups keeps failing) but it is silent non-enforcement, not active destructive removal. Recorded here to correct the task's filed premise before implementation; does not change the required fix.
+
+FIX SHAPE: single choke point. Both callers already funnel through _resolve(); no changes needed in sync_user() or sync_platform() themselves.
+
+IMPLEMENTATION STEPS (single PR; two production files + three test files, one subsystem, no decomposition needed)
+
+STEP 1 -- desired_state.py: discover_group_slugs propagates failure [AC#2]
+Change return type from `set[str]` to `OperationResult[set[str]]`. On `list_result.is_success` False: return `OperationResult.error(list_result.status, message=list_result.message, error_code=list_result.error_code, retry_after=list_result.retry_after)` (keep the existing discover_groups_failed warning log for operator visibility). On success: wrap the existing discovered-set computation in `OperationResult.success(data=discovered)`. Update the method's docstring to state the propagate-on-failure contract (replacing "non-fatal ... proceeds with an empty rule set"), and update the module docstring's one-line mention of discover_group_slugs to match.
+
+STEP 2 -- application.py: _resolve() handles the new return type [AC#2, AC#3]
+Replace:
+    discovered = self._membership_builder.discover_group_slugs(self._config, platform)
+    effective = resolve_effective_policy(self._config, platform, discovered)
+    return adapter, effective, None
+with:
+    discovered_result = self._membership_builder.discover_group_slugs(self._config, platform)
+    if not discovered_result.is_success:
+        return None, None, discovered_result
+    effective = resolve_effective_policy(self._config, platform, discovered_result.data or set())
+    return adapter, effective, None
+No changes needed to sync_user() or sync_platform(): both already do `if error is not None: return error` immediately after calling _resolve().
+
+STEP 3 -- test infrastructure: two FakeDirectory doubles gain injectable list_groups failure [enables AC#3]
+- app/tests/integration/packages/access/sync/conftest.py FakeDirectory: add `list_groups_result: OperationResult | None = None` constructor param; `list_groups()` returns it when set, else current behaviour (mirrors the batch_members_result/group_result_by_slug injection pattern TASK-77 added).
+- app/tests/unit/packages/access/sync/test_application.py FakeDirectory: same addition; also add a `list_groups_result` passthrough parameter to the `make_coordinator()` factory, defaulting to None so every existing test is unaffected.
+
+STEP 4 -- new tests, section C in app/tests/integration/packages/access/sync/test_desired_state.py [AC#3]
+- test_should_discover_matching_group_slugs: happy-path regression (none exists today) -- matching slugs returned, non-matching filtered, result.is_success, result.data is the expected set.
+- test_should_propagate_error_when_group_discovery_fails: FakeDirectory with `list_groups_result=OperationResult.error(OperationStatus.TRANSIENT_ERROR, message="rate limited", error_code="429", retry_after=30)`; assert not is_success, status/error_code/retry_after match, data is None.
+Add C1/C2 entries to the module docstring's "Scenarios covered" list, matching the existing A/B lettering convention.
+
+STEP 5 -- new tests, section F-06 in app/tests/unit/packages/access/sync/test_application.py [AC#3]
+- test_sync_user_propagates_error_when_group_discovery_fails: make_coordinator(list_groups_result=OperationResult.error(TRANSIENT_ERROR, ...)); assert coordinator.sync_user(...) is not success, status/error_code match, and adapter.calls is empty (reconcile_user never invoked).
+- test_sync_platform_propagates_error_when_group_discovery_fails: same shape for sync_platform(...), asserting adapter.calls is empty (reconcile_platform never invoked).
+These are the tests that directly prove AC#3: a platform/user sync no longer proceeds as if the platform had zero managed groups when discovery fails.
+
+VALIDATION
+cd app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)' && uv run ruff check . && uv run pytest tests --ignore=tests/smoke
+Plus: `git diff --name-only` -> expect only app/packages/access/sync/desired_state.py, app/packages/access/sync/application.py, app/tests/integration/packages/access/sync/conftest.py, app/tests/integration/packages/access/sync/test_desired_state.py, app/tests/unit/packages/access/sync/test_application.py.
+Plus: run app/tests/unit/packages/access/sync/** and app/tests/integration/packages/access/sync/** explicitly and confirm all pre-existing tests remain green unmodified (proves Steps 1/2 are additive, not restructuring).
+
+AC TRACEABILITY
+AC#1 (determine deliberate vs oversight) -> recorded above (human-confirmed): oversight, same defect class as TASK-77 -- no test required, evidentiary record only. Blast-radius correction also recorded (human-confirmed) alongside it.
+AC#2 (propagate failure to both callers) -> Steps 1-2 (single choke point at _resolve(), confirmed sufficient for both sync_user and sync_platform).
+AC#3 (test proves no zero-managed-groups treatment) -> Steps 4-5 (four new tests: direct discover_group_slugs coverage plus both application-level callers).
+
+ASSUMPTIONS / OPEN QUESTIONS FOR REVIEWER
+1. Confirmed with the human during planning (2026-09-04): AC#1 is oversight/fix, not deliberate-design-document-only.
+2. Confirmed with the human during planning (2026-09-04): the task's filed blast-radius description ("removal of every user from every currently-managed group") is corrected to "silent skip of entitlement grant/revoke enforcement for the platform" per the PolicyEngine.plan_actions trace above -- this does not change the fix, only the recorded severity mechanism.
+3. Fix is scoped to discover_group_slugs + _resolve() only (not sync_user/sync_platform bodies) since both already funnel through the shared tuple contract -- flagged for reviewer awareness since the task's own filing anticipated changes at both call sites.
+
+BLAST RADIUS / ROLLBACK
+Blast radius: discover_group_slugs()'s failure handling in packages/access/sync/desired_state.py, and _resolve()'s handling of that result in packages/access/sync/application.py -- consumed only by AccessSyncApplicationService.sync_user() and .sync_platform(). No schema, API, or adapter changes. Behaviourally, an IDP outage during group discovery now correctly aborts sync_user/sync_platform (surfacing as an error result, already logged/dispatched via existing error-handling paths) instead of silently proceeding with an effective policy that has zero entitlement rules for that platform. Rollback is a straight revert of the two production files + their tests; no data migration or dual-write concerns.
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request improves the reliability of the access sync process by ensuring that failures during group discovery in the identity provider (IDP) are properly propagated as errors, rather than being silently treated as an empty group set. This prevents accidental disabling of entitlement enforcement when the directory is unreachable. The changes also include comprehensive tests to verify the new error handling behavior.

**Error propagation and reliability improvements:**

* Changed `discover_group_slugs` in `desired_state.py` to return an error result if group discovery fails, instead of returning an empty set. This ensures that a directory failure cannot be mistaken for "no managed groups" and avoids silently disabling enforcement. [[1]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L209-R217) [[2]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L224-R232) [[3]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L239-R247)
* Updated the `_resolve` method in `application.py` to handle and propagate group discovery errors, aborting sync operations when group discovery fails.

**Testing and test infrastructure:**

* Added and updated integration and unit tests to verify that group discovery errors are correctly propagated and that sync operations are aborted when discovery fails. This includes new test cases for both user and platform sync scenarios. [[1]](diffhunk://#diff-a287c6ab9dd8b1b96cc07af295d44e0b01fd6b5b22e2da50ba4fb58eef1cfd71R454-R523) [[2]](diffhunk://#diff-4bd82121befcde7ed3f40346698466017ce69f4dee20cadc9791db2d8a8a4368R472-R510)
* Enhanced test fakes (`FakeDirectory`, test helpers) to support simulating group discovery errors via a new `list_groups_result` parameter. [[1]](diffhunk://#diff-384a0de4d5456504c8d30cfbc9c15750dd602ba707733fc546c65c5253bc9bf7R115-R123) [[2]](diffhunk://#diff-384a0de4d5456504c8d30cfbc9c15750dd602ba707733fc546c65c5253bc9bf7R179-R180) [[3]](diffhunk://#diff-4bd82121befcde7ed3f40346698466017ce69f4dee20cadc9791db2d8a8a4368R224-R230) [[4]](diffhunk://#diff-4bd82121befcde7ed3f40346698466017ce69f4dee20cadc9791db2d8a8a4368R294-R295) [[5]](diffhunk://#diff-4bd82121befcde7ed3f40346698466017ce69f4dee20cadc9791db2d8a8a4368R316) [[6]](diffhunk://#diff-4bd82121befcde7ed3f40346698466017ce69f4dee20cadc9791db2d8a8a4368R335)

**Documentation and backlog:**

* Updated documentation and backlog status to reflect that the issue (TASK-78) is resolved and to clarify the new error propagation behavior. [[1]](diffhunk://#diff-62b4ec33c09587777858f72267cbed4d772d53af2dd36b847be88ca826ac1e59L12-R13) [[2]](diffhunk://#diff-edb951062e7f8224def85cbc620ffd1c0626ed76d21a056e1b69676988d8f0d5L6-R13)

These changes collectively ensure that directory failures during group discovery are never mistaken for the absence of managed groups, improving the safety and reliability of the access sync process.