### PR TITLE
Feat/remove org specific defaults

### DIFF
--- a/app/packages/access/README.md
+++ b/app/packages/access/README.md
@@ -30,8 +30,7 @@ All access feature settings are unified under a single `AccessSettings` object (
 | `ACCESS_SYNC_JOB_TTL_SECONDS` | `86400` | Retention for completed/failed sync records |
 | `ACCESS_SYNC_LOCK_STALE_SECONDS` | `14400` | Lock age before a running job is treated as stale |
 | `ACCESS_REQUESTS_ENABLED` | `false` | Enable the access requests feature |
-| `ACCESS_REQUESTS_MANAGER_GROUP_SLUG` | `sg-managers` | Primary approver group |
-| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | `sg-org-admins` | Fallback approver group |
+| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | none (required if enabled) | Fallback approver group (e.g. `sg-org-admins`) |
 | `ACCESS_REQUESTS_MIN_APPROVER_COUNT` | `1` | Approvals needed before a request is approved |
 | `ACCESS_REQUESTS_REQUEST_TTL_HOURS` | `72` | Hours before an open request expires |
 | `ACCESS_CATALOG_ENABLED` | `false` | Enable the catalog browse feature |

--- a/app/packages/access/common/README.md
+++ b/app/packages/access/common/README.md
@@ -33,8 +33,7 @@ settings.catalog.enabled        # ACCESS_CATALOG_ENABLED
 | `ACCESS_SYNC_JOB_TTL_SECONDS` | `settings.sync.job_ttl_seconds` | `86400` |
 | `ACCESS_SYNC_LOCK_STALE_SECONDS` | `settings.sync.lock_stale_seconds` | `14400` |
 | `ACCESS_REQUESTS_ENABLED` | `settings.requests.enabled` | `false` |
-| `ACCESS_REQUESTS_MANAGER_GROUP_SLUG` | `settings.requests.manager_group_slug` | `sg-managers` |
-| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | `settings.requests.fallback_approver_slug` | `sg-org-admins` |
+| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | `settings.requests.fallback_approver_slug` | none (required if enabled) |
 | `ACCESS_REQUESTS_MIN_APPROVER_COUNT` | `settings.requests.min_approver_count` | `1` |
 | `ACCESS_REQUESTS_REQUEST_TTL_HOURS` | `settings.requests.request_ttl_hours` | `72` |
 | `ACCESS_CATALOG_ENABLED` | `settings.catalog.enabled` | `false` |

--- a/app/packages/access/common/settings.py
+++ b/app/packages/access/common/settings.py
@@ -24,7 +24,7 @@ not part of this env-var settings consolidation.
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -73,17 +73,25 @@ class AccessRequestsSettings(BaseModel):
 
     Env vars:
         ACCESS_REQUESTS_ENABLED                 — master on/off switch
-        ACCESS_REQUESTS_MANAGER_GROUP_SLUG      — IDP group whose members may submit delegated requests
-        ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG  — org-level approver fallback group slug
+        ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG  — org-level approver fallback group slug;
+                                                  required whenever enabled, no default
         ACCESS_REQUESTS_MIN_APPROVER_COUNT      — minimum affirmative decisions to approve
         ACCESS_REQUESTS_REQUEST_TTL_HOURS       — hours before a pending request expires
     """
 
     enabled: bool = False
-    manager_group_slug: str = "sg-managers"
-    fallback_approver_slug: str = "sg-org-admins"
+    fallback_approver_slug: str = ""
     min_approver_count: int = 1
     request_ttl_hours: int = 72
+
+    @model_validator(mode="after")
+    def _validate_fallback_approver_slug(self) -> AccessRequestsSettings:
+        # Settings are constructed on every boot, so the requirement only applies when enabled.
+        if not self.enabled:
+            return self
+        if not self.fallback_approver_slug.strip():
+            raise ValueError("ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG must be set when ACCESS_REQUESTS_ENABLED is true")
+        return self
 
 
 class AccessCatalogSettings(BaseModel):

--- a/app/packages/access/request/README.md
+++ b/app/packages/access/request/README.md
@@ -8,7 +8,7 @@ Manages the full lifecycle of user access requests: submission, approval, reject
 
 1. User submits a request with `platform` and `group_slug` (e.g. `sg-aws-scratch`).
 2. The service resolves the group in the IDP and derives the `entitlement_id` token server-side (`scratch`).
-3. Approver candidates are resolved from the group's owners, falling back to `sg-org-admins`.
+3. Approver candidates are resolved from the group's owners, falling back to the configured `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` group.
 4. On approval threshold met, the service writes the membership directly to the IDP (Google Workspace) — the source of truth.
 5. An `access_request_approved` event is dispatched, triggering Access Sync to propagate the change to the external platform (e.g. AWS Identity Center).
 6. When Access Sync completes, the request transitions to `completed` (or `failed`).
@@ -76,8 +76,7 @@ All request settings are in `AccessRequestsSettings` (a slice of `AccessSettings
 | Env var | Default | Description |
 |---|---|---|
 | `ACCESS_REQUESTS_ENABLED` | `false` | Master on/off switch. All routes return `503` when disabled. |
-| `ACCESS_REQUESTS_MANAGER_GROUP_SLUG` | `sg-managers` | Primary approver group slug |
-| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | `sg-org-admins` | Fallback approver group slug |
+| `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` | none (required if enabled) | Fallback approver group slug (e.g. `sg-org-admins`) |
 | `ACCESS_REQUESTS_MIN_APPROVER_COUNT` | `1` | Approval threshold |
 | `ACCESS_REQUESTS_REQUEST_TTL_HOURS` | `72` | Hours before an open request expires |
 

--- a/app/packages/access/request/__init__.py
+++ b/app/packages/access/request/__init__.py
@@ -52,7 +52,6 @@ def startup_warmup(logger) -> None:
     logger.info(
         "access_requests_settings_loaded",
         enabled=settings.enabled,
-        manager_group_slug=settings.manager_group_slug,
         fallback_approver_slug=settings.fallback_approver_slug,
         min_approver_count=settings.min_approver_count,
         request_ttl_hours=settings.request_ttl_hours,

--- a/app/packages/access/request/service.py
+++ b/app/packages/access/request/service.py
@@ -121,7 +121,8 @@ class AccessRequestService:
         dispatcher: Event dispatcher for publishing domain events.
         policy: Managed-group policy owning canonical address, managed-domain
             and group-key decisions the directory provider no longer makes.
-        fallback_approver_slug: Org-level fallback approver group slug.
+        fallback_approver_slug: Org-level fallback approver group slug; required,
+            no default — construction fails without it.
         min_approver_count: Minimum number of approvals required.
     """
 
@@ -132,7 +133,7 @@ class AccessRequestService:
         runtime_config: AccessRuntimeConfig,
         dispatcher: EventDispatcher,
         policy: ManagedGroupPolicy,
-        fallback_approver_slug: str = "sg-org-admins",
+        fallback_approver_slug: str,
         min_approver_count: int = 1,
     ) -> None:
         self._repo = repository

