### PR TITLE
Feat/access subfeatures cutover

### DIFF
--- a/app/packages/access/catalog/providers.py
+++ b/app/packages/access/catalog/providers.py
@@ -16,6 +16,7 @@ from packages.access.catalog.parsers import (
     FallbackCatalogSlugParser,
 )
 from packages.access.catalog.service import CatalogService
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.common.providers import get_access_runtime_config
 from packages.access.common.settings import AccessCatalogSettings, get_access_settings
 
@@ -73,5 +74,6 @@ def get_catalog_service() -> CatalogService:
         runtime_config=runtime_config,
         directory=directory,
         parsers=parser_map,
+        policy=ManagedGroupPolicy.from_config(runtime_config),
         display_names=display_names,
     )

--- a/app/packages/access/catalog/service.py
+++ b/app/packages/access/catalog/service.py
@@ -19,6 +19,7 @@ from packages.access.catalog.domain import (
     PlatformSummary,
 )
 from packages.access.catalog.parsers import CatalogSlugParser, FallbackCatalogSlugParser
+from packages.access.common.group_policy import ManagedGroupPolicy
 
 if TYPE_CHECKING:
     from infrastructure.directory.provider import DirectoryProvider
@@ -50,6 +51,8 @@ class CatalogService:
         directory: IDP directory provider for group discovery and membership checks.
         parsers: Mapping of platform key → ``CatalogSlugParser``.
             Platforms without an entry fall back to ``FallbackCatalogSlugParser``.
+        policy: Managed-group policy owning canonical address, slug and
+            managed-domain decisions the directory provider no longer makes.
         display_names: Optional mapping of platform key → human-readable name.
     """
 
@@ -58,11 +61,13 @@ class CatalogService:
         runtime_config: AccessRuntimeConfig,
         directory: DirectoryProvider,
         parsers: dict[str, CatalogSlugParser],
+        policy: ManagedGroupPolicy,
         display_names: dict[str, str] | None = None,
     ) -> None:
         self._config = runtime_config
         self._directory = directory
         self._parsers = parsers
+        self._policy = policy
         self._display_names = display_names or {}
         self._fallback_parser = FallbackCatalogSlugParser()
         self.logger = logger
@@ -140,8 +145,8 @@ class CatalogService:
         prefix = self._config.group_prefix(normalized)
         parser = self._parsers.get(normalized, self._fallback_parser)
 
-        # Discover IDP groups matching the platform prefix.
-        discovery_result = self._directory.list_groups(query=prefix)
+        # Discover IDP groups generically; managed-group policy is applied here.
+        discovery_result = self._directory.list_groups()
         if not discovery_result.is_success or discovery_result.data is None:
             log.error(
                 "catalog_group_discovery_failed",
@@ -161,7 +166,18 @@ class CatalogService:
         provisioned_count = 0
 
         for group in sorted(groups, key=lambda g: g.group_slug):
-            slug = group.group_slug.strip().lower()
+            if not self._policy.matches_prefix(group, prefix):
+                continue
+            # A listing must not fail because one unrelated group is out of domain.
+            if not self._policy.is_managed(group):
+                log.warning(
+                    "catalog_group_outside_managed_domain",
+                    group_slug=group.group_slug,
+                )
+                continue
+
+            slug = self._policy.canonical_slug(group)
+            group_email = self._policy.canonical_email(group)
 
             # Skip the authn lifecycle group — it's not a requestable entitlement.
             if slug == authn_slug.lower():
@@ -182,7 +198,7 @@ class CatalogService:
             parsed_token = parser.parse(token)
 
             already_provisioned = self._check_membership(
-                group_email=group.group_email,
+                group_email=group_email,
                 user_email=user_email,
                 log=log,
                 token=token,
@@ -191,7 +207,7 @@ class CatalogService:
             entry = EntitlementEntry(
                 token=token,
                 group_slug=slug,
-                group_email=group.group_email,
+                group_email=group_email,
                 mode=mode,  # type: ignore[arg-type]
                 requestable=requestable,
                 already_provisioned=already_provisioned,

--- a/app/packages/access/request/policies.py
+++ b/app/packages/access/request/policies.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from packages.access.common.config import EntitlementMode
+from packages.access.common.group_policy import ManagedGroupPolicy
 
 if TYPE_CHECKING:
     from infrastructure.directory.models import DirectoryGroup
@@ -71,6 +72,7 @@ def resolve_approver_candidates(
     directory_group: DirectoryGroup,
     fallback_slug: str,
     directory: DirectoryProvider,
+    policy: ManagedGroupPolicy,
 ) -> list[str]:
     """Resolve an ordered list of eligible approver emails for a target group.
 
