### PR TITLE
Feat/relocate managed group policy

### DIFF
--- a/.github/agents/implementation.agent.md
+++ b/.github/agents/implementation.agent.md
@@ -1,7 +1,7 @@
 ---
 name: implementation
 description: Implementation mode for features with pre-authored failing tests and approved architecture decisions.
-tools: ["search", "edit/editFiles", "execute/getTerminalOutput", "execute/runInTerminal", "read/terminalLastCommand", "read/terminalSelection", "execute/createAndRunTask", "agent"]
+tools: [vscode/askQuestions, vscode/memory, vscode/resolveMemoryFileUri, vscode/toolSearch, execute/getTerminalOutput, execute/createAndRunTask, execute/runInTerminal, read/terminalSelection, read/terminalLastCommand, read/readFile, agent, vscodeTasks/createAndRunTask, vscodeGeneral/usages, vscodeGeneral/toolSearch, edit/editFiles, search, web, todo]
 model: Auto (copilot)
 handoffs:
   - label: Return to Feature Architecture

--- a/app/infrastructure/directory/google.py
+++ b/app/infrastructure/directory/google.py
@@ -447,6 +447,7 @@ class GoogleDirectoryProvider:
                 name=item.get("name") or item.get("displayName"),
                 description=item.get("description"),
                 provider="google",
+                aliases=tuple(self._extract_group_aliases(item)),
             )
         )
 
@@ -486,6 +487,7 @@ class GoogleDirectoryProvider:
                 name=item.get("name") or item.get("displayName"),
                 description=item.get("description"),
                 provider="google",
+                aliases=tuple(self._extract_group_aliases(item)),
             )
         )
 

--- a/app/infrastructure/directory/models.py
+++ b/app/infrastructure/directory/models.py
@@ -42,7 +42,18 @@ class DirectoryMember:
 
 @dataclass(frozen=True)
 class DirectoryGroup:
-    """Canonical managed group returned by all directory providers."""
+    """Canonical managed group returned by all directory providers.
+
+    ``aliases`` holds the secondary addresses the identity provider reports as
+    routing to this group. It is a vendor-neutral fact, not a policy decision:
+    consumers decide which address is canonical, never this model. It never
+    repeats ``group_email``, and it is empty when the provider has no such
+    concept, so no consumer may treat a non-empty tuple as guaranteed.
+
+    Per-provider source: Google merges ``aliases[]`` and ``nonEditableAliases[]``;
+    Entra ID maps ``proxyAddresses`` with the primary ``SMTP:`` entry dropped and
+    the scheme prefix stripped.
+    """
 
     group_email: str
     group_slug: str
@@ -50,6 +61,7 @@ class DirectoryGroup:
     name: str | None = None
     description: str | None = None
     provider: str | None = None
+    aliases: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/app/tests/unit/infrastructure/directory/test_google.py
+++ b/app/tests/unit/infrastructure/directory/test_google.py
@@ -793,6 +793,68 @@ class TestGetGroup:
         assert not result.is_success
         assert result.error_code == "DIRECTORY_GROUP_PAYLOAD_INVALID"
 
+    def test_returns_merged_group_aliases_from_both_google_alias_fields(self, provider, google_service):
+        # Arrange
+        google_service.groups.return_value.get.return_value = _request(
+            {
+                "email": "sg-admin@example.com",
+                "id": "group-1",
+                "name": "Admins",
+                "aliases": ["Admin-Alias@Example.com", "admin-alias@example.com"],
+                "nonEditableAliases": [
+                    "admin-alias@example.com.test-google-a.com",
+                    "Legacy-Admins@Example.com",
+                ],
+            }
+        )
+
+        # Act
+        result = provider.get_group("sg-admin@example.com")
+
+        # Assert
+        assert result.is_success
+        assert result.data.aliases == (
+            "admin-alias@example.com",
+            "admin-alias@example.com.test-google-a.com",
+            "legacy-admins@example.com",
+        )
+        assert result.data.group_email == "sg-admin@example.com"
+
+    def test_returns_empty_aliases_when_payload_has_no_alias_fields(self, provider, google_service):
+        # Arrange
+        google_service.groups.return_value.get.return_value = _request(
+            {
+                "email": "sg-admin@example.com",
+                "id": "group-1",
+                "name": "Admins",
+            }
+        )
+
+        # Act
+        result = provider.get_group("sg-admin@example.com")
+
+        # Assert
+        assert result.is_success
+        assert result.data.aliases == ()
+
+    def test_ignores_malformed_alias_payload_values(self, provider, google_service):
+        # Arrange
+        google_service.groups.return_value.get.return_value = _request(
+            {
+                "email": "sg-admin@example.com",
+                "id": "group-1",
+                "aliases": "admin-alias@example.com",
+                "nonEditableAliases": [123, None, "  Ops-Alias@Example.com  "],
+            }
+        )
+
+        # Act
+        result = provider.get_group("sg-admin@example.com")
+
+        # Assert
+        assert result.is_success
+        assert result.data.aliases == ("ops-alias@example.com",)
+
 
 class TestAddGroupMember:
     def test_adds_member_and_returns_canonical_member(self, provider, google_service):
@@ -1101,6 +1163,7 @@ class TestListGroups:
                 name="FinOps",
                 description=None,
                 provider="google",
+                aliases=("sg-aws-finops@example.com",),
             )
         ]
 
@@ -1244,6 +1307,44 @@ class TestListGroups:
         assert result.is_success
         assert result.data[0].group_email == "aws-finops@example.com"
         assert result.data[0].group_slug == "aws-finops"
+
+    def test_empty_query_returns_group_aliases(self, provider, google_service):
+        # Arrange
+        _install_pages(
+            google_service.groups.return_value,
+            "groups",
+            [
+                [
+                    {
+                        "email": "aws-finops@example.com",
+                        "aliases": ["sg-aws-finops@example.com"],
+                        "nonEditableAliases": ["aws-finops@example.com.test-google-a.com"],
+                        "id": "group-10",
+                        "name": "FinOps",
+                    }
+                ]
+            ],
+        )
+
+        # Act
+        result = provider.list_groups(query="")
+
+        # Assert
+        assert result.is_success
+        assert result.data == [
+            DirectoryGroup(
+                group_email="aws-finops@example.com",
+                group_slug="aws-finops",
+                provider_group_id="group-10",
+                name="FinOps",
+                description=None,
+                provider="google",
+                aliases=(
+                    "sg-aws-finops@example.com",
+                    "aws-finops@example.com.test-google-a.com",
+                ),
+            )
+        ]
 
     def test_returns_empty_list_when_groups_key_is_empty(self, provider, google_service):
         # Arrange

--- a/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
+++ b/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:02'
+updated_date: '2026-09-04 14:25'
 labels:
   - layering
 milestone: m-3
@@ -48,9 +49,91 @@ NOT IN SCOPE: any Google vendor-mirror work; changing the DirectoryProvider Prot
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GoogleDirectoryProvider contains no managed-group prefix, alias-preference or managed-domain logic; grep for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix and _extract_managed_group_email returns zero hits under app/infrastructure/
-- [ ] #2 DIRECTORY_MANAGED_GROUP_PREFIX, DIRECTORY_MANAGED_GROUP_DOMAIN and DIRECTORY_ENFORCE_MANAGED_GROUP_EMAIL no longer live in DirectorySettings; the policy is owned by packages/access through its own settings partition
+- [ ] #1 GoogleDirectoryProvider contains no managed-group prefix, alias-preference or managed-domain logic; grep for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix and _extract_managed_group_email returns zero hits under app/infrastructure/, and _normalize_email no longer completes bare values with a group domain
+- [ ] #2 DIRECTORY_MANAGED_GROUP_PREFIX, DIRECTORY_MANAGED_GROUP_DOMAIN and DIRECTORY_ENFORCE_MANAGED_GROUP_EMAIL no longer exist anywhere: per plan decision D3 the prefix is derived from AccessRuntimeConfig naming rather than re-homed, the domain is owned by packages/access as AccessRuntimeConfig.dir_domain, and enforce_managed_group_email is deleted outright - with no duplicate second home created for any of them
 - [ ] #3 The chosen mechanism - feature-side filtering of generic results, or an injected policy strategy - is stated in the task notes with its rationale, rather than the branching simply moving up one layer
-- [ ] #4 packages/access/catalog and packages/access/sync retain their current observable behaviour, proven by their existing test suites passing with only the seam relocated
+- [ ] #4 packages/access/catalog, packages/access/sync and packages/access/request retain their current observable behaviour, proven by their existing test suites plus the new characterization tests the slices add (the managed path has no existing coverage - see plan fact F4)
 - [ ] #5 A group outside the managed domain is returned unchanged by the generic provider and rejected (or ignored) by the feature, with a test at the feature boundary rather than the infrastructure one
