### PR TITLE
Feat/access common managed group policy

### DIFF
--- a/app/packages/access/README.md
+++ b/app/packages/access/README.md
@@ -52,6 +52,7 @@ All sub-packages share a single `AccessRuntimeConfig` instance loaded once at st
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {
@@ -109,6 +110,7 @@ The runtime config JSON is the single place you define the group naming conventi
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {
@@ -122,6 +124,7 @@ The runtime config JSON is the single place you define the group naming conventi
 | Field | Type | Description |
 |---|---|---|
 | `dir_prefix` | string | Leading segment of every managed IDP group slug (e.g. `sg`) |
+| `dir_domain` | string | Email domain of managed IDP groups (e.g. `cds-snc.ca`). **Required, no default** — the application is agnostic of the organization running it |
 | `dir_separator` | string | Separator between naming segments (almost always `-`) |
 | `platforms` | object | One key per active platform; key is the `platform` value used in API calls |
 
@@ -141,6 +144,7 @@ By default every managed group is `sync_managed` — Access Sync will enforce it
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {
@@ -177,6 +181,7 @@ Use `ACCESS_CONFIG_SOURCE=file_json` and point `ACCESS_CONFIG_REF` at a local fi
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {

--- a/app/packages/access/access.local.json
+++ b/app/packages/access/access.local.json
@@ -1,5 +1,6 @@
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {

--- a/app/packages/access/catalog/README.md
+++ b/app/packages/access/catalog/README.md
@@ -41,6 +41,7 @@ The `known_envs` set controls which segments are treated as environment qualifie
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": { "authn_token": "authn", "authn_removal_mode": "delete" }

--- a/app/packages/access/common/README.md
+++ b/app/packages/access/common/README.md
@@ -57,6 +57,7 @@ Key fields:
 | Field | Example | Description |
 |---|---|---|
 | `dir_prefix` | `sg` | Org-wide IDP group prefix |
+| `dir_domain` | `cds-snc.ca` | Email domain of managed IDP groups; required, no default |
 | `dir_separator` | `-` | Segment separator |
 | `platforms` | `{"aws": PlatformPolicy(...)}` | Per-platform policy |
 
@@ -69,7 +70,7 @@ Key methods:
 
 ### `config/loaders.py`
 
-Config loader implementations. The source is selected by `ACCESS_CONFIG_SOURCE` (via `settings.config.source`). Supported sources: `bundle`, `file_json`, `inline_json`, `env`.
+Config loader implementations. The source is selected by `ACCESS_CONFIG_SOURCE` (via `settings.config.source`). Supported sources: `bundle`, `file_json`, `inline_json`, `env`. The default `bundle` source carries no configuration and reports `CONFIG_NOT_CONFIGURED`.
 
 ### `events.py`
 

--- a/app/packages/access/common/config/loaders.py
+++ b/app/packages/access/common/config/loaders.py
@@ -5,10 +5,11 @@ AccessRuntimeConfig.  This module serves the entire access feature domain —
 sync, catalog, and request all share one runtime config loaded here.
 
 Config loader sources:
-    bundle      - Built-in empty bundle. Default for local development.
+    bundle      - No built-in configuration; reports CONFIG_NOT_CONFIGURED.
     inline_json - Parse ACCESS_CONFIG_REF as inline JSON text.
     file_json   - Read ACCESS_CONFIG_REF as a path to a local JSON file.
-    env         - Read from ACCESS_CONFIG_ENV_DIR_PREFIX / ACCESS_CONFIG_ENV_PLATFORMS_JSON.
+    env         - Read from ACCESS_CONFIG_ENV_DIR_PREFIX / ACCESS_CONFIG_ENV_DIR_DOMAIN /
+                  ACCESS_CONFIG_ENV_PLATFORMS_JSON.
 """
 
 from __future__ import annotations
@@ -90,6 +91,7 @@ class RuntimeConfigJsonModel(BaseModel):
 
         {
           "dir_prefix": "sg",
+          "dir_domain": "example.com",
           "dir_separator": "-",
           "platforms": {
             "aws": {
@@ -109,7 +111,8 @@ class RuntimeConfigJsonModel(BaseModel):
         }
     """
 
-    dir_prefix: str
+    dir_prefix: str = Field(min_length=1)
+    dir_domain: str = Field(min_length=1)
     dir_separator: str = "-"
     platforms: dict[str, PlatformPolicyConfigModel] = Field(default_factory=dict)
     extensions: dict[str, Any] = Field(default_factory=dict)
@@ -122,6 +125,7 @@ class RuntimeConfigJsonModel(BaseModel):
 
 def _build_runtime_config(
     dir_prefix: str,
+    dir_domain: str,
     dir_separator: str,
     platforms_model: dict[str, PlatformPolicyConfigModel],
     extensions: dict[str, Any] | None = None,
@@ -149,6 +153,7 @@ def _build_runtime_config(
 
     return AccessRuntimeConfig(
         dir_prefix=dir_prefix,
+        dir_domain=dir_domain,
         dir_separator=dir_separator,
         platforms=platforms,
         extensions=dict(extensions or {}),
@@ -172,11 +177,12 @@ def _validate_runtime_config_payload(
     try:
         config = _build_runtime_config(
             dir_prefix=validated.dir_prefix,
+            dir_domain=validated.dir_domain,
             dir_separator=validated.dir_separator,
             platforms_model=validated.platforms,
             extensions=validated.extensions,
         )
-    except ValidationError as exc:
+    except ValueError as exc:
         return OperationResult.error(
             status=OperationStatus.PERMANENT_ERROR,
             message=f"{error_prefix}_invalid_extensions: {exc}",
@@ -194,17 +200,20 @@ def _validate_runtime_config_payload(
 
 
 class BundleConfigLoader:
-    """Returns an empty bundle (no platforms configured).
+    """Reports that access is enabled but has no configuration source.
 
-    The feature enters "waiting mode": no adapters are registered and
-    sync_user returns POLICY_NOT_FOUND gracefully until a real source is set.
+    ``bundle`` is the default ACCESS_CONFIG_SOURCE, so this is the path taken
+    when the feature is switched on without being configured.
     """
 
     def load(self, ref: str) -> OperationResult[AccessRuntimeConfig]:
-        config = AccessRuntimeConfig(dir_prefix="", platforms={})
-        return OperationResult.success(
-            data=config,
-            message=f"bundle_config_loaded ref={ref} platforms=0 (waiting mode)",
+        return OperationResult.error(
+            status=OperationStatus.PERMANENT_ERROR,
+            message=(
+                f"bundle_config_not_configured ref={ref}: access is enabled but no runtime "
+                "configuration is available; set ACCESS_CONFIG_SOURCE and ACCESS_CONFIG_REF"
+            ),
+            error_code="CONFIG_NOT_CONFIGURED",
         )
 
 
@@ -231,12 +240,14 @@ class EnvConfigLoader:
 
     Reads:
         ACCESS_CONFIG_ENV_DIR_PREFIX     — IDP group prefix (e.g. ``sg``)
+        ACCESS_CONFIG_ENV_DIR_DOMAIN     — managed group email domain
         ACCESS_CONFIG_ENV_DIR_SEPARATOR  — segment separator; default ``-``
         ACCESS_CONFIG_ENV_PLATFORMS_JSON — platforms block as a JSON string
     """
 
     class _EnvModel(BaseSettings):
         dir_prefix: str = Field(default="", alias="ACCESS_CONFIG_ENV_DIR_PREFIX")
+        dir_domain: str = Field(default="", alias="ACCESS_CONFIG_ENV_DIR_DOMAIN")
         dir_separator: str = Field(default="-", alias="ACCESS_CONFIG_ENV_DIR_SEPARATOR")
         platforms_json: str = Field(default="{}", alias="ACCESS_CONFIG_ENV_PLATFORMS_JSON")
 
@@ -254,6 +265,12 @@ class EnvConfigLoader:
                 message="env_config_missing_dir_prefix: ACCESS_CONFIG_ENV_DIR_PREFIX must be set",
                 error_code="CONFIG_INVALID_SHAPE",
             )
+        if not env.dir_domain:
+            return OperationResult.error(
+                status=OperationStatus.PERMANENT_ERROR,
+                message="env_config_missing_dir_domain: ACCESS_CONFIG_ENV_DIR_DOMAIN must be set",
+                error_code="CONFIG_INVALID_SHAPE",
+            )
         try:
             platforms_payload = json.loads(env.platforms_json)
         except json.JSONDecodeError as exc:
@@ -265,6 +282,7 @@ class EnvConfigLoader:
         return _validate_runtime_config_payload(
             payload={
                 "dir_prefix": env.dir_prefix,
+                "dir_domain": env.dir_domain,
                 "dir_separator": env.dir_separator,
                 "platforms": platforms_payload,
             },

--- a/app/packages/access/common/config/settings.py
+++ b/app/packages/access/common/config/settings.py
@@ -60,15 +60,29 @@ class EntitlementModeOverride:
 
 @dataclass(frozen=True)
 class AccessRuntimeConfig:
-    """Fully-resolved runtime configuration shared across access sub-packages."""
+    """Fully-resolved runtime configuration shared across access sub-packages.
+
+    ``dir_domain`` is the authoritative email domain of managed IDP groups. It is
+    required and has no default anywhere: this application must stay agnostic of
+    the organization running it, so an absent value is a startup error rather
+    than a silent fallback to someone else's directory.
+    """
 
     dir_prefix: str
+    dir_domain: str
     dir_separator: str = "-"
     platforms: dict[str, PlatformPolicy] = field(default_factory=dict)
     entitlement_mode_overrides: list[EntitlementModeOverride] = field(default_factory=list)
     # Typed extensions for catalog feature; empty dict when not present.
     extensions: dict[str, Any] = field(default_factory=dict)
     catalog_extensions: CatalogExtensions | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a config the access feature cannot operate with."""
+        if not self.dir_prefix.strip():
+            raise ValueError("access_runtime_config_invalid: dir_prefix must be a non-empty value")
+        if not self.dir_domain.strip():
+            raise ValueError("access_runtime_config_invalid: dir_domain must be a non-empty value")
 
     def group_prefix(self, platform: str) -> str:
         """Return the IDP group slug prefix for a given platform."""

--- a/app/packages/access/common/group_policy.py
+++ b/app/packages/access/common/group_policy.py
@@ -1,0 +1,84 @@
+"""Feature-side owner of managed-group policy.
+
+The DirectoryProvider is deliberately generic and no longer decides which of a
+group's addresses is canonical, nor whether a group is managed; this module is
+where those decisions live for the access feature.
+"""
+
+from dataclasses import dataclass
+
+from infrastructure.directory.models import DirectoryGroup
+from packages.access.common.config.settings import AccessRuntimeConfig
+from packages.access.common.naming import AccessGroupNaming
+
+
+@dataclass(frozen=True)
+class ManagedGroupPolicy:
+    """Pure value object deciding managed-group identity for access.
+
+    Args:
+        prefix: Organization-wide managed-group prefix (for example, ``sg-``).
+        domain: Authoritative email domain of managed groups.
+    """
+
+    prefix: str
+    domain: str
+
+    def __post_init__(self) -> None:
+        """Normalize both fields and reject blanks.
+
+        A blank prefix is not merely useless: every ``startswith`` check would
+        succeed, making every alias look managed.
+        """
+        prefix = self.prefix.strip().lower()
+        domain = self.domain.strip().lower()
+        if not prefix:
+            raise ValueError("managed_group_policy_invalid: prefix must be a non-empty value")
+        if not domain:
+            raise ValueError("managed_group_policy_invalid: domain must be a non-empty value")
+        object.__setattr__(self, "prefix", prefix)
+        object.__setattr__(self, "domain", domain)
+
+    @classmethod
+    def from_config(cls, config: AccessRuntimeConfig) -> ManagedGroupPolicy:
+        """Build the policy from the access runtime configuration."""
+        naming = AccessGroupNaming(
+            dir_prefix=config.dir_prefix,
+            dir_separator=config.dir_separator,
+        )
+        return cls(prefix=naming.managed_prefix, domain=config.dir_domain)
+
+    def canonical_email(self, group: DirectoryGroup) -> str:
+        """Return the group's canonical managed address.
+
+        The first alias in provider-reported order whose local part carries the
+        managed prefix and whose domain is the managed domain wins; otherwise
+        the primary group email.
+        """
+        for alias in group.aliases:
+            candidate = alias.strip().lower()
+            local_part, _, domain = candidate.partition("@")
+            if domain == self.domain and local_part.startswith(self.prefix):
+                return candidate
+        return group.group_email.strip().lower()
+
+    def canonical_slug(self, group: DirectoryGroup) -> str:
+        """Return the local part of the group's canonical email."""
+        return self.canonical_email(group).partition("@")[0]
+
+    def is_managed(self, group: DirectoryGroup) -> bool:
+        """Return whether the group's canonical email sits in the managed domain."""
+        return self.canonical_email(group).partition("@")[2] == self.domain
+
+    def matches_prefix(self, group: DirectoryGroup, prefix: str) -> bool:
+        """Return whether the primary email or any alias carries ``prefix``."""
+        normalized = prefix.strip().lower()
+        candidates = (group.group_email, *group.aliases)
+        return any(candidate.strip().lower().startswith(normalized) for candidate in candidates)
+
+    def group_key(self, slug: str) -> str:
+        """Return the managed group address for a slug, never a bare slug."""
+        value = slug.strip().lower()
+        if "@" in value:
+            return value
+        return f"{value}@{self.domain}"

--- a/app/packages/access/common/naming.py
+++ b/app/packages/access/common/naming.py
@@ -15,6 +15,14 @@ class AccessGroupNaming:
     dir_prefix: str
     dir_separator: str = "-"
 
+    @property
+    def managed_prefix(self) -> str:
+        """Return the organization-wide managed-group prefix (``sg-``).
+
+        Unlike :meth:`group_prefix`, this is not scoped to a platform.
+        """
+        return f"{self.dir_prefix}{self.dir_separator}"
+
     def group_prefix(self, platform: str) -> str:
         """Return the group slug prefix for a platform.
 

--- a/app/packages/access/sync/README.md
+++ b/app/packages/access/sync/README.md
@@ -27,6 +27,7 @@ Runtime config is a JSON document with this shape:
 ```json
 {
   "dir_prefix": "sg",
+  "dir_domain": "example.com",
   "dir_separator": "-",
   "platforms": {
     "aws": {
@@ -41,6 +42,7 @@ Runtime config is a JSON document with this shape:
 | Field | Description |
 |---|---|
 | `dir_prefix` | Organization-wide IDP group prefix (e.g. `sg`) |
+| `dir_domain` | Email domain of managed IDP groups (e.g. `cds-snc.ca`); required, no default |
 | `dir_separator` | Separator between prefix segments (almost always `-`) |
 | `platforms.<key>` | Platform key, used to look up adapters and derive slugs |
 | `adapter_type` | Which adapter implementation to use: `aws_identity_center` or `fake` (default: `fake`) |
@@ -53,7 +55,7 @@ Env var `ACCESS_CONFIG_SOURCE` controls which loader is used. It is read from `s
 
 | `ACCESS_CONFIG_SOURCE` | `ACCESS_CONFIG_REF` | When to use |
 |---|---|---|
-| `bundle` (default) | ignored | Local dev — no platforms configured, feature in waiting mode |
+| `bundle` (default) | ignored | No built-in configuration — loading fails with `CONFIG_NOT_CONFIGURED` when access is enabled but unconfigured |
 | `file_json` | Absolute path to a local JSON file | Local dev with a real config (e.g. `access-sync.local.json`) |
 | `inline_json` | The full JSON document as a string | Useful in CI or one-off testing |
 | `env` | ignored | **Production via SSM bundle** — reads flat env vars (see below) |
@@ -61,16 +63,17 @@ Env var `ACCESS_CONFIG_SOURCE` controls which loader is used. It is read from `s
 
 ### env source (production)
 
-When `ACCESS_CONFIG_SOURCE=env`, no JSON file or inline document is needed. The loader reads three env vars that `entry.sh` populates from the SSM parameter bundle at container startup:
+When `ACCESS_CONFIG_SOURCE=env`, no JSON file or inline document is needed. The loader reads flat env vars that `entry.sh` populates from the SSM parameter bundle at container startup:
 
 ```
 ACCESS_CONFIG_SOURCE=env
-ACCESS_SYNC_DIR_PREFIX=sg
-ACCESS_SYNC_DIR_SEPARATOR=-
-ACCESS_SYNC_PLATFORMS_JSON={"aws": {"adapter_type": "aws_identity_center", "authn_token": "authn", "authn_removal_mode": "delete"}}
+ACCESS_CONFIG_ENV_DIR_PREFIX=sg
+ACCESS_CONFIG_ENV_DIR_DOMAIN=cds-snc.ca
+ACCESS_CONFIG_ENV_DIR_SEPARATOR=-
+ACCESS_CONFIG_ENV_PLATFORMS_JSON={"aws": {"adapter_type": "aws_identity_center", "authn_token": "authn", "authn_removal_mode": "delete"}}
 ```
 
-`ACCESS_SYNC_PLATFORMS_JSON` is the platforms block only — not the full config document. Add these vars to the `sre-bot-config` (or `sre-bot-config-infrastructure`) SSM parameter alongside the other app config.
+`ACCESS_CONFIG_ENV_PLATFORMS_JSON` is the platforms block only — not the full config document. Add these vars to the `sre-bot-config` (or `sre-bot-config-infrastructure`) SSM parameter alongside the other app config.
 
 **For local development**, use `file_json` instead:
 

--- a/app/tests/integration/packages/access/sync/conftest.py
+++ b/app/tests/integration/packages/access/sync/conftest.py
@@ -396,11 +396,13 @@ def make_sync_config():
         authn_removal_mode: str = "delete",
         mode_overrides: dict[str, Literal["sync_managed", "ephemeral", "deactivated"]] | None = None,
         dir_prefix: str = "sg",
+        dir_domain: str = "example.com",
         dir_separator: str = "-",
         adapter_type: str = "fake",
     ) -> AccessSyncRuntimeConfig:
         return AccessSyncRuntimeConfig(
             dir_prefix=dir_prefix,
+            dir_domain=dir_domain,
             dir_separator=dir_separator,
             platforms={
                 platform: PlatformPolicy(
@@ -522,6 +524,7 @@ def aws_config() -> AccessSyncRuntimeConfig:
     """
     return AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={
             "aws": PlatformPolicy(

--- a/app/tests/integration/packages/access/sync/test_desired_state.py
+++ b/app/tests/integration/packages/access/sync/test_desired_state.py
@@ -72,6 +72,7 @@ def _make_builder_and_effective(
     """Return (DirectoryMembershipBuilder, EffectivePlatformPolicy)."""
     config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             platform: PlatformPolicy(
                 authn_token="authn",
@@ -316,6 +317,7 @@ def _make_platform_builder_and_effective(
     """Return (DirectoryMembershipBuilder, EffectivePlatformPolicy) for platform builds."""
     config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             platform: PlatformPolicy(
                 authn_token="authn",
@@ -467,6 +469,7 @@ def _make_discovery_builder(
     """Return (DirectoryMembershipBuilder, AccessSyncRuntimeConfig) for discovery."""
     config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             platform: PlatformPolicy(
                 authn_token="authn",

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_providers.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_providers.py
@@ -12,6 +12,7 @@ from packages.access.common.config import InlineJsonConfigLoader
 def _runtime_config_from_payload() -> object:
     payload = {
         "dir_prefix": "sg",
+        "dir_domain": "example.com",
         "dir_separator": "-",
         "platforms": {
             "aws": {

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
@@ -61,10 +61,12 @@ def make_runtime_config(
     authn_token: str = "authn",
     mode_overrides: dict | None = None,
     dir_prefix: str = "sg",
+    dir_domain: str = "example.com",
     dir_separator: str = "-",
 ) -> AccessSyncRuntimeConfig:
     return AccessSyncRuntimeConfig(
         dir_prefix=dir_prefix,
+        dir_domain=dir_domain,
         dir_separator=dir_separator,
         platforms={
             platform: PlatformPolicy(
@@ -111,6 +113,7 @@ def test_list_platforms_should_return_summary_for_each_configured_platform():
     # Arrange
     cfg = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={
             "aws": PlatformPolicy(authn_token="authn"),
@@ -161,6 +164,7 @@ def test_list_platforms_should_use_display_name_from_runtime_extensions_via_prov
 ):
     payload = {
         "dir_prefix": "sg",
+        "dir_domain": "example.com",
         "dir_separator": "-",
         "platforms": {
             "aws": {
@@ -210,7 +214,7 @@ def test_list_platforms_should_derive_authn_group_slug_from_config():
 
 def test_list_platforms_should_return_empty_list_when_no_platforms_configured():
     # Arrange
-    cfg = AccessSyncRuntimeConfig(dir_prefix="sg", platforms={})
+    cfg = AccessSyncRuntimeConfig(dir_prefix="sg", dir_domain="example.com", platforms={})
     service = make_service(runtime_config=cfg)
 
     # Act
@@ -445,6 +449,7 @@ def test_list_entitlements_should_fall_back_to_fallback_parser_for_unknown_platf
     # Arrange — platform is "custom"; no parser registered
     cfg = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={"custom": PlatformPolicy(authn_token="authn")},
     )
     groups = [make_group(slug="sg-custom-role1", email="sg-custom-role1@example.com")]

--- a/app/tests/unit/packages/access/common/test_access_group_policy.py
+++ b/app/tests/unit/packages/access/common/test_access_group_policy.py
@@ -1,0 +1,157 @@
+"""Behavior tests for the feature-side managed-group policy (TASK-76.2)."""
+
+import pytest
+
+from infrastructure.directory.models import DirectoryGroup
+from packages.access.common.config.settings import AccessRuntimeConfig
+from packages.access.common.group_policy import ManagedGroupPolicy
+
+MANAGED_DOMAIN = "example.com"
+
+
+def make_group(
+    group_email: str,
+    aliases: tuple[str, ...] = (),
+    group_slug: str = "slug",
+) -> DirectoryGroup:
+    return DirectoryGroup(
+        group_email=group_email,
+        group_slug=group_slug,
+        provider_group_id="gid-1",
+        aliases=aliases,
+    )
+
+
+@pytest.fixture
+def policy() -> ManagedGroupPolicy:
+    return ManagedGroupPolicy(prefix="sg-", domain=MANAGED_DOMAIN)
+
+
+@pytest.mark.unit
+def test_canonical_email_prefers_managed_alias_over_primary_email(policy):
+    """A managed-prefix alias in the managed domain wins over the primary email."""
+    group = make_group("team@example.com", aliases=("sg-aws-admins@example.com",))
+
+    assert policy.canonical_email(group) == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_canonical_email_ignores_prefixed_alias_in_foreign_domain(policy):
+    """A prefixed alias outside the managed domain must not be preferred."""
+    group = make_group("team@example.com", aliases=("sg-aws-admins@other.test",))
+
+    assert policy.canonical_email(group) == "team@example.com"
+
+
+@pytest.mark.unit
+def test_canonical_email_ignores_in_domain_alias_without_managed_prefix(policy):
+    """An in-domain alias lacking the managed prefix must not be preferred."""
+    group = make_group("team@example.com", aliases=("all-staff@example.com",))
+
+    assert policy.canonical_email(group) == "team@example.com"
+
+
+@pytest.mark.unit
+def test_canonical_email_falls_back_to_primary_when_alias_tuple_empty(policy):
+    """An empty alias tuple is legitimate, never an error."""
+    group = make_group("sg-aws-admins@example.com")
+
+    assert policy.canonical_email(group) == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_canonical_email_takes_first_matching_alias_in_provider_order(policy):
+    """Provider-reported alias order is the tie-break between two matches."""
+    group = make_group(
+        "team@example.com",
+        aliases=("sg-aws-admins@example.com", "sg-aws-readers@example.com"),
+    )
+
+    assert policy.canonical_email(group) == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_canonical_slug_returns_local_part_of_canonical_email(policy):
+    """The slug comes from the canonical email, not from group_email."""
+    group = make_group("team@example.com", aliases=("sg-aws-admins@example.com",))
+
+    assert policy.canonical_slug(group) == "sg-aws-admins"
+
+
+@pytest.mark.unit
+def test_is_managed_is_false_for_group_outside_managed_domain(policy):
+    """Feature boundary: an out-of-domain canonical email is not managed."""
+    group = make_group("sg-aws-admins@other.test")
+
+    assert policy.is_managed(group) is False
+
+
+@pytest.mark.unit
+def test_is_managed_is_true_when_managed_alias_rescues_foreign_primary(policy):
+    """is_managed runs on the canonical value, not the primary email."""
+    group = make_group("team@other.test", aliases=("sg-aws-admins@example.com",))
+
+    assert policy.is_managed(group) is True
+
+
+@pytest.mark.unit
+def test_matches_prefix_matches_on_primary_email(policy):
+    group = make_group("sg-aws-admins@example.com")
+
+    assert policy.matches_prefix(group, "sg-aws-") is True
+
+
+@pytest.mark.unit
+def test_matches_prefix_matches_on_alias_when_primary_does_not(policy):
+    group = make_group("team@example.com", aliases=("sg-aws-admins@example.com",))
+
+    assert policy.matches_prefix(group, "sg-aws-") is True
+
+
+@pytest.mark.unit
+def test_matches_prefix_is_false_when_no_candidate_matches(policy):
+    group = make_group("team@example.com", aliases=("all-staff@example.com",))
+
+    assert policy.matches_prefix(group, "sg-aws-") is False
+
+
+@pytest.mark.unit
+def test_group_key_composes_slug_with_managed_domain(policy):
+    assert policy.group_key("sg-aws-admins") == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_group_key_normalizes_a_value_that_already_has_a_domain(policy):
+    assert policy.group_key("  SG-AWS-Admins@Example.com ") == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("prefix", "domain"),
+    [
+        ("sg-", ""),
+        ("sg-", "   "),
+        ("", MANAGED_DOMAIN),
+        ("   ", MANAGED_DOMAIN),
+    ],
+)
+def test_managed_group_policy_rejects_blank_prefix_or_domain(prefix, domain):
+    """A blank prefix would make every alias look managed; a blank domain is unusable."""
+    with pytest.raises(ValueError):
+        ManagedGroupPolicy(prefix=prefix, domain=domain)
+
+
+@pytest.mark.unit
+def test_from_config_derives_org_wide_prefix_and_normalizes_domain():
+    """Prefix is derived from existing naming fields; no new setting is introduced."""
+    config = AccessRuntimeConfig(
+        dir_prefix="sg",
+        dir_domain="  Example.COM ",
+        dir_separator="-",
+        platforms={},
+    )
+
+    policy = ManagedGroupPolicy.from_config(config)
+
+    assert policy.prefix == "sg-"
+    assert policy.domain == "example.com"

--- a/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
+++ b/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
@@ -38,6 +38,7 @@ class _FakeDirectory:
 def _runtime_config(mode_overrides: dict[str, str]) -> AccessRuntimeConfig:
     return AccessRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={
             "aws": PlatformPolicy(

--- a/app/tests/unit/packages/access/common/test_access_runtime_config_extensions.py
+++ b/app/tests/unit/packages/access/common/test_access_runtime_config_extensions.py
@@ -8,6 +8,7 @@ from packages.access.common.config import InlineJsonConfigLoader
 def test_runtime_config_extensions_catalog_is_typed_and_attribute_accessible():
     payload = {
         "dir_prefix": "sg",
+        "dir_domain": "example.com",
         "dir_separator": "-",
         "platforms": {
             "aws": {
@@ -39,6 +40,7 @@ def test_runtime_config_extensions_catalog_is_typed_and_attribute_accessible():
 def test_runtime_config_extensions_invalid_parser_known_envs_shape_fails():
     payload = {
         "dir_prefix": "sg",
+        "dir_domain": "example.com",
         "dir_separator": "-",
         "platforms": {
             "aws": {

--- a/app/tests/unit/packages/access/common/test_access_runtime_config_validation.py
+++ b/app/tests/unit/packages/access/common/test_access_runtime_config_validation.py
@@ -1,0 +1,28 @@
+"""Behavior tests for AccessRuntimeConfig invariants (TASK-76.2)."""
+
+import pytest
+
+from packages.access.common.config.settings import AccessRuntimeConfig
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("dir_domain", ["", "   "])
+def test_runtime_config_rejects_blank_dir_domain(dir_domain):
+    """A blank domain is what makes group keys unusable, so it must be unconstructible."""
+    with pytest.raises(ValueError):
+        AccessRuntimeConfig(dir_prefix="sg", dir_domain=dir_domain)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("dir_prefix", ["", "   "])
+def test_runtime_config_rejects_blank_dir_prefix(dir_prefix):
+    with pytest.raises(ValueError):
+        AccessRuntimeConfig(dir_prefix=dir_prefix, dir_domain="example.com")
+
+
+@pytest.mark.unit
+def test_runtime_config_accepts_fully_specified_values():
+    config = AccessRuntimeConfig(dir_prefix="sg", dir_domain="example.com", dir_separator="-")
+
+    assert config.dir_domain == "example.com"
+    assert config.group_prefix("aws") == "sg-aws-"

--- a/app/tests/unit/packages/access/request/test_policies.py
+++ b/app/tests/unit/packages/access/request/test_policies.py
@@ -32,6 +32,7 @@ def make_config(
 ) -> AccessRuntimeConfig:
     return AccessRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={
             platform: PlatformPolicy(

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -33,6 +33,7 @@ def make_config(
 ) -> AccessRuntimeConfig:
     return AccessRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={
             platform: PlatformPolicy(

--- a/app/tests/unit/packages/access/sync/conftest.py
+++ b/app/tests/unit/packages/access/sync/conftest.py
@@ -113,6 +113,7 @@ def make_runtime_config(make_platform_policy):
     def _make(
         platform: str = "aws",
         dir_prefix: str = "sg",
+        dir_domain: str = "example.com",
         dir_separator: str = "-",
         platforms: dict | None = None,
         **policy_kwargs: object,
@@ -121,6 +122,7 @@ def make_runtime_config(make_platform_policy):
             platforms = {platform: make_platform_policy(**policy_kwargs)}  # type: ignore[arg-type]
         return AccessRuntimeConfig(
             dir_prefix=dir_prefix,
+            dir_domain=dir_domain,
             dir_separator=dir_separator,
             platforms=platforms,
         )

--- a/app/tests/unit/packages/access/sync/test_application.py
+++ b/app/tests/unit/packages/access/sync/test_application.py
@@ -319,6 +319,7 @@ def make_coordinator(
         adapter = FakeAdapter(current_entitlement_ids=current_ids or set(), user_exists=user_exists)
     config = AccessRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             platform: PlatformPolicy(
                 authn_token="authn",
@@ -402,6 +403,7 @@ def test_sync_user_policy_not_found():
 def test_sync_user_adapter_not_found():
     config = AccessRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={"aws": PlatformPolicy()},
     )
     directory_provider: Any = FakeDirectory()

--- a/app/tests/unit/packages/access/sync/test_config.py
+++ b/app/tests/unit/packages/access/sync/test_config.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from infrastructure.operations import OperationStatus
 from packages.access.common.config import (
     BundleConfigLoader,
     EnvConfigLoader,
@@ -86,11 +87,14 @@ def test_get_access_config_loader_returns_file_json():
 
 
 @pytest.mark.unit
-def test_bundle_config_loader_load_returns_success():
-    """BundleConfigLoader.load() must return a successful OperationResult."""
-    loader = BundleConfigLoader()
-    result = loader.load("default")
-    assert result.is_success
+def test_bundle_config_loader_reports_not_configured():
+    """Access enabled without a configured source must fail loudly, not enter waiting mode."""
+    result = BundleConfigLoader().load("default")
+
+    assert not result.is_success
+    assert result.status is OperationStatus.PERMANENT_ERROR
+    assert result.error_code == "CONFIG_NOT_CONFIGURED"
+    assert "ACCESS_CONFIG_SOURCE" in (result.message or "")
 
 
 @pytest.mark.unit
@@ -145,6 +149,7 @@ def test_inline_json_loader_preserves_extensions_for_catalog():
 @pytest.mark.unit
 def test_env_config_loader_reads_access_config_env_names(monkeypatch):
     monkeypatch.setenv("ACCESS_CONFIG_ENV_DIR_PREFIX", "sg")
+    monkeypatch.setenv("ACCESS_CONFIG_ENV_DIR_DOMAIN", "example.com")
     monkeypatch.setenv("ACCESS_CONFIG_ENV_DIR_SEPARATOR", "-")
     monkeypatch.setenv(
         "ACCESS_CONFIG_ENV_PLATFORMS_JSON",
@@ -156,7 +161,59 @@ def test_env_config_loader_reads_access_config_env_names(monkeypatch):
     assert result.is_success
     assert result.data is not None
     assert result.data.dir_prefix == "sg"
+    assert result.data.dir_domain == "example.com"
     assert "aws" in result.data.platforms
+
+
+@pytest.mark.unit
+def test_env_config_loader_requires_dir_domain(monkeypatch):
+    monkeypatch.delenv("ACCESS_CONFIG_ENV_DIR_DOMAIN", raising=False)
+    monkeypatch.setenv("ACCESS_CONFIG_ENV_DIR_PREFIX", "sg")
+
+    result = EnvConfigLoader().load("unused")
+
+    assert not result.is_success
+    assert result.error_code == "CONFIG_INVALID_SHAPE"
+    assert "ACCESS_CONFIG_ENV_DIR_DOMAIN" in (result.message or "")
+
+
+@pytest.mark.unit
+def test_inline_json_loader_requires_dir_domain():
+    payload = json.dumps({"dir_prefix": "sg", "dir_separator": "-", "platforms": {}})
+
+    result = InlineJsonConfigLoader().load(payload)
+
+    assert not result.is_success
+    assert result.error_code == "CONFIG_INVALID_SHAPE"
+
+
+@pytest.mark.unit
+def test_file_json_loader_requires_dir_domain(tmp_path):
+    path = tmp_path / "access.json"
+    path.write_text(json.dumps({"dir_prefix": "sg", "platforms": {}}), encoding="utf-8")
+
+    result = FileJsonConfigLoader().load(str(path))
+
+    assert not result.is_success
+    assert result.error_code == "CONFIG_INVALID_SHAPE"
+
+
+@pytest.mark.unit
+def test_inline_json_loader_carries_dir_domain_onto_runtime_config():
+    payload = json.dumps(
+        {
+            "dir_prefix": "sg",
+            "dir_domain": "example.com",
+            "dir_separator": "-",
+            "platforms": {},
+        }
+    )
+
+    result = InlineJsonConfigLoader().load(payload)
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.dir_domain == "example.com"
 
 
 @pytest.mark.unit

--- a/app/tests/unit/packages/access/sync/test_config.py
+++ b/app/tests/unit/packages/access/sync/test_config.py
@@ -103,6 +103,7 @@ def test_inline_json_config_loader_parses_platforms():
     payload = json.dumps(
         {
             "dir_prefix": "sg",
+            "dir_domain": "example.com",
             "dir_separator": "-",
             "platforms": {
                 "aws": {
@@ -127,6 +128,7 @@ def test_inline_json_loader_preserves_extensions_for_catalog():
     payload = json.dumps(
         {
             "dir_prefix": "sg",
+            "dir_domain": "example.com",
             "dir_separator": "-",
             "platforms": {
                 "aws": {

--- a/app/tests/unit/packages/access/sync/test_policies.py
+++ b/app/tests/unit/packages/access/sync/test_policies.py
@@ -102,6 +102,7 @@ def test_group_prefix_derives_from_dir_prefix_and_platform(make_runtime_config):
 def test_group_prefix_custom_separator():
     config = AccessSyncRuntimeConfig(
         dir_prefix="corp",
+        dir_domain="example.com",
         dir_separator=".",
         platforms={"gcp": PlatformPolicy()},
     )
@@ -118,6 +119,7 @@ def test_authn_group_slug_derives_correctly(make_runtime_config):
 def test_authn_group_slug_custom_token():
     config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         dir_separator="-",
         platforms={"aws": PlatformPolicy(authn_token="login")},
     )

--- a/app/tests/unit/packages/access/sync/test_providers.py
+++ b/app/tests/unit/packages/access/sync/test_providers.py
@@ -17,6 +17,7 @@ def test_get_access_sync_adapters_registers_aws_and_fake(
     providers.get_access_sync_adapters.cache_clear()
     runtime_config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             "aws": make_platform_policy(adapter_type="aws_identity_center"),
             "fake": make_platform_policy(adapter_type="fake"),
@@ -55,6 +56,7 @@ def test_get_access_sync_adapters_raises_for_unknown_adapter_type(
     providers.get_access_sync_adapters.cache_clear()
     runtime_config = AccessSyncRuntimeConfig(
         dir_prefix="sg",
+        dir_domain="example.com",
         platforms={
             "fake": make_platform_policy(adapter_type="fake"),
             "custom": make_platform_policy(adapter_type="custom_unsupported"),

--- a/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
+++ b/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:02'
-updated_date: '2026-09-04 14:42'
+updated_date: '2026-09-04 15:46'
 labels:
   - layering
 milestone: m-3
@@ -54,7 +54,7 @@ NOT IN SCOPE: any Google vendor-mirror work; changing the DirectoryProvider Prot
 - [ ] #3 The chosen mechanism - feature-side filtering of generic results, or an injected policy strategy - is stated in the task notes with its rationale, rather than the branching simply moving up one layer
 - [ ] #4 packages/access/catalog, packages/access/sync and packages/access/request retain their current observable behaviour, proven by their existing test suites plus the new characterization tests the slices add (the managed path has no existing coverage - see plan fact F4)
 - [ ] #5 A group outside the managed domain is returned unchanged by the generic provider and rejected (or ignored) by the feature, with a test at the feature boundary rather than the infrastructure one
-- [ ] #6 All four subtasks TASK-76.1 through TASK-76.4 are Done and the DIRECTORY_MANAGED / MANAGED_GROUP grep across terraform, Makefile and app config returns zero hits at close
+- [ ] #6 All five subtasks TASK-76.1 through TASK-76.5 are Done and the DIRECTORY_MANAGED / MANAGED_GROUP grep across terraform, Makefile and app config returns zero hits at close
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -151,5 +151,38 @@ WHAT THIS CHANGES FOR THE REMAINING SLICES:
 What F4 got right: there is no coverage of the managed path at the FEATURE boundary, and no coverage of DirectorySettings' managed fields beyond env loading. The gap is one of placement, not of existence.
 
 R1 RESEARCH OUTCOME feeding D1 (from TASK-76.1 planning, human-raised): group aliases are not a Google-only concept, so putting them on the canonical model does not couple infrastructure to one IDP. Google exposes aliases[]/nonEditableAliases[]; Microsoft Graph exposes proxyAddresses ('Email addresses for the group that direct to the same group mailbox', uppercase SMTP: marking the primary); an IDP without the concept returns empty. Full citations and the per-provider mapping obligation are in TASK-76.1's plan.
+---
+
+author: @task-planner
+created: 2026-09-04 15:32
+---
+PLAN CORRECTION AND DECISION EXTENSION from TASK-76.2 planning (2026-09-04).
+
+D3 IS FACTUALLY WRONG ON THE PREFIX. D3 states that managed_group_prefix is 'DELETED, not moved' because 'AccessRuntimeConfig.dir_prefix + dir_separator already produce this exact value through AccessGroupNaming.group_prefix'. They do not. group_prefix(platform) returns the PLATFORM-SCOPED prefix 'sg-aws-' (app/packages/access/common/naming.py:18-23), while DIRECTORY_MANAGED_GROUP_PREFIX is the ORG-WIDE 'sg-' that _extract_managed_group_email applies across all platforms (app/infrastructure/directory/google.py:277). The org-wide value has no accessor today.
+
+The conclusion survives, the mechanism changes: the value is still DERIVED from existing fields and still gets no setting, but TASK-76.2 must add AccessGroupNaming.managed_prefix (= dir_prefix + dir_separator) to expose it. Human-approved 2026-09-04. AC#2 on TASK-76.2 was reworded to name it.
+
+D6 (NEW, human-approved 2026-09-04) - THE ACCESS RUNTIME CONFIG ENFORCES ITS OWN INVARIANTS. Planning TASK-76.2 surfaced that BundleConfigLoader fabricates AccessRuntimeConfig(dir_prefix='', platforms={}) as a 'waiting mode' sentinel, i.e. the feature's own config type can represent a state the feature cannot operate in. That is the same class of latent defect D5 was written for. Human direction: 'if we state that for the feature to work, we need prefix, then we need the code to reflect the requirement... the feature is currently disabled, so it's best to fix as we make changes. we will have to take time to reassess the whole logic of the access business feature before enabling it.'
+
+So, in TASK-76.2:
+- AccessRuntimeConfig gains a __post_init__ rejecting blank dir_prefix and blank dir_domain, making an unusable config unconstructible rather than merely unloadable. This is the D3 dir_domain re-homing plus a correction to the pre-existing dir_prefix gap.
+- BundleConfigLoader returns PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of the hollow config. Verified safe: get_access_runtime_config() is only reached behind each sub-feature's enabled gate (sync/__init__.py:74-81, catalog/__init__.py:40, request/__init__.py:68; the only other caller, jobs/scheduled_tasks.py:186, is registered nowhere), so with every ACCESS_*_ENABLED false (F6) no environment loads this config at all.
+- The 'bundle' source itself is KEPT so ACCESS_CONFIG_SOURCE values, the loader factory and the READMEs are unchanged. Whether it still earns its place once it can only error is left as an open question on TASK-76.2 rather than decided.
+
+D7 (NEW) - MULTI-DOMAIN STAYS WITH TASK-79. D4 already parks dir_domain as feature-owned configuration. TASK-76.2 additionally confirms it as a SINGLE required domain with strict case-insensitive equality - a faithful port of google.py:466-471 - on the basis that multi-domain support is a new capability rather than a gap between code and intent. Flagged as an explicit assumption in TASK-76.2's plan for reviewer challenge.
+
+ALSO: F4 remains inaccurate as already noted in the 14:42 comment; TASK-76.2 needs no provider-test relocation itself, but TASK-76.3 and TASK-76.4 still do.
+---
+
+author: @task-planner
+created: 2026-09-04 15:46
+---
+NEW CHILD SLICE TASK-76.5 CREATED 2026-09-04 (human-directed, from a finding raised while planning TASK-76.2): 'Remove organization-specific defaults from access settings' (dep TASK-76.2, m-3).
+
+WHY IT SITS UNDER TASK-76. Confirming TASK-76.2's org-agnostic rule (no default for dir_domain anywhere; absent means a named startup error) surfaced the same defect class left behind in the same package: AccessRequestsSettings.manager_group_slug='sg-managers' and fallback_approver_slug='sg-org-admins' (packages/access/common/settings.py:83-84), the second duplicated as a constructor default at request/service.py:131. Each is wrong twice - an organization's own group names presented as universal defaults, and a literal re-encoding of the 'sg-' prefix that dir_prefix + dir_separator already own, which is the same second-home duplication D3 removed for the managed-group prefix.
+
+AC#6 AMENDED accordingly: the all-children bar now reads TASK-76.1 through TASK-76.5 rather than 76.1 through 76.4. The other five ACs are unchanged (restated verbatim, since --acceptance-criteria replaces the whole list). No plan rewrite: the slice sequence in the plan still describes the managed-group relocation itself, which TASK-76.5 does not change - it is adjacent cleanup parked here rather than a sixth step of the relocation.
+
+DELIBERATELY EXCLUDED FROM TASK-76.5, needs its own task with a deployment step: AWS_ADMIN_GROUPS=['sre-ifs@cds-snc.ca'] (infrastructure/configuration/features/aws_ops.py:28). Same defect class, different risk - plan fact F7 already grep-verified that no terraform or Makefile override exists, so that default is what every environment actually uses today at modules/permissions/handler.py:40. Removing it without first provisioning the value breaks a live feature, and its consumer sits in app/modules/, frozen under decisions/migration.md rule 1.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
+++ b/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-76.2
 title: Introduce ManagedGroupPolicy and dir_domain in packages/access/common
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-04 14:17'
-updated_date: '2026-09-04 15:47'
+updated_date: '2026-09-04 16:06'
 labels:
   - layering
 milestone: m-3
@@ -43,15 +44,15 @@ TESTING (decisions/testing.md). Pure unit tests, no doubles needed for a value o
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ManagedGroupPolicy exists in app/packages/access/common as a frozen dataclass with no I/O and no imports from app/integrations, exposing canonical email, canonical slug, managed-domain check, alias-aware prefix match and slug-to-key composition
-- [ ] #2 The managed prefix is derived from the existing AccessRuntimeConfig naming (dir_prefix plus dir_separator, exposed as AccessGroupNaming.managed_prefix) and is not introduced as a new setting anywhere
-- [ ] #3 AccessRuntimeConfig carries dir_domain as a required non-empty field, with loader, bundle, dev-fixture and README plumbing updated; no AccessSettings feature env var and no infrastructure setting is added for it - the only new env name is the document-assembly ACCESS_CONFIG_ENV_DIR_DOMAIN, mirroring the existing ACCESS_CONFIG_ENV_DIR_PREFIX
-- [ ] #4 A DirectoryGroup whose canonical email is outside the managed domain is rejected by ManagedGroupPolicy, proven by a unit test at the feature boundary (parent AC#5)
-- [ ] #5 Unit tests cover alias preference including the wrong-domain-alias case, primary-email fallback on an empty alias tuple, alias-based prefix matching, key composition, and blank prefix or domain failing validation
-- [ ] #6 No file under app/infrastructure/ is modified by this slice
-- [ ] #7 mypy, ruff and the full non-smoke pytest run are green
-- [ ] #8 AccessRuntimeConfig rejects a blank dir_prefix or dir_domain at construction, and BundleConfigLoader returns a PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of fabricating an empty waiting-mode config, each covered by a test
-- [ ] #9 The two deliberate non-ports are implemented and their rationale recorded in the notes: matches_prefix drops the provider's unreachable no-candidates-means-match branch, and group_key can never emit a bare slug
+- [x] #1 ManagedGroupPolicy exists in app/packages/access/common as a frozen dataclass with no I/O and no imports from app/integrations, exposing canonical email, canonical slug, managed-domain check, alias-aware prefix match and slug-to-key composition
+- [x] #2 The managed prefix is derived from the existing AccessRuntimeConfig naming (dir_prefix plus dir_separator, exposed as AccessGroupNaming.managed_prefix) and is not introduced as a new setting anywhere
+- [x] #3 AccessRuntimeConfig carries dir_domain as a required non-empty field, with loader, bundle, dev-fixture and README plumbing updated; no AccessSettings feature env var and no infrastructure setting is added for it - the only new env name is the document-assembly ACCESS_CONFIG_ENV_DIR_DOMAIN, mirroring the existing ACCESS_CONFIG_ENV_DIR_PREFIX
+- [x] #4 A DirectoryGroup whose canonical email is outside the managed domain is rejected by ManagedGroupPolicy, proven by a unit test at the feature boundary (parent AC#5)
+- [x] #5 Unit tests cover alias preference including the wrong-domain-alias case, primary-email fallback on an empty alias tuple, alias-based prefix matching, key composition, and blank prefix or domain failing validation
+- [x] #6 No file under app/infrastructure/ is modified by this slice
+- [x] #7 mypy, ruff and the full non-smoke pytest run are green
+- [x] #8 AccessRuntimeConfig rejects a blank dir_prefix or dir_domain at construction, and BundleConfigLoader returns a PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of fabricating an empty waiting-mode config, each covered by a test
+- [x] #9 The two deliberate non-ports are implemented and their rationale recorded in the notes: matches_prefix drops the provider's unreachable no-candidates-means-match branch, and group_key can never emit a bare slug
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -211,6 +212,30 @@ R1 (was open question 1) - THE dir_domain VALUE IN THE FIXTURE. Resolved by H6: 
 
 R2 (was open question 2) - THE "bundle" SOURCE IS KEPT, no follow-up task. The question was whether a loader that can now only return an error still earns its place. It does, and more than before: "bundle" is the DEFAULT value of ACCESS_CONFIG_SOURCE, so it is precisely the code path that turns "someone enabled access without configuring it" into one named, self-explaining CONFIG_NOT_CONFIGURED error. Deleting it would force the default to file_json against a ref that does not exist, degrading that clear message into a generic CONFIG_NOT_FOUND about a missing path. The alternative is strictly worse, so this is settled rather than deferred.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED 2026-09-04 (implementation mode). Task left In Progress for human DoD verification.
+
+PRODUCTION CHANGES (4 files, 1 new):
+- NEW app/packages/access/common/group_policy.py - frozen ManagedGroupPolicy(prefix, domain) with from_config, canonical_email, canonical_slug, is_managed, matches_prefix, group_key. __post_init__ strips+lowercases both fields and rejects blanks. Only infrastructure import is the DirectoryGroup dataclass; no I/O, no app.integrations.
+- common/naming.py - AccessGroupNaming.managed_prefix property (dir_prefix + dir_separator), the org-wide prefix distinct from platform-scoped group_prefix(platform). No new setting.
+- common/config/settings.py - AccessRuntimeConfig gains required dir_domain (no default) plus __post_init__ rejecting blank dir_prefix or dir_domain.
+- common/config/loaders.py - RuntimeConfigJsonModel gains dir_domain (min_length=1) and dir_prefix is now min_length=1; docstring example updated; _build_runtime_config/_validate_runtime_config_payload thread the field, and the post-validate except widened from ValidationError to ValueError so the dataclass invariants surface as CONFIG_INVALID_SHAPE; EnvConfigLoader reads ACCESS_CONFIG_ENV_DIR_DOMAIN with an explicit missing-value check naming the variable; BundleConfigLoader now returns PERMANENT_ERROR CONFIG_NOT_CONFIGURED naming ACCESS_CONFIG_SOURCE/ACCESS_CONFIG_REF instead of fabricating a waiting-mode config.
+
+FIXTURES/DOCS: access.local.json uses the neutral example.com (H6/D-76.2-h - no organization-specific default anywhere in code or schema); packages/access, common, catalog and sync READMEs gained the dir_domain row/sample, the bundle source is documented as not-configured, and the sync README env block was corrected to the real ACCESS_CONFIG_ENV_* names it had been misreporting.
+
+AC#9 NON-PORTS AS PLANNED: (i) matches_prefix does not reproduce the provider's 'no candidates -> True' branch - both Google mappers already reject an email-less group (DIRECTORY_GROUP_EMAIL_REQUIRED), so it is unreachable feature-side; (ii) group_key can never emit a bare slug, since a blank domain is unconstructible.
+
+TEST EVIDENCE: pre-authored suites test_access_group_policy.py (14 cases) and test_access_runtime_config_validation.py (3 cases) plus the updated loader cases in sync/test_config.py all pass. Mechanical dir_domain plumbing applied to the two config factories and the remaining keyword construction sites / document payloads (13 test files).
+
+GATES: ruff clean. pytest tests/unit/packages/access + tests/integration/packages/access = 362 passed; human ran the full make test with one remaining failure (catalog display-name payload), since fixed. mypy reports no new errors in any touched file - the 95 findings are the pre-existing baseline in modules/ and untouched access files.
+
+AC#6 verified: git status shows zero modified paths under app/infrastructure/.
+
+FOR HUMAN VERIFICATION: full non-smoke pytest re-run after the final fix; confirm the F4 grep (no ACCESS_CONFIG_* in terraform/Makefile) still holds at merge time.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
+++ b/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
@@ -4,7 +4,7 @@ title: Introduce ManagedGroupPolicy and dir_domain in packages/access/common
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:17'
-updated_date: '2026-09-04 14:42'
+updated_date: '2026-09-04 15:47'
 labels:
   - layering
 milestone: m-3
@@ -44,13 +44,173 @@ TESTING (decisions/testing.md). Pure unit tests, no doubles needed for a value o
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 ManagedGroupPolicy exists in app/packages/access/common as a frozen dataclass with no I/O and no imports from app/integrations, exposing canonical email, canonical slug, managed-domain check, alias-aware prefix match and slug-to-key composition
-- [ ] #2 The managed prefix is derived from the existing AccessRuntimeConfig naming (dir_prefix plus dir_separator) and is not introduced as a new setting anywhere
-- [ ] #3 AccessRuntimeConfig carries dir_domain, validated as required and non-empty, with loader/bundle/fixture plumbing updated; no ACCESS_ env var and no infrastructure setting is added for it
-- [ ] #4 A DirectoryGroup whose email is outside the managed domain is rejected by ManagedGroupPolicy, proven by a unit test at the feature boundary (parent AC#5)
-- [ ] #5 Unit tests cover alias preference including the wrong-domain-alias case, primary-email fallback, alias-based prefix matching, key composition, and blank dir_domain failing validation
+- [ ] #2 The managed prefix is derived from the existing AccessRuntimeConfig naming (dir_prefix plus dir_separator, exposed as AccessGroupNaming.managed_prefix) and is not introduced as a new setting anywhere
+- [ ] #3 AccessRuntimeConfig carries dir_domain as a required non-empty field, with loader, bundle, dev-fixture and README plumbing updated; no AccessSettings feature env var and no infrastructure setting is added for it - the only new env name is the document-assembly ACCESS_CONFIG_ENV_DIR_DOMAIN, mirroring the existing ACCESS_CONFIG_ENV_DIR_PREFIX
+- [ ] #4 A DirectoryGroup whose canonical email is outside the managed domain is rejected by ManagedGroupPolicy, proven by a unit test at the feature boundary (parent AC#5)
+- [ ] #5 Unit tests cover alias preference including the wrong-domain-alias case, primary-email fallback on an empty alias tuple, alias-based prefix matching, key composition, and blank prefix or domain failing validation
 - [ ] #6 No file under app/infrastructure/ is modified by this slice
 - [ ] #7 mypy, ruff and the full non-smoke pytest run are green
+- [ ] #8 AccessRuntimeConfig rejects a blank dir_prefix or dir_domain at construction, and BundleConfigLoader returns a PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of fabricating an empty waiting-mode config, each covered by a test
+- [ ] #9 The two deliberate non-ports are implemented and their rationale recorded in the notes: matches_prefix drops the provider's unreachable no-candidates-means-match branch, and group_key can never emit a bare slug
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+SLICE 2 of TASK-76 (coordinator decisions D1, D3, D5). Planned 2026-09-04. Feature-only; nothing under app/infrastructure/ is touched. The policy is built and configured here but not yet wired into catalog/sync/request - TASK-76.3 does that.
+
+## Human decisions taken during planning (2026-09-04)
+
+H1. ENFORCE THE REQUIREMENT IN THE TYPE, do not model "not configured" as a hollow config. Human: "if we state that for the feature to work, we need prefix, then we need the code to reflect the requirement... the feature is currently disabled, so it's best to fix as we make changes." AccessRuntimeConfig therefore validates its own invariants and an invalid instance becomes unconstructible, rather than validation living only in the JSON document model.
+
+H2. BundleConfigLoader returns a PERMANENT_ERROR (CONFIG_NOT_CONFIGURED) instead of fabricating AccessRuntimeConfig(dir_prefix="", platforms={}). Chosen over deleting the "bundle" source outright; on review the source is KEPT permanently (see R2).
+
+H3. AccessGroupNaming gains a derived org-wide prefix helper; coordinator D3's claim that group_prefix already yields the managed prefix is factually wrong and is corrected on TASK-76 (see F2).
+
+H4. Single required dir_domain with strict matching. Human: "if there's a gap in the code versus the intended logic, then we fix now. we will have to take time to reassess the whole logic of the access business feature before enabling it." Multi-domain/owned-domain discovery is a NEW CAPABILITY owned by TASK-79, not a gap between code and intent, so it is not pulled in here. Recorded as assumption A3 for reviewer challenge.
+
+H5 (review, 2026-09-04). THE CONTRACT IN ONE LINE: enabling the access feature means its required settings must be present; disabling it means the rest of the app runs without prejudice. Both halves are already load-bearing in this design - F3 proves the disabled half, and H1/H2 deliver the enabled half as a clean startup error rather than a late, opaque IDP failure.
+
+H6 (review, 2026-09-04). NO ORGANIZATION-SPECIFIC DEFAULTS. The app is being made agnostic of the organization running it, so dir_domain gets NO default value anywhere in code, settings or schema - absent means startup error, exactly like any other required setting. Illustrative values are permitted in DOCUMENTATION (the READMEs may use cds-snc.ca as an example), but the committed dev fixture uses the neutral example.com placeholder rather than baking one organization's domain into a shipped file.
+
+## Grounding facts verified 2026-09-04
+
+F1. TASK-76.1 HAS LANDED. DirectoryGroup carries aliases: tuple[str, ...] = () (infrastructure/directory/models.py:44-66), populated by both _build_group (google.py:449) and _build_managed_group (google.py:490). The enabler this slice consumes exists.
+
+F2. COORDINATOR D3 IS INACCURATE. AccessGroupNaming.group_prefix(platform) returns the PLATFORM-SCOPED prefix "sg-aws-" (naming.py:18-23), while DIRECTORY_MANAGED_GROUP_PREFIX is the ORG-WIDE "sg-" that _extract_managed_group_email applies across all platforms (google.py:277). The org-wide value has no existing accessor, so it must be derived - dir_prefix + dir_separator - not merely referenced. Still no new setting, so AC#2 holds. Correction posted on TASK-76.
+
+F3. RUNTIME CONFIG IS ONLY LOADED BEHIND THE ENABLED GATE, which is what makes H1/H2/H5 safe for every environment. get_access_runtime_config() (common/providers.py:24) raises RuntimeError on load failure, and every caller sits behind a disabled-feature early return: sync/__init__.py:74-81, catalog/__init__.py:40, request/__init__.py:68, plus the lazily-built providers (sync/providers.py:32,63; catalog/providers.py:36,64; request/providers.py:45). jobs/scheduled_tasks.py:186 reconcile_access_sync is defined but registered nowhere - the live registration is register_background_jobs (sync/__init__.py:96), itself gated on enabled. With every ACCESS_*_ENABLED false (coordinator F6), no environment loads this config at all, so a missing dir_domain cannot affect an app that has access turned off.
+
+F4. NO DEPLOYMENT SURFACE. grep of terraform/, Makefile and app/Makefile for ACCESS_CONFIG returns zero hits, so no SSM parameter, task definition or CI variable carries the config source, ref or any ACCESS_CONFIG_ENV_* value. Adding a required document field costs no environment migration. RE-RUN BEFORE MERGE.
+
+F5. AccessRuntimeConfig CONSTRUCTION SITES: 8 total. Production - loaders.py:150 (_build_runtime_config) and loaders.py:204 (BundleConfigLoader). Tests - tests/unit/packages/access/sync/conftest.py:122, sync/test_application.py:320 and :403, request/test_service.py:34, request/test_policies.py:33, common/test_access_mode_override_contract.py:39. Plus the catalog and integration suites which construct through the same class under the alias AccessSyncRuntimeConfig (catalog/test_access_catalog_service.py:66,112,213,446; sync/test_providers.py:18,56) and the integration factory (tests/integration/packages/access/sync/conftest.py make_sync_config). EVERY ONE USES KEYWORD ARGUMENTS, so inserting dir_domain as a second non-defaulted field breaks no call syntactically - only the missing-value errors surface, which is the intent.
+
+F6. DOCUMENT-SHAPED TEST PAYLOADS also need the new key: catalog/test_access_catalog_providers.py:14, catalog/test_access_catalog_service.py:163, common/test_access_runtime_config_extensions.py:10 and :41, sync/test_config.py:101 and :125 all feed dicts through the loaders.
+
+F7. THE DEV FIXTURE AND DOCS carry the document shape: packages/access/access.local.json (referenced by packages/access/README.md:66-71 and packages/access/sync/README.md:79) and the RuntimeConfigJsonModel docstring example (loaders.py:88-107). All three must gain dir_domain or local dev breaks on the first load.
+
+F8. PROVIDER LOGIC BEING REPRODUCED (the specification for this slice, per the TASK-76.1 advisory that the managed path IS already pinned by tests/unit/infrastructure/directory/test_google.py):
+  - _extract_managed_group_email (google.py:269-285): first alias whose LOCAL PART starts with the managed prefix AND whose domain equals the managed domain; otherwise the primary email. Iterates alias order as reported.
+  - _matches_managed_group_prefix (google.py:306-313): primary email or any alias starts with the prefix; returns True when there are no candidates at all.
+  - _build_managed_group domain check (google.py:466-471): exact equality of the canonical email's domain against the managed domain.
+  - _normalize_email group half (google.py:211-220): strip+lower, and compose {slug}@{domain} when the value has no "@".
+
+F9 (review, 2026-09-04). ORGANIZATION-SPECIFIC DEFAULTS EXIST ELSEWHERE AND ARE OUT OF SCOPE HERE. Found while confirming H6: AccessRequestsSettings.manager_group_slug = "sg-managers" and fallback_approver_slug = "sg-org-admins" (packages/access/common/settings.py:83-84, duplicated as a default argument at request/service.py:131) bake both an organization's group names AND a literal copy of the "sg-" prefix convention into code defaults; outside access, AWS_ADMIN_GROUPS defaults to ["sre-ifs@cds-snc.ca"] (infrastructure/configuration/features/aws_ops.py:28). These are the same class of problem H6 describes but belong to no acceptance criterion here. Flagged to the human for a follow-up task rather than folded in.
+
+## Decisions for this slice
+
+D-76.2-a. HOME AND SHAPE. New app/packages/access/common/group_policy.py holding a frozen dataclass ManagedGroupPolicy(prefix: str, domain: str) - a pure value object: no I/O, no app.integrations import, and its only infrastructure import is the DirectoryGroup model (packages -> infrastructure is downward, decisions/layers.md). It lives in common/ because catalog, sync and request all consume it (decisions/feature-packages.md: common/ admits types with two or more subdomain consumers and no I/O). It is NOT re-exported from packages/access/common/__init__.py, which is deliberately export-free; consumers import the module path, exactly as they already do for common.naming.AccessGroupNaming.
+
+D-76.2-b. API, fixed here because TASK-76.3 is written against it:
+  from_config(config: AccessRuntimeConfig) -> ManagedGroupPolicy   # prefix = AccessGroupNaming(...).managed_prefix, domain = config.dir_domain
+  canonical_email(group: DirectoryGroup) -> str
+  canonical_slug(group: DirectoryGroup) -> str
+  is_managed(group: DirectoryGroup) -> bool
+  matches_prefix(group: DirectoryGroup, prefix: str) -> bool
+  group_key(slug: str) -> str
+Semantics port F8 exactly, with the deliberate exceptions in D-76.2-c. is_managed and canonical_slug are evaluated on canonical_email(group), not on group.group_email, because that is the value the provider's domain check ran against.
+
+D-76.2-c. TWO DELIBERATE NON-PORTS, both defect corrections under coordinator D5:
+  (i) matches_prefix does NOT reproduce _matches_managed_group_prefix's "no candidates -> True" branch. That branch let a group with no resolvable email survive discovery; feature-side it is unreachable, since both provider mappers already reject a group with no email (DIRECTORY_GROUP_EMAIL_REQUIRED, google.py:427-431), so every DirectoryGroup reaching the feature has a group_email. Porting it would add an unreachable branch.
+  (ii) group_key never emits a bare slug. The provider's completion branch silently produced an unusable key when the domain was empty; here a blank domain is impossible by construction (D-76.2-e).
+
+D-76.2-d. PREFIX DERIVATION (H3). AccessGroupNaming gains managed_prefix - a property returning f"{dir_prefix}{dir_separator}" (for example "sg-"), documented as the org-wide managed-group prefix as distinct from the platform-scoped group_prefix(platform). Pure derivation from existing fields; no setting is introduced anywhere, so AC#2 is satisfied by construction.
+
+D-76.2-e. INVARIANTS LIVE IN THE TYPES (H1):
+  - AccessRuntimeConfig gains dir_domain: str as a required (non-defaulted) field placed immediately after dir_prefix, and a __post_init__ that raises ValueError when dir_prefix or dir_domain is blank after stripping. Validating dir_prefix too is the explicit ask in H1 and is what turns today's hollow bundle into a compile-time-visible contradiction rather than a runtime surprise. This is boundary validation - the object is built from an external document - not defensive coding.
+  - ManagedGroupPolicy.__post_init__ strips+lowercases both fields (via object.__setattr__, the standard frozen-dataclass normalization) and raises ValueError when either is blank. A blank prefix is not merely useless: "".startswith checks succeed for every alias, so an unvalidated blank would make every alias look managed.
+
+D-76.2-f. LOADER PLUMBING:
+  - RuntimeConfigJsonModel gains dir_domain: str = Field(min_length=1); the docstring example gains the key. inline_json and file_json therefore fail with CONFIG_INVALID_SHAPE when it is absent.
+  - EnvConfigLoader._EnvModel gains dir_domain aliased to ACCESS_CONFIG_ENV_DIR_DOMAIN, with an explicit missing-value check mirroring the existing dir_prefix check (loaders.py:251-257) so the failure names the variable. This is a document-ASSEMBLY variable of the same class as ACCESS_CONFIG_ENV_DIR_PREFIX, not a feature setting on AccessSettings; AC#3's blanket wording is amended accordingly (see AC changes).
+  - BundleConfigLoader.load returns OperationResult.error(PERMANENT_ERROR, error_code="CONFIG_NOT_CONFIGURED") naming ACCESS_CONFIG_SOURCE/ACCESS_CONFIG_REF in the message (H2). Per F3 this is only reachable when a sub-feature is enabled, so the practical meaning is "access enabled but never configured", which must fail loudly.
+
+D-76.2-g. SINGLE DOMAIN, strict, case-insensitive equality; no subdomain matching, no domain list (H4). TASK-79 replaces this with an IDP-authoritative capability.
+
+D-76.2-h (review). NO DEFAULT FOR dir_domain ANYWHERE (H6). Not on AccessRuntimeConfig, not on RuntimeConfigJsonModel, not on the env loader model - absent means a named startup error. packages/access/access.local.json uses "example.com"; the READMEs may show a real organization domain as an illustrative example. Any reviewer who sees a default value creep in for this field should reject it: a default here would silently route one organization's group lookups at another's directory.
+
+## Ordered steps
+
+STEP 1 (AC#2) - app/packages/access/common/naming.py. Add the managed_prefix property per D-76.2-d, with a one-line docstring distinguishing it from group_prefix(platform). ~5 LOC.
+
+STEP 2 (AC#3) - app/packages/access/common/config/settings.py. Add dir_domain: str immediately after dir_prefix on AccessRuntimeConfig and the __post_init__ invariant from D-76.2-e. Update the class docstring to say the domain is the authoritative managed-group email domain and is required with no default. ~10 LOC.
+
+STEP 3 (AC#3) - app/packages/access/common/config/loaders.py. Apply D-76.2-f: RuntimeConfigJsonModel field + docstring example, _build_runtime_config signature and pass-through, _validate_runtime_config_payload wiring, EnvConfigLoader model/check/docstring, BundleConfigLoader error return and docstring. ~30 LOC.
+
+STEP 4 (AC#1, AC#4) - NEW app/packages/access/common/group_policy.py. Implement ManagedGroupPolicy per D-76.2-a/b/c/e. ~60 LOC including docstrings. Module docstring states that this is the feature-side owner of managed-group policy that the DirectoryProvider deliberately no longer carries - that is the one thing the code cannot show on its own.
+
+STEP 5 (AC#3) - fixtures and docs (F7, H6). Add dir_domain to packages/access/access.local.json using example.com, to the RuntimeConfigJsonModel docstring example, and to the config samples in packages/access/README.md and packages/access/sync/README.md; note in the README source list that bundle now reports "not configured" rather than yielding an empty config, and that dir_domain is required with no default.
+
+STEP 6 (AC#5) - new tests, per the matrix below.
+
+STEP 7 (AC#7) - mechanical test updates: the two runtime-config factories (tests/unit/packages/access/sync/conftest.py:115, tests/integration/packages/access/sync/conftest.py make_sync_config) gain a dir_domain: str = "example.com" parameter, which covers most call sites; then the direct constructions in F5 and the document payloads in F6 get the key. Any test asserting bundle waiting-mode success is rewritten against the new error contract rather than deleted.
+
+STEP 8 (AC#6, AC#7) - validation: cd app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'; uv run ruff check .; uv run pytest tests --ignore=tests/smoke. Then git status to prove nothing under app/infrastructure/ changed, and re-run F4's ACCESS_CONFIG grep.
+
+## Test matrix (decisions/testing.md - unit layer, pure value object so no doubles, no network, no time)
+
+NEW app/tests/unit/packages/access/common/test_access_group_policy.py (feature-prefixed name per the access naming guard at tests/unit/packages/access/test_access_test_file_naming.py):
+| # | Case | AC |
+| 1 | canonical_email prefers a managed-prefix alias in the managed domain over the primary email | 5 |
+| 2 | alias with the managed prefix but a FOREIGN domain is not preferred; primary wins (the nonEditableAliases guard from the TASK-76.1 advisory) | 5 |
+| 3 | alias in the managed domain WITHOUT the managed prefix is not preferred | 5 |
+| 4 | empty aliases tuple falls back to the primary email - () is legitimate, never an error | 5 |
+| 5 | first matching alias wins, asserted on a two-matching-alias payload, pinning IDP order as the tie-break | 5 |
+| 6 | canonical_slug returns the local part of the CANONICAL email, not of group_email, on a payload where they differ | 1 |
+| 7 | is_managed is False for a group whose canonical email is outside the domain - THE FEATURE-BOUNDARY TEST for parent AC#5 | 4 |
+| 8 | is_managed is True when the primary email is out-of-domain but a managed alias is in-domain (proves it runs on the canonical value) | 4 |
+| 9 | matches_prefix matches on the primary email | 5 |
+| 10 | matches_prefix matches on an alias when the primary does not | 5 |
+| 11 | matches_prefix is False when neither primary nor alias matches | 5 |
+| 12 | group_key composes a bare slug into slug@domain, and passes through / normalizes a value that already has "@" | 5 |
+| 13 | ManagedGroupPolicy with a blank domain, and with a blank prefix, each raise ValueError | 5 |
+| 14 | from_config derives "sg-" from dir_prefix="sg" + dir_separator="-" and takes the domain from dir_domain, normalizing mixed case and surrounding whitespace | 2,5 |
+
+NEW app/tests/unit/packages/access/common/test_access_runtime_config_validation.py:
+| 15 | AccessRuntimeConfig with a blank or whitespace dir_domain raises ValueError | 3,5 |
+| 16 | AccessRuntimeConfig with a blank dir_prefix raises ValueError | 3 |
+| 17 | a fully-specified config constructs and exposes dir_domain (guards against over-strict validation) | 3 |
+
+UPDATED app/tests/unit/packages/access/sync/test_config.py (existing home of the loader suite):
+| 18 | BundleConfigLoader.load returns PERMANENT_ERROR with CONFIG_NOT_CONFIGURED - replaces the current waiting-mode success assertion at ~line 90 | 3 |
+| 19 | inline_json and file_json documents missing dir_domain fail with CONFIG_INVALID_SHAPE | 3 |
+| 20 | a document carrying dir_domain loads it onto AccessRuntimeConfig | 3 |
+| 21 | EnvConfigLoader without ACCESS_CONFIG_ENV_DIR_DOMAIN fails naming the variable; with it set (monkeypatch.setenv, never a pyproject env block) it loads | 3 |
+
+## AC traceability
+
+AC#1 -> STEP 4 -> tests 6,7,12. AC#2 -> STEP 1 -> test 14. AC#3 -> STEPS 2,3,5 -> tests 15-21. AC#4 -> STEP 4 -> tests 7,8. AC#5 -> STEP 6 -> tests 1-5,9-14. AC#6 -> STEP 8 (git status). AC#7 -> STEP 8. AC#8 (bundle) -> STEP 3 -> test 18. AC#9 (non-ports) -> STEP 4 -> tests 11,12.
+
+## Assumptions and how they were verified
+
+A1. Tightening the config cannot break a running environment because the load is gated on the enabled flag -> F3. Re-verify before merge that no new unguarded get_access_runtime_config() call site has appeared.
+A2. Inserting a second non-defaulted field is safe because every construction is keyword-based -> F5. Re-run the grep before merge.
+A3. H4 is read as "single required domain now, multi-domain is TASK-79's new capability rather than a gap". FLAGGED FOR REVIEWER: if the intent was instead that multi-domain is itself the gap, this slice grows a dir_domains tuple and test 7/8 change shape - say so at plan review, not during implementation.
+A4. No deployment surface carries ACCESS_CONFIG_* -> F4. Re-run before merge.
+A5. Access remains disabled in every environment (coordinator F6). If any ACCESS_*_ENABLED has since been set, H1/H2 stop being free and the bundle change needs a rollout note.
+
+## Blast radius and rollback
+
+Bounded to app/packages/access/common/ (4 production files, one of them new), one JSON dev fixture and two READMEs. Nothing under app/infrastructure/ or app/modules/. Runtime impact is nil while the feature is disabled; the only behaviour change reachable at all is BundleConfigLoader's error return, and only for an operator who enables access without configuring it - who is today served a hollow config that would fail later and more confusingly. Test churn is wide but shallow: two factories absorb most of it. Single git revert restores everything; no data, no migration, no ordering constraint against any other PR beyond TASK-76.1, which is already merged.
+
+## Size gate
+
+Roughly 105 production LOC across 4 Python files plus 1 JSON fixture and 2 markdown files; one subsystem (packages/access/common); additive apart from one deliberate loader behaviour change. Test changes are ~180 new LOC in 2 new files plus one-line edits in about 12 existing files. Comfortably inside the single-PR gate on production LOC and subsystem spread; the wide-but-shallow test churn is mechanical and reviewable in one pass. No further decomposition.
+
+## Alignment with the wider programme
+
+- decisions/layers.md: the policy sits in packages/, imports downward into infrastructure.directory.models only, and names no vendor type. It is the feature-side owner that lets TASK-76.4 make the provider unconditionally generic.
+- decisions/configuration.md: one owning class per value. dir_domain gets exactly one home (AccessRuntimeConfig); managed_group_prefix gets none, because it is derived; enforce_managed_group_email is not re-homed at all.
+- decisions/sdk-typing.md and outbound-clients.md: untouched. This slice adds no vendor type to any signature and no SDK call; it consumes the canonical DirectoryGroup dataclass, which is exactly the adapter-translated domain type those records prescribe.
+- decisions/migration.md / feature-packages.md: no app/modules/ file is touched and no hookimpl or entry-point is added - common/ stays a namespace of types and values, not a plugin.
+- TASK-25.1.6 chain: no overlap. The only open sibling touching Directory is TASK-25.1.6.5 (modules/provisioning/groups.py, deletion of integrations/google_workspace/google_directory.py, retry_request retirement); it neither reads AccessRuntimeConfig nor constructs DirectoryGroup policy.
+
+## Review resolutions (2026-09-04)
+
+R1 (was open question 1) - THE dir_domain VALUE IN THE FIXTURE. Resolved by H6: packages/access/access.local.json uses "example.com" (neutral placeholder in a committed file), the READMEs may illustrate with a real organization domain such as cds-snc.ca, and NO default exists in code. A developer running locally against a real directory overrides the fixture; a missing value is an ordinary startup error, not a silent fallback.
+
+R2 (was open question 2) - THE "bundle" SOURCE IS KEPT, no follow-up task. The question was whether a loader that can now only return an error still earns its place. It does, and more than before: "bundle" is the DEFAULT value of ACCESS_CONFIG_SOURCE, so it is precisely the code path that turns "someone enabled access without configuring it" into one named, self-explaining CONFIG_NOT_CONFIGURED error. Deleting it would force the default to file_json against a ref that does not exist, degrading that clear message into a generic CONFIG_NOT_FOUND about a missing path. The alternative is strictly worse, so this is settled rather than deferred.
+<!-- SECTION:PLAN:END -->
 
 ## Comments
 
@@ -67,5 +227,44 @@ THREE CONSTRAINTS FOR YOUR POLICY:
 3. nonEditableAliases (domain-mirror addresses outside the primary domain, e.g. the *.test-google-a.com forms) are merged into the same tuple. Your prefix+domain filter is what excludes them - a prefix-only match would let them through, which the provider's current logic also guards against by checking the domain.
 
 Also relevant to your dir_domain work: TASK-76.1's research confirmed both major IDPs expose group aliases (Google aliases[]/nonEditableAliases[]; Entra proxyAddresses), so the policy's alias handling is portable - but the OWNED-DOMAIN question remains hand-maintained configuration until TASK-79 lands, exactly as coordinator decision D4 records.
+---
+
+author: @task-planner
+created: 2026-09-04 15:32
+---
+PLANNED 2026-09-04. Plan written; task stays To Do pending human review.
+
+ACCEPTANCE CRITERIA CHANGED (all were unchecked; restated in place):
+- AC#2 now names AccessGroupNaming.managed_prefix, because coordinator D3 was wrong that group_prefix already yields this value - it returns the platform-scoped 'sg-aws-', not the org-wide 'sg-'. Correction posted on TASK-76.
+- AC#3 reworded. It previously forbade adding ANY ACCESS_ env var, which would leave the 'env' config source structurally unable to supply a now-required field. The intent (D3) is 'no standalone AccessSettings feature setting'; ACCESS_CONFIG_ENV_DIR_DOMAIN is a document-assembly variable of the same class as the existing ACCESS_CONFIG_ENV_DIR_PREFIX. Human-approved during planning.
+- AC#4 now says 'canonical email' rather than 'email', matching the provider behaviour being reproduced (the domain check runs on the alias-preferred value).
+- AC#5 now names the empty-alias-tuple fallback explicitly, per the TASK-76.1 advisory.
+- NEW AC#8 and AC#9 carry the two human decisions taken during planning (see below).
+
+TWO HUMAN DECISIONS taken during planning that widen this slice slightly beyond its original description:
+1. AccessRuntimeConfig enforces its own invariants (non-empty dir_prefix AND dir_domain) rather than the JSON model alone, so an invalid config becomes unconstructible. Human: 'if we state that for the feature to work, we need prefix, then we need the code to reflect the requirement... the feature is currently disabled, so it's best to fix as we make changes.'
+2. Consequently BundleConfigLoader can no longer fabricate AccessRuntimeConfig(dir_prefix='', platforms={}) as 'waiting mode' and instead returns PERMANENT_ERROR CONFIG_NOT_CONFIGURED. Verified safe: the runtime config is only loaded behind each sub-feature's enabled gate (sync/__init__.py:74-81, catalog/__init__.py:40, request/__init__.py:68), so the only reachable meaning is 'access enabled but never configured', which must fail loudly.
+
+TWO OPEN QUESTIONS are recorded at the end of the plan: the dir_domain value for the local dev fixture and READMEs, and whether the 'bundle' source should be retired entirely as a follow-up now that it can only return an error.
+---
+
+author: @task-planner
+created: 2026-09-04 15:42
+---
+BOTH OPEN QUESTIONS RESOLVED 2026-09-04 (human review). Plan updated in place; see H5, H6, D-76.2-h, R1 and R2.
+
+R1 - NO ORGANIZATION-SPECIFIC DEFAULTS. dir_domain gets no default anywhere in code, settings or schema: absent means an ordinary named startup error, like any other required setting. The committed dev fixture packages/access/access.local.json uses the neutral example.com; the READMEs may illustrate with a real organization domain. A default here would be worse than absent - it would silently point one organization's group lookups at another's directory.
+
+R2 - THE 'bundle' SOURCE IS KEPT, no follow-up task filed. My question was whether a loader that can now only return an error still earns its place. It does: 'bundle' is the DEFAULT ACCESS_CONFIG_SOURCE, so it is exactly the path that turns 'access was enabled but never configured' into one named CONFIG_NOT_CONFIGURED error. Deleting it would force the default to file_json against a nonexistent ref, degrading that clear message into a generic CONFIG_NOT_FOUND about a missing path.
+
+CONTRACT CONFIRMED (H5): enabling access requires its settings to be present; disabling it leaves the rest of the app running without prejudice. Both halves already hold in this design - plan fact F3 proves the disabled half (the runtime config is only loaded behind each sub-feature's enabled gate), and H1/H2 deliver the enabled half as a clean startup error instead of a late, opaque IDP failure.
+
+OUT-OF-SCOPE FINDING RAISED, NOT FOLDED IN (new plan fact F9). Confirming the org-agnostic rule surfaced three organization-specific defaults that this task's ACs do not cover: AccessRequestsSettings.manager_group_slug='sg-managers' and fallback_approver_slug='sg-org-admins' (packages/access/common/settings.py:83-84, duplicated as a default argument at request/service.py:131 - these bake in both an organization's group names and a literal second copy of the 'sg-' prefix convention), and AWS_ADMIN_GROUPS=['sre-ifs@cds-snc.ca'] (infrastructure/configuration/features/aws_ops.py:28). Awaiting a decision on whether to file a follow-up task; not actioned here.
+---
+
+author: @task-planner
+created: 2026-09-04 15:47
+---
+FOLLOW-UP FILED 2026-09-04: the out-of-scope org-specific defaults recorded as plan fact F9 are now owned by TASK-76.5 (Remove organization-specific defaults from access settings), created as a sibling slice under TASK-76 with a dependency on this task. The access half (manager_group_slug, fallback_approver_slug and its duplicated constructor default) is in that task's scope; AWS_ADMIN_GROUPS is explicitly excluded there because it is a LIVE default with no terraform override, so removing it needs a provisioning step and touches a frozen module. Nothing in TASK-76.2's own scope or ACs changes.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
+++ b/backlog/tasks/task-76.2 - Introduce-ManagedGroupPolicy-and-dir_domain-in-packages-access-common.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-76.2
 title: Introduce ManagedGroupPolicy and dir_domain in packages/access/common
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-04 14:17'
-updated_date: '2026-09-04 16:06'
+updated_date: '2026-09-04 16:07'
 labels:
   - layering
 milestone: m-3

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -4,7 +4,7 @@ title: 'Cut access catalog, sync and request onto the generic DirectoryProvider 
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:18'
-updated_date: '2026-09-04 14:43'
+updated_date: '2026-09-04 15:32'
 labels:
   - layering
 milestone: m-3
@@ -56,5 +56,32 @@ created: 2026-09-04 14:43
 ADVISORY from TASK-76.1 planning (2026-09-04). Coordinator plan fact F4 is inaccurate (correction posted on TASK-76): the managed-group provider behaviour IS already pinned by app/tests/unit/infrastructure/directory/test_google.py, whose mock_directory_settings fixture (lines 135-142) runs the provider with managed_group_prefix='sg-' and managed_group_domain='example.com'. Managed-alias preference (line 1075), managed-domain mismatch (line 1119) and the alias-aware discovery skip (line 1108) are the exact behaviours your cut-over must reproduce at the feature boundary - read them as the specification instead of deriving one from scratch. What genuinely has no coverage is the packages/access side, so AC#4's 'existing test suites' still proves little there and your slice must add those tests.
 
 Enabler note: DirectoryGroup.aliases (TASK-76.1) is a tuple of IDP-reported secondary addresses, strip+lower normalized, empty when the IDP has no such concept - so any feature-side alias handling must tolerate () rather than requiring a non-empty tuple.
+---
+
+author: @task-planner
+created: 2026-09-04 15:32
+---
+ADVISORY from TASK-76.2 planning (2026-09-04). The API you cut over to is now frozen - write your call sites against exactly this.
+
+app/packages/access/common/group_policy.py, frozen dataclass ManagedGroupPolicy(prefix, domain):
+  ManagedGroupPolicy.from_config(config: AccessRuntimeConfig) -> ManagedGroupPolicy
+  canonical_email(group: DirectoryGroup) -> str
+  canonical_slug(group: DirectoryGroup) -> str
+  is_managed(group: DirectoryGroup) -> bool
+  matches_prefix(group: DirectoryGroup, prefix: str) -> bool
+  group_key(slug: str) -> str
+Not re-exported from packages.access.common.__init__ (which is deliberately export-free) - import the module path, as the code already does for common.naming.
+
+FOUR THINGS THAT AFFECT YOUR SLICE:
+
+1. is_managed and canonical_slug are evaluated on canonical_email(group), NOT on group.group_email, because that is the value the provider's domain check ran against (google.py:466-471 operates on _extract_managed_group_email's output). Do not re-derive slugs from group_email at your call sites.
+
+2. matches_prefix DELIBERATELY DOES NOT reproduce _matches_managed_group_prefix's 'no candidates -> True' branch (google.py:311). That branch kept a group with no resolvable email in the listing; feature-side it is unreachable because both provider mappers already reject an email-less group (DIRECTORY_GROUP_EMAIL_REQUIRED, google.py:427-431). If your cut-over relocates the existing provider test for that branch, relocate it as 'a group with no email never reaches the feature', not as a policy behaviour.
+
+3. THE PREFIX YOU PASS TO matches_prefix IS THE PLATFORM-SCOPED ONE. The policy's own prefix field is the ORG-WIDE 'sg-' (used only for alias preference); config.group_prefix(platform) is 'sg-aws-' and remains what catalog/service.py:140 and desired_state.py:219 pass as the match argument. The two are different values - coordinator D3 conflated them and has been corrected on TASK-76.
+
+4. CONFIG IS NOW STRICT, WHICH CHANGES YOUR TEST SETUP. AccessRuntimeConfig gains a required non-empty dir_domain and rejects a blank dir_prefix or dir_domain at construction, and BundleConfigLoader now returns PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of an empty 'waiting mode' config. Any test of yours that leaned on the hollow bundle must construct a config explicitly. TASK-76.2 adds a dir_domain parameter to both make_runtime_config (tests/unit/packages/access/sync/conftest.py) and make_sync_config (tests/integration/packages/access/sync/conftest.py), defaulting to example.com - use those factories rather than hand-rolling.
+
+Unchanged: your error-versus-omission decision (AC#3) is still yours to make and record; the policy returns a plain bool from is_managed precisely so each call site can choose.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
+++ b/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
@@ -1,0 +1,68 @@
+---
+id: TASK-76.5
+title: Remove organization-specific defaults from access settings
+status: To Do
+assignee: []
+created_date: '2026-09-04 15:46'
+labels:
+  - layering
+  - configuration
+milestone: m-3
+dependencies:
+  - TASK-76.2
+references:
+  - decisions/configuration.md
+  - decisions/feature-packages.md
+  - app/packages/access/common/settings.py
+  - app/packages/access/request/service.py
+parent_task_id: TASK-76
+priority: medium
+ordinal: 153000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Raised 2026-09-04 while planning TASK-76.2, from human direction: the app was originally built with hardcoded values and defaults matching one organization's domain, roles and group names, and is being made agnostic of the organization running it. TASK-76.2 establishes the rule for one value (dir_domain: no default anywhere, absent means a named startup error). This task applies the same rule to the organization-specific defaults it left behind in packages/access.
+
+THE PROBLEM. Two access settings ship an organization's own group names as code defaults:
+- AccessRequestsSettings.manager_group_slug = 'sg-managers' (app/packages/access/common/settings.py:83)
+- AccessRequestsSettings.fallback_approver_slug = 'sg-org-admins' (app/packages/access/common/settings.py:84)
+
+Both are wrong twice over. First, they are organization-specific values presented as universal defaults - an operator who never sets them silently gets another organization's group names, and the request feature then resolves approvers against groups that do not exist in their directory. Second, both literals re-encode the 'sg-' group prefix that AccessRuntimeConfig.dir_prefix + dir_separator already own, which is exactly the second-home duplication decisions/configuration.md forbids and which TASK-76 decision D3 removed for the managed-group prefix.
+
+The fallback slug is additionally duplicated as a constructor default at app/packages/access/request/service.py:131 (fallback_approver_slug: str = 'sg-org-admins'), so the same organization-specific literal has two homes inside one feature. Live wiring passes the setting through at packages/access/request/__init__.py:55-56 and providers.py:47, so the constructor default is only reachable by direct construction and tests - it is dead weight that keeps the literal alive.
+
+Consumers to keep working: resolve_approver_candidates (request/policies.py:72,103) receives fallback_slug and passes it straight to get_group_members as a group key, and request/service.py:303,310 supply it. Note the interaction with TASK-76.2 decision D2: after TASK-76.3 no access call site may pass a bare slug to DirectoryProvider, so whatever shape this value takes must still compose into a group key through ManagedGroupPolicy.group_key.
+
+SCOPE.
+1. Remove both organization-specific defaults so an unset value is a named configuration error rather than a silent wrong-organization lookup, consistent with the contract TASK-76.2 records as H5/H6.
+2. DECIDE AND RECORD the owning home rather than moving the literals: these are org group-naming facts of the same class as dir_prefix/dir_separator/dir_domain, which TASK-76 decision D3 puts on the AccessRuntimeConfig runtime document - versus keeping them as ACCESS_REQUESTS_* env settings. Pick one, state the rationale, do not split one convention across both mechanisms.
+3. DECIDE AND RECORD whether the slugs stay whole configured values or are composed from the existing naming (AccessGroupNaming). If composed, they must go through AccessGroupNaming rather than a fresh 'sg-' string literal; if whole, say why explicitly so the duplication is a deliberate choice rather than an oversight.
+4. Delete the duplicated constructor default at request/service.py:131 so the value has exactly one home.
+5. Update tests and fixtures to supply explicit values; no test may depend on an implicit organization default.
+
+NOT IN SCOPE, and why.
+- AWS_ADMIN_GROUPS = ['sre-ifs@cds-snc.ca'] (app/infrastructure/configuration/features/aws_ops.py:28). Same class of problem, different risk: unlike access, this default is LIVE. TASK-76's plan fact F7 grep-verified there is no terraform or Makefile override anywhere, so that default is what every environment actually uses today at modules/permissions/handler.py:40. Removing it without first provisioning the value through SSM/terraform breaks a running feature, and its consumer sits in app/modules/, frozen under decisions/migration.md rule 1. It needs its own task with a deployment step, not this one.
+- infrastructure/configuration/features/groups.py::GROUP_DOMAIN (legacy, TASK-76 decision D4 names it) and TASK-74/75's approved-participant-domain (an allow-list policy, not an identity fact).
+- Any change to ManagedGroupPolicy, the DirectoryProvider, or anything under app/infrastructure/.
+
+PRECONDITION: TASK-76.2 must land first - it establishes the no-default rule, the AccessRuntimeConfig invariant pattern and the AccessGroupNaming derivation this task follows.
+
+WHY THIS IS SAFE NOW: packages/access is not enabled in any environment (TASK-76 plan fact F6) and no ACCESS_ env var is set in terraform or either Makefile (verified 2026-09-04), so removing these defaults costs no rollout. RE-VERIFY BOTH BEFORE MERGE.
+
+TESTING (decisions/testing.md). Unit tests at the settings/config boundary proving a missing value fails with a named error rather than falling back; request-service and approver-resolution tests updated to supply explicit values through their existing fixtures. Feature-boundary assertions, not settings-internals assertions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No organization-specific group name remains as a default anywhere under app/packages: grep for 'sg-managers' and 'sg-org-admins' returns zero hits outside test fixtures and documentation examples
+- [ ] #2 The duplicated fallback_approver_slug default at app/packages/access/request/service.py:131 is removed so the value has exactly one owning home per decisions/configuration.md
+- [ ] #3 The owning home is decided and recorded with rationale - AccessRuntimeConfig runtime document versus ACCESS_REQUESTS_ env settings - rather than the literals simply moving; one convention is not split across both mechanisms
+- [ ] #4 The decision on whether the slugs are whole configured values or composed through AccessGroupNaming is recorded, and no new 'sg-' string literal is introduced either way
+- [ ] #5 A missing value produces a named configuration error consistent with the TASK-76.2 contract: enabling access requires its settings to be present, disabling it leaves the rest of the app unaffected, proven by a test
+- [ ] #6 Whatever shape the fallback slug takes still composes into a directory group key through ManagedGroupPolicy.group_key, so no bare slug reaches DirectoryProvider (TASK-76.2 decision D2)
+- [ ] #7 The existing access request suites pass with fixtures supplying explicit values, and no test depends on an implicit organization default
+- [ ] #8 No file under app/infrastructure/ or app/modules/ is modified, and AWS_ADMIN_GROUPS is left untouched
+- [ ] #9 mypy, ruff and the full non-smoke pytest run are green
+<!-- AC:END -->

--- a/backlog/tasks/task-79 - Make-organization-owned-domains-an-IDP-authoritative-directory-capability-instead-of-hand-maintained-per-feature-constants.md
+++ b/backlog/tasks/task-79 - Make-organization-owned-domains-an-IDP-authoritative-directory-capability-instead-of-hand-maintained-per-feature-constants.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:19'
+updated_date: '2026-09-04 15:33'
 labels:
   - layering
 milestone: m-3
@@ -48,3 +49,21 @@ Do the decision work before the code; this is architecture-mode work first. It i
 - [ ] #4 Each of the three existing hand-maintained domain constants is dispositioned as derived, retained-as-policy, or retired, with the disposition recorded
 - [ ] #5 mypy, ruff and the full non-smoke pytest run are green
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @task-planner
+created: 2026-09-04 15:33
+---
+ADVISORY from TASK-76.2 planning (2026-09-04). Your eventual replacement target now has a precise address.
+
+The hand-maintained owned-domain constant this task exists to retire lands, for the access feature, as AccessRuntimeConfig.dir_domain (app/packages/access/common/config/settings.py) - a REQUIRED, non-empty-validated field on the runtime config document, consumed only through ManagedGroupPolicy (app/packages/access/common/group_policy.py). It is a single domain with strict case-insensitive equality, a faithful port of the provider check at app/infrastructure/directory/google.py:466-471.
+
+Two consequences for your scope:
+- The multi-domain / subdomain gap is deliberately NOT closed in TASK-76, on the reasoning that owned-domain discovery is a new DirectoryProvider capability rather than a defect in the existing code. If that reasoning is wrong, TASK-76.2's plan flags it as assumption A3 for challenge.
+- When list_domains / primary_domain lands, the single feature-side seam to redirect is ManagedGroupPolicy.from_config, plus removing dir_domain from the runtime config document, its JSON schema (RuntimeConfigJsonModel), the ACCESS_CONFIG_ENV_DIR_DOMAIN assembly variable and packages/access/access.local.json. No other access file reads the domain directly.
+
+The other two hand-maintained copies named in TASK-76 decision D4 are unaffected by this slice: infrastructure/configuration/features/groups.py GROUP_DOMAIN (legacy) and TASK-74/75's approved-participant-domain, which is an allow-list policy rather than an identity fact.
+---
+<!-- COMMENTS:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a required `dir_domain` (managed group email domain) field to the access runtime configuration, making the application explicitly aware of which email domain its managed groups belong to. The change is enforced across configuration loaders, runtime config validation, and documentation, and a new `ManagedGroupPolicy` value object is added to encapsulate the logic for managed group identity. The default "bundle" config source now fails fast if not configured, rather than silently accepting an empty configuration.

**Configuration and Validation Changes:**

* Added a required `dir_domain` field (managed group email domain) to the runtime configuration model, all config loaders, and the `AccessRuntimeConfig` dataclass, with validation to ensure it is always present and non-empty. [[1]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7L112-R115) [[2]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R243-R250) [[3]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R268-R273) [[4]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7L197-R216) [[5]](diffhunk://#diff-c664832ff9ec305d0eec2fdc2ac88300baac8323d2e82bea8778f7d74b3c7b7eL63-R86)
* Updated all config loader sources (`env`, `file_json`, etc.) and example config files to support and require the new `dir_domain` field. [[1]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R94) [[2]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R128) [[3]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R156) [[4]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7R285) [[5]](diffhunk://#diff-ccdf5654680fe2c853b9e4e1abc306884f37a0ebdb4dcbf8ceb015377137d51fR3)

**Documentation Updates:**

* Updated all relevant `README.md` files and configuration documentation to describe the new `dir_domain` field, its purpose, and its required status. [[1]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55R55) [[2]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55R113) [[3]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55R127) [[4]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55R147) [[5]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55R184) [[6]](diffhunk://#diff-b1707f3566d7f0884e1693901090f3e0e16d25d76c196cc8c208ffca065f6de6R44) [[7]](diffhunk://#diff-a72a58b9c1196671faf9a6c29cdfdb94b3158e781659e6aea4377a6d4318a4acR60) [[8]](diffhunk://#diff-208d56095a4634bb68749c91b5beaa5b19c783ebda39ddd9fa6a6a944bfc3b64R30) [[9]](diffhunk://#diff-208d56095a4634bb68749c91b5beaa5b19c783ebda39ddd9fa6a6a944bfc3b64R45)
* Clarified documentation and examples for environment variable configuration, including the new `ACCESS_CONFIG_ENV_DIR_DOMAIN` variable. [[1]](diffhunk://#diff-208d56095a4634bb68749c91b5beaa5b19c783ebda39ddd9fa6a6a944bfc3b64L56-R76) [[2]](diffhunk://#diff-794370f77e0915e2d66094ff69e966ba2b206ff54726250ccf73bccc6492d7d7L8-R12) [[3]](diffhunk://#diff-a72a58b9c1196671faf9a6c29cdfdb94b3158e781659e6aea4377a6d4318a4acL72-R73)

**Policy and Naming Logic:**

* Added a new `ManagedGroupPolicy` value object in `group_policy.py` to encapsulate logic for determining managed group identity, canonical email, and slug, using the new `dir_domain` and prefix.
* Added a `managed_prefix` property to `AccessGroupNaming` to consistently generate the organization-wide group prefix.

**Error Handling and Defaults:**

* The default `bundle` config source now reports `CONFIG_NOT_CONFIGURED` and fails fast if no configuration is present, rather than silently starting in a "waiting mode."

These changes together ensure that the access feature is always explicitly configured with the correct managed group email domain, improving correctness and safety when managing IDP groups.