@@ -86,12 +88,13 @@ def resolve_approver_candidates(
         directory_group: Resolved canonical group from the IDP.
         fallback_slug: Org-level fallback group slug (e.g. ``"sg-org-admins"``).
         directory: IDP directory provider; read-only calls only.
+        policy: Managed-group policy composing canonical addresses and keys.
 
     Returns:
         Ordered list of approver email strings; may be empty.
     """
     members_result = directory.get_group_members(
-        group_key=directory_group.group_email,
+        group_key=policy.canonical_email(directory_group),
         include_member_types={"USER"},
     )
     if members_result.is_success and members_result.data:
@@ -100,7 +103,7 @@ def resolve_approver_candidates(
             return owners
 
     fallback_result = directory.get_group_members(
-        group_key=fallback_slug,
+        group_key=policy.group_key(fallback_slug),
         include_member_types={"USER"},
     )
     if fallback_result.is_success and fallback_result.data:

--- a/app/packages/access/request/providers.py
+++ b/app/packages/access/request/providers.py
@@ -14,6 +14,7 @@ from infrastructure.events import (
     get_event_dispatcher,
 )
 from infrastructure.storage import get_storage_service
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.common.providers import get_access_runtime_config
 from packages.access.common.settings import AccessRequestsSettings, get_access_settings
 from packages.access.request.service import AccessRequestService
@@ -39,11 +40,13 @@ def get_access_request_service() -> AccessRequestService:
     feature settings into a single fully-assembled service instance.
     """
     settings = get_access_request_settings()
+    runtime_config = get_access_runtime_config()
     return AccessRequestService(
         repository=get_access_request_repository(),
         directory=get_directory_provider(),
-        runtime_config=get_access_runtime_config(),
+        runtime_config=runtime_config,
         dispatcher=get_event_dispatcher(),
+        policy=ManagedGroupPolicy.from_config(runtime_config),
         fallback_approver_slug=settings.fallback_approver_slug,
         min_approver_count=settings.min_approver_count,
     )

--- a/app/packages/access/request/service.py
+++ b/app/packages/access/request/service.py
@@ -31,6 +31,7 @@ from infrastructure.events import Event, EventDispatcher
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig
 from packages.access.common.events import SYNC_COMPLETED, SYNC_FAILED
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.request import events as request_events
 from packages.access.request.domain import (
     AccessRequest,
@@ -118,6 +119,8 @@ class AccessRequestService:
         runtime_config: Access runtime config shared with Access Sync —
             the single source of truth for entitlement mode semantics.
         dispatcher: Event dispatcher for publishing domain events.
+        policy: Managed-group policy owning canonical address, managed-domain
+            and group-key decisions the directory provider no longer makes.
         fallback_approver_slug: Org-level fallback approver group slug.
         min_approver_count: Minimum number of approvals required.
     """
@@ -128,6 +131,7 @@ class AccessRequestService:
         directory: DirectoryProvider,
         runtime_config: AccessRuntimeConfig,
         dispatcher: EventDispatcher,
+        policy: ManagedGroupPolicy,
         fallback_approver_slug: str = "sg-org-admins",
         min_approver_count: int = 1,
     ) -> None:
@@ -135,6 +139,7 @@ class AccessRequestService:
         self._directory = directory
         self._config = runtime_config
         self._dispatcher = dispatcher
+        self._policy = policy
         self._fallback_approver_slug = fallback_approver_slug
         self._min_approver_count = min_approver_count
         self.logger = logger
@@ -184,7 +189,7 @@ class AccessRequestService:
         log.info("access_request_intake_started")
 
         # Step 1: resolve group
-        group_result = self._directory.get_group(group_slug)
+        group_result = self._directory.get_group(self._policy.group_key(group_slug))
         if not group_result.is_success or group_result.data is None:
             log.warning(
                 "access_request_intake_rejected",
@@ -208,6 +213,20 @@ class AccessRequestService:
                 message="Managed group has no email address; cannot process request.",
                 error_code="DIRECTORY_GROUP_EMAIL_REQUIRED",
             )
+
+        # An explicitly requested group out of domain is a configuration fault.
+        if not self._policy.is_managed(directory_group):
+            log.warning(
+                "access_request_intake_rejected",
+                reason="directory_group_domain_mismatch",
+            )
+            return OperationResult.error(
+                OperationStatus.PERMANENT_ERROR,
+                message=f"Group outside managed domain: {group_slug}",
+                error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH",
+            )
+
+        canonical_email = self._policy.canonical_email(directory_group)
 
         # Derive entitlement_id from the group slug by stripping the platform prefix.
         # For sg-aws-scratch with platform=aws and prefix sg-aws-, token is "scratch".
@@ -240,7 +259,7 @@ class AccessRequestService:
             )
 
         # Step 3: eligibility — direction-aware membership check
-        membership_result = self._directory.check_membership(directory_group.group_email, user_email)
+        membership_result = self._directory.check_membership(canonical_email, user_email)
         if membership_result.is_success and membership_result.data is not None:
             is_member = membership_result.data.is_member
             if request_type == "grant" and is_member:
@@ -268,7 +287,7 @@ class AccessRequestService:
         # of the specific target group, not a member of a global manager group.
         if actor_type == "delegated":
             members_result = self._directory.get_group_members(
-                group_key=directory_group.group_email,
+                group_key=canonical_email,
                 include_member_types={"USER"},
             )
             if not members_result.is_success:
@@ -302,6 +321,7 @@ class AccessRequestService:
             directory_group=directory_group,
             fallback_slug=self._fallback_approver_slug,
             directory=self._directory,
+            policy=self._policy,
         )
         if not approvers:
             log.error(
@@ -342,7 +362,7 @@ class AccessRequestService:
             request_type=request_type,  # type: ignore[arg-type]
             platform=platform,
             group_slug=group_slug,
-            group_email=directory_group.group_email,
+            group_email=canonical_email,
             provider_group_id=directory_group.provider_group_id,
             entitlement_type=entitlement_type,
             entitlement_id=entitlement_id,
@@ -371,9 +391,9 @@ class AccessRequestService:
         if auto_approved:
             idp_result: OperationResult[DirectoryMember] | OperationResult[None]
             if request_type == "grant":
-                idp_result = self._directory.add_group_member(directory_group.group_email, user_email)
+                idp_result = self._directory.add_group_member(canonical_email, user_email)
             else:
-                idp_result = self._directory.remove_group_member(directory_group.group_email, user_email)
+                idp_result = self._directory.remove_group_member(canonical_email, user_email)
             if not idp_result.is_success:
                 fail_now = datetime.now(tz=UTC)
                 failed = replace(request, status="failed", updated_at=fail_now)

--- a/app/packages/access/sync/desired_state.py
+++ b/app/packages/access/sync/desired_state.py
@@ -8,9 +8,9 @@ The coordinator resolves effective policy once per run via
 ``resolve_effective_policy`` and passes the result to
 ``build_user_state_from_effective`` (single-user) or
 ``build_platform_state_from_effective`` (batch reconciliation).  Discovery
-of IDP groups is handled by ``discover_group_slugs`` which queries the
-directory with the platform prefix and returns matching slugs, propagating
-any directory failure to the caller.
+of IDP groups is handled by ``discover_group_slugs`` which lists the
+directory generically and applies the platform prefix and managed-group
+policy locally, propagating any directory failure to the caller.
 """
 
 from typing import TYPE_CHECKING
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from infrastructure.operations import OperationResult, OperationStatus
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.sync.domain import DesiredPlatformState, DesiredUserState
 from packages.access.sync.policies import EffectivePlatformPolicy, EntitlementRule
 
@@ -39,8 +40,9 @@ class DirectoryMembershipBuilder:
     failures through the standard result contract without catching exceptions.
     """
 
-    def __init__(self, directory: DirectoryProvider) -> None:
+    def __init__(self, directory: DirectoryProvider, policy: ManagedGroupPolicy) -> None:
         self._directory = directory
+        self._policy = policy
 
     def build_user_state_from_effective(
         self,
@@ -91,9 +93,18 @@ class DirectoryMembershipBuilder:
                     error_code=user_groups_result.error_code,
                 )
 
-            user_group_slugs: set[str] = {
-                group.group_slug.lower() for group in (user_groups_result.data or []) if group.group_slug
-            }
+            user_group_slugs: set[str] = set()
+            for group in user_groups_result.data or []:
+                # A listing must not fail because one group is out of domain.
+                if not self._policy.is_managed(group):
+                    log.warning(
+                        "user_group_outside_managed_domain",
+                        group_slug=group.group_slug,
+                    )
+                    continue
+                slug = self._policy.canonical_slug(group)
+                if slug:
+                    user_group_slugs.add(slug)
 
             required_entitlements = [
                 rule for rule in effective.sync_managed_rules() if rule.group_slug.lower() in user_group_slugs
@@ -127,7 +138,7 @@ class DirectoryMembershipBuilder:
         """
         log = logger.bind(platform=effective.platform)
 
-        authn_group_result = self._directory.get_group(effective.authn_group_slug)
+        authn_group_result = self._directory.get_group(self._policy.group_key(effective.authn_group_slug))
         if not authn_group_result.is_success or not authn_group_result.data:
             return OperationResult.error(
                 OperationStatus.NOT_FOUND,
@@ -135,7 +146,14 @@ class DirectoryMembershipBuilder:
                 error_code="GROUP_NOT_FOUND",
             )
 
-        authn_email = authn_group_result.data.group_email
+        if not self._policy.is_managed(authn_group_result.data):
+            return OperationResult.error(
+                OperationStatus.PERMANENT_ERROR,
+                message=f"Authn group outside managed domain: {effective.authn_group_slug}",
+                error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH",
+            )
+
+        authn_email = self._policy.canonical_email(authn_group_result.data)
         authn_members_result = self._directory.get_group_members(
             authn_email,
             include_member_types={"USER"},
@@ -152,7 +170,7 @@ class DirectoryMembershipBuilder:
 
         email_to_rule: dict[str, EntitlementRule] = {}
         for rule in effective.sync_managed_rules():
-            group_result = self._directory.get_group(rule.group_slug)
+            group_result = self._directory.get_group(self._policy.group_key(rule.group_slug))
             if not group_result.is_success and group_result.status != OperationStatus.NOT_FOUND:
                 return OperationResult.error(
                     group_result.status,
@@ -166,7 +184,14 @@ class DirectoryMembershipBuilder:
                     group_slug=rule.group_slug,
                 )
                 continue
-            email_to_rule[group_result.data.group_email] = rule
+            # An explicitly configured group out of domain is a configuration fault.
+            if not self._policy.is_managed(group_result.data):
+                return OperationResult.error(
+                    OperationStatus.PERMANENT_ERROR,
+                    message=f"Group outside managed domain: {rule.group_slug}",
+                    error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH",
+                )
+            email_to_rule[self._policy.canonical_email(group_result.data)] = rule
 
         desired_members_by_entitlement: dict[str, set[str]] = {}
         entitlement_slug_by_id: dict[str, str] = {rule.entitlement_id: rule.group_slug for rule in effective.sync_managed_rules()}
@@ -208,17 +233,17 @@ class DirectoryMembershipBuilder:
         config: AccessRuntimeConfig,
         platform: str,
     ) -> OperationResult[set[str]]:
-        """Discover IDP group slugs for a platform by querying with the platform prefix.
+        """Discover IDP group slugs for a platform via a generic directory listing.
 
-        Uses ``config.group_prefix(platform)`` as the query and filters results
-        to slugs that start with that prefix.  An IDP failure is propagated as
-        an error result: a caller must never be able to mistake an unreachable
-        directory for "this platform declares no managed groups", since an
-        empty rule set silently disables entitlement enforcement.
+        Results are filtered client-side to ``config.group_prefix(platform)``
+        and to the managed domain.  An IDP failure is propagated as an error
+        result: a caller must never be able to mistake an unreachable directory
+        for "this platform declares no managed groups", since an empty rule set
+        silently disables entitlement enforcement.
         """
         prefix = config.group_prefix(platform)
         log = logger.bind(platform=platform, group_prefix=prefix)
-        list_result = self._directory.list_groups(query=prefix)
+        list_result = self._directory.list_groups()
         if not list_result.is_success:
             log.warning(
                 "discover_groups_failed",
@@ -232,13 +257,20 @@ class DirectoryMembershipBuilder:
             )
 
         groups = list_result.data if isinstance(list_result.data, list) else []
-        discovered = {
-            group.group_slug.strip().lower()
-            for group in groups
-            if group.group_slug
-            and isinstance(group.group_slug, str)
-            and group.group_slug.strip().lower().startswith(prefix.lower())
-        }
+        discovered: set[str] = set()
+        for group in groups:
+            if not self._policy.matches_prefix(group, prefix):
+                continue
+            # Discovery must not be taken down by one out-of-domain group.
+            if not self._policy.is_managed(group):
+                log.warning(
+                    "discover_groups_outside_managed_domain",
+                    group_slug=group.group_slug,
+                )
+                continue
+            slug = self._policy.canonical_slug(group)
+            if slug.startswith(prefix.lower()):
+                discovered.add(slug)
         log.info(
             "discover_groups_completed",
             discovered_count=len(discovered),
@@ -251,8 +283,8 @@ class DirectoryMembershipBuilder:
         group_slug: str,
         user_email: str,
     ) -> OperationResult[bool]:
-        """Resolve group slug to email and check user membership."""
-        group_result = self._directory.get_group(group_slug)
+        """Resolve group slug to its canonical email and check user membership."""
+        group_result = self._directory.get_group(self._policy.group_key(group_slug))
         if not group_result.is_success:
             return OperationResult.error(
                 group_result.status,
@@ -268,8 +300,16 @@ class DirectoryMembershipBuilder:
                 error_code="GROUP_NOT_FOUND",
             )
 
+        # An explicitly requested group out of domain is a configuration fault.
+        if not self._policy.is_managed(group):
+            return OperationResult.error(
+                OperationStatus.PERMANENT_ERROR,
+                message=f"Group outside managed domain: {group_slug}",
+                error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH",
+            )
+
         membership_result = self._directory.check_membership(
-            group.group_email,
+            self._policy.canonical_email(group),
             user_email,
         )
         if not membership_result.is_success:

--- a/app/packages/access/sync/providers.py
+++ b/app/packages/access/sync/providers.py
@@ -4,6 +4,7 @@ from infrastructure.directory import get_directory_provider
 from infrastructure.events import get_event_dispatcher
 from infrastructure.idempotency import IdempotencyStore, build_idempotency_store
 from infrastructure.storage import get_storage_service
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.common.providers import get_access_runtime_config
 from packages.access.common.settings import AccessSyncSettings, get_access_settings
 from packages.access.sync.adapters import AccessSyncAdapter
@@ -58,10 +59,14 @@ def get_access_sync_job_status_store() -> JobStatusStore:
 @functools.lru_cache(maxsize=1)
 def get_access_sync_coordinator() -> AccessSyncApplicationService:
     """Return the singleton AccessSyncApplicationService instance."""
+    config = get_access_runtime_config()
     return AccessSyncApplicationService(
         adapters=get_access_sync_adapters(),
-        config=get_access_runtime_config(),
-        membership_builder=DirectoryMembershipBuilder(directory=get_directory_provider()),
+        config=config,
+        membership_builder=DirectoryMembershipBuilder(
+            directory=get_directory_provider(),
+            policy=ManagedGroupPolicy.from_config(config),
+        ),
         repository=get_sync_run_repository(),
         dispatcher=get_event_dispatcher(),
     )

--- a/app/tests/integration/packages/access/sync/conftest.py
+++ b/app/tests/integration/packages/access/sync/conftest.py
@@ -51,6 +51,7 @@ from infrastructure.directory.models import (
 from infrastructure.operations import OperationResult
 from packages.access.common.config import AccessRuntimeConfig as AccessSyncRuntimeConfig
 from packages.access.common.config import PlatformPolicy
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.sync.adapters.aws_identity_center import AwsIdentityCenterAdapter
 from packages.access.sync.application import AccessSyncApplicationService
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
@@ -129,9 +130,10 @@ class FakeDirectory:
             provider_group_id=f"gid-{slug}",
         )
 
-    def get_group(self, slug: str) -> OperationResult:
+    def get_group(self, group_key: str) -> OperationResult:
         # Groups always exist in the IDP directory unless a per-slug result is injected;
         # the membership question is answered by check_membership / get_user_groups.
+        slug = group_key.partition("@")[0]
         if slug in self._group_result_by_slug:
             return self._group_result_by_slug[slug]
         return OperationResult.success(data=self._make_group(slug))
@@ -485,7 +487,7 @@ def make_coordinator(make_sync_config):
         coordinator = AccessSyncApplicationService(
             adapters={platform: adapter},
             config=config,
-            membership_builder=DirectoryMembershipBuilder(directory_provider),
+            membership_builder=DirectoryMembershipBuilder(directory_provider, ManagedGroupPolicy.from_config(config)),
         )
         return coordinator, adapter
 

--- a/app/tests/integration/packages/access/sync/test_desired_state.py
+++ b/app/tests/integration/packages/access/sync/test_desired_state.py
@@ -36,6 +36,9 @@ Scenarios covered:
 
   B4  A per-rule non-NOT_FOUND group lookup failure must propagate.
 
+  B5  A per-rule group outside the managed domain must propagate as a
+      hard error rather than being silently skipped.
+
   C1  Group discovery returns the platform-prefixed slugs and filters out
       foreign-platform groups.
 
@@ -45,9 +48,11 @@ Scenarios covered:
 
 import pytest
 
+from infrastructure.directory.models import DirectoryGroup
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig as AccessSyncRuntimeConfig
 from packages.access.common.config import PlatformPolicy
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
 from packages.access.sync.policies import resolve_effective_policy
 
@@ -86,7 +91,7 @@ def _make_builder_and_effective(
         transitive_membership_slugs=transitive_membership_slugs,
         user_direct_group_slugs=user_direct_group_slugs,
     )
-    builder = DirectoryMembershipBuilder(directory)
+    builder = DirectoryMembershipBuilder(directory, ManagedGroupPolicy.from_config(config))
     effective = resolve_effective_policy(config, platform, discovered_slugs)
     return builder, effective
 
@@ -332,7 +337,7 @@ def _make_platform_builder_and_effective(
         batch_members_result=batch_members_result,
         group_result_by_slug=group_result_by_slug,
     )
-    builder = DirectoryMembershipBuilder(directory)
+    builder = DirectoryMembershipBuilder(directory, ManagedGroupPolicy.from_config(config))
     effective = resolve_effective_policy(config, platform, discovered_slugs)
     return builder, effective
 
@@ -455,6 +460,35 @@ def test_should_propagate_error_when_group_lookup_transiently_fails():
     assert result.data is None
 
 
+@pytest.mark.integration
+def test_should_propagate_error_when_rule_group_is_outside_managed_domain():
+    """An explicitly configured out-of-domain group is a fault, not a silent skip."""
+    # Arrange
+    builder, effective = _make_platform_builder_and_effective(
+        discovered_slugs={"sg-aws-admin", "sg-aws-readonly"},
+        group_members={
+            "sg-aws-authn": ["alice@example.com", "bob@example.com"],
+            "sg-aws-readonly": ["bob@example.com"],
+        },
+        group_result_by_slug={
+            "sg-aws-admin": OperationResult.success(
+                data=DirectoryGroup(
+                    group_email="sg-aws-admin@other-tenant.com",
+                    group_slug="sg-aws-admin",
+                    provider_group_id="gid-sg-aws-admin",
+                )
+            )
+        },
+    )
+
+    # Act
+    result = builder.build_platform_state_from_effective(effective)
+
+    # Assert
+    assert not result.is_success
+    assert result.error_code == "DIRECTORY_GROUP_DOMAIN_MISMATCH"
+
+
 # ---------------------------------------------------------------------------
 # C: discover_group_slugs
 # ---------------------------------------------------------------------------
@@ -482,7 +516,7 @@ def _make_discovery_builder(
         discovered_slugs=discovered_slugs,
         list_groups_result=list_groups_result,
     )
-    return DirectoryMembershipBuilder(directory), config
+    return DirectoryMembershipBuilder(directory, ManagedGroupPolicy.from_config(config)), config
 
 
 @pytest.mark.integration

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
@@ -15,6 +15,7 @@ from packages.access.common.config import (
     InlineJsonConfigLoader,
     PlatformPolicy,
 )
+from packages.access.common.group_policy import ManagedGroupPolicy
 
 # ---------------------------------------------------------------------------
 # Stub helpers
@@ -479,3 +480,108 @@ def test_list_entitlements_should_return_empty_list_when_no_groups_discovered():
     # Assert
     assert result.is_success
     assert result.data == []
+
+
+# ---------------------------------------------------------------------------
+# ManagedGroupPolicy cut-over (TASK-76.3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _GenericFakeDirectory:
+    """Stub for the generic (unqueried) listing path; records every query used."""
+
+    groups_result: OperationResult = field(default_factory=lambda: OperationResult.success(data=[]))
+    memberships: dict[str, OperationResult] = field(default_factory=dict)
+    queries: list[str] = field(default_factory=list)
+
+    def list_groups(self, query: str = "", limit: int | None = None) -> OperationResult:
+        self.queries.append(query)
+        return self.groups_result
+
+    def check_membership(self, group_email: str, user_email: str) -> OperationResult:
+        return self.memberships.get(
+            group_email,
+            OperationResult.success(
+                data=MembershipCheckResult(
+                    group_email=group_email,
+                    group_slug="",
+                    provider_group_id=None,
+                    user_email=user_email,
+                    is_member=False,
+                )
+            ),
+        )
+
+
+def make_policy_service(directory: _GenericFakeDirectory) -> CatalogService:
+    return CatalogService(
+        runtime_config=make_runtime_config(),
+        directory=directory,
+        parsers={},
+        policy=ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+    )
+
+
+def test_list_entitlements_should_discover_groups_without_a_prefix_query():
+    directory = _GenericFakeDirectory(
+        groups_result=OperationResult.success(data=[make_group(slug="sg-aws-admin")]),
+    )
+    service = make_policy_service(directory)
+
+    result = service.list_entitlements(platform="aws", user_email="u@x.com")
+
+    assert result.is_success
+    assert directory.queries == [""]
+
+
+def test_list_entitlements_should_use_alias_preferred_canonical_email_and_slug():
+    group = DirectoryGroup(
+        group_email="legacy-admin@example.com",
+        group_slug="legacy-admin",
+        provider_group_id="gid-001",
+        aliases=("sg-aws-admin@example.com",),
+    )
+    directory = _GenericFakeDirectory(groups_result=OperationResult.success(data=[group]))
+    service = make_policy_service(directory)
+
+    result = service.list_entitlements(platform="aws", user_email="u@x.com")
+
+    assert result.is_success
+    assert [(e.token, e.group_slug, e.group_email) for e in result.data] == [
+        ("admin", "sg-aws-admin", "sg-aws-admin@example.com")
+    ]
+
+
+def test_list_entitlements_should_exclude_group_not_matching_platform_prefix():
+    directory = _GenericFakeDirectory(
+        groups_result=OperationResult.success(
+            data=[
+                make_group(slug="sg-aws-admin"),
+                make_group(slug="sg-gcp-admin", email="sg-gcp-admin@example.com"),
+            ]
+        ),
+    )
+    service = make_policy_service(directory)
+
+    result = service.list_entitlements(platform="aws", user_email="u@x.com")
+
+    assert result.is_success
+    assert [e.group_slug for e in result.data] == ["sg-aws-admin"]
+
+
+def test_list_entitlements_should_omit_out_of_domain_group_without_failing_listing():
+    directory = _GenericFakeDirectory(
+        groups_result=OperationResult.success(
+            data=[
+                make_group(slug="sg-aws-admin"),
+                make_group(slug="sg-aws-external", email="sg-aws-external@other-tenant.com"),
+            ]
+        ),
+    )
+    service = make_policy_service(directory)
+
+    result = service.list_entitlements(platform="aws", user_email="u@x.com")
+
+    assert result.is_success
+    assert [e.group_slug for e in result.data] == ["sg-aws-admin"]

--- a/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
+++ b/app/tests/unit/packages/access/catalog/test_access_catalog_service.py
@@ -26,14 +26,11 @@ from packages.access.common.group_policy import ManagedGroupPolicy
 class _FakeDirectory:
     """Stub that lets each test declare its own IDP responses."""
 
-    groups_by_prefix: dict[str, OperationResult] = field(default_factory=dict)
+    groups_result: OperationResult = field(default_factory=lambda: OperationResult.success(data=[]))
     memberships: dict[str, OperationResult] = field(default_factory=dict)
 
-    def list_groups(self, query: str) -> OperationResult:
-        return self.groups_by_prefix.get(
-            query,
-            OperationResult.success(data=[]),
-        )
+    def list_groups(self, query: str = "", limit: int | None = None) -> OperationResult:
+        return self.groups_result
 
     def check_membership(self, group_email: str, user_email: str) -> OperationResult:
         return self.memberships.get(
@@ -101,6 +98,7 @@ def make_service(
         runtime_config=cfg,
         directory=directory or _FakeDirectory(),
         parsers=parsers or {},
+        policy=ManagedGroupPolicy.from_config(cfg),
         display_names=display_names,
     )
 
@@ -246,7 +244,7 @@ def test_list_entitlements_should_return_not_found_for_unknown_platform():
 
 def test_list_entitlements_should_normalize_platform_key_to_lowercase():
     # Arrange
-    directory = _FakeDirectory(groups_by_prefix={"sg-aws-": OperationResult.success(data=[])})
+    directory = _FakeDirectory(groups_result=OperationResult.success(data=[]))
     service = make_service(directory=directory)
 
     # Act — mixed case
@@ -264,12 +262,10 @@ def test_list_entitlements_should_normalize_platform_key_to_lowercase():
 def test_list_entitlements_should_return_error_when_group_discovery_fails():
     # Arrange
     directory = _FakeDirectory(
-        groups_by_prefix={
-            "sg-aws-": OperationResult.error(
-                OperationStatus.PERMANENT_ERROR,
-                message="IDP unavailable",
-            )
-        }
+        groups_result=OperationResult.error(
+            OperationStatus.PERMANENT_ERROR,
+            message="IDP unavailable",
+        )
     )
     service = make_service(directory=directory)
 
@@ -293,7 +289,7 @@ def test_list_entitlements_should_return_entry_for_each_entitlement_group():
         make_group(slug="sg-aws-readonly", email="sg-aws-readonly@example.com"),
     ]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
         memberships={
             "sg-aws-admin@example.com": OperationResult.success(
                 data=MembershipCheckResult(
@@ -332,7 +328,7 @@ def test_list_entitlements_should_exclude_authn_group():
         make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com"),
     ]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
     )
     service = make_service(directory=directory)
 
@@ -351,7 +347,7 @@ def test_list_entitlements_should_annotate_membership_correctly():
         make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com"),
     ]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
         memberships={
             "sg-aws-admin@example.com": OperationResult.success(
                 data=MembershipCheckResult(
@@ -377,7 +373,7 @@ def test_list_entitlements_should_set_membership_to_none_when_check_fails():
     # Arrange — membership check returns error
     groups = [make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com")]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
         memberships={"sg-aws-admin@example.com": OperationResult.error(OperationStatus.PERMANENT_ERROR, message="IDP hiccup")},
     )
     service = make_service(directory=directory)
@@ -399,7 +395,7 @@ def test_list_entitlements_should_mark_sync_managed_token_as_requestable():
     # Arrange — no mode override; default is sync_managed
     groups = [make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com")]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
     )
     service = make_service(directory=directory)
 
@@ -416,7 +412,7 @@ def test_list_entitlements_should_mark_deactivated_token_as_not_requestable():
     cfg = make_runtime_config(platform="aws", mode_overrides={"admin": "deactivated"})
     groups = [make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com")]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
     )
     service = make_service(runtime_config=cfg, directory=directory)
 
@@ -432,7 +428,7 @@ def test_list_entitlements_should_use_registered_parser_for_platform():
     # Arrange
     groups = [make_group(slug="sg-aws-admin", email="sg-aws-admin@example.com")]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
     )
     service = make_service(
         directory=directory,
@@ -455,7 +451,7 @@ def test_list_entitlements_should_fall_back_to_fallback_parser_for_unknown_platf
     )
     groups = [make_group(slug="sg-custom-role1", email="sg-custom-role1@example.com")]
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-custom-": OperationResult.success(data=groups)},
+        groups_result=OperationResult.success(data=groups),
     )
     service = make_service(runtime_config=cfg, directory=directory, parsers={})
 
@@ -470,7 +466,7 @@ def test_list_entitlements_should_fall_back_to_fallback_parser_for_unknown_platf
 def test_list_entitlements_should_return_empty_list_when_no_groups_discovered():
     # Arrange
     directory = _FakeDirectory(
-        groups_by_prefix={"sg-aws-": OperationResult.success(data=[])},
+        groups_result=OperationResult.success(data=[]),
     )
     service = make_service(directory=directory)
 

--- a/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
+++ b/app/tests/unit/packages/access/common/test_access_mode_override_contract.py
@@ -6,6 +6,7 @@ from infrastructure.directory.models import DirectoryGroup, MembershipCheckResul
 from infrastructure.operations import OperationResult
 from packages.access.catalog.service import CatalogService
 from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.request.policies import check_entitlement_mode
 from packages.access.sync.policies import resolve_effective_policy
 
@@ -16,7 +17,7 @@ class _FakeDirectory:
 
     groups: list[DirectoryGroup]
 
-    def list_groups(self, query: str) -> OperationResult[list[DirectoryGroup]]:
+    def list_groups(self, query: str = "", limit: int | None = None) -> OperationResult[list[DirectoryGroup]]:
         return OperationResult.success(data=list(self.groups))
 
     def check_membership(
@@ -63,6 +64,7 @@ def _catalog_mode(config: AccessRuntimeConfig) -> tuple[str, bool]:
             ]
         ),
         parsers={},
+        policy=ManagedGroupPolicy.from_config(config),
     )
     result = service.list_entitlements(platform="aws", user_email="user@example.com")
     assert result.is_success

--- a/app/tests/unit/packages/access/request/test_policies.py
+++ b/app/tests/unit/packages/access/request/test_policies.py
@@ -27,6 +27,8 @@ from packages.access.request.policies import (
 # Helpers / factories
 # ---------------------------------------------------------------------------
 
+_POLICY = ManagedGroupPolicy(prefix="sg-", domain="example.com")
+
 
 def make_config(
     platform: str = "aws",
@@ -164,7 +166,7 @@ def test_resolve_approver_candidates_returns_owners_first():
         ]
     )
     group = make_directory_group()
-    result = resolve_approver_candidates(group, "sg-org-admins", directory)
+    result = resolve_approver_candidates(group, "sg-org-admins", directory, _POLICY)
     assert "owner@example.com" in result
     assert "manager@example.com" in result
     assert "member@example.com" not in result
@@ -181,7 +183,7 @@ def test_resolve_approver_candidates_falls_back_to_org_admins():
 
     directory.get_group_members.side_effect = get_group_members
     group = make_directory_group()
-    result = resolve_approver_candidates(group, "sg-org-admins", directory)
+    result = resolve_approver_candidates(group, "sg-org-admins", directory, _POLICY)
     assert result == ["admin@example.com"]
 
 
@@ -190,7 +192,7 @@ def test_resolve_approver_candidates_returns_empty_when_all_fail():
     directory = MagicMock()
     directory.get_group_members.return_value = OperationResult.success(data=[])
     group = make_directory_group()
-    result = resolve_approver_candidates(group, "sg-org-admins", directory)
+    result = resolve_approver_candidates(group, "sg-org-admins", directory, _POLICY)
     assert result == []
 
 
@@ -202,7 +204,7 @@ def test_resolve_approver_candidates_returns_empty_on_directory_error():
         OperationStatus.TRANSIENT_ERROR, message="Directory unavailable"
     )
     group = make_directory_group()
-    result = resolve_approver_candidates(group, "sg-org-admins", directory)
+    result = resolve_approver_candidates(group, "sg-org-admins", directory, _POLICY)
     assert result == []
 
 

--- a/app/tests/unit/packages/access/request/test_policies.py
+++ b/app/tests/unit/packages/access/request/test_policies.py
@@ -4,6 +4,7 @@ All functions are pure — no mocks required for entitlement-mode and
 approval-count tests.  DirectoryProvider tests use simple in-memory stubs.
 """
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ import pytest
 from infrastructure.directory.models import DirectoryGroup, DirectoryMember
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.request.domain import AccessRequest, ApprovalDecision
 from packages.access.request.policies import (
     check_entitlement_mode,
@@ -202,6 +204,51 @@ def test_resolve_approver_candidates_returns_empty_on_directory_error():
     group = make_directory_group()
     result = resolve_approver_candidates(group, "sg-org-admins", directory)
     assert result == []
+
+
+@pytest.mark.unit
+def test_resolve_approver_candidates_resolves_owners_via_canonical_alias_email():
+    directory = MagicMock()
+    directory.get_group_members.return_value = OperationResult.success(data=[make_member("owner@example.com", role="OWNER")])
+    group = make_directory_group(
+        group_email="legacy-admins@example.com",
+        group_slug="legacy-admins",
+    )
+    group = replace(group, aliases=("sg-aws-admins@example.com",))
+
+    result = resolve_approver_candidates(
+        group,
+        "sg-org-admins",
+        directory,
+        ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+    )
+
+    assert result == ["owner@example.com"]
+    assert directory.get_group_members.call_args.kwargs["group_key"] == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_resolve_approver_candidates_composes_fallback_slug_through_policy():
+    directory = MagicMock()
+    fallback_keys: list[str] = []
+
+    def get_group_members(group_key, include_member_types=None):
+        fallback_keys.append(group_key)
+        if group_key == "sg-aws-admins@example.com":
+            return OperationResult.success(data=[make_member("member@example.com", role="MEMBER")])
+        return OperationResult.success(data=[make_member("admin@example.com", role="OWNER")])
+
+    directory.get_group_members.side_effect = get_group_members
+
+    result = resolve_approver_candidates(
+        make_directory_group(),
+        "sg-org-admins",
+        directory,
+        ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+    )
+
+    assert result == ["admin@example.com"]
+    assert fallback_keys[-1] == "sg-org-admins@example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -19,6 +19,7 @@ from infrastructure.events import Event
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
 from packages.access.common.events import SYNC_COMPLETED, SYNC_FAILED
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.request.domain import AccessRequest, ApprovalDecision
 from packages.access.request.service import AccessRequestService
 
@@ -1031,3 +1032,79 @@ def test_revoke_request_type_in_approved_event_metadata():
 
     approved_event = next(e for e in dispatcher.dispatched if e.event_type == "access_request_approved")
     assert approved_event.metadata["request_type"] == "revoke"
+
+
+# ---------------------------------------------------------------------------
+# ManagedGroupPolicy cut-over (TASK-76.3)
+# ---------------------------------------------------------------------------
+
+
+def make_policy_service(directory: MagicMock) -> AccessRequestService:
+    return AccessRequestService(
+        repository=FakeRepository(),  # type: ignore[arg-type]
+        directory=directory,
+        runtime_config=make_config(),
+        dispatcher=FakeDispatcher(),  # type: ignore[arg-type]
+        policy=ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+    )
+
+
+def submit(service: AccessRequestService):
+    return service.submit_request(
+        user_email="user@example.com",
+        actor_email="user@example.com",
+        actor_type="self",
+        request_type="grant",
+        platform="aws",
+        group_slug="sg-aws-admins",
+        entitlement_type="group",
+        justification="Need access.",
+    )
+
+
+@pytest.mark.unit
+def test_submit_request_should_resolve_group_by_composed_group_key():
+    directory = MagicMock()
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group())
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
+    directory.get_group_members.return_value = OperationResult.success(
+        data=[DirectoryMember(email="approver@example.com", role="OWNER")]
+    )
+
+    submit(make_policy_service(directory))
+
+    assert directory.get_group.call_args.args[0] == "sg-aws-admins@example.com"
+
+
+@pytest.mark.unit
+def test_submit_request_should_reject_group_outside_managed_domain():
+    directory = MagicMock()
+    directory.get_group.return_value = OperationResult.success(data=make_directory_group(email="sg-aws-admins@other-tenant.com"))
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
+
+    result = submit(make_policy_service(directory))
+
+    assert not result.is_success
+    assert result.error_code == "DIRECTORY_GROUP_DOMAIN_MISMATCH"
+
+
+@pytest.mark.unit
+def test_submit_request_should_persist_canonical_alias_group_email():
+    directory = MagicMock()
+    directory.get_group.return_value = OperationResult.success(
+        data=replace(
+            make_directory_group(email="legacy-admins@example.com", slug="legacy-admins"),
+            aliases=("sg-aws-admins@example.com",),
+        )
+    )
+    directory.check_membership.return_value = OperationResult.success(data=make_membership(is_member=False))
+    directory.get_group_members.return_value = OperationResult.success(
+        data=[DirectoryMember(email="approver@example.com", role="OWNER")]
+    )
+
+    result = submit(make_policy_service(directory))
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.group_email == "sg-aws-admins@example.com"
+    assert directory.check_membership.call_args.args[0] == "sg-aws-admins@example.com"

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -146,6 +146,7 @@ def make_service(
         directory=directory,
         runtime_config=config or make_config(),
         dispatcher=dispatcher,  # type: ignore[arg-type]
+        policy=ManagedGroupPolicy(prefix="sg-", domain="example.com"),
         fallback_approver_slug=fallback_approver_slug,
         min_approver_count=min_approver_count,
     )

--- a/app/tests/unit/packages/access/sync/test_application.py
+++ b/app/tests/unit/packages/access/sync/test_application.py
@@ -21,6 +21,7 @@ from infrastructure.directory.models import (
 )
 from infrastructure.operations import OperationResult, OperationStatus
 from packages.access.common.config import AccessRuntimeConfig, PlatformPolicy
+from packages.access.common.group_policy import ManagedGroupPolicy
 from packages.access.sync.application import AccessSyncApplicationService
 from packages.access.sync.desired_state import DirectoryMembershipBuilder
 from packages.access.sync.domain import (
@@ -248,7 +249,8 @@ class FakeDirectory:
             ]
         )
 
-    def get_group(self, slug: str) -> OperationResult:
+    def get_group(self, group_key: str) -> OperationResult:
+        slug = group_key.partition("@")[0]
         return OperationResult.success(
             data=DirectoryGroup(
                 group_email=f"{slug}@example.com",
@@ -339,7 +341,7 @@ def make_coordinator(
     coordinator = AccessSyncApplicationService(
         adapters={platform: adapter},
         config=config,
-        membership_builder=DirectoryMembershipBuilder(directory_provider),
+        membership_builder=DirectoryMembershipBuilder(directory_provider, ManagedGroupPolicy.from_config(config)),
     )
     return coordinator, adapter
 
@@ -410,7 +412,7 @@ def test_sync_user_adapter_not_found():
     coordinator = AccessSyncApplicationService(
         adapters={},
         config=config,
-        membership_builder=DirectoryMembershipBuilder(directory_provider),
+        membership_builder=DirectoryMembershipBuilder(directory_provider, ManagedGroupPolicy.from_config(config)),
     )
     result = coordinator.sync_user("alice@example.com", "aws")
     assert not result.is_success

--- a/app/tests/unit/packages/access/sync/test_desired_state.py
+++ b/app/tests/unit/packages/access/sync/test_desired_state.py
@@ -102,7 +102,9 @@ class FakeDirectory:
     def list_users(self, query: str = "", limit: int | None = None) -> OperationResult:  # pragma: no cover - unused
         raise NotImplementedError
 
-    def add_group_member(self, group_key: str, user_email: str, role: str = "MEMBER") -> OperationResult:  # pragma: no cover - unused
+    def add_group_member(
+        self, group_key: str, user_email: str, role: str = "MEMBER"
+    ) -> OperationResult:  # pragma: no cover - unused
         raise NotImplementedError
 
     def remove_group_member(self, group_key: str, user_email: str) -> OperationResult:  # pragma: no cover - unused
@@ -380,9 +382,7 @@ def test_build_platform_state_should_batch_members_by_canonical_alias_email():
 @pytest.mark.unit
 def test_discover_group_slugs_should_exclude_foreign_platform_group(make_runtime_config):
     directory = FakeDirectory(
-        list_groups_result=OperationResult.success(
-            data=[make_group("sg-aws-admins"), make_group("sg-gcp-admins")]
-        )
+        list_groups_result=OperationResult.success(data=[make_group("sg-aws-admins"), make_group("sg-gcp-admins")])
     )
     builder = make_builder(directory)
 

--- a/app/tests/unit/packages/access/sync/test_desired_state.py
+++ b/app/tests/unit/packages/access/sync/test_desired_state.py
@@ -1,0 +1,451 @@
+"""Unit tests for DirectoryMembershipBuilder's ManagedGroupPolicy cut-over (TASK-76.3).
+
+Covers the feature-side managed-group decisions the DirectoryProvider no longer
+makes: canonical email/slug resolution, managed-domain filtering, and group-key
+composition. Uses a Protocol-conformant DirectoryProvider fake per
+decisions/testing.md — never MagicMock.
+"""
+
+import pytest
+
+from infrastructure.directory.models import (
+    DirectoryGroup,
+    DirectoryMember,
+    MembershipCheckResult,
+)
+from infrastructure.directory.provider import DirectoryProvider
+from infrastructure.operations import OperationResult, OperationStatus
+from packages.access.common.config import EntitlementRule
+from packages.access.common.group_policy import ManagedGroupPolicy
+from packages.access.sync.desired_state import DirectoryMembershipBuilder
+from packages.access.sync.policies import EffectivePlatformPolicy
+
+# ---------------------------------------------------------------------------
+# Fakes and factories
+# ---------------------------------------------------------------------------
+
+
+class FakeDirectory:
+    """Protocol-conformant DirectoryProvider double recording its call keys."""
+
+    def __init__(
+        self,
+        groups: dict[str, DirectoryGroup] | None = None,
+        user_groups: OperationResult | None = None,
+        list_groups_result: OperationResult | None = None,
+        members: dict[str, list[DirectoryMember]] | None = None,
+        is_member: bool = True,
+    ) -> None:
+        self._groups = groups or {}
+        self._user_groups = user_groups or OperationResult.success(data=[])
+        self._list_groups_result = list_groups_result or OperationResult.success(data=[])
+        self._members = members or {}
+        self._is_member = is_member
+        self.get_group_keys: list[str] = []
+        self.list_groups_queries: list[str] = []
+        self.check_membership_keys: list[str] = []
+
+    def get_group(self, group_key: str) -> OperationResult:
+        self.get_group_keys.append(group_key)
+        group = self._groups.get(group_key)
+        if group is None:
+            return OperationResult.error(
+                OperationStatus.NOT_FOUND,
+                message=f"not found: {group_key}",
+                error_code="GROUP_NOT_FOUND",
+            )
+        return OperationResult.success(data=group)
+
+    def list_groups(self, query: str = "", limit: int | None = None) -> OperationResult:
+        self.list_groups_queries.append(query)
+        return self._list_groups_result
+
+    def get_user_groups(self, user_email: str) -> OperationResult:
+        return self._user_groups
+
+    def check_membership(self, group_key: str, user_email: str) -> OperationResult:
+        self.check_membership_keys.append(group_key)
+        return OperationResult.success(
+            data=MembershipCheckResult(
+                group_email=group_key,
+                group_slug=group_key.partition("@")[0],
+                provider_group_id="gid-authn",
+                user_email=user_email,
+                is_member=self._is_member,
+            )
+        )
+
+    def get_group_members(
+        self,
+        group_key: str,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult:
+        return OperationResult.success(data=self._members.get(group_key, []))
+
+    def get_group_members_batch(
+        self,
+        group_keys: list[str],
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult:
+        return OperationResult.success(data={key: self._members.get(key, []) for key in group_keys})
+
+    # Unused surface — present so the fake satisfies the full protocol.
+    def warmup(self) -> OperationResult:  # pragma: no cover - unused
+        return OperationResult.success()
+
+    def health_check(self) -> OperationResult:  # pragma: no cover - unused
+        return OperationResult.success()
+
+    def get_user(self, email: str) -> OperationResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def list_users(self, query: str = "", limit: int | None = None) -> OperationResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def add_group_member(self, group_key: str, user_email: str, role: str = "MEMBER") -> OperationResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def remove_group_member(self, group_key: str, user_email: str) -> OperationResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def list_groups_with_members(
+        self,
+        query: str = "",
+        limit: int | None = None,
+        include_member_types: set[str] | None = None,
+    ) -> OperationResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def make_policy() -> ManagedGroupPolicy:
+    return ManagedGroupPolicy(prefix="sg-", domain="example.com")
+
+
+def make_group(
+    slug: str,
+    email: str | None = None,
+    aliases: tuple[str, ...] = (),
+    provider_group_id: str = "gid-001",
+) -> DirectoryGroup:
+    return DirectoryGroup(
+        group_email=email if email is not None else f"{slug}@example.com",
+        group_slug=slug,
+        provider_group_id=provider_group_id,
+        aliases=aliases,
+    )
+
+
+def make_rule(slug: str, entitlement_id: str) -> EntitlementRule:
+    return EntitlementRule(group_slug=slug, entitlement_id=entitlement_id)
+
+
+def make_effective(rules: list[EntitlementRule] | None = None) -> EffectivePlatformPolicy:
+    return EffectivePlatformPolicy(
+        platform="aws",
+        authn_group_slug="sg-aws-authn",
+        authn_removal_mode="delete",
+        entitlement_rules=rules or [],
+    )
+
+
+def make_builder(directory: FakeDirectory) -> DirectoryMembershipBuilder:
+    return DirectoryMembershipBuilder(directory, make_policy())  # type: ignore[arg-type]
+
+
+AUTHN_GROUP = make_group("sg-aws-authn", provider_group_id="gid-authn")
+
+
+@pytest.mark.unit
+def test_fake_directory_should_conform_to_directory_provider_protocol():
+    assert isinstance(FakeDirectory(), DirectoryProvider)
+
+
+# ---------------------------------------------------------------------------
+# build_user_state_from_effective — list-shaped: omit out-of-domain groups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_user_state_should_omit_out_of_domain_group_from_user_groups():
+    directory = FakeDirectory(
+        groups={"sg-aws-authn@example.com": AUTHN_GROUP},
+        user_groups=OperationResult.success(
+            data=[
+                make_group("sg-aws-admins"),
+                make_group("sg-aws-readers", email="sg-aws-readers@other-tenant.com"),
+            ]
+        ),
+    )
+    builder = make_builder(directory)
+    effective = make_effective(
+        [
+            make_rule("sg-aws-admins", "admins"),
+            make_rule("sg-aws-readers", "readers"),
+        ]
+    )
+
+    result = builder.build_user_state_from_effective("user@example.com", effective)
+
+    assert result.is_success
+    assert result.data is not None
+    assert [rule.entitlement_id for rule in result.data.required_entitlements] == ["admins"]
+
+
+@pytest.mark.unit
+def test_build_user_state_should_match_rules_on_alias_preferred_canonical_slug():
+    directory = FakeDirectory(
+        groups={"sg-aws-authn@example.com": AUTHN_GROUP},
+        user_groups=OperationResult.success(
+            data=[
+                make_group(
+                    "legacy-admins",
+                    email="legacy-admins@example.com",
+                    aliases=("sg-aws-admins@example.com",),
+                )
+            ]
+        ),
+    )
+    builder = make_builder(directory)
+    effective = make_effective([make_rule("sg-aws-admins", "admins")])
+
+    result = builder.build_user_state_from_effective("user@example.com", effective)
+
+    assert result.is_success
+    assert result.data is not None
+    assert [rule.entitlement_id for rule in result.data.required_entitlements] == ["admins"]
+
+
+# ---------------------------------------------------------------------------
+# _check_group_membership — get-shaped: composed key and domain-mismatch error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_user_state_should_fetch_authn_group_by_composed_group_key():
+    directory = FakeDirectory(groups={"sg-aws-authn@example.com": AUTHN_GROUP})
+    builder = make_builder(directory)
+
+    builder.build_user_state_from_effective("user@example.com", make_effective())
+
+    assert directory.get_group_keys == ["sg-aws-authn@example.com"]
+
+
+@pytest.mark.unit
+def test_build_user_state_should_error_when_authn_group_is_outside_managed_domain():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": make_group(
+                "sg-aws-authn",
+                email="sg-aws-authn@other-tenant.com",
+                provider_group_id="gid-authn",
+            )
+        }
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_user_state_from_effective("user@example.com", make_effective())
+
+    assert not result.is_success
+    assert result.error_code == "DIRECTORY_GROUP_DOMAIN_MISMATCH"
+
+
+@pytest.mark.unit
+def test_build_user_state_should_check_membership_against_canonical_alias_email():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": make_group(
+                "legacy-authn",
+                email="legacy-authn@example.com",
+                aliases=("sg-aws-authn@example.com",),
+                provider_group_id="gid-authn",
+            )
+        }
+    )
+    builder = make_builder(directory)
+
+    builder.build_user_state_from_effective("user@example.com", make_effective())
+
+    assert directory.check_membership_keys == ["sg-aws-authn@example.com"]
+
+
+# ---------------------------------------------------------------------------
+# build_platform_state_from_effective — get-shaped: propagate domain mismatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_platform_state_should_fetch_groups_by_composed_group_key():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": AUTHN_GROUP,
+            "sg-aws-admins@example.com": make_group("sg-aws-admins"),
+        },
+        members={"sg-aws-authn@example.com": [DirectoryMember(email="user@example.com")]},
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_platform_state_from_effective(make_effective([make_rule("sg-aws-admins", "admins")]))
+
+    assert result.is_success
+    assert directory.get_group_keys == [
+        "sg-aws-authn@example.com",
+        "sg-aws-admins@example.com",
+    ]
+
+
+@pytest.mark.unit
+def test_build_platform_state_should_error_when_authn_group_is_outside_managed_domain():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": make_group(
+                "sg-aws-authn",
+                email="sg-aws-authn@other-tenant.com",
+                provider_group_id="gid-authn",
+            )
+        }
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_platform_state_from_effective(make_effective())
+
+    assert not result.is_success
+    assert result.error_code == "DIRECTORY_GROUP_DOMAIN_MISMATCH"
+
+
+@pytest.mark.unit
+def test_build_platform_state_should_error_when_rule_group_is_outside_managed_domain():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": AUTHN_GROUP,
+            "sg-aws-admins@example.com": make_group(
+                "sg-aws-admins",
+                email="sg-aws-admins@other-tenant.com",
+            ),
+        },
+        members={"sg-aws-authn@example.com": [DirectoryMember(email="user@example.com")]},
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_platform_state_from_effective(make_effective([make_rule("sg-aws-admins", "admins")]))
+
+    assert not result.is_success
+    assert result.error_code == "DIRECTORY_GROUP_DOMAIN_MISMATCH"
+
+
+@pytest.mark.unit
+def test_build_platform_state_should_skip_not_found_rule_group_without_error():
+    directory = FakeDirectory(
+        groups={"sg-aws-authn@example.com": AUTHN_GROUP},
+        members={"sg-aws-authn@example.com": [DirectoryMember(email="user@example.com")]},
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_platform_state_from_effective(make_effective([make_rule("sg-aws-admins", "admins")]))
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.desired_members_by_entitlement == {}
+
+
+@pytest.mark.unit
+def test_build_platform_state_should_batch_members_by_canonical_alias_email():
+    directory = FakeDirectory(
+        groups={
+            "sg-aws-authn@example.com": AUTHN_GROUP,
+            "sg-aws-admins@example.com": make_group(
+                "legacy-admins",
+                email="legacy-admins@example.com",
+                aliases=("sg-aws-admins@example.com",),
+            ),
+        },
+        members={
+            "sg-aws-authn@example.com": [DirectoryMember(email="user@example.com")],
+            "sg-aws-admins@example.com": [DirectoryMember(email="user@example.com")],
+        },
+    )
+    builder = make_builder(directory)
+
+    result = builder.build_platform_state_from_effective(make_effective([make_rule("sg-aws-admins", "admins")]))
+
+    assert result.is_success
+    assert result.data is not None
+    assert result.data.desired_members_by_entitlement == {"admins": {"user@example.com"}}
+
+
+# ---------------------------------------------------------------------------
+# discover_group_slugs — list-shaped: generic listing plus client-side policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_discover_group_slugs_should_exclude_foreign_platform_group(make_runtime_config):
+    directory = FakeDirectory(
+        list_groups_result=OperationResult.success(
+            data=[make_group("sg-aws-admins"), make_group("sg-gcp-admins")]
+        )
+    )
+    builder = make_builder(directory)
+
+    result = builder.discover_group_slugs(make_runtime_config(), "aws")
+
+    assert result.is_success
+    assert result.data == {"sg-aws-admins"}
+    assert directory.list_groups_queries == [""]
+
+
+@pytest.mark.unit
+def test_discover_group_slugs_should_omit_out_of_domain_group_without_failing(make_runtime_config):
+    directory = FakeDirectory(
+        list_groups_result=OperationResult.success(
+            data=[
+                make_group("sg-aws-admins"),
+                make_group("sg-aws-external", email="sg-aws-external@other-tenant.com"),
+            ]
+        )
+    )
+    builder = make_builder(directory)
+
+    result = builder.discover_group_slugs(make_runtime_config(), "aws")
+
+    assert result.is_success
+    assert result.data == {"sg-aws-admins"}
+
+
+@pytest.mark.unit
+def test_discover_group_slugs_should_use_alias_preferred_canonical_slug(make_runtime_config):
+    directory = FakeDirectory(
+        list_groups_result=OperationResult.success(
+            data=[
+                make_group(
+                    "legacy-admins",
+                    email="legacy-admins@example.com",
+                    aliases=("sg-aws-admins@example.com",),
+                )
+            ]
+        )
+    )
+    builder = make_builder(directory)
+
+    result = builder.discover_group_slugs(make_runtime_config(), "aws")
+
+    assert result.is_success
+    assert result.data == {"sg-aws-admins"}
+
+
+@pytest.mark.unit
+def test_discover_group_slugs_should_propagate_directory_failure(make_runtime_config):
+    directory = FakeDirectory(
+        list_groups_result=OperationResult.error(
+            OperationStatus.TRANSIENT_ERROR,
+            message="idp unavailable",
+            error_code="DIRECTORY_UNAVAILABLE",
+        )
+    )
+    builder = make_builder(directory)
+
+    result = builder.discover_group_slugs(make_runtime_config(), "aws")
+
+    assert not result.is_success
+    assert result.status == OperationStatus.TRANSIENT_ERROR
+    assert result.error_code == "DIRECTORY_UNAVAILABLE"
+    assert result.data is None

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -4,7 +4,7 @@ title: 'Cut access catalog, sync and request onto the generic DirectoryProvider 
 status: To Do
 assignee: []
 created_date: '2026-09-04 14:18'
-updated_date: '2026-09-04 15:32'
+updated_date: '2026-09-04 16:48'
 labels:
   - layering
 milestone: m-3
@@ -46,7 +46,137 @@ TESTING (decisions/testing.md). Protocol-conformant fakes for DirectoryProvider 
 - [ ] #5 The existing access catalog, sync and request suites pass, with any provider-side managed assertions relocated to the feature boundary rather than dropped
 - [ ] #6 No file under app/infrastructure/ and no file under app/modules/ is modified by this slice
 - [ ] #7 mypy, ruff and the full non-smoke pytest run are green
+- [ ] #8 The single-user authn membership check in DirectoryMembershipBuilder._check_group_membership (desired_state.py) also composes its get_group call through policy.group_key and applies the same get-shaped domain-mismatch handling as build_platform_state_from_effective (found during planning; not named in the task description's enumerated call-site list)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+SLICE 3 of TASK-76 (coordinator decisions D1, D2, D5). Planned 2026-09-04. Behaviour-bearing slice: after this, packages/access no longer relies on any managed-group behaviour from the provider, but nothing under app/infrastructure/ or app/modules/ is touched — the provider keeps _build_managed_group unused-by-the-feature until TASK-76.4 deletes it.
+
+## Human decisions taken during planning (2026-09-04) — see task comment for full rationale
+
+D-a. Every downstream read of a fetched DirectoryGroup's group_email is routed through policy.canonical_email(), not only the literal call sites the task description names.
+D-b. Error-vs-omission split confirmed: OMIT+warn for list-shaped ops (catalog list_entitlements, discover_group_slugs, get_user_groups); ERROR (propagate) for every get-shaped op (get_group call sites, including the per-rule loop and the single-user authn check).
+D-c. Policy is constructor-injected (policy: ManagedGroupPolicy) into CatalogService, DirectoryMembershipBuilder and AccessRequestService, built once per subdomain's providers.py via ManagedGroupPolicy.from_config(get_access_runtime_config()) — not derived internally from the runtime_config each service already holds.
+D-d. New AC#8 folds in a call site found during planning (_check_group_membership in desired_state.py) that passes a bare slug to get_group but was not named in the task text.
+
+## Grounding facts verified 2026-09-04
+
+F1. list_groups(query="") already resolves to the generic _build_group mapper in the CURRENT provider (google.py: `if not query_str: map_fn = self._build_group; managed_prefix = None`), returning aliases and no domain filtering, regardless of DirectorySettings' managed_group_prefix/domain. Switching catalog/service.py and desired_state.py's discover_group_slugs from list_groups(query=prefix) to list_groups() therefore needs ZERO infrastructure change in this slice — verified by reading google.py directly, not assumed from the coordinator plan's F2.
+
+F2. Only ONE access-side consumer of get_user_groups exists: DirectoryMembershipBuilder.build_user_state_from_effective (desired_state.py). Grep-confirmed across app/packages/access/**. Satisfies the task's "identify every consumer" instruction.
+
+F3. Every existing test fixture already builds DirectoryGroup with group_email=f"{slug}@{domain}" where domain equals the runtime config's dir_domain ("example.com" everywhere) and no aliases — so canonical_email/canonical_slug/is_managed are no-ops against every EXISTING fixture (is_managed is always True, canonical_slug always equals group_slug). This means most existing assertions keep passing unchanged; only fixtures/dicts that are literally keyed or shaped around the OLD query-based server-side filtering need restructuring (F4), and NEW tests are needed to actually exercise alias-preference, prefix-mismatch and domain-mismatch (nothing today constructs an out-of-domain or alias-bearing DirectoryGroup on the access side).
+
+F4. catalog/test_access_catalog_service.py's `_FakeDirectory.list_groups(self, query: str)` keys a `groups_by_prefix: dict[str, OperationResult]` by the exact query string (e.g. "sg-aws-"). Since production will call list_groups() with no query, every one of that file's ~15 call sites configuring `groups_by_prefix={"sg-aws-": ...}` will silently start returning the default empty list unless the fake is restructured. test_access_mode_override_contract.py's `_FakeDirectory` and sync's FakeDirectory doubles (test_application.py, integration conftest.py) already IGNORE query when filtering client-side themselves or return the configured set unconditionally, so they need no such restructuring — only their DirectoryMembershipBuilder(...) constructor call sites need the new policy= argument (F5).
+
+F5. DirectoryMembershipBuilder(...) is constructed directly (not via providers.py) at 6 test call sites: tests/unit/packages/access/sync/test_application.py:342,413; tests/integration/packages/access/sync/conftest.py:488; tests/integration/packages/access/sync/test_desired_state.py:89,335,485. All are positional (`DirectoryMembershipBuilder(directory)` or `DirectoryMembershipBuilder(directory_provider)`) — each needs a second positional/keyword policy argument.
+
+F6. request/service.py's existing add_group_member/remove_group_member call-arg assertions (test_service.py:450,958,1000) already assert the CANONICAL email form ("sg-aws-admins@example.com"), identical to what policy.canonical_email() will compute for that fixture (no aliases, domain matches) — these assertions need NO change. request/service.py uses a MagicMock() directory by default in tests, so argument-shape changes (bare slug -> policy.group_key(slug)) are invisible to it except where a test asserts exact call args on get_group/get_group_members with a bare slug — none found (grep-confirmed; only add/remove_group_member call-arg assertions exist, and those already use the full email).
+
+F7. discover_group_slugs' OperationResult failure-propagation contract (TASK-78, merged) is unchanged by this slice: the `if not list_result.is_success: return OperationResult.error(...)` branch is untouched; only the success-path mapping loop changes.
+
+F8. AccessGroupNaming.managed_prefix (policy's own prefix field) is ORG-WIDE ("sg-"), while every prefix argument passed to policy.matches_prefix() in this slice is the PLATFORM-SCOPED config.group_prefix(platform) ("sg-aws-") — confirmed against TASK-76.2's advisory #2 point 3. Do not conflate the two.
+
+## Production changes, by file
+
+### 1. packages/access/catalog/service.py
+- Import `from packages.access.common.group_policy import ManagedGroupPolicy` (module import, runtime use).
+- `__init__` gains `policy: ManagedGroupPolicy` (positional, after `directory`); store as `self._policy`.
+- `list_entitlements`: replace `self._directory.list_groups(query=prefix)` with `self._directory.list_groups()`. In the loop over `groups`: skip (continue, no log) when `not self._policy.matches_prefix(group, prefix)`; skip with a warning log (`catalog_group_outside_managed_domain`, list-shaped -> omit, D-b) when `not self._policy.is_managed(group)`; derive `slug = self._policy.canonical_slug(group)` (drop the old `.strip().lower()` — the policy already normalizes); keep the existing `slug == authn_slug.lower()` and `slug.startswith(prefix.lower())` guards unchanged, operating on the canonical slug; set `group_email=self._policy.canonical_email(group)` on the built `EntitlementEntry` (was `group.group_email`).
+
+### 2. packages/access/catalog/providers.py
+- `get_catalog_service()`: construct `policy = ManagedGroupPolicy.from_config(runtime_config)` and pass `policy=policy` into `CatalogService(...)`.
+
+### 3. packages/access/sync/desired_state.py
+- Import `ManagedGroupPolicy` (runtime use, not TYPE_CHECKING).
+- `DirectoryMembershipBuilder.__init__(self, directory: DirectoryProvider, policy: ManagedGroupPolicy)`; store `self._policy`.
+- `build_user_state_from_effective`: after `get_user_groups`, replace the `user_group_slugs` set comprehension with a loop that, per returned group, warns+skips (`user_group_outside_managed_domain`, list-shaped -> omit) when `not self._policy.is_managed(group)`, else adds `self._policy.canonical_slug(group)`.
+- `build_platform_state_from_effective`: `authn_group_result = self._directory.get_group(self._policy.group_key(effective.authn_group_slug))`; after success, if `not self._policy.is_managed(authn_group_result.data)` return `OperationResult.error(OperationStatus.PERMANENT_ERROR, message=f"Authn group outside managed domain: {effective.authn_group_slug}", error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH")` (get-shaped -> error, D-b); `authn_email = self._policy.canonical_email(authn_group_result.data)` (was `.group_email`). In the per-rule loop: `group_result = self._directory.get_group(self._policy.group_key(rule.group_slug))`; keep the existing NOT_FOUND-skip and other-error-propagate branches; after a successful, present result, if `not self._policy.is_managed(group_result.data)` return the same DIRECTORY_GROUP_DOMAIN_MISMATCH error (get-shaped, per-rule is still an explicit configured fault per D-b) — do not silently `continue`; else `email_to_rule[self._policy.canonical_email(group_result.data)] = rule` (was `.group_email`).
+- `discover_group_slugs`: replace `self._directory.list_groups(query=prefix)` with `self._directory.list_groups()`; in the mapping comprehension, first filter to `self._policy.matches_prefix(group, prefix)` (silent skip — different platform, expected), then warn+skip when `not self._policy.is_managed(group)` (list-shaped -> omit), then add `self._policy.canonical_slug(group)` to `discovered`.
+- `_check_group_membership` (AC#8, found during planning): `group_result = self._directory.get_group(self._policy.group_key(group_slug))`; after the existing not-found guard, add: if `not self._policy.is_managed(group)` return `OperationResult.error(OperationStatus.PERMANENT_ERROR, message=f"Group outside managed domain: {group_slug}", error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH")` (get-shaped -> error); `membership_result = self._directory.check_membership(self._policy.canonical_email(group), user_email)` (was `group.group_email`).
+
+### 4. packages/access/sync/providers.py
+- `get_access_sync_coordinator()`: construct `policy = ManagedGroupPolicy.from_config(config)` (config already fetched via `get_access_runtime_config()`) and pass `policy=policy` into `DirectoryMembershipBuilder(directory=get_directory_provider(), policy=policy)`.
+
+### 5. packages/access/request/service.py
+- Import `ManagedGroupPolicy` (runtime use).
+- `__init__` gains `policy: ManagedGroupPolicy` (after `runtime_config`); store `self._policy`.
+- `submit_request`: `group_result = self._directory.get_group(self._policy.group_key(group_slug))`; keep the existing NOT_FOUND handling; after `directory_group = group_result.data`, add a domain check — if `not self._policy.is_managed(directory_group)` return `OperationResult.error(OperationStatus.PERMANENT_ERROR, message=f"Group outside managed domain: {group_slug}", error_code="DIRECTORY_GROUP_DOMAIN_MISMATCH")` (get-shaped -> error); compute `canonical_email = self._policy.canonical_email(directory_group)` once, and use it in place of every subsequent `directory_group.group_email` read: the `check_membership` call, the delegated-actor `get_group_members` call, the `AccessRequest(... group_email=canonical_email ...)` construction, and both `add_group_member`/`remove_group_member` calls (D-a). Keep the existing `if not directory_group.group_email:` provider-invariant guard unchanged (it is a data-presence check, not a policy decision) — it runs before `canonical_email` is computed. Do NOT touch the later `request.group_email` reads (lines ~545,547,808,810) — those read the value already persisted on the `AccessRequest` domain object from a prior `submit_request` call, which is already canonical by construction; they are untouched.
+- `resolve_approver_candidates(...)` call: pass `policy=self._policy` (new argument, see file 7).
+
+### 6. packages/access/request/providers.py
+- `get_access_request_service()`: construct `policy = ManagedGroupPolicy.from_config(get_access_runtime_config())` and pass `policy=policy` into `AccessRequestService(...)`.
+
+### 7. packages/access/request/policies.py
+- Import `ManagedGroupPolicy` (runtime use, not TYPE_CHECKING — it is called, not just typed).
+- `resolve_approver_candidates(directory_group: DirectoryGroup, fallback_slug: str, directory: DirectoryProvider, policy: ManagedGroupPolicy) -> list[str]`: replace `group_key=directory_group.group_email` with `group_key=policy.canonical_email(directory_group)`; replace `group_key=fallback_slug` with `group_key=policy.group_key(fallback_slug)` (D-a covers the first; the second is the slug->key composition already named in the task text).
+
+No file under app/infrastructure/ or app/modules/ is touched by any of the above (AC#6).
+
+## Test changes
+
+NEW app/tests/unit/packages/access/sync/test_desired_state.py — DirectoryMembershipBuilder currently has NO unit-level test file (only integration coverage plus indirect coverage via test_application.py). Add focused unit tests using a Protocol-conformant fake DirectoryProvider (not MagicMock) and a hand-built ManagedGroupPolicy(prefix="sg-", domain="example.com"):
+| # | Case |
+| 1 | build_user_state_from_effective omits an out-of-domain group from get_user_groups results (warning logged, no error) and still returns the in-domain entitlements |
+| 2 | build_user_state_from_effective uses an alias-preferred canonical slug (alias in managed domain/prefix) to match against effective.sync_managed_rules(), not the raw group_slug |
+| 3 | build_platform_state_from_effective returns DIRECTORY_GROUP_DOMAIN_MISMATCH when the authn group is out of domain |
+| 4 | build_platform_state_from_effective returns DIRECTORY_GROUP_DOMAIN_MISMATCH when a per-rule entitlement group is out of domain (not silently skipped) |
+| 5 | build_platform_state_from_effective still skips (not errors) a per-rule NOT_FOUND group, unchanged from today |
+| 6 | discover_group_slugs excludes a foreign-platform group via matches_prefix even though list_groups now returns everything |
+| 7 | discover_group_slugs omits (warns, does not error) an out-of-domain group that happens to match the prefix syntactically |
+| 8 | discover_group_slugs still propagates an IDP failure as an error (TASK-78 contract), proven against the new no-query call |
+| 9 | _check_group_membership (via build_user_state_from_effective's authn path) returns DIRECTORY_GROUP_DOMAIN_MISMATCH when the authn group is out of domain (AC#8) |
+| 10 | get_group/get_group calls are asserted to receive the fully-qualified key composed by policy.group_key, never a bare slug (AC#1) |
+
+UPDATED app/tests/unit/packages/access/catalog/test_access_catalog_service.py — restructure `_FakeDirectory`: drop `groups_by_prefix` dict-by-query, replace with a single `groups_result: OperationResult = OperationResult.success(data=[])` field returned regardless of query/limit args; mechanically update all ~15 call sites (`groups_by_prefix={"sg-aws-": X}` -> `groups_result=X`); update `make_service`/`make_group` call sites to pass `policy=ManagedGroupPolicy(prefix="sg-", domain="example.com")` (or `ManagedGroupPolicy.from_config(cfg)`). ADD new cases: canonical email/slug used in output when a group carries a managed-prefix alias; a prefix-non-matching group is excluded; an out-of-domain group is omitted with a warning (not an error) and does not fail the whole listing.
+
+UPDATED app/tests/unit/packages/access/common/test_access_mode_override_contract.py — add `policy=` to the `CatalogService(...)` construction in `_catalog_mode`; no other change (its `_FakeDirectory.list_groups` already ignores `query`).
+
+UPDATED app/tests/unit/packages/access/sync/test_application.py — add `policy=` to both `DirectoryMembershipBuilder(directory_provider)` call sites (lines 342, 413).
+
+UPDATED app/tests/integration/packages/access/sync/conftest.py and test_desired_state.py — add `policy=` to all 4 `DirectoryMembershipBuilder(...)` call sites (F5); add one new integration scenario asserting the C1 "foreign-platform group excluded" case still holds now that list_groups is called with no query (client-side matches_prefix does the exclusion instead of the fake's own query-based filter); add one new scenario for get-shaped domain-mismatch propagation (mirrors unit cases 3/4 at the integration layer, per decisions/testing.md's integration-layer role).
+
+UPDATED app/tests/unit/packages/access/request/test_service.py and test_policies.py — add `policy=` to `AccessRequestService(...)` and `resolve_approver_candidates(...)` call sites; verify (do not need to change, per F6) the existing `add_group_member`/`remove_group_member` call-arg assertions still pass. ADD one new case in test_service.py: `submit_request` returns `DIRECTORY_GROUP_DOMAIN_MISMATCH` when the resolved group is out of the configured managed domain. ADD one new case in test_policies.py: `resolve_approver_candidates` resolves owners via `policy.canonical_email` when the target group carries a managed alias, and composes `fallback_slug` through `policy.group_key`.
+
+Keep every existing assertion that currently pins provider-side managed behaviour (there is none on the access side per TASK-76.2's F4 correction — that finding was about the INFRASTRUCTURE test suite, not packages/access) — so AC#5's "relocated rather than dropped" is satisfied by these new access-boundary tests standing alongside the unchanged existing suites, not by moving anything out of test_google.py (that relocation is TASK-76.4's job).
+
+## AC traceability
+
+AC#1 -> production section (group_key/policy usage in all 5 files) -> test_desired_state.py case 10, catalog new cases, request new cases.
+AC#2 -> desired_state.py discover_group_slugs (F7, untouched failure branch) -> test_desired_state.py case 8.
+AC#3 -> D-b applied file-by-file above -> test_desired_state.py cases 1,3,4,7; catalog omit case; request error case.
+AC#4 -> F2 (single consumer), build_user_state_from_effective change -> test_desired_state.py cases 1,2.
+AC#5 -> all UPDATED test files -> full suite green.
+AC#6 -> git status check at merge.
+AC#7 -> mypy/ruff/pytest run.
+AC#8 -> _check_group_membership change -> test_desired_state.py case 9.
+
+## Assumptions and how they were verified
+
+A1. list_groups(query="") needs no infrastructure change today -> F1, read directly from google.py, not inferred.
+A2. get_user_groups has exactly one access-side consumer -> F2, grep-verified.
+A3. Existing fixtures are domain-neutral to this change (is_managed always True today) -> F3, read every fixture's DirectoryGroup construction.
+A4. MagicMock-based request/service.py tests are not broken by the argument-shape change -> F6, grep for call-arg assertions found none keyed on a bare slug.
+A5. Re-verify F1 before merge: if any environment or test has since configured DirectorySettings.managed_group_prefix/domain (still zero per TASK-76 coordinator's re-run instruction), list_groups(query="") could route through a different mapper than assumed. Re-run the coordinator's F2 grep at merge time.
+
+## Blast radius and rollback
+
+Production: 7 files across catalog/sync/request (service + providers + policies), ~110-160 LOC, one subsystem (packages/access), zero files under app/infrastructure/ or app/modules/. Runtime impact is nil while access remains disabled in every environment (coordinator F6); the only observable-if-enabled behaviour changes are the new domain-mismatch error surfaces (previously either silently passed through as if managed, since every environment's provider-level managed config is empty) and the switch from a server-side query to a full list_groups() call (F1 shows this hits the same generic mapper either way, so no data shape change — only potentially more rows fetched per call, already true of the managed path per TASK-76 coordinator's performance note). Test churn: ~10 files, mechanical for ~8 of them (constructor/call-site argument additions), substantive new coverage in 3 (new test_desired_state.py, extended test_access_catalog_service.py, extended test_service.py/test_policies.py). Single git revert restores everything; depends only on TASK-76.2 (merged).
+
+## Size gate
+
+~110-160 production LOC across 7 files in one subsystem (packages/access), no cross-subsystem spread, no infrastructure/modules touch. Test changes are wider (~10 files) but shallow-mechanical in most of them, matching the precedent already accepted for TASK-76.2. Comfortably inside the single-PR gate; no further decomposition.
+
+## Alignment with the wider programme
+
+- decisions/layers.md / feature-packages.md: no change to app/infrastructure/ or app/modules/; the feature-owned adapters boundary (packages/<feature>/adapters/) is not implicated since DirectoryProvider is a Path A portable capability, not a Path B adapter.
+- decisions/migration.md: app/modules/ untouched; no overlap with TASK-25.1.6.5 (modules/provisioning/groups.py, google_directory.py deletion) — confirmed by reading that task, which touches only app/modules/ and app/integrations/google_workspace/, never packages/access.
+- decisions/testing.md: new unit tests use a Protocol-conformant DirectoryProvider fake, not MagicMock, for the new DirectoryMembershipBuilder suite; existing MagicMock use in request/service.py tests is pre-existing and not introduced by this slice.
+- TASK-78: discover_group_slugs' OperationResult propagation contract is read, not modified (F7).
+- TASK-76.4 (next slice): this slice's is_managed/canonical_email/canonical_slug/group_key calls are exactly what stays correct once the provider stops doing any of this itself — no call site here assumes the provider will keep applying managed policy.
+<!-- SECTION:PLAN:END -->
 
 ## Comments
 
@@ -83,5 +213,20 @@ FOUR THINGS THAT AFFECT YOUR SLICE:
 4. CONFIG IS NOW STRICT, WHICH CHANGES YOUR TEST SETUP. AccessRuntimeConfig gains a required non-empty dir_domain and rejects a blank dir_prefix or dir_domain at construction, and BundleConfigLoader now returns PERMANENT_ERROR CONFIG_NOT_CONFIGURED instead of an empty 'waiting mode' config. Any test of yours that leaned on the hollow bundle must construct a config explicitly. TASK-76.2 adds a dir_domain parameter to both make_runtime_config (tests/unit/packages/access/sync/conftest.py) and make_sync_config (tests/integration/packages/access/sync/conftest.py), defaulting to example.com - use those factories rather than hand-rolling.
 
 Unchanged: your error-versus-omission decision (AC#3) is still yours to make and record; the policy returns a plain bool from is_managed precisely so each call site can choose.
+---
+
+created: 2026-09-04 16:46
+---
+PLANNING findings and human decisions (2026-09-04), recorded before the plan below.
+
+HUMAN DECISION 1 (canonical_email scope). Every downstream read of a fetched DirectoryGroup's .group_email — not only the call sites the task text enumerates — is routed through policy.canonical_email(). This reaches request/service.py's check_membership call, the delegated-actor get_group_members owner check, event-dispatch metadata, add_group_member/remove_group_member, and the AccessRequest.group_email persisted to the store, plus request/policies.py's resolve_approver_candidates (which gains a policy: ManagedGroupPolicy parameter). Chosen for forward-safety: today (F2/F6, TASK-76 coordinator) the provider's own alias-preference is inert everywhere so this is behaviourally a no-op, but TASK-76.4 makes the provider return only the raw primary email, at which point these reads would silently stop being canonical if left unwrapped.
+
+HUMAN DECISION 2 (error-vs-omission split, AC#3). Confirmed: OMIT with a warning log for list-shaped operations (catalog list_entitlements, sync discover_group_slugs, get_user_groups) — one stray/foreign/out-of-domain group must not take down a listing. ERROR (propagate, do not skip) for get-shaped operations — every get_group call site, including the per-rule loop inside build_platform_state_from_effective and the single-group fetch inside _check_group_membership, since each is an explicitly configured or explicitly requested group and a domain mismatch there is a real configuration fault, consistent with the existing non-NOT_FOUND propagation already in that method and with the reliability posture TASK-77/TASK-78 established in this same file.
+
+GAP FOUND DURING PLANNING (now AC#8). DirectoryMembershipBuilder._check_group_membership (desired_state.py, used only by build_user_state_from_effective's authn check) calls self._directory.get_group(group_slug) with a bare slug — the same defect class as the enumerated call sites, but not named in the task description. Folded into this slice's scope since it is the same file/subdomain; not spun out to a sibling task.
+
+DESIGN DECISION (constructor injection). CatalogService, DirectoryMembershipBuilder and AccessRequestService each receive policy: ManagedGroupPolicy as an explicit constructor parameter, built once per subdomain's providers.py via ManagedGroupPolicy.from_config(get_access_runtime_config()) — not derived internally from the runtime_config each service already holds. Chosen for parity: DirectoryMembershipBuilder has no runtime_config field today (only discover_group_slugs receives config per-call), so it must receive the policy directly; the same pattern is applied to all three for one consistent construction story and easier test substitution.
+
+VERIFIED SAFE: list_groups(query="") already resolves to the generic _build_group mapper in the current provider (google.py list_groups: `if not query_str: map_fn = self._build_group`), so switching catalog/sync discovery to an empty-query call requires zero infrastructure change in this slice — confirmed by reading app/infrastructure/directory/google.py directly, not assumed from the coordinator plan.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-76.3
 title: 'Cut access catalog, sync and request onto the generic DirectoryProvider path'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-04 14:18'
-updated_date: '2026-09-04 16:48'
+updated_date: '2026-09-04 17:28'
 labels:
   - layering
 milestone: m-3
@@ -39,14 +40,14 @@ TESTING (decisions/testing.md). Protocol-conformant fakes for DirectoryProvider 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 catalog, sync and request obtain canonical group email, slug, prefix matching and group keys exclusively through ManagedGroupPolicy; no access-side call passes a bare slug to DirectoryProvider
-- [ ] #2 sync discover_group_slugs keeps the OperationResult failure-propagation contract introduced by TASK-78, with a test proving an IDP failure still propagates rather than yielding an empty set
-- [ ] #3 The error-versus-omission decision for out-of-domain groups is made per call-site shape, implemented, and recorded with its rationale in the task notes
-- [ ] #4 Every access-side consumer of get_user_groups applies the managed-domain filter feature-side, covered by tests
-- [ ] #5 The existing access catalog, sync and request suites pass, with any provider-side managed assertions relocated to the feature boundary rather than dropped
-- [ ] #6 No file under app/infrastructure/ and no file under app/modules/ is modified by this slice
+- [x] #1 catalog, sync and request obtain canonical group email, slug, prefix matching and group keys exclusively through ManagedGroupPolicy; no access-side call passes a bare slug to DirectoryProvider
+- [x] #2 sync discover_group_slugs keeps the OperationResult failure-propagation contract introduced by TASK-78, with a test proving an IDP failure still propagates rather than yielding an empty set
+- [x] #3 The error-versus-omission decision for out-of-domain groups is made per call-site shape, implemented, and recorded with its rationale in the task notes
+- [x] #4 Every access-side consumer of get_user_groups applies the managed-domain filter feature-side, covered by tests
+- [x] #5 The existing access catalog, sync and request suites pass, with any provider-side managed assertions relocated to the feature boundary rather than dropped
+- [x] #6 No file under app/infrastructure/ and no file under app/modules/ is modified by this slice
 - [ ] #7 mypy, ruff and the full non-smoke pytest run are green
-- [ ] #8 The single-user authn membership check in DirectoryMembershipBuilder._check_group_membership (desired_state.py) also composes its get_group call through policy.group_key and applies the same get-shaped domain-mismatch handling as build_platform_state_from_effective (found during planning; not named in the task description's enumerated call-site list)
+- [x] #8 The single-user authn membership check in DirectoryMembershipBuilder._check_group_membership (desired_state.py) also composes its get_group call through policy.group_key and applies the same get-shaped domain-mismatch handling as build_platform_state_from_effective (found during planning; not named in the task description's enumerated call-site list)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -177,6 +178,37 @@ Production: 7 files across catalog/sync/request (service + providers + policies)
 - TASK-78: discover_group_slugs' OperationResult propagation contract is read, not modified (F7).
 - TASK-76.4 (next slice): this slice's is_managed/canonical_email/canonical_slug/group_key calls are exactly what stays correct once the provider stops doing any of this itself — no call site here assumes the provider will keep applying managed policy.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED 2026-09-04. Plan followed with no deviations. 7 production files, all under app/packages/access; zero files under app/infrastructure/ or app/modules/ touched (AC#6, verified via git status).
+
+PRODUCTION
+- catalog/service.py: CatalogService gains `policy: ManagedGroupPolicy`; list_groups() is now a generic listing, with matches_prefix / is_managed / canonical_slug / canonical_email applied feature-side; EntitlementEntry carries the canonical email.
+- catalog/providers.py, sync/providers.py, request/providers.py: policy built once per subdomain via ManagedGroupPolicy.from_config(runtime_config).
+- sync/desired_state.py: DirectoryMembershipBuilder gains `policy`; get_group calls compose policy.group_key(slug) in build_platform_state_from_effective (authn + per-rule) and in _check_group_membership (AC#8); get_user_groups results filtered feature-side; discover_group_slugs lists generically and filters client-side; check_membership / get_group_members / get_group_members_batch keyed by canonical_email.
+- request/service.py: AccessRequestService gains `policy`; get_group composed through group_key; a single canonical_email drives check_membership, the delegated-actor owner check, the persisted AccessRequest.group_email, and add/remove_group_member.
+- request/policies.py: resolve_approver_candidates takes `policy`; owners resolved via canonical_email, fallback via group_key.
+
+AC#3 DECISION (error vs omission), as planned and now implemented:
+- OMIT + warning log for list-shaped operations: catalog list_entitlements (catalog_group_outside_managed_domain), sync discover_group_slugs (discover_groups_outside_managed_domain), get_user_groups (user_group_outside_managed_domain). Rationale: one stray or foreign group must never take down a whole listing or silently disable entitlement enforcement by failing discovery.
+- ERROR (PERMANENT_ERROR / DIRECTORY_GROUP_DOMAIN_MISMATCH) for every get-shaped operation: build_platform_state_from_effective authn group and per-rule group, _check_group_membership, request submit_request. Rationale: an explicitly configured or explicitly requested group sitting outside the managed domain is a real configuration fault, consistent with the non-NOT_FOUND propagation already in that file.
+Prefix-mismatch (a foreign-platform group) is a silent skip everywhere - it is expected, not anomalous.
+
+AC#2: discover_group_slugs' TASK-78 failure-propagation branch is untouched; proven by test_discover_group_slugs_should_propagate_directory_failure against the new no-query call.
+AC#4: get_user_groups has exactly one access-side consumer (build_user_state_from_effective); it now applies is_managed feature-side, covered by two unit tests.
+
+TESTS
+- New app/tests/unit/packages/access/sync/test_desired_state.py (pre-authored) passes: Protocol-conformant DirectoryProvider fake, alias preference, domain mismatch, composed group keys, discovery filtering and failure propagation.
+- Pre-authored catalog / request / policies cases pass unchanged.
+- Mechanically updated existing suites: catalog _FakeDirectory restructured from groups_by_prefix (keyed by the now-absent query) to a single groups_result; policy= added at CatalogService / DirectoryMembershipBuilder / AccessRequestService / resolve_approver_candidates call sites (unit + integration); sync fakes' get_group now accepts a fully-qualified key.
+- Added one integration scenario (B5) asserting a per-rule out-of-domain group propagates DIRECTORY_GROUP_DOMAIN_MISMATCH.
+
+EVIDENCE: `make test` green (human-run). `make lint` / `uv run ruff check .` clean. Access suites: 386 passed.
+
+AC#7 LEFT UNCHECKED FOR HUMAN VERIFICATION: ruff and the full non-smoke pytest run are green. mypy reports one error in a touched file - packages/access/catalog/service.py `"object" has no attribute "warning"` on the pre-existing `log: object` parameter of _check_membership - confirmed PRE-EXISTING by running mypy on the stashed base revision (same error at the pre-change line number). No new mypy error is introduced by this slice; fixing that annotation is out of scope here.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
+++ b/backlog/tasks/task-76.3 - Cut-access-catalog-sync-and-request-onto-the-generic-DirectoryProvider-path.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-76.3
 title: 'Cut access catalog, sync and request onto the generic DirectoryProvider path'
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-04 14:18'
-updated_date: '2026-09-04 17:28'
+updated_date: '2026-09-04 17:30'
 labels:
   - layering
 milestone: m-3


### PR DESCRIPTION
# Summary | Résumé

Moves access catalog, sync, and request flows onto the generic DirectoryProvider path using feature-owned ManagedGroupPolicy for group keys, canonical emails/slugs, prefix matching, and managed-domain validation.

List operations now omit out-of-domain groups with warnings, while explicitly requested or configured out-of-domain groups return DIRECTORY_GROUP_DOMAIN_MISMATCH. Directory failures continue to propagate correctly.

Adds focused catalog, sync, and request coverage, including alias handling, domain filtering, canonical group resolution, and sync failure propagation. No infrastructure or legacy module files were changed.