+- [ ] #6 All four subtasks TASK-76.1 through TASK-76.4 are Done and the DIRECTORY_MANAGED / MANAGED_GROUP grep across terraform, Makefile and app config returns zero hits at close
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+COORDINATOR TASK. Planned 2026-09-04. No code lands on TASK-76 itself; it holds the decisions and the slice sequence. Implementation happens in TASK-76.1 through TASK-76.4.
+
+## Decisions taken (human-approved 2026-09-04)
+
+D1. MECHANISM (satisfies AC#3): FEATURE-SIDE FILTERING, not an injected policy strategy.
+The DirectoryProvider is a portable capability meant to serve any business feature (decisions/layers.md: a portable capability's Protocol is capability-shaped and vendor-neutral). An injected strategy would leave the branching inside infrastructure and merely rename the coupling. Instead the provider becomes unconditionally generic and packages/access owns a ManagedGroupPolicy value object.
+Enabler: DirectoryGroup currently carries no aliases, so the feature cannot reproduce either alias preference (_extract_managed_group_email) or client-side alias prefix matching (_matches_managed_group_prefix) from what the Protocol returns. The model therefore gains aliases as a plain vendor-neutral FACT (what the IDP reports), while all POLICY (which alias is canonical, which prefix is managed, which domain is authoritative) moves to the feature. Adding a field to a frozen dataclass is not a change to the DirectoryProvider Protocol method set, so this stays inside the task's NOT-IN-SCOPE boundary.
+
+D2. BARE-EMAIL COMPLETION: option (a), the provider becomes STRICT.
+_normalize_email (google.py:211-220) today completes a bare local-part into an email using the managed group domain, and is applied to USER emails as well as group keys (lines 523, 751-752, 803-804, 834-835, 1064) - a group-scoped policy silently applied to user identifiers. That is exactly the leak this task exists to remove. After the cut the provider only strips/lowercases; every caller passes a fully-qualified key. Slug-to-email composition becomes a ManagedGroupPolicy responsibility on the access side. Verified safe for every live caller - see F7.
+
+D3. SETTINGS HOMES (satisfies AC#2), per decisions/configuration.md - one env var has exactly one owning class, settings live with the code they configure, no duplication:
+  - managed_group_prefix: DELETED, not moved. AccessRuntimeConfig.dir_prefix + dir_separator already produce this exact value through AccessGroupNaming.group_prefix (app/packages/access/common/naming.py:18-23). Moving it would create the second home configuration.md forbids.
+  - managed_group_domain: MOVED to AccessRuntimeConfig as dir_domain, alongside dir_prefix/dir_separator - NOT to an AccessSettings env var. It is the same class of fact as dir_prefix (the org's group-naming convention) and is loaded from the same runtime document; splitting one convention across two config mechanisms is the duplication configuration.md targets. It also avoids an SSM/terraform env rename.
+  - enforce_managed_group_email: DELETED outright. It defaults True, is unset everywhere, and its False branch is the silent-group-drop defect TASK-25.1.6.3 recorded as finding #4. After the cut, a group with no resolvable email is unconditionally an error.
+  - The residual DirectorySettings (provider, cache_ttl_seconds, warmup fields) is relocated from infrastructure/configuration/infrastructure/directory.py to app/infrastructure/directory/settings.py in the final slice, per configuration.md's rule that settings migration rides with whatever work already touches the domain rather than waiting for TASK-24.
+
+D4. RESEARCH OUTCOME on org-level domain ownership (asked for during planning).
+Both major IDPs model the set of domains an org owns as a DIRECTORY-LEVEL RESOURCE discovered from the platform, not as application configuration: Microsoft Graph exposes a domain resource per tenant with isVerified/isDefault/isRoot/isInitial (learn.microsoft.com/en-us/graph/api/resources/domain), and Google Admin SDK Directory exposes domains.list per customer (developers.google.com/workspace/admin/directory/reference/rest/v1/domains/list). The best-practice answer is therefore that owned/primary domains are an IDP-authoritative capability, not a hand-maintained constant - and this repo is already accumulating hand-maintained copies in three places: infrastructure/configuration/features/groups.py::GROUP_DOMAIN (legacy), DIRECTORY_MANAGED_GROUP_DOMAIN (this task), and the package-local approved-participant-domain setting from TASK-74/TASK-75. Those are NOT the same concept though: TASK-74's is an ALLOW-LIST policy (which external domains may participate), while this one is an IDENTITY fact (which domain we own). Because closing this properly needs a new DirectoryProvider capability (list_domains / primary_domain) plus a decision-record amendment, and this task explicitly excludes Protocol method-set changes, it is raised as sibling TASK-79 rather than absorbed here. TASK-76 deliberately parks dir_domain as feature-owned configuration in the meantime; TASK-79 is its eventual generic replacement.
+
+D5. DEFECT-CORRECTION POSTURE, added after the human clarified deployment status (see F6).
+packages/access is unreleased. Where current provider behaviour on the managed path is a latent defect rather than a working contract, the slices CORRECT it instead of faithfully porting it. Two named corrections: (i) an empty group domain must stop producing an unusable bare-slug group key - dir_domain is validated as required non-empty by the access runtime config, failing loudly at load rather than silently at the IDP call; (ii) the silent success(None) group drop disappears with enforce_managed_group_email (D3). AC#4 is therefore read as preserving INTENDED behaviour as expressed by tests, not as bug-compatible porting.
+
+## Grounding facts verified during planning
+
+F1. PRECONDITION MET. The _build_group / _build_managed_group split from TASK-25.1.6.3 has landed (google.py:420-451 generic, 453-493 managed). This is the seam.
+F2. THE MANAGED BRANCH IS INERT IN PRODUCTION. Re-verified 2026-09-04 by grepping terraform/, app/pyproject.toml, Makefile and app/Makefile for DIRECTORY_MANAGED / DIRECTORY_ENFORCE / MANAGED_GROUP: zero hits. managed_group_domain and managed_group_prefix default to empty string and enforce_managed_group_email defaults True. Consequences, which every slice depends on: (i) _managed_group_query_prefix always returns None today, so list_groups never takes the full-list-plus-client-filter path; (ii) _extract_managed_group_email always falls through to the primary email; (iii) _build_managed_group's domain check never rejects; (iv) _normalize_email's completion branch is DEAD CODE - with an empty domain it never fires. So _build_managed_group is observationally identical to _build_group today, and the relocation is a near-pure refactor in production terms. RE-RUN THIS GREP BEFORE EACH SLICE MERGES - if any environment has since set one of these, the risk assessment changes and the slice stops.
+F3. RESOLVED BY F6. The planning-time question of whether get_group(slug) with an empty dir_domain is broken in production is answered: the path is never exercised, so it is latent-broken. D5 corrects it rather than preserving it.
+F4. NO EXISTING TESTS cover the managed-group provider logic at all - coverage is limited to DirectorySettings env loading (tests/unit/infrastructure/configuration/test_directory_settings.py) and stubbed catalog/sync directory fakes. AC#4's existing suites therefore prove little on their own; each slice must add the missing characterization/behaviour tests rather than lean on them. New tests follow decisions/testing.md: unit tests with Protocol-conformant fakes for the policy and the feature services, provider mapping tests as unit tests over recorded Google payload dicts, no network, feature-boundary assertions rather than infrastructure-boundary ones (AC#5).
+F5. ACCESS CONSUMERS to carry across: catalog/service.py:144 list_groups(query=prefix); sync/desired_state.py:221 list_groups(query=prefix) and :130/:155 get_group(slug); request/service.py:187 get_group(slug); request/policies.py:93/102 get_group_members(group_email or fallback_slug); provider-side get_user_groups (google.py:1097) which filters to the managed domain via _build_managed_group.
+F6. DEPLOYMENT STATUS (human, 2026-09-04). packages/access is NOT enabled in any environment. It was in-development as the replacement for the frozen modules/provisioning feature, and the antipatterns found while building it are what triggered the wider rearchitecture. Consequences: (i) production risk for the access half of this work is zero, and F2's inertness is explained rather than coincidental; (ii) there is no rollout, env-migration or backward-compatibility burden for dir_domain, which strengthens D3's choice of AccessRuntimeConfig over an env var; (iii) latent defects on the access path may be corrected, not preserved (D5).
+F7. LIVE MODULE CONSUMERS ARE ALREADY ON THE PROVIDER, AND ARE ALREADY SAFE FOR D2. Correction to an earlier draft of this plan, which wrongly deferred D2's production impact to future tasks: TASK-25.1.6.4 is DONE and merged, so app/modules/ consumers call DirectoryProvider today. Enumerated and verified 2026-09-04, every one already passes a fully-qualified key, so removing _normalize_email's completion branch is a no-op for all of them:
+  - modules/permissions/handler.py:40 get_group_members(group_key), keys from AWS_ADMIN_GROUPS. Grep-verified: NO terraform or Makefile override exists, so the default ['sre-ifs@cds-snc.ca'] (infrastructure/configuration/features/aws_ops.py:28) is what every environment uses - a full email.
+  - modules/reports/google_groups.py:100 get_group_members(group.group_email) - provider-returned, fully qualified by construction.
+  - modules/dev/google.py:170-171 get_group_members / check_membership on resolved_group_email, which is first_group.group_email from a list_groups result (dev/google.py:143) - fully qualified.
+  - modules/provisioning/users.py calls list_users() with no key at all.
+  This is belt-and-braces on top of F2(iv): the completion branch is already dead code because the domain is empty everywhere. TASK-76.4 re-verifies this enumeration at merge time rather than trusting it.
+
+## Size gate
+
+Combined change spans the infrastructure model, the Google provider, two settings homes, three access subdomains and their tests - past the single-PR gate on file count and subsystem spread even though production behaviour is inert. Decomposed into four sequenced slices, each independently reviewable and green on merge, per the human's direction to use TASK-76 as coordinator. The slices stay separate despite the zero-risk finding because the gate exists for reviewability, and because each PR must be green on merge - which forbids stripping the infrastructure path before the feature owns it.
+
+## Slice sequence
+
+TASK-76.1 - Expose IDP group aliases on the canonical DirectoryGroup model. Infrastructure-only, purely additive, no behaviour change. Unblocks feature-side alias policy.
+TASK-76.2 - Introduce ManagedGroupPolicy and dir_domain in packages/access/common. Feature-only, additive, not yet wired into the services. Carries the AC#5 feature-boundary test and D5's required-domain validation.
+TASK-76.3 - Cut catalog, sync and request over to the generic provider path through ManagedGroupPolicy. The behaviour-bearing slice; carries AC#4.
+TASK-76.4 - Strip the managed-group policy and its settings out of infrastructure/directory and relocate the residual DirectorySettings to its target home. Subtractive cleanup; satisfies AC#1 and AC#2, and owns the F7 re-verification of the live module consumers.
+
+No temporary shims are required: because the provider keeps both mappers until TASK-76.4, slices 1 through 3 are additive and the old path stays live until the last slice removes it. TASK-76 is checked off and closed only once all four are done and the AC#1 grep returns zero.
+
+## Sibling-task impacts
+
+- TASK-25.1.6.5 (To Do) is the only open task needing an advisory: it migrates modules/provisioning/groups.py onto the batched provider surface, so its new call sites must pass fully-qualified keys and must not expect managed-domain filtering from get_user_groups. Advisory posted there.
+- TASK-25.1.6.4 and TASK-22.4 are DONE. No advisory belongs on completed work; the constraints that concerned them are carried forward here as F7 and enforced by TASK-76.4's own acceptance criteria instead.
+- TASK-79 (new) carries the IDP-authoritative owned-domains capability from D4.
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: task-planner
+created: 2026-09-04 14:20
+---
+PLANNED 2026-09-04. TASK-76 is now a COORDINATOR: the implementation plan holds the decisions (D1 feature-side policy, D2 strict provider keys, D3 settings homes with prefix deleted rather than moved, D4 owned-domains research, D5 defect-correction posture) and the work is decomposed into TASK-76.1 through TASK-76.4 under the single-PR size gate. Sibling TASK-79 was raised from the D4 research. Cross-task advisories were posted to TASK-25.1.6.4, TASK-25.1.6.5 and TASK-22.4. Do not implement against TASK-76 directly.
+---
+
+author: task-planner
+created: 2026-09-04 14:25
+---
+PLAN CORRECTED 2026-09-04. An earlier draft of this plan claimed D2's production impact would land on TASK-25.1.6.4 and TASK-25.1.6.5, and advisory comments were posted to TASK-25.1.6.4 and TASK-22.4. That was wrong on two counts and the human called it out: both of those tasks are DONE, so posting planning advisories there is noise on closed work, and the TASK-22.4 sequencing advice (prefer TASK-76.4 first) was impossible since that migration had already merged. Those two comments are being reverted via git.
+
+What the mistake actually surfaced, now folded into the plan as fact F7: because TASK-25.1.6.4 is merged, app/modules/ consumers are ALREADY on DirectoryProvider, so D2's strict-key change has live production reach today and TASK-76.4 must verify it rather than defer it. All four live call sites were enumerated and verified to pass fully-qualified keys already (AWS_ADMIN_GROUPS has no terraform override and defaults to a full email; the other three use provider-returned emails or no key at all), which is belt-and-braces on top of F2(iv) - the completion branch is dead code while the domain is empty. A new acceptance criterion on TASK-76.4 makes that re-verification a merge-time requirement.
+
+TASK-25.1.6.5 remains To Do and keeps its advisory; it is legitimately forward-looking work.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
+++ b/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:02'
-updated_date: '2026-09-04 14:25'
+updated_date: '2026-09-04 14:42'
 labels:
   - layering
 milestone: m-3
@@ -135,5 +135,21 @@ PLAN CORRECTED 2026-09-04. An earlier draft of this plan claimed D2's production
 What the mistake actually surfaced, now folded into the plan as fact F7: because TASK-25.1.6.4 is merged, app/modules/ consumers are ALREADY on DirectoryProvider, so D2's strict-key change has live production reach today and TASK-76.4 must verify it rather than defer it. All four live call sites were enumerated and verified to pass fully-qualified keys already (AWS_ADMIN_GROUPS has no terraform override and defaults to a full email; the other three use provider-returned emails or no key at all), which is belt-and-braces on top of F2(iv) - the completion branch is dead code while the domain is empty. A new acceptance criterion on TASK-76.4 makes that re-verification a merge-time requirement.
 
 TASK-25.1.6.5 remains To Do and keeps its advisory; it is legitimately forward-looking work.
+---
+
+created: 2026-09-04 14:42
+---
+PLAN FACT F4 IS INACCURATE - correction from planning TASK-76.1 (2026-09-04).
+
+F4 states there are NO existing tests covering the managed-group provider logic. There are. app/tests/unit/infrastructure/directory/test_google.py (1755 lines) exercises the managed path directly: the mock_directory_settings fixture (lines 135-142) sets managed_group_prefix='sg-' and managed_group_domain='example.com', so the provider fixture runs with managed policy ACTIVE, unlike every deployed environment (F2). Concretely covered today: managed-alias preference (line 1075), managed-domain mismatch returning DIRECTORY_GROUP_DOMAIN_MISMATCH (line 1119), alias-aware discovery skipping a group with no email (line 1108), and the generic empty-query mapping path including the outside-the-managed-domain case (lines 1200+).
+
+WHAT THIS CHANGES FOR THE REMAINING SLICES:
+- TASK-76.3 and TASK-76.4 must RELOCATE these existing assertions to the feature boundary (AC#5), not author characterization tests from scratch as F4 implies. The behaviour is already pinned; the question is where it is pinned.
+- TASK-76.1 must UPDATE an existing assertion, not only add new ones: test_google.py:1075 asserts full DirectoryGroup equality against a payload carrying aliases.
+- AC#4's reliance on 'existing test suites' is stronger than F4 credited for the provider half, and unchanged (weak) for the packages/access half.
+
+What F4 got right: there is no coverage of the managed path at the FEATURE boundary, and no coverage of DirectorySettings' managed fields beyond env loading. The gap is one of placement, not of existence.
+
+R1 RESEARCH OUTCOME feeding D1 (from TASK-76.1 planning, human-raised): group aliases are not a Google-only concept, so putting them on the canonical model does not couple infrastructure to one IDP. Google exposes aliases[]/nonEditableAliases[]; Microsoft Graph exposes proxyAddresses ('Email addresses for the group that direct to the same group mailbox', uppercase SMTP: marking the primary); an IDP without the concept returns empty. Full citations and the per-provider mapping obligation are in TASK-76.1's plan.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
+++ b/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-76.1
 title: Expose IDP-reported group aliases on the canonical DirectoryGroup model
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-04 14:17'
-updated_date: '2026-09-04 14:57'
+updated_date: '2026-09-04 15:02'
 labels:
   - layering
 milestone: m-3

--- a/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
+++ b/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
@@ -4,6 +4,7 @@ title: Expose IDP-reported group aliases on the canonical DirectoryGroup model
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:17'
+updated_date: '2026-09-04 14:42'
 labels:
   - layering
 milestone: m-3
@@ -39,4 +40,97 @@ TESTING (decisions/testing.md). Unit tests over recorded Google group payload di
 - [ ] #3 Unit tests at the mapper seam cover a group with aliases, a group without aliases, and confirm no other DirectoryGroup field changed
 - [ ] #4 No managed-group policy or setting is added, removed or relocated by this slice, and no file under app/packages/ is modified
 - [ ] #5 mypy, ruff and the full non-smoke pytest run are green
+- [ ] #6 DirectoryGroup.aliases is documented as a vendor-neutral fact with its per-IDP source named (Google aliases[] + nonEditableAliases[]; Entra proxyAddresses minus the primary SMTP: entry; empty tuple when the IDP has no such concept) and stated never to repeat group_email, so a future entra_id provider inherits a stated obligation rather than a Google-shaped signature
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+SLICE 1 of TASK-76 (coordinator decision D1). Planned 2026-09-04. Infrastructure-only, purely additive, no production behaviour change.
+
+## R1 - Cross-IDP research (raised during planning: is "aliases" a Google-only signature?)
+
+The objection was that a shared infrastructure capability must not adopt a single vendor's shape and then have business features build on it. Verified against vendor docs 2026-09-04:
+
+- GOOGLE (Admin SDK Directory, Group resource): aliases[] - "Read-only. The list of a group's alias email addresses"; nonEditableAliases[] - "the group's non-editable alias email addresses that are outside of the account's primary domain or subdomains. These are functioning email addresses used by the group". Source: developers.google.com/workspace/admin/directory/reference/rest/v1/groups
+- MICROSOFT ENTRA ID (Graph v1.0, group resource) - the DIRECTORY_PROVIDER='entra_id' branch already declared in DirectorySettings: proxyAddresses, String collection, "Email addresses for the group that direct to the same group mailbox. For example: [\"SMTP: bob@contoso.com\", \"smtp: bob@sales.contoso.com\"]". Returned by default, read-only, not nullable. Uppercase 'SMTP:' marks the primary (what the 'mail' property reports); lowercase 'smtp:' entries are the secondaries. Source: learn.microsoft.com/en-us/graph/api/resources/group
+
+CONCLUSION: 'additional email addresses that route to this group' is a cross-vendor directory FACT, not a Google artefact, so a single vendor-neutral field on the canonical model is safe. Per-provider mapping obligation:
+- Google -> aliases[] + nonEditableAliases[]
+- Entra -> proxyAddresses, dropping the uppercase 'SMTP:' primary and stripping the scheme prefix
+- An IDP with no such concept (Okta groups carry no mail aliases) -> the empty default
+
+DOWNSTREAM IMPACT IF A PROVIDER CANNOT SUPPLY IT: the field defaults to (), and TASK-76.2's ManagedGroupPolicy then sees only the primary email - which is exactly the behaviour that provider would have had regardless. No consumer may treat a non-empty aliases tuple as required. That obligation is written into the model docstring rather than left to be inferred, so a future entra_id provider inherits a stated contract.
+
+## Decisions for this slice
+
+D-76.1-a. ONE MERGED FIELD, not two: aliases: tuple[str, ...] = (). Google's two lists are merged exactly as _extract_group_aliases already merges them. No consumer distinguishes them - TASK-76.2's policy filters by prefix AND domain, which already excludes the nonEditableAliases domain-mirrors - and Entra's proxyAddresses has no equivalent split. A separate non_editable_aliases field would be a Google-shaped field with zero consumers, i.e. precisely the coupling R1 was asked to avoid.
+
+D-76.1-b. CONTRACT: aliases holds SECONDARY addresses only; group_email is never repeated in the tuple. True for Google by construction (aliases[] excludes the primary); stated explicitly so the Entra mapping knows to drop the uppercase SMTP: entry.
+
+D-76.1-c. NORMALIZATION UNCHANGED (human-confirmed during planning). _extract_group_aliases keeps routing through _normalize_email, including its bare-local-part -> {slug}@{domain} completion that TASK-76.4/D2 deletes. Per coordinator fact F2(iv) that branch is dead code (managed domain is empty in every environment), so alias values are strip+lower in practice. Honours AC#2's 'identical normalization'.
+
+D-76.1-d. Tuple, not list or frozenset: keeps DirectoryGroup frozen-hashable and preserves IDP-reported order, which TASK-76.2's alias-preference policy iterates deterministically.
+
+## Grounding facts verified 2026-09-04
+
+F-a. CORRECTION TO COORDINATOR FACT F4. TASK-76's plan states no existing tests cover the managed-group provider logic. That is wrong. app/tests/unit/infrastructure/directory/test_google.py (1755 lines) exercises it directly: the mock_directory_settings fixture (lines 135-142) sets managed_group_prefix='sg-' and managed_group_domain='example.com', and there are tests for managed-alias preference (line 1075), domain mismatch (line 1119), alias-aware discovery skips (line 1108) and generic empty-query mapping (line 1200+). Consequences: (i) this slice must UPDATE an existing assertion, not only add new ones; (ii) TASK-76.3/76.4 must RELOCATE these assertions to the feature boundary rather than author characterization tests from scratch. Correction posted as a comment on TASK-76.
+
+F-b. FOUR MAPPER CALL SITES, all inside app/infrastructure/directory/google.py: get_group -> _build_managed_group (723); list_groups -> map_fn, which is _build_group on the empty-query path (895) and _build_managed_group otherwise (921), applied at 947; get_user_groups -> _build_managed_group (1097). Both mappers construct DirectoryGroup at 443 and 482 respectively. Populating both mappers therefore covers every path.
+
+F-c. NO OTHER DirectoryGroup PRODUCER EXISTS. grep 'DirectoryGroup(' finds constructions only in google.py (2) and test files (9). infrastructure/directory/ contains no entra_id implementation yet (files: __init__.py, factory.py, google.py, models.py, provider.py). Nothing under app/packages/ or app/modules/ constructs one.
+
+F-d. NO SERIALIZATION OR PERSISTENCE OF DirectoryGroup. No asdict/model_dump/store write of the dataclass exists, so an added field cannot break a stored shape or a cache key.
+
+F-e. ALL TEST CONSTRUCTIONS USE KEYWORD ARGUMENTS, so an appended defaulted field breaks none of them. Only one test asserts full DirectoryGroup equality against a payload that carries aliases: test_google.py:1075 test_prefers_managed_alias_when_primary_email_uses_old_pattern. test_google.py:1224 uses the same alias payload but asserts only group_email/group_slug, so it is unaffected.
+
+F-f. NO CONFLICT WITH THE OPEN 25.1.6 CHAIN. TASK-25.1.6.5 is the only sibling still To Do that touches Directory; its scope is modules/provisioning/groups.py, deletion of integrations/google_workspace/google_directory.py and retirement of integrations/utils/api.py::retry_request. It neither reads nor constructs DirectoryGroup mappers. Nothing in this slice affects decisions/sdk-typing.md convergence: the mappers already take dict[str, Any] from the stub-typed discovery Resource and this slice adds no vendor type to any signature.
+
+## Ordered steps
+
+STEP 1 (AC#1, AC#6) - app/infrastructure/directory/models.py, DirectoryGroup (line 44).
+Add 'aliases: tuple[str, ...] = ()' as the last field so every existing keyword construction stays valid. Extend the class docstring with the vendor-neutral contract from R1/D-76.1-b: secondary routing addresses reported by the IDP, never including group_email, empty when the provider has no such concept, with the Google and Entra source properties named. Dataclass stays frozen.
+
+STEP 2 (AC#2) - app/infrastructure/directory/google.py.
+In _build_group (443) and _build_managed_group (482), pass aliases=tuple(self._extract_group_aliases(item)). Reuse _extract_group_aliases (253-266) untouched, so ordering, dedup and normalization are byte-identical to what the managed policy consumes today (D-76.1-c). No other line in either mapper changes; no settings are read that were not already read.
+
+STEP 3 (AC#3) - app/tests/unit/infrastructure/directory/test_google.py:1075.
+Update test_prefers_managed_alias_when_primary_email_uses_old_pattern's expected DirectoryGroup to carry aliases=('sg-aws-finops@example.com',). This is the F-e break and the proof the managed mapper now surfaces the fact it previously consumed and discarded.
+
+STEP 4 (AC#3) - same file, new tests (matrix below). Both mappers get seam coverage: _build_managed_group through TestGetGroup, _build_group through TestListGroups' empty-query path.
+
+STEP 5 (AC#4, AC#5) - validation and boundary check. Run the gates; confirm git status shows changes only under app/infrastructure/directory/ and app/tests/unit/infrastructure/directory/, with nothing under app/packages/ and no settings file touched.
+
+## Test matrix (all in app/tests/unit/infrastructure/directory/test_google.py - unit layer, no network, MagicMock discovery service already in place per decisions/testing.md)
+
+| Case | Test | Mapper | AC |
+| Happy - both Google alias lists merged in order, deduped, lowercased | TestGetGroup::test_returns_merged_group_aliases_from_both_google_alias_fields | _build_managed_group | 2,3 |
+| Happy - generic path surfaces aliases too, asserted by full DirectoryGroup equality so no other field changed | TestListGroups::test_empty_query_returns_group_aliases | _build_group | 2,3 |
+| Boundary - payload with no alias keys yields the empty tuple | TestGetGroup::test_returns_empty_aliases_when_payload_has_no_alias_fields | _build_managed_group | 1,3 |
+| Boundary - non-list alias value and non-string entries are ignored rather than raising | TestGetGroup::test_ignores_malformed_alias_payload_values | _build_managed_group | 2,3 |
+| Regression - managed alias preference still resolves canonical email AND now reports the alias | existing test at line 1075, updated | _build_managed_group | 2,3 |
+
+No new test file is created: test_google.py is the feature-prefixed home for this seam and already carries the fixtures.
+
+## Assumptions and how they were verified
+
+A1. No consumer constructs DirectoryGroup positionally or relies on its field count -> grep 'DirectoryGroup(' across app/ (F-c, F-e). Re-run before merge.
+A2. No stored/serialized representation of DirectoryGroup exists -> F-d. Re-run before merge.
+A3. Adding a field to a model does not affect the runtime_checkable DirectoryProvider Protocol, which constrains methods, not model fields.
+A4. COORDINATOR-MANDATED PRE-MERGE CHECK (TASK-76 F2): grep terraform/, app/pyproject.toml, Makefile and app/Makefile for DIRECTORY_MANAGED / DIRECTORY_ENFORCE / MANAGED_GROUP and confirm zero hits. If any environment has since set one, stop and re-assess: the managed path would no longer be inert and _extract_group_aliases' domain completion would start firing.
+
+## Blast radius and rollback
+
+Additive, defaulted field plus one keyword argument in two mapper call sites. No new settings, no env vars, no terraform, no CI change, no ordering constraint with any other PR. Worst case is a mis-mapped alias tuple that nothing reads yet, since the first consumer lands in TASK-76.2. A single git revert fully restores prior behaviour. Blast radius is bounded to app/infrastructure/directory/ plus one test file.
+
+## Size gate
+
+Approximately 6 production LOC across 2 files (models.py, google.py); roughly 70 test LOC in 1 existing test file. One subsystem, purely additive, no refactor mixed with behaviour. Comfortably inside the single-PR gate; no further decomposition needed.
+
+## Sibling impacts (advisories posted)
+
+- TASK-76 - F4 correction (F-a above).
+- TASK-76.2 - consumes the field; contract and Entra mapping obligation recorded here.
+- TASK-76.4 - must relocate the existing managed-path assertions listed in F-a to the feature boundary, and its D2 removal of _normalize_email's completion branch also changes how aliases are normalized (a no-op while the managed domain is empty).
+- TASK-25.1.6.5 - no impact (F-f); no advisory needed.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
+++ b/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
@@ -1,0 +1,42 @@
+---
+id: TASK-76.1
+title: Expose IDP-reported group aliases on the canonical DirectoryGroup model
+status: To Do
+assignee: []
+created_date: '2026-09-04 14:17'
+labels:
+  - layering
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-76
+priority: medium
+ordinal: 148000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 1 of TASK-76 (see the coordinator plan, decision D1). Infrastructure-only, purely additive, no behaviour change.
+
+WHY. packages/access cannot own managed-group policy while the only alias information the IDP returns is consumed and discarded inside GoogleDirectoryProvider. _extract_managed_group_email (app/infrastructure/directory/google.py:269-285) picks a canonical email by preferring an alias with the managed prefix, and _matches_managed_group_prefix (google.py:306-313) filters on aliases - both read _extract_group_aliases (google.py:~255-266) and neither surfaces the aliases to the caller. DirectoryGroup (app/infrastructure/directory/models.py) has no aliases field, so a feature-side policy is impossible to write without this slice.
+
+FACT vs POLICY. The aliases a directory reports for a group are a vendor-neutral FACT about the group, in the same class as name and description, and belong on the canonical model. Which alias is canonical, which prefix is managed and which domain is authoritative are POLICY and are NOT part of this slice - they stay where they are until TASK-76.3 cuts over and TASK-76.4 deletes them.
+
+SCOPE.
+- Add aliases: tuple[str, ...] = () to the frozen DirectoryGroup dataclass. Tuple, not list, to keep the dataclass hashable and immutable per the type-model boundary rules.
+- Populate it in BOTH _build_group (google.py:420-451) and _build_managed_group (google.py:453-493), reusing the existing _extract_group_aliases helper. Normalization must match what the existing alias logic assumes (stripped, lowercased) so TASK-76.2's policy sees the same values the provider does today.
+- Add the missing provider mapping unit tests (per TASK-76 plan fact F4 there are none today).
+
+NOT IN SCOPE. Any change to DirectoryProvider's method set; any removal or relocation of managed-group policy or settings; any change in packages/access.
+
+TESTING (decisions/testing.md). Unit tests over recorded Google group payload dicts at the mapper seam: a group with aliases populates them in order; a group with no aliases yields an empty tuple; existing group fields are unchanged. No network, no moto needed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 DirectoryGroup carries aliases as an immutable tuple field defaulting to empty, and remains a frozen dataclass
+- [ ] #2 Both _build_group and _build_managed_group populate aliases from the provider payload using the existing extraction helper, with identical normalization to the current alias logic
+- [ ] #3 Unit tests at the mapper seam cover a group with aliases, a group without aliases, and confirm no other DirectoryGroup field changed
+- [ ] #4 No managed-group policy or setting is added, removed or relocated by this slice, and no file under app/packages/ is modified
+- [ ] #5 mypy, ruff and the full non-smoke pytest run are green
+<!-- AC:END -->

--- a/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
+++ b/backlog/tasks/task-76.1 - Expose-IDP-reported-group-aliases-on-the-canonical-DirectoryGroup-model.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-76.1
 title: Expose IDP-reported group aliases on the canonical DirectoryGroup model
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-04 14:17'
-updated_date: '2026-09-04 14:42'
+updated_date: '2026-09-04 14:57'
 labels:
   - layering
 milestone: m-3
@@ -35,12 +36,12 @@ TESTING (decisions/testing.md). Unit tests over recorded Google group payload di
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 DirectoryGroup carries aliases as an immutable tuple field defaulting to empty, and remains a frozen dataclass
-- [ ] #2 Both _build_group and _build_managed_group populate aliases from the provider payload using the existing extraction helper, with identical normalization to the current alias logic
-- [ ] #3 Unit tests at the mapper seam cover a group with aliases, a group without aliases, and confirm no other DirectoryGroup field changed
-- [ ] #4 No managed-group policy or setting is added, removed or relocated by this slice, and no file under app/packages/ is modified
-- [ ] #5 mypy, ruff and the full non-smoke pytest run are green
-- [ ] #6 DirectoryGroup.aliases is documented as a vendor-neutral fact with its per-IDP source named (Google aliases[] + nonEditableAliases[]; Entra proxyAddresses minus the primary SMTP: entry; empty tuple when the IDP has no such concept) and stated never to repeat group_email, so a future entra_id provider inherits a stated obligation rather than a Google-shaped signature
+- [x] #1 DirectoryGroup carries aliases as an immutable tuple field defaulting to empty, and remains a frozen dataclass
+- [x] #2 Both _build_group and _build_managed_group populate aliases from the provider payload using the existing extraction helper, with identical normalization to the current alias logic
+- [x] #3 Unit tests at the mapper seam cover a group with aliases, a group without aliases, and confirm no other DirectoryGroup field changed
+- [x] #4 No managed-group policy or setting is added, removed or relocated by this slice, and no file under app/packages/ is modified
+- [x] #5 mypy, ruff and the full non-smoke pytest run are green
+- [x] #6 DirectoryGroup.aliases is documented as a vendor-neutral fact with its per-IDP source named (Google aliases[] + nonEditableAliases[]; Entra proxyAddresses minus the primary SMTP: entry; empty tuple when the IDP has no such concept) and stated never to repeat group_email, so a future entra_id provider inherits a stated obligation rather than a Google-shaped signature
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -134,3 +135,24 @@ Approximately 6 production LOC across 2 files (models.py, google.py); roughly 70
 - TASK-76.4 - must relocate the existing managed-path assertions listed in F-a to the feature boundary, and its D2 removal of _normalize_email's completion branch also changes how aliases are normalized (a no-op while the managed domain is empty).
 - TASK-25.1.6.5 - no impact (F-f); no advisory needed.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED (2026-09-04). Slice 1 of TASK-76: additive only, no behaviour change.
+
+PRODUCTION CHANGES (2 files, 4 LOC):
+- infrastructure/directory/models.py: DirectoryGroup gains 'aliases: tuple[str, ...] = ()' as the last field (keeps all existing keyword constructions valid, dataclass stays frozen/hashable). Docstring extended with the vendor-neutral contract: secondary routing addresses reported by the IDP, never repeating group_email, empty when the provider has no such concept; per-provider source named for Google (aliases[] + nonEditableAliases[]) and Entra (proxyAddresses minus the primary SMTP: entry).
+- infrastructure/directory/google.py: both _build_group and _build_managed_group now pass aliases=tuple(self._extract_group_aliases(item)). The helper is untouched, so ordering, dedup and normalization are byte-identical to what the managed-group policy consumes today.
+
+TEST EVIDENCE (tests were pre-authored on the branch):
+- tests/unit/infrastructure/directory/test_google.py TestGetGroup: merged-both-alias-lists, empty-when-no-alias-keys, malformed-payload-values-ignored (_build_managed_group seam).
+- TestListGroups::test_empty_query_returns_group_aliases asserts full DirectoryGroup equality on the empty-query path, proving _build_group populates aliases and no other field changed.
+- Existing test_prefers_managed_alias_when_primary_email_uses_old_pattern updated to expect aliases=('sg-aws-finops@example.com',).
+
+VALIDATION: tests/unit/infrastructure/directory -> 103 passed. ruff check . -> All checks passed. mypy infrastructure/directory -> 1 error, PRE-EXISTING and unrelated (google.py:923 map_fn reassignment variance between _build_group and _build_managed_group return types; not introduced by this slice). Full 'make test' run by the human -> all green.
+
+BOUNDARY CHECK (AC#4): no settings added/removed/relocated, no managed-group policy moved, nothing under app/packages/ touched.
+
+FOR HUMAN VERIFICATION (DoD): confirm the aliases contract wording in the DirectoryGroup docstring is the obligation you want a future entra_id provider to inherit; nothing consumes the field yet (first consumer lands in TASK-76.2).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
+++ b/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
@@ -1,0 +1,52 @@
+---
+id: TASK-76.2
+title: Introduce ManagedGroupPolicy and dir_domain in packages/access/common
+status: To Do
+assignee: []
+created_date: '2026-09-04 14:17'
+labels:
+  - layering
+milestone: m-3
+dependencies:
+  - TASK-76.1
+parent_task_id: TASK-76
+priority: medium
+ordinal: 149000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 2 of TASK-76 (see the coordinator plan, decisions D1, D3, D5). Feature-only, additive; the new policy is not yet wired into the services - TASK-76.3 does that.
+
+WHY. Per D1 the DirectoryProvider becomes unconditionally generic and packages/access owns the managed-group policy. This slice builds that owner and its configuration so the cutover slice is a pure call-site change.
+
+SCOPE.
+
+1. New app/packages/access/common/group_policy.py holding a frozen dataclass ManagedGroupPolicy - a pure value object, no I/O, no infrastructure imports beyond the DirectoryGroup model. It belongs in common/ because catalog, sync and request all consume it (decisions/feature-packages.md: common/ admits types with two or more subdomain consumers and no I/O). Responsibilities, each replacing one piece of provider logic:
+   - canonical_email(group) - alias preference, replacing _extract_managed_group_email (google.py:269-285). Prefers an alias whose local part starts with the managed prefix AND whose domain is the managed domain; falls back to the group's primary email.
+   - canonical_slug(group) - the local part of the canonical email, replacing the slug derivation currently baked into the mappers.
+   - is_managed(group) - domain enforcement, replacing the DIRECTORY_GROUP_DOMAIN_MISMATCH branch in _build_managed_group (google.py:466-471). Returns a boolean; the feature decides whether a non-match is an error or an omission (see AC below).
+   - matches_prefix(group, prefix) - alias-aware prefix matching, replacing _matches_managed_group_prefix (google.py:306-313).
+   - group_key(slug) - slug-to-email composition, replacing the group half of _normalize_email (google.py:211-220) per D2.
+   Construct it from AccessRuntimeConfig so the prefix comes from the existing AccessGroupNaming path (dir_prefix + dir_separator) and is NOT duplicated as its own setting (D3).
+
+2. AccessRuntimeConfig (app/packages/access/common/config/settings.py) gains dir_domain alongside dir_prefix and dir_separator, plus whatever loader/bundle schema and fixtures carry the document. Per D5 it is REQUIRED and validated non-empty at load: an empty domain is what makes group_key produce an unusable bare slug today, and access is unreleased (plan fact F6) so there is no compatibility burden in tightening this. Failing loudly at config load beats failing opaquely at the IDP call.
+
+3. Do NOT add an AccessSettings env var for the domain, and do NOT re-home managed_group_prefix or enforce_managed_group_email - D3 deletes both. Nothing in this slice may create a second home for a value that already exists (decisions/configuration.md).
+
+NOT IN SCOPE. Wiring the policy into catalog/sync/request (TASK-76.3). Any change under app/infrastructure/ (TASK-76.4).
+
+TESTING (decisions/testing.md). Pure unit tests, no doubles needed for a value object. Cover: alias preference wins over primary email; alias with the right prefix but wrong domain is not preferred; no matching alias falls back to primary; is_managed rejects an out-of-domain group (this is the AC#5 feature-boundary test the parent task requires); matches_prefix hits on an alias as well as on the primary email; group_key composes slug plus domain; AccessRuntimeConfig with a missing or blank dir_domain fails validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ManagedGroupPolicy exists in app/packages/access/common as a frozen dataclass with no I/O and no imports from app/integrations, exposing canonical email, canonical slug, managed-domain check, alias-aware prefix match and slug-to-key composition
+- [ ] #2 The managed prefix is derived from the existing AccessRuntimeConfig naming (dir_prefix plus dir_separator) and is not introduced as a new setting anywhere
+- [ ] #3 AccessRuntimeConfig carries dir_domain, validated as required and non-empty, with loader/bundle/fixture plumbing updated; no ACCESS_ env var and no infrastructure setting is added for it
+- [ ] #4 A DirectoryGroup whose email is outside the managed domain is rejected by ManagedGroupPolicy, proven by a unit test at the feature boundary (parent AC#5)
+- [ ] #5 Unit tests cover alias preference including the wrong-domain-alias case, primary-email fallback, alias-based prefix matching, key composition, and blank dir_domain failing validation
+- [ ] #6 No file under app/infrastructure/ is modified by this slice
+- [ ] #7 mypy, ruff and the full non-smoke pytest run are green
+<!-- AC:END -->

--- a/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
+++ b/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
@@ -4,6 +4,7 @@ title: Introduce ManagedGroupPolicy and dir_domain in packages/access/common
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:17'
+updated_date: '2026-09-04 14:42'
 labels:
   - layering
 milestone: m-3
@@ -50,3 +51,21 @@ TESTING (decisions/testing.md). Pure unit tests, no doubles needed for a value o
 - [ ] #6 No file under app/infrastructure/ is modified by this slice
 - [ ] #7 mypy, ruff and the full non-smoke pytest run are green
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-04 14:42
+---
+ADVISORY from TASK-76.1 planning (2026-09-04).
+
+The enabler you depend on is now specified. DirectoryGroup gains 'aliases: tuple[str, ...] = ()' - IDP-reported SECONDARY routing addresses, never repeating group_email, normalized strip+lower, in IDP-reported order with duplicates removed. It is populated by BOTH the generic and managed Google mappers, so ManagedGroupPolicy sees the same alias values _extract_managed_group_email and _matches_managed_group_prefix consume inside the provider today.
+
+THREE CONSTRAINTS FOR YOUR POLICY:
+1. Treat an empty tuple as legitimate, never as an error: an IDP with no alias concept (Okta) or a provider that has not implemented the mapping returns (). The policy must then fall back to the primary email, which is what today's _extract_managed_group_email does anyway when no alias matches the prefix.
+2. Alias ORDER is the IDP's, and Google's merge puts editable aliases[] before nonEditableAliases[]. If your alias-preference rule needs determinism beyond 'first match wins on the provider's order', state the ordering rule explicitly in the policy rather than relying on the tuple.
+3. nonEditableAliases (domain-mirror addresses outside the primary domain, e.g. the *.test-google-a.com forms) are merged into the same tuple. Your prefix+domain filter is what excludes them - a prefix-only match would let them through, which the provider's current logic also guards against by checking the domain.
+
+Also relevant to your dir_domain work: TASK-76.1's research confirmed both major IDPs expose group aliases (Google aliases[]/nonEditableAliases[]; Entra proxyAddresses), so the policy's alias handling is portable - but the OWNED-DOMAIN question remains hand-maintained configuration until TASK-79 lands, exactly as coordinator decision D4 records.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -1,0 +1,48 @@
+---
+id: TASK-76.3
+title: 'Cut access catalog, sync and request onto the generic DirectoryProvider path'
+status: To Do
+assignee: []
+created_date: '2026-09-04 14:18'
+labels:
+  - layering
+milestone: m-3
+dependencies:
+  - TASK-76.2
+parent_task_id: TASK-76
+priority: medium
+ordinal: 150000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 3 of TASK-76 (see the coordinator plan, decisions D1, D2, D5). The behaviour-bearing slice. Feature-only: after it, packages/access no longer relies on any managed-group behaviour from the provider, but the provider still carries that behaviour unused until TASK-76.4 deletes it. That is what keeps this PR green on its own without a shim.
+
+CALL SITES to move (plan fact F5), each through ManagedGroupPolicy from TASK-76.2:
+- app/packages/access/catalog/service.py:144 - list_groups(query=prefix) becomes a generic listing plus policy.matches_prefix filtering, with policy.canonical_slug driving the slug the entitlement derivation uses (service.py:157 onward). Note the prefix query path is inert today (plan fact F2) so the server-side-query-to-client-filter change is not a regression.
+- app/packages/access/sync/desired_state.py:221 discover_group_slugs - same treatment. Careful: TASK-78 recently changed this method to return OperationResult and propagate list_groups failures. Preserve that contract exactly; do not reintroduce an empty-set fallback.
+- app/packages/access/sync/desired_state.py:130 and :155 - get_group(slug) becomes get_group(policy.group_key(slug)).
+- app/packages/access/request/service.py:187 - same get_group key composition.
+- app/packages/access/request/policies.py:93 and :102 - get_group_members already passes a full group_email at :93; the fallback_slug at :102 must be composed through policy.group_key.
+- get_user_groups: the provider currently filters results to the managed domain via _build_managed_group (google.py:1097). That filter moves to the access consumer through policy.is_managed. Identify every access-side consumer of get_user_groups before changing it and cover each.
+
+DECISION TO MAKE AND RECORD IN NOTES: whether an out-of-domain group is an ERROR or an OMISSION at each feature call site. The provider today returns DIRECTORY_GROUP_DOMAIN_MISMATCH (a hard error) from the mapper, which for a LIST operation means one stray group fails the whole listing. Parent AC#5 explicitly allows either rejected or ignored. Recommended and to be confirmed during implementation: OMIT with a warning log for list-shaped operations (discovery must not be taken down by one unrelated group), ERROR for get-shaped operations (an explicitly requested group being out of domain is a real fault). State the choice and rationale in the notes.
+
+PERFORMANCE. Generic listing plus client-side filtering fetches every group and filters locally. This is not a regression: the managed path already did exactly that (full unfiltered list plus _matches_managed_group_prefix), and per plan fact F2 the server-side query path is the one in use today. If the unfiltered listing is judged too costly for catalog and sync, raise it as a follow-up rather than reintroducing provider-side policy.
+
+NOT IN SCOPE. Deleting anything under app/infrastructure/ (TASK-76.4). Touching app/modules/provisioning, which is frozen under decisions/migration.md rule 1.
+
+TESTING (decisions/testing.md). Protocol-conformant fakes for DirectoryProvider - not MagicMock - returning DirectoryGroup values including aliases and out-of-domain entries. Assertions at the feature boundary: catalog entitlement listing, sync discovery and platform state, request submission. Keep the existing access suites green; where an existing test asserted provider-side managed behaviour, move that assertion to the feature boundary rather than deleting it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 catalog, sync and request obtain canonical group email, slug, prefix matching and group keys exclusively through ManagedGroupPolicy; no access-side call passes a bare slug to DirectoryProvider
+- [ ] #2 sync discover_group_slugs keeps the OperationResult failure-propagation contract introduced by TASK-78, with a test proving an IDP failure still propagates rather than yielding an empty set
+- [ ] #3 The error-versus-omission decision for out-of-domain groups is made per call-site shape, implemented, and recorded with its rationale in the task notes
+- [ ] #4 Every access-side consumer of get_user_groups applies the managed-domain filter feature-side, covered by tests
+- [ ] #5 The existing access catalog, sync and request suites pass, with any provider-side managed assertions relocated to the feature boundary rather than dropped
+- [ ] #6 No file under app/infrastructure/ and no file under app/modules/ is modified by this slice
+- [ ] #7 mypy, ruff and the full non-smoke pytest run are green
+<!-- AC:END -->

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -4,6 +4,7 @@ title: 'Cut access catalog, sync and request onto the generic DirectoryProvider 
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:18'
+updated_date: '2026-09-04 14:43'
 labels:
   - layering
 milestone: m-3
@@ -46,3 +47,14 @@ TESTING (decisions/testing.md). Protocol-conformant fakes for DirectoryProvider 
 - [ ] #6 No file under app/infrastructure/ and no file under app/modules/ is modified by this slice
 - [ ] #7 mypy, ruff and the full non-smoke pytest run are green
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-04 14:43
+---
+ADVISORY from TASK-76.1 planning (2026-09-04). Coordinator plan fact F4 is inaccurate (correction posted on TASK-76): the managed-group provider behaviour IS already pinned by app/tests/unit/infrastructure/directory/test_google.py, whose mock_directory_settings fixture (lines 135-142) runs the provider with managed_group_prefix='sg-' and managed_group_domain='example.com'. Managed-alias preference (line 1075), managed-domain mismatch (line 1119) and the alias-aware discovery skip (line 1108) are the exact behaviours your cut-over must reproduce at the feature boundary - read them as the specification instead of deriving one from scratch. What genuinely has no coverage is the packages/access side, so AC#4's 'existing test suites' still proves little there and your slice must add those tests.
+
+Enabler note: DirectoryGroup.aliases (TASK-76.1) is a tuple of IDP-reported secondary addresses, strip+lower normalized, empty when the IDP has no such concept - so any feature-side alias handling must tolerate () rather than requiring a non-empty tuple.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.4 - Strip-managed-group-policy-and-settings-out-of-infrastructure-directory.md
+++ b/backlog/tasks/task-76.4 - Strip-managed-group-policy-and-settings-out-of-infrastructure-directory.md
@@ -1,0 +1,54 @@
+---
+id: TASK-76.4
+title: Strip managed-group policy and settings out of infrastructure directory
+status: To Do
+assignee: []
+created_date: '2026-09-04 14:19'
+updated_date: '2026-09-04 14:25'
+labels:
+  - layering
+milestone: m-3
+dependencies:
+  - TASK-76.3
+parent_task_id: TASK-76
+priority: medium
+ordinal: 151000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 4 of TASK-76, the subtractive cleanup that satisfies parent AC#1 and AC#2 (see the coordinator plan, decisions D2, D3). Infrastructure-only; safe because TASK-76.3 already moved every access consumer off this behaviour.
+
+DELETE from app/infrastructure/directory/google.py:
+- _extract_managed_group_email (269-285), _managed_group_query_prefix (286-305), _matches_managed_group_prefix (306-313), _build_managed_group (453-493).
+- The _managed_group_domain and _managed_group_prefix instance attributes (constructor, 67-68).
+- The strategy switch in list_groups (885-948): the method passes the caller's query straight through to the vendor and always maps with _build_group. The client-side post-filter block disappears with it.
+- get_group (697-738), get_user_groups (1050-1129) and get_group_members switch to _build_group. Their docstrings must stop referring to managed groups and to DIRECTORY_MANAGED_GROUP_DOMAIN.
+- The domain-completion half of _normalize_email (211-220) per D2: it strips and lowercases only, and callers pass fully-qualified keys. Check all eleven call sites (523, 614, 686, 708, 751-752, 803-804, 834-835, 1064).
+- The DIRECTORY_GROUP_DOMAIN_MISMATCH error code, if nothing else emits it.
+
+DELETE from app/infrastructure/configuration/infrastructure/directory.py: managed_group_domain, managed_group_prefix and enforce_managed_group_email, plus their docstring lines (21-22, 59-73). Update tests/unit/infrastructure/configuration/test_directory_settings.py, which asserts on all three (lines 27-28 and the defaults test).
+
+RELOCATE the residual DirectorySettings (provider, require_startup_warmup, startup_preload_groups, cache_ttl_seconds, startup_warmup_timeout_seconds) plus get_directory_settings from app/infrastructure/configuration/infrastructure/directory.py to app/infrastructure/directory/settings.py, deleting the old home and updating importers including app/infrastructure/directory/factory.py and the settings test. decisions/configuration.md requires this migration to ride with work that already touches the domain rather than waiting for TASK-24, and forbids adding the slice to the legacy Settings aggregator. Verify before editing whether the aggregator file still exists and whether it references DirectorySettings. If this relocation turns out to pull in more importers than expected and pushes the PR past the size gate, split it into TASK-76.5 rather than shipping an oversized diff.
+
+PROTOCOL DOCS. app/infrastructure/directory/provider.py's get_group docstring promises a canonical MANAGED group and accepts a managed-group slug. Reword to the generic contract: a fully-qualified group key. The method SET is unchanged, per the parent task's boundary.
+
+VERIFY BEFORE MERGE. Re-run the plan's fact F2 grep (DIRECTORY_MANAGED, DIRECTORY_ENFORCE, MANAGED_GROUP across terraform/, Makefile, app/Makefile, app/pyproject.toml). If any environment has since set one of these, stop and re-assess.
+
+TESTING. Provider unit tests asserting the generic contract: list_groups passes the query through and never full-lists as a side effect of the query shape; a group outside any particular domain maps successfully and unchanged (parent AC#5's provider half); a group with no email is a hard error with no silent success-None path; _normalize_email leaves a bare value bare. Existing access suites from TASK-76.3 must stay green untouched - that is the proof the seam moved rather than the behaviour.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 grep for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix, _extract_managed_group_email and _build_managed_group returns zero hits under app/infrastructure/ (parent AC#1)
+- [ ] #2 _normalize_email no longer completes a bare value with any domain, and every internal call site is confirmed to receive fully-qualified keys
+- [ ] #3 list_groups applies no query-shape strategy switch and no client-side filtering; get_group, get_group_members and get_user_groups all map through the generic builder
+- [ ] #4 DIRECTORY_MANAGED_GROUP_DOMAIN, DIRECTORY_MANAGED_GROUP_PREFIX and DIRECTORY_ENFORCE_MANAGED_GROUP_EMAIL are deleted from DirectorySettings and from its tests, with no replacement setting created in infrastructure (parent AC#2)
+- [ ] #5 The residual DirectorySettings lives at app/infrastructure/directory/settings.py, the infrastructure/configuration/infrastructure/directory.py home is deleted, importers are updated, and no slice is added to the legacy Settings aggregator
+- [ ] #6 The DirectoryProvider Protocol docstrings describe a generic, vendor-neutral contract with no managed-group language, and its method set is unchanged
+- [ ] #7 The fact F2 grep across terraform, Makefile and app config is re-run at merge time and still returns zero hits
+- [ ] #8 Provider unit tests cover query pass-through, successful mapping of an out-of-domain group, a missing-email group as a hard error with no silent drop, and bare-value pass-through in email normalization
+- [ ] #9 The access suites from TASK-76.3 pass unmodified, and mypy, ruff and the full non-smoke pytest run are green
+- [ ] #10 The four live app/modules/ DirectoryProvider consumers enumerated in the parent plan's fact F7 (permissions/handler.py:40, reports/google_groups.py:100, dev/google.py:170-171, provisioning/users.py) are re-verified at merge time to pass fully-qualified keys, so removing the email-completion branch is a no-op for them; the verification is recorded in the task notes
+<!-- AC:END -->

--- a/backlog/tasks/task-76.4 - Strip-managed-group-policy-and-settings-out-of-infrastructure-directory.md
+++ b/backlog/tasks/task-76.4 - Strip-managed-group-policy-and-settings-out-of-infrastructure-directory.md
@@ -4,7 +4,7 @@ title: Strip managed-group policy and settings out of infrastructure directory
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:19'
-updated_date: '2026-09-04 14:25'
+updated_date: '2026-09-04 14:43'
 labels:
   - layering
 milestone: m-3
@@ -52,3 +52,16 @@ TESTING. Provider unit tests asserting the generic contract: list_groups passes 
 - [ ] #9 The access suites from TASK-76.3 pass unmodified, and mypy, ruff and the full non-smoke pytest run are green
 - [ ] #10 The four live app/modules/ DirectoryProvider consumers enumerated in the parent plan's fact F7 (permissions/handler.py:40, reports/google_groups.py:100, dev/google.py:170-171, provisioning/users.py) are re-verified at merge time to pass fully-qualified keys, so removing the email-completion branch is a no-op for them; the verification is recorded in the task notes
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-04 14:43
+---
+ADVISORY from TASK-76.1 planning (2026-09-04). Two items for your scope.
+
+1. EXISTING PROVIDER TESTS TO RELOCATE, NOT RE-AUTHOR. Coordinator plan fact F4 is wrong (correction posted on TASK-76): app/tests/unit/infrastructure/directory/test_google.py already pins the managed path, because its mock_directory_settings fixture (lines 135-142) sets managed_group_prefix='sg-' and managed_group_domain='example.com'. The assertions you must move to the feature boundary or delete with the code are: managed-alias preference (line 1075), managed-domain mismatch -> DIRECTORY_GROUP_DOMAIN_MISMATCH (line 1119), alias-aware discovery skipping an email-less group (line 1108), and the empty-query generic-mapping cases (lines 1200+, which stay and become the only behaviour). The fixture's managed settings themselves must go with the settings.
+
+2. ALIAS NORMALIZATION CHANGES UNDER YOUR D2 CUT. TASK-76.1 populates DirectoryGroup.aliases via _extract_group_aliases, which routes each alias through _normalize_email - including the bare-local-part -> {slug}@{domain} completion that D2 deletes. So removing that branch also changes how ALIASES are normalized, not just group/user keys. It is a no-op while the managed domain is empty (F2(iv)), but state it in the PR and cover it with a test: after the cut, an alias value is strip+lower only, and a bare local part stays bare. Re-run the F2 grep (DIRECTORY_MANAGED / DIRECTORY_ENFORCE / MANAGED_GROUP across terraform, Makefiles, pyproject) before merge - if any environment has set the domain, this stops being a no-op.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-79 - Make-organization-owned-domains-an-IDP-authoritative-directory-capability-instead-of-hand-maintained-per-feature-constants.md
+++ b/backlog/tasks/task-79 - Make-organization-owned-domains-an-IDP-authoritative-directory-capability-instead-of-hand-maintained-per-feature-constants.md
@@ -1,0 +1,50 @@
+---
+id: TASK-79
+title: >-
+  Make organization-owned domains an IDP-authoritative directory capability
+  instead of hand-maintained per-feature constants
+status: To Do
+assignee: []
+created_date: '2026-09-04 14:19'
+labels:
+  - layering
+milestone: m-3
+dependencies:
+  - TASK-76.4
+priority: medium
+ordinal: 152000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Raised 2026-09-04 by task-planner while planning TASK-76, from a human-requested research question: where should the concept of the domains the organization owns actually live, given the SRE bot is not a SaaS but still has an app-level domain-management concern.
+
+RESEARCH FINDING. Both major identity platforms model the set of domains an organization owns as a directory-level RESOURCE discovered from the platform, not as application configuration:
+- Microsoft Graph exposes a domain resource per tenant carrying isVerified, isDefault, isRoot and isInitial, with ownership established by DNS verification (learn.microsoft.com/en-us/graph/api/resources/domain).
+- Google Admin SDK Directory exposes domains.list per customer, returning the customer's domains including the primary one (developers.google.com/workspace/admin/directory/reference/rest/v1/domains/list).
+The best-practice conclusion is that owned and primary domains are an IDP-authoritative FACT the app should read, not a constant the app should be told - which is exactly the shape decisions/layers.md gives a portable capability.
+
+THE PROBLEM TODAY. The codebase is accumulating hand-maintained copies of domain knowledge in unrelated places:
+- app/infrastructure/configuration/features/groups.py::GROUP_DOMAIN (legacy).
+- DIRECTORY_MANAGED_GROUP_DOMAIN in DirectorySettings, which TASK-76 relocates to packages/access as AccessRuntimeConfig.dir_domain.
+- The package-local approved-participant-domain setting from TASK-74 and TASK-75 in oncall_sync.
+These are not all the same concept and must not be blindly merged: TASK-74's is an ALLOW-LIST POLICY answering which external domains may participate, while the other two are an IDENTITY FACT answering which domain the organization owns. This task is about the identity fact; the allow-list policy stays feature-owned.
+
+SCOPE TO DECIDE THEN BUILD.
+1. Whether DirectoryProvider gains a capability for this (for example list_domains or primary_domain) returning a canonical, vendor-neutral frozen dataclass, with the Google implementation on domains.list and a documented Entra mapping. TASK-76 explicitly excluded Protocol method-set changes, which is why this is a separate task.
+2. Whether the result is cached or warmed at startup, given directory domains change rarely - relates to the existing DirectorySettings warmup and cache TTL fields.
+3. Which of the three existing constants can then be derived rather than configured, and which must remain policy. Expected outcome: AccessRuntimeConfig.dir_domain becomes derivable and its required-non-empty validation from TASK-76.2 can relax; the legacy GROUP_DOMAIN retires with modules/; TASK-74's allow-list stays.
+4. Whether decisions/configuration.md or decisions/layers.md needs an amendment recording the general rule - prefer reading an authoritative fact from the platform over configuring a mirror of it - since this is the second time the pattern has come up.
+
+Do the decision work before the code; this is architecture-mode work first. It is sequenced after TASK-76.4 so it amends a clean generic provider rather than one still carrying managed-group policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A written decision records whether owned/primary domains become a DirectoryProvider capability, with the Google domains.list and Microsoft Graph domain resource mappings cited, and any needed amendment to decisions/configuration.md or decisions/layers.md is made
+- [ ] #2 The identity-fact concept and the allow-list-policy concept are explicitly kept distinct, with TASK-74/TASK-75's participant-domain setting left feature-owned
+- [ ] #3 If the capability is adopted: it returns a vendor-neutral frozen dataclass, is covered by provider unit tests over recorded payloads, and its caching/warmup behaviour is decided and tested
+- [ ] #4 Each of the three existing hand-maintained domain constants is dispositioned as derived, retained-as-policy, or retired, with the disposition recorded
+- [ ] #5 mypy, ruff and the full non-smoke pytest run are green
+<!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces support for group email aliases in the directory integration, specifically for Google as a provider. The changes ensure that secondary addresses (aliases) associated with groups are correctly extracted, normalized, and exposed in the `DirectoryGroup` model. Comprehensive tests have been added to validate the handling of aliases, including edge cases and malformed data.

**Directory group alias support:**

* Extended the `DirectoryGroup` model to include an `aliases` field, which holds secondary addresses as reported by the identity provider, along with detailed documentation on its semantics and per-provider mapping.
* Updated Google directory integration methods (`_build_group` and `_build_managed_group` in `google.py`) to extract and populate the `aliases` field from both `aliases[]` and `nonEditableAliases[]` in the provider payload. [[1]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR450) [[2]](diffhunk://#diff-4158a3688bcee3677c6fab1fe10f5d43033b7fcf047a402dc3a5f2ac79834e0cR490)

**Testing and validation:**

* Added unit tests to verify correct merging, normalization, and filtering of group aliases, including handling of absent or malformed alias fields, and ensuring the model's `aliases` attribute is populated as expected. [[1]](diffhunk://#diff-a00570770828cb10890af92db727e9bd295c15dbe6ad9b2e77377969ac65dc1eR796-R857) [[2]](diffhunk://#diff-a00570770828cb10890af92db727e9bd295c15dbe6ad9b2e77377969ac65dc1eR1166) [[3]](diffhunk://#diff-a00570770828cb10890af92db727e9bd295c15dbe6ad9b2e77377969ac65dc1eR1311-R1348)

**Miscellaneous:**

* Updated the `.github/agents/implementation.agent.md` file to expand the list of available tools for implementation agents.
* Updated the `updated_date` in a backlog task file.