--- a/app/tests/unit/packages/access/common/test_settings.py
+++ b/app/tests/unit/packages/access/common/test_settings.py
@@ -183,11 +183,12 @@ def test_access_settings_accepts_requests_json_blob(monkeypatch):
     """ACCESS_REQUESTS may be set as a JSON blob to configure the entire requests slice."""
     monkeypatch.setenv(
         "ACCESS_REQUESTS",
-        '{"enabled": true, "min_approver_count": 3, "request_ttl_hours": 24}',
+        '{"enabled": true, "fallback_approver_slug": "sg-org-admins", "min_approver_count": 3, "request_ttl_hours": 24}',
     )
 
     s = AccessSettings(_env_file=None).requests
     assert s.enabled is True
+    assert s.fallback_approver_slug == "sg-org-admins"
     assert s.min_approver_count == 3
     assert s.request_ttl_hours == 24
 

--- a/app/tests/unit/packages/access/common/test_settings.py
+++ b/app/tests/unit/packages/access/common/test_settings.py
@@ -43,13 +43,46 @@ def test_access_sync_settings_defaults():
 
 @pytest.mark.unit
 def test_access_requests_settings_defaults():
-    """AccessRequestsSettings must provide correct defaults with no env vars."""
+    """AccessRequestsSettings must default to disabled with no organization-specific group names."""
     s = AccessRequestsSettings()
     assert s.enabled is False
-    assert s.manager_group_slug == "sg-managers"
-    assert s.fallback_approver_slug == "sg-org-admins"
+    assert not hasattr(s, "manager_group_slug")
+    assert s.fallback_approver_slug == ""
     assert s.min_approver_count == 1
     assert s.request_ttl_hours == 72
+
+
+@pytest.mark.unit
+def test_access_requests_settings_requires_fallback_approver_slug_when_enabled():
+    """Enabling the feature without a fallback approver slug must fail with a named error."""
+    with pytest.raises((ValueError, ValidationError)) as exc_info:
+        AccessRequestsSettings(enabled=True)
+
+    assert "ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_access_requests_settings_enabled_with_fallback_slug_constructs():
+    """An explicitly configured fallback approver slug must satisfy the enabled contract."""
+    s = AccessRequestsSettings(enabled=True, fallback_approver_slug="sg-org-admins")
+    assert s.enabled is True
+    assert s.fallback_approver_slug == "sg-org-admins"
+
+
+@pytest.mark.unit
+def test_access_requests_settings_disabled_ignores_missing_fallback_slug():
+    """Leaving the feature disabled must not require access request configuration."""
+    s = AccessRequestsSettings(enabled=False)
+    assert s.enabled is False
+    assert s.fallback_approver_slug == ""
+
+
+@pytest.mark.unit
+def test_access_settings_constructs_when_requests_disabled_and_unconfigured():
+    """The root settings object must build with no ACCESS_ env vars set (boot safety)."""
+    s = AccessSettings(_env_file=None)
+    assert s.requests.enabled is False
+    assert s.requests.fallback_approver_slug == ""
 
 
 @pytest.mark.unit
@@ -106,14 +139,12 @@ def test_access_settings_reads_config_flat_env_vars(monkeypatch):
 def test_access_settings_reads_requests_flat_env_vars(monkeypatch):
     """AccessSettings must resolve ACCESS_REQUESTS_* flat env vars into the requests slice."""
     monkeypatch.setenv("ACCESS_REQUESTS_ENABLED", "true")
-    monkeypatch.setenv("ACCESS_REQUESTS_MANAGER_GROUP_SLUG", "sg-leads")
     monkeypatch.setenv("ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG", "sg-admins")
     monkeypatch.setenv("ACCESS_REQUESTS_MIN_APPROVER_COUNT", "2")
     monkeypatch.setenv("ACCESS_REQUESTS_REQUEST_TTL_HOURS", "48")
 
     s = AccessSettings(_env_file=None).requests
     assert s.enabled is True
-    assert s.manager_group_slug == "sg-leads"
     assert s.fallback_approver_slug == "sg-admins"
     assert s.min_approver_count == 2
     assert s.request_ttl_hours == 48

--- a/app/tests/unit/packages/access/request/test_access_request_package_init.py
+++ b/app/tests/unit/packages/access/request/test_access_request_package_init.py
@@ -45,7 +45,6 @@ def test_request_startup_warmup_registers_handlers_and_warms_runtime_config(
 
     class _Settings:
         enabled = True
-        manager_group_slug = "sg-managers"
         fallback_approver_slug = "sg-org-admins"
         min_approver_count = 1
         request_ttl_hours = 72
@@ -84,7 +83,6 @@ def test_request_startup_warmup_registers_handlers_via_event_dispatcher(monkeypa
 
     class _Settings:
         enabled = True
-        manager_group_slug = "sg-managers"
         fallback_approver_slug = "sg-org-admins"
         min_approver_count = 1
         request_ttl_hours = 72

--- a/app/tests/unit/packages/access/request/test_service.py
+++ b/app/tests/unit/packages/access/request/test_service.py
@@ -1047,7 +1047,21 @@ def make_policy_service(directory: MagicMock) -> AccessRequestService:
         runtime_config=make_config(),
         dispatcher=FakeDispatcher(),  # type: ignore[arg-type]
         policy=ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+        fallback_approver_slug="sg-org-admins",
     )
+
+
+@pytest.mark.unit
+def test_service_construction_should_require_explicit_fallback_approver_slug():
+    """The service must not supply an organization-specific fallback approver slug of its own."""
+    with pytest.raises(TypeError):
+        AccessRequestService(  # type: ignore[call-arg]
+            repository=FakeRepository(),  # type: ignore[arg-type]
+            directory=MagicMock(),
+            runtime_config=make_config(),
+            dispatcher=FakeDispatcher(),  # type: ignore[arg-type]
+            policy=ManagedGroupPolicy(prefix="sg-", domain="example.com"),
+        )
 
 
 def submit(service: AccessRequestService):

--- a/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
+++ b/backlog/tasks/task-76 - Relocate-managed-group-policy-out-of-infrastructure-directory-into-packages-access.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-03 18:02'
-updated_date: '2026-09-04 15:46'
+updated_date: '2026-09-04 23:06'
 labels:
   - layering
 milestone: m-3
@@ -49,12 +49,12 @@ NOT IN SCOPE: any Google vendor-mirror work; changing the DirectoryProvider Prot
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GoogleDirectoryProvider contains no managed-group prefix, alias-preference or managed-domain logic; grep for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix and _extract_managed_group_email returns zero hits under app/infrastructure/, and _normalize_email no longer completes bare values with a group domain
-- [ ] #2 DIRECTORY_MANAGED_GROUP_PREFIX, DIRECTORY_MANAGED_GROUP_DOMAIN and DIRECTORY_ENFORCE_MANAGED_GROUP_EMAIL no longer exist anywhere: per plan decision D3 the prefix is derived from AccessRuntimeConfig naming rather than re-homed, the domain is owned by packages/access as AccessRuntimeConfig.dir_domain, and enforce_managed_group_email is deleted outright - with no duplicate second home created for any of them
-- [ ] #3 The chosen mechanism - feature-side filtering of generic results, or an injected policy strategy - is stated in the task notes with its rationale, rather than the branching simply moving up one layer
-- [ ] #4 packages/access/catalog, packages/access/sync and packages/access/request retain their current observable behaviour, proven by their existing test suites plus the new characterization tests the slices add (the managed path has no existing coverage - see plan fact F4)
-- [ ] #5 A group outside the managed domain is returned unchanged by the generic provider and rejected (or ignored) by the feature, with a test at the feature boundary rather than the infrastructure one
-- [ ] #6 All five subtasks TASK-76.1 through TASK-76.5 are Done and the DIRECTORY_MANAGED / MANAGED_GROUP grep across terraform, Makefile and app config returns zero hits at close
+- [x] #1 GoogleDirectoryProvider contains no managed-group prefix, alias-preference or managed-domain logic; grep for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix and _extract_managed_group_email returns zero hits under app/infrastructure/, and _normalize_email no longer completes bare values with a group domain
+- [x] #2 DIRECTORY_MANAGED_GROUP_PREFIX, DIRECTORY_MANAGED_GROUP_DOMAIN and DIRECTORY_ENFORCE_MANAGED_GROUP_EMAIL no longer exist anywhere: per plan decision D3 the prefix is derived from AccessRuntimeConfig naming rather than re-homed, the domain is owned by packages/access as AccessRuntimeConfig.dir_domain, and enforce_managed_group_email is deleted outright - with no duplicate second home created for any of them
+- [x] #3 The chosen mechanism - feature-side filtering of generic results, or an injected policy strategy - is stated in the task notes with its rationale, rather than the branching simply moving up one layer
+- [x] #4 packages/access/catalog, packages/access/sync and packages/access/request retain their current observable behaviour, proven by their existing test suites plus the new characterization tests the slices add (the managed path has no existing coverage - see plan fact F4)
+- [x] #5 A group outside the managed domain is returned unchanged by the generic provider and rejected (or ignored) by the feature, with a test at the feature boundary rather than the infrastructure one
+- [x] #6 All five subtasks TASK-76.1 through TASK-76.5 are Done and the DIRECTORY_MANAGED / MANAGED_GROUP grep across terraform, Makefile and app config returns zero hits at close
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -117,6 +117,28 @@ No temporary shims are required: because the provider keeps both mappers until T
 - TASK-25.1.6.4 and TASK-22.4 are DONE. No advisory belongs on completed work; the constraints that concerned them are carried forward here as F7 and enforced by TASK-76.4's own acceptance criteria instead.
 - TASK-79 (new) carries the IDP-authoritative owned-domains capability from D4.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+COORDINATOR CLOSE-OUT VERIFICATION 2026-09-04. No code landed on TASK-76 itself; all work shipped in TASK-76.1 through TASK-76.5, which are all Done. Every parent AC re-verified empirically against the merged tree rather than inferred from child completion.
+
+AC#1 — grep across app/infrastructure/ for _managed_group_prefix, _managed_group_domain, _managed_group_query_prefix, _matches_managed_group_prefix and _extract_managed_group_email returns ZERO hits. google.py::_normalize_email (line 209-215) is now strip+lowercase only, with a docstring stating callers supply fully-qualified keys — D2's strict-provider cut is in place and the bare-value domain completion is gone.
+
+AC#2 — grep for DIRECTORY_MANAGED / MANAGED_GROUP / ENFORCE_MANAGED across app/, terraform/, Makefile, backlog/docs and decisions/ (all .py/.tf/.toml/.md/Makefile) returns ZERO hits. Confirmed no second home was created: dir_domain lives once on AccessRuntimeConfig (packages/access/common/config/settings.py:72, with the D6 __post_init__ rejecting blank values at line 84-85); the org-wide prefix is DERIVED via AccessGroupNaming.managed_prefix (common/naming.py:19) and consumed through ManagedGroupPolicy.from_config (common/group_policy.py:49) rather than configured; enforce_managed_group_email is deleted outright with no replacement.
+
+AC#3 — mechanism is D1, FEATURE-SIDE FILTERING, not an injected policy strategy: the provider is unconditionally generic and packages/access owns ManagedGroupPolicy (common/group_policy.py:16), a value object built from the runtime config. Rationale recorded in the plan: an injected strategy would have left the branching inside infrastructure and merely renamed the coupling, whereas decisions/layers.md requires a portable capability's Protocol to stay capability-shaped and vendor-neutral. The enabler was exposing IDP-reported aliases on DirectoryGroup as a vendor-neutral FACT (TASK-76.1) so the feature could reproduce alias preference itself.
+
+AC#4 — full non-smoke suite green (make test, user-run 2026-09-04) with catalog, sync and request behaviour pinned by the relocated and newly added tests. Note the correction to plan fact F4 already recorded in the 14:42 comment: the managed path DID have provider-level coverage, so the slices relocated those assertions to the feature boundary rather than authoring characterization tests from scratch.
+
+AC#5 — feature-boundary rejection is proven at the feature, not the provider: request/test_service.py:1095 (test_submit_request_should_reject_group_outside_managed_domain) and sync/test_desired_state.py:236/299/318 all assert DIRECTORY_GROUP_DOMAIN_MISMATCH, plus common/test_access_group_policy.py:82/90 covering is_managed on the canonical value including the managed-alias-rescues-foreign-primary case.
+
+AC#6 — TASK-76.1, 76.2, 76.3, 76.4 and 76.5 all report Status: Done; the DIRECTORY_MANAGED / MANAGED_GROUP grep returns zero as recorded under AC#2. F2's standing instruction to re-run the environment grep before each merge was honoured on the final slice: zero ACCESS_* and zero DIRECTORY_MANAGED* hits in terraform/, Makefile and app/Makefile, so no environment's configuration or boot changes.
+
+CARRIED FORWARD, not regressions: TASK-79 holds D4's IDP-authoritative owned-domains capability (list_domains / primary_domain), which eventually replaces dir_domain as feature-owned configuration; D7 keeps single-domain strict case-insensitive matching until then. TASK-25.1.6.5 keeps its advisory to pass fully-qualified keys and not expect managed-domain filtering from get_user_groups. AWS_ADMIN_GROUPS remains the one LIVE organization-specific default, deliberately excluded from TASK-76.5 because removing it needs a deployment step and its consumer is frozen under decisions/migration.md rule 1 — it still needs its own task.
+
+LEFT FOR HUMAN DoD VERIFICATION: this task is a coordinator with no diff of its own, so closing it is a confirmation that the five child PRs together satisfy the intent. Two child decisions were explicitly flagged for reviewer challenge and remain open for review — TASK-76.2's D7 single-domain assumption, and TASK-76.5's D3 (fallback_approver_slug staying an ACCESS_REQUESTS_ env var rather than moving to AccessRuntimeConfig). Status left To Do for a human to close.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
+++ b/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
@@ -4,6 +4,7 @@ title: Remove organization-specific defaults from access settings
 status: To Do
 assignee: []
 created_date: '2026-09-04 15:46'
+updated_date: '2026-09-04 20:59'
 labels:
   - layering
   - configuration
@@ -66,3 +67,103 @@ TESTING (decisions/testing.md). Unit tests at the settings/config boundary provi
 - [ ] #8 No file under app/infrastructure/ or app/modules/ is modified, and AWS_ADMIN_GROUPS is left untouched
 - [ ] #9 mypy, ruff and the full non-smoke pytest run are green
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+PLANNED 2026-09-04. Dependency TASK-76.2 (and siblings 76.1/76.3/76.4) are all Done and merged, so this plan is grounded against the CURRENT shipped code, not the coordinator's pre-76.3 line numbers (which have drifted).
+
+## Grounding facts verified 2026-09-04 (read directly, not inferred)
+
+F1. manager_group_slug IS CONFIRMED DEAD CODE, not merely defaulted wrong. Repo-wide grep across app/ (excluding caches) finds exactly one production read: packages/access/request/__init__.py:55, inside `startup_warmup`'s structured log call (`logger.info("access_requests_settings_loaded", manager_group_slug=settings.manager_group_slug, ...)`). It is never passed into AccessRequestService, never read by service.py or policies.py. service.py's own Step-4 comment is explicit that delegated-actor authorization checks OWNER/MANAGER membership of the TARGET group, "not a member of a global manager group" — the setting's docstring claim ("IDP group whose members may submit delegated requests") describes behavior that was never wired.
+
+F2. CRITICAL DESIGN CONSTRAINT — naively removing the pydantic default would break every environment's boot, not just misconfigured ones. AccessRequestsSettings is a plain BaseModel nested inside AccessSettings (a BaseSettings), constructed EAGERLY and UNCONDITIONALLY: request/__init__.py::startup_warmup calls `get_access_request_settings()` (which constructs the whole AccessSettings singleton) as its FIRST line, BEFORE checking `settings.enabled`. Per TASK-76 coordinator fact F6/TASK-76.2 fact F9, zero ACCESS_ env vars are set in any environment today. If fallback_approver_slug became a bare required field (no default at all), `AccessRequestsSettings()`/`AccessSettings()` would raise ValidationError on EVERY boot in EVERY environment, not just ones that enable access without configuring it — a universal regression, and a direct violation of the H5/AC#5 contract ("disabling access leaves the rest of the app unaffected"). This differs from AccessRuntimeConfig's dir_domain (TASK-76.2/D6): that dataclass's `__post_init__` is safe to always-raise-on-blank because it is only ever constructed lazily, behind each subfeature's own `if settings.enabled:` gate (`get_access_runtime_config()` is never called unconditionally). AccessRequestsSettings has no equivalent lazy gate — the settings object itself IS what callers read to find `enabled`.
+
+F3. THE FIX PATTERN ALREADY EXISTS IN THIS REPO: `integrations/slack/settings.py::SlackSettings._validate_transport_credentials`, a `@model_validator(mode="after")` that short-circuits immediately when `not self.ENABLED`, and otherwise raises `ValueError` naming the missing env var. Same file's `BOT_TOKEN: str = Field(default="", alias=...)` is the precedent for using an empty string (not an organization-specific value) as the "unconfigured" sentinel default for a required-when-enabled string setting. This plan reproduces both: `fallback_approver_slug: str = ""` plus a mirroring model_validator gated on `self.enabled`.
+
+F4. TASK-76.3 already composes the fallback slug through `ManagedGroupPolicy.group_key` (packages/access/request/policies.py:103-106, inside `resolve_approver_candidates`), so parent AC#6 is PRE-SATISFIED by prior work — this task only re-verifies it, it does not add that composition.
+
+F5. Exhaustive current-state call-site list (grep-verified 2026-09-04, all under app/packages/access/ plus their READMEs and app/tests/unit — zero hits anywhere else in app/, zero in app/tests/integration):
+  - common/settings.py:76 (docstring line for MANAGER_GROUP_SLUG), :77 (docstring line for FALLBACK_APPROVER_SLUG, keep/reword), :83 (`manager_group_slug: str = "sg-managers"`, delete), :84 (`fallback_approver_slug: str = "sg-org-admins"`, change to `""` + validator).
+  - request/service.py:124 (docstring, reword to "required; no default"), :135 (`fallback_approver_slug: str = "sg-org-admins"` constructor default, remove default → required param), :143 (`self._fallback_approver_slug = fallback_approver_slug`, unchanged), :322/:330 (reads, unchanged).
+  - request/__init__.py:55 (`manager_group_slug=settings.manager_group_slug,` log kwarg, delete); :56 (`fallback_approver_slug=...`, unchanged).
+  - request/providers.py:50 (`fallback_approver_slug=settings.fallback_approver_slug`) — NO CHANGE, already passes the settings value through explicitly; this is exactly why AC#2 calls the constructor default "dead weight reachable only by direct construction and tests."
+  - Three READMEs (packages/access/README.md:33-34, packages/access/common/README.md:36-37, packages/access/request/README.md:79-80): each has one MANAGER_GROUP_SLUG row (delete) and one FALLBACK_APPROVER_SLUG row (default column changes from `sg-org-admins` to `none (required if enabled)`, description keeps an illustrative example per parent AC#1's documentation-example carve-out).
+  - Tests: app/tests/unit/packages/access/common/test_settings.py:49-50 (defaults assertions), :108-117 (env-var-override test); app/tests/unit/packages/access/request/test_access_request_package_init.py:48,87 (`_Settings`/fixture attrs); app/tests/unit/packages/access/request/test_service.py — `make_service` helper (already explicit, no change) and `make_policy_service` (~line 1044, currently omits `fallback_approver_slug` and relies on the constructor default being removed here — MUST be updated to pass it explicitly).
+  - request/policies.py and test_policies.py: no change — `resolve_approver_candidates(fallback_slug, ...)` is already a plain required parameter, not settings-sourced; existing literal `"sg-org-admins"` test arguments are fixture inputs, not defaults, and AC#1 permits them.
+
+## Human decisions (asked during planning, both confirmed 2026-09-04)
+
+D1 — manager_group_slug is DELETED OUTRIGHT (field, env var, docstring lines, README rows, the __init__.py log kwarg, and the two test fixture attributes), not merely un-defaulted. Rationale: F1 proves it is genuinely orphaned; requiring an operator to configure a variable that does nothing would be a worse outcome than removing it, and removing it still satisfies AC#1's literal "no default remains" bar (there is no field left to default).
+
+D2 — fallback_approver_slug stays a WHOLE configured value (operator supplies the complete slug, e.g. `sg-org-admins`), not composed from `AccessGroupNaming.managed_prefix` + a local part. Rationale: composing would assume every organization's fallback/org-admin approver group necessarily follows the same `sg-`-managed-group naming convention as regular synced entitlement groups, which is not established anywhere in the codebase and is a bigger, unrequested behavioral assumption than this task's scope warrants.
+
+## My decisions (grounded in code/decisions, not asked — flagged for reviewer challenge)
+
+D3 — OWNING HOME: fallback_approver_slug STAYS an `AccessRequestsSettings` env var (`ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG`), not moved to `AccessRuntimeConfig`. Rationale, by contrast with TASK-76.2's dir_domain precedent: dir_domain feeds `ManagedGroupPolicy`, consumed across THREE subdomains (catalog, sync, request) and is loaded once from the shared runtime-config document those subdomains all read. fallback_approver_slug is read by exactly ONE subdomain (`AccessRequestService`/`resolve_approver_candidates`, request-only) — promoting it into the cross-subdomain runtime document would violate the "narrowest settings slice" rule (decisions/configuration.md, feature-packages.md, settings-singleton skill) by coupling catalog/sync's config loading to a value they never use. Reviewer: override this if the intent was uniform homing with dir_domain regardless of consumer scope.
+
+D4 — ENFORCEMENT MECHANISM: a `@model_validator(mode="after")` on `AccessRequestsSettings` — `if self.enabled and not self.fallback_approver_slug.strip(): raise ValueError(...)` — replaces the removed default, with the field itself defaulting to `""`. This is not optional polish; F2 shows an unconditional required field breaks boot everywhere. Modeled exactly on `SlackSettings._validate_transport_credentials` (short-circuit when disabled, raise naming the env var when enabled-but-unset) and `SlackSettings.BOT_TOKEN`'s empty-string sentinel. Satisfies AC#5's exact wording: enabling requires the value present (raises), disabling leaves the rest of the app unaffected (empty string is falsy-safe and never read for real work while disabled).
+
+## Production changes
+
+1. `packages/access/common/settings.py` — delete the `ACCESS_REQUESTS_MANAGER_GROUP_SLUG` docstring line and the `manager_group_slug` field; change `fallback_approver_slug: str = "sg-org-admins"` to `fallback_approver_slug: str = ""`; reword its docstring line to state it is required whenever `enabled=True`, with no organization-specific default; add `from pydantic import model_validator` (already imports `field_validator`, extend the import) and the new `_validate_fallback_approver_slug` method on `AccessRequestsSettings` per D4.
+2. `packages/access/request/service.py` — remove the default from the `fallback_approver_slug` constructor parameter (becomes a required, no-default `str`, staying before the still-defaulted `min_approver_count`, which is valid parameter ordering); reword its Args docstring line to "required; no default — construction fails without it" (mirrors AccessRuntimeConfig's own required-field docstring convention from TASK-76.2).
+3. `packages/access/request/__init__.py` — remove the `manager_group_slug=settings.manager_group_slug,` line from the `startup_warmup` structured log call.
+4. `packages/access/README.md`, `packages/access/common/README.md`, `packages/access/request/README.md` — delete the MANAGER_GROUP_SLUG row from each settings table; change the FALLBACK_APPROVER_SLUG row's default column to `none (required if enabled)` in each, keeping the description column's illustrative example.
+
+No file under `app/infrastructure/` or `app/modules/` is touched (AC#8); `AWS_ADMIN_GROUPS` is untouched; `request/providers.py` needs no change (F5).
+
+## Test changes
+
+- `app/tests/unit/packages/access/common/test_settings.py`:
+  - `test_access_requests_settings_defaults`: remove the `manager_group_slug` assertion; change to construct `AccessRequestsSettings()` (disabled by default) and assert `fallback_approver_slug == ""` — proving the disabled-by-default construction still succeeds.
+  - `test_access_settings_reads_requests_flat_env_vars`: remove the `ACCESS_REQUESTS_MANAGER_GROUP_SLUG` `monkeypatch.setenv` call and its assertion; keep the `FALLBACK_APPROVER_SLUG` env var and assertion unchanged.
+  - NEW `test_access_requests_settings_requires_fallback_approver_slug_when_enabled`: `AccessRequestsSettings(enabled=True)` raises (`pytest.raises((ValueError, ValidationError))`) naming `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG` in the message.
+  - NEW `test_access_requests_settings_enabled_with_fallback_slug_constructs`: `AccessRequestsSettings(enabled=True, fallback_approver_slug="sg-org-admins")` constructs without error.
+  - NEW `test_access_requests_settings_disabled_ignores_missing_fallback_slug`: `AccessRequestsSettings(enabled=False)` constructs fine with no fallback slug set (the disabling-is-unaffected half of AC#5).
+- `app/tests/unit/packages/access/request/test_access_request_package_init.py`: remove the `manager_group_slug = "sg-managers"` line from both `_Settings` fixture classes (~lines 48 and 87); `fallback_approver_slug` stays as an explicit fixture value.
+- `app/tests/unit/packages/access/request/test_service.py`: update `make_policy_service` (~line 1044) to pass `fallback_approver_slug="sg-org-admins"` explicitly to `AccessRequestService(...)`, since the constructor no longer supplies one. `make_service`'s own helper default is unchanged (already explicit at the real constructor call).
+- No change needed to `test_policies.py` (F5) or any integration test (F5 — zero hits).
+
+## AC traceability
+
+AC#1 -> settings.py field deletion + README row deletions (Production 1,4) -> test_settings.py updated defaults test; grep re-run at merge.
+AC#2 -> service.py constructor default removal (Production 2) -> test_service.py's `make_policy_service` update proves the constructor now requires the argument.
+AC#3 -> D3 (recorded above, no code change — it is a decision, not a migration).
+AC#4 -> D2 (recorded above) + settings.py using `""` not a new `sg-` literal -> grep re-run at merge confirms no new `sg-` literal.
+AC#5 -> D4's model_validator (Production 1) -> the three NEW test_settings.py cases.
+AC#6 -> F4 (already implemented by TASK-76.3; this task only re-verifies) -> existing `test_policies.py::resolve_approver_candidates` composed-fallback-slug case, re-run unmodified.
+AC#7 -> all UPDATED test files -> full suite green.
+AC#8 -> grep for any diff under app/infrastructure/ or app/modules/, and confirm aws_ops.py untouched, at merge (git status).
+AC#9 -> mypy/ruff/pytest run at merge.
+
+## Assumptions and how to verify them
+
+A1. No environment has set any `ACCESS_REQUESTS_*` env var since TASK-76's coordinator last checked (F6/F9) — re-run that grep across terraform/, Makefile, app/Makefile before merge; if one now sets `ACCESS_REQUESTS_ENABLED=true` without `ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG`, this change would newly fail that environment's boot (the intended, named failure mode, but confirm it isn't a silent surprise for someone mid-rollout).
+A2. `make_policy_service` in test_service.py is the only direct `AccessRequestService(...)` construction relying on the now-removed default — re-grep for `AccessRequestService(` before merge to confirm no other call site was missed.
+A3. pydantic-settings' nested-model construction correctly triggers `AccessRequestsSettings`'s own `model_validator` when `AccessSettings()` builds the `requests` slice from partial env data — this is the same mechanism `SlackSettings` already relies on for its own `BaseSettings`-level validator, so treated as proven precedent rather than re-verified from scratch; confirm with the new test_settings.py cases at implementation time.
+
+## Blast radius and rollback
+
+Production: 4 files (settings.py, service.py, __init__.py, 3 READMEs), well under 50 changed production LOC, one subsystem (`packages/access`), no terraform/CI. Zero observable behavior change in any current environment: every environment has `ACCESS_REQUESTS_ENABLED` unset/false today (F6), so the new validator never fires, and `manager_group_slug` was already inert (F1). The only reachable behavior change is the new named boot failure for an operator who sets `ACCESS_REQUESTS_ENABLED=true` without also setting the fallback slug — a strictly better outcome than today's silent wrong-organization default. Single `git revert` restores everything; no data, no migration, no ordering constraint beyond TASK-76.2 (already merged).
+
+## Size gate
+
+Comfortably inside the single-PR gate: ~40-60 production LOC across 4 files (one of them 3 near-identical README edits), one subsystem, no infra/modules touch, no mixed refactor-and-behavior-across-subsystems. No decomposition needed.
+
+## Alignment with the wider programme
+
+- decisions/configuration.md: one owning class per value — fallback_approver_slug's only home is `AccessRequestsSettings` (D3); manager_group_slug gets no home at all (deleted, D1).
+- decisions/feature-packages.md / settings-singleton skill: narrowest-slice settings ownership — this task keeps a request-only value out of the shared `AccessRuntimeConfig` that catalog/sync also read.
+- decisions/layers.md / migration.md: no file under `app/infrastructure/` or `app/modules/` is touched; `AWS_ADMIN_GROUPS` (the one LIVE org-specific default, frozen-module consumer) is explicitly out of scope and untouched, per the task's own NOT-IN-SCOPE section.
+- TASK-76 coordinator: this is the last open child (76.1-76.4 all Done); once this lands, parent AC#6 ("all five subtasks Done") can be verified.
+<!-- SECTION:PLAN:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-04 20:59
+---
+PLANNED 2026-09-04. Two human decisions taken via clarifying questions before writing the plan: (1) manager_group_slug is dead code (only ever logged, never consumed by any authorization logic) - deleted outright rather than merely un-defaulted; (2) fallback_approver_slug stays a whole configured value, not composed via AccessGroupNaming.managed_prefix. CRITICAL FINDING (F2 in plan): naively removing fallback_approver_slug's pydantic default would break boot in every environment (not just misconfigured ones), since AccessRequestsSettings is constructed eagerly/unconditionally before the enabled check runs - fixed with a model_validator gated on self.enabled, mirroring integrations/slack/settings.py::SlackSettings exactly (empty-string sentinel + raise-when-enabled-and-unset). Owning-home decision (D3, not asked - grounded in feature-packages.md/settings-singleton's narrowest-slice rule): fallback_approver_slug stays an AccessRequestsSettings env var rather than moving to AccessRuntimeConfig, since only the request subdomain consumes it (unlike dir_domain, shared via ManagedGroupPolicy across catalog/sync/request). Fits one PR comfortably (~40-60 prod LOC, 4 files, one subsystem). Ready for human plan review.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
+++ b/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-76.5
 title: Remove organization-specific defaults from access settings
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-04 15:46'
-updated_date: '2026-09-04 20:59'
+updated_date: '2026-09-04 22:40'
 labels:
   - layering
   - configuration
@@ -57,15 +58,15 @@ TESTING (decisions/testing.md). Unit tests at the settings/config boundary provi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No organization-specific group name remains as a default anywhere under app/packages: grep for 'sg-managers' and 'sg-org-admins' returns zero hits outside test fixtures and documentation examples
-- [ ] #2 The duplicated fallback_approver_slug default at app/packages/access/request/service.py:131 is removed so the value has exactly one owning home per decisions/configuration.md
-- [ ] #3 The owning home is decided and recorded with rationale - AccessRuntimeConfig runtime document versus ACCESS_REQUESTS_ env settings - rather than the literals simply moving; one convention is not split across both mechanisms
-- [ ] #4 The decision on whether the slugs are whole configured values or composed through AccessGroupNaming is recorded, and no new 'sg-' string literal is introduced either way
-- [ ] #5 A missing value produces a named configuration error consistent with the TASK-76.2 contract: enabling access requires its settings to be present, disabling it leaves the rest of the app unaffected, proven by a test
-- [ ] #6 Whatever shape the fallback slug takes still composes into a directory group key through ManagedGroupPolicy.group_key, so no bare slug reaches DirectoryProvider (TASK-76.2 decision D2)
-- [ ] #7 The existing access request suites pass with fixtures supplying explicit values, and no test depends on an implicit organization default
-- [ ] #8 No file under app/infrastructure/ or app/modules/ is modified, and AWS_ADMIN_GROUPS is left untouched
-- [ ] #9 mypy, ruff and the full non-smoke pytest run are green
+- [x] #1 No organization-specific group name remains as a default anywhere under app/packages: grep for 'sg-managers' and 'sg-org-admins' returns zero hits outside test fixtures and documentation examples
+- [x] #2 The duplicated fallback_approver_slug default at app/packages/access/request/service.py:131 is removed so the value has exactly one owning home per decisions/configuration.md
+- [x] #3 The owning home is decided and recorded with rationale - AccessRuntimeConfig runtime document versus ACCESS_REQUESTS_ env settings - rather than the literals simply moving; one convention is not split across both mechanisms
+- [x] #4 The decision on whether the slugs are whole configured values or composed through AccessGroupNaming is recorded, and no new 'sg-' string literal is introduced either way
+- [x] #5 A missing value produces a named configuration error consistent with the TASK-76.2 contract: enabling access requires its settings to be present, disabling it leaves the rest of the app unaffected, proven by a test
+- [x] #6 Whatever shape the fallback slug takes still composes into a directory group key through ManagedGroupPolicy.group_key, so no bare slug reaches DirectoryProvider (TASK-76.2 decision D2)
+- [x] #7 The existing access request suites pass with fixtures supplying explicit values, and no test depends on an implicit organization default
+- [x] #8 No file under app/infrastructure/ or app/modules/ is modified, and AWS_ADMIN_GROUPS is left untouched
+- [x] #9 mypy, ruff and the full non-smoke pytest run are green
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -158,6 +159,32 @@ Comfortably inside the single-PR gate: ~40-60 production LOC across 4 files (one
 - decisions/layers.md / migration.md: no file under `app/infrastructure/` or `app/modules/` is touched; `AWS_ADMIN_GROUPS` (the one LIVE org-specific default, frozen-module consumer) is explicitly out of scope and untouched, per the task's own NOT-IN-SCOPE section.
 - TASK-76 coordinator: this is the last open child (76.1-76.4 all Done); once this lands, parent AC#6 ("all five subtasks Done") can be verified.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED 2026-09-04, plan followed as written with one addition found at test time.
+
+PRODUCTION (6 files, ~25 changed LOC):
+- packages/access/common/settings.py: deleted manager_group_slug field + its docstring line (D1); fallback_approver_slug default changed from 'sg-org-admins' to '' with a reworded docstring; added model_validator(mode='after') _validate_fallback_approver_slug raising ValueError naming ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG only when self.enabled (D4, mirroring SlackSettings._validate_transport_credentials).
+- packages/access/request/service.py: fallback_approver_slug is now a required constructor parameter (no default); Args docstring reworded.
+- packages/access/request/__init__.py: removed the manager_group_slug kwarg from the startup_warmup log call.
+- packages/access/README.md, common/README.md, request/README.md: MANAGER_GROUP_SLUG rows deleted; FALLBACK_APPROVER_SLUG default column now 'none (required if enabled)'. request/README.md 'How it works' step 3 also reworded from 'falling back to sg-org-admins' to the configured env var name (it read as a hardcoded fact, not an example).
+- providers.py unchanged as planned (F5).
+
+TESTS:
+- test_settings.py: defaults test asserts no manager_group_slug field and fallback == ''; flat-env-var test drops MANAGER_GROUP_SLUG; three new cases (enabled-without-slug raises naming the env var, enabled-with-slug constructs, disabled-without-slug constructs) plus a root AccessSettings boot-safety case.
+- test_access_request_package_init.py: manager_group_slug removed from both _Settings fixtures.
+- test_service.py: make_policy_service now passes fallback_approver_slug explicitly; new test_service_construction_should_require_explicit_fallback_approver_slug asserts TypeError without it.
+- NOT IN PLAN, found at test time: test_access_settings_accepts_requests_json_blob set ACCESS_REQUESTS='{"enabled": true, ...}' with no fallback slug and was relying on the removed implicit default (exactly the AC#7 anti-pattern). Blob updated to include fallback_approver_slug. This incidentally proves A3 — the nested model_validator does fire through pydantic-settings JSON-blob construction.
+- test_policies.py unchanged (F4/AC#6 pre-satisfied by TASK-76.3), re-run green.
+
+VERIFICATION: A1 re-verified — grep for ACCESS_REQUESTS/ACCESS_SYNC/ACCESS_CATALOG/ACCESS_CONFIG across terraform/, Makefile, app/Makefile returns zero hits, so no environment boot changes. A2 re-verified — AccessRequestService( has exactly two call sites (providers.py, already explicit; test_service.py, now explicit). AC#1 grep: remaining sg-org-admins hits are three documentation examples (two README table description columns, one policies.py docstring 'e.g.') and test fixture arguments, all inside the AC's carve-out; zero sg-managers hits anywhere. AC#8: git diff --stat main -- app/infrastructure app/modules is empty; aws_ops.py untouched.
+
+GATES: ruff clean; mypy shows zero errors in any touched file (the 94 repo-wide errors are the pre-existing baseline, all in app/modules and unrelated packages); full non-smoke suite green via make test (user-run).
+
+LEFT FOR HUMAN DoD VERIFICATION: review of decision D3 (fallback_approver_slug stays an ACCESS_REQUESTS_ env var rather than moving to AccessRuntimeConfig — flagged in the plan for reviewer challenge) and D4's empty-string sentinel; task left In Progress.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
+++ b/backlog/tasks/task-76.5 - Remove-organization-specific-defaults-from-access-settings.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-76.5
 title: Remove organization-specific defaults from access settings
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-04 15:46'
-updated_date: '2026-09-04 22:40'
+updated_date: '2026-09-04 23:04'
 labels:
   - layering
   - configuration


### PR DESCRIPTION
# Summary | Résumé

This pull request removes the organization-specific default group settings for access requests, making the fallback approver group slug (`ACCESS_REQUESTS_FALLBACK_APPROVER_SLUG`) a required configuration when the feature is enabled, and eliminates the unused manager group slug. It also adds validation to enforce this requirement, updates documentation, and adjusts tests to reflect the new contract.

**Configuration and Validation Changes**
- The `manager_group_slug` field is removed from `AccessRequestsSettings`, and `fallback_approver_slug` now defaults to an empty string and is required (with validation) whenever access requests are enabled. If `ACCESS_REQUESTS_ENABLED` is true but no fallback approver slug is configured, service startup will fail with a clear error.
- The `AccessRequestService` constructor now requires an explicit `fallback_approver_slug` argument with no default, enforcing the contract at runtime. [[1]](diffhunk://#diff-f39d87dda15a7a3390288fd64bf2f24572150f1a1738d12ca714b1299463f1f2L135-R136) [[2]](diffhunk://#diff-dd979e6e8c19d5007dffbc85fe9408b6c95df3c3c4bbac801acefbc84d181155R1050-R1063)

**Documentation Updates**
- All relevant documentation (`README.md` files) is updated to remove references to `manager_group_slug` and clarify that `fallback_approver_slug` is required if requests are enabled, with no default. [[1]](diffhunk://#diff-079312216ceedf4e56e76fc7d780f8389af11d2ccb7e8c512d5062f1a2cfeb55L33-R33) [[2]](diffhunk://#diff-a72a58b9c1196671faf9a6c29cdfdb94b3158e781659e6aea4377a6d4318a4acL36-R36) [[3]](diffhunk://#diff-8c867a9f39913b4b84d6e0df1a95c06559c1d8359bff73ba03862cb38951de92L11-R11) [[4]](diffhunk://#diff-8c867a9f39913b4b84d6e0df1a95c06559c1d8359bff73ba03862cb38951de92L79-R79)

**Test Suite Adjustments**
- Unit tests are updated to remove checks for `manager_group_slug`, ensure that missing `fallback_approver_slug` fails validation when enabled, and that the settings object can be constructed safely when requests are disabled or unconfigured. Additional tests verify correct JSON and environment variable handling. [[1]](diffhunk://#diff-3d807556ab7976dcc04b2346230da5d54cc55d6a0f4c35fca28a394312848450L46-R87) [[2]](diffhunk://#diff-3d807556ab7976dcc04b2346230da5d54cc55d6a0f4c35fca28a394312848450L109-L116) [[3]](diffhunk://#diff-3d807556ab7976dcc04b2346230da5d54cc55d6a0f4c35fca28a394312848450L155-R191) [[4]](diffhunk://#diff-6d31c7aa5e6916eb1c6f5778ca03e6d6d5d3b51ca538c1d310e8d5870d038103L48) [[5]](diffhunk://#diff-6d31c7aa5e6916eb1c6f5778ca03e6d6d5d3b51ca538c1d310e8d5870d038103L87) [[6]](diffhunk://#diff-dd979e6e8c19d5007dffbc85fe9408b6c95df3c3c4bbac801acefbc84d181155R1050-R1063)

**Minor Code and Logging Updates**
- Logging and configuration code is updated to remove references to `manager_group_slug` and ensure only the fallback approver slug is reported or required.

These changes ensure that organization-specific group slugs are never defaulted, making configuration explicit and safer for multi-tenant or portable deployments.