### PR TITLE
feat: add user-invocable flag to agents and update copilot instructions

### DIFF
--- a/.claude/agents/architecture.md
+++ b/.claude/agents/architecture.md
@@ -8,6 +8,7 @@ skills:
   - architecture-review
   - backlog-task-workflow
 color: orange
+user-invocable: false
 ---
 
 You are in App-Level Architecture Mode. Follow the `architecture-review` skill.

--- a/.claude/agents/codebase-researcher.md
+++ b/.claude/agents/codebase-researcher.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash, WebFetch
 model: haiku
 effort: low
 color: cyan
+user-invocable: false
 ---
 
 You survey this repository and report findings. You never edit files.

--- a/.claude/agents/feature-architecture.md
+++ b/.claude/agents/feature-architecture.md
@@ -10,6 +10,7 @@ skills:
   - fastapi-api-patterns
   - implementation-planning
 color: purple
+user-invocable: false
 ---
 
 You are in Feature Architecture Mode. Follow the `feature-architecture` skill.

--- a/.claude/agents/implementation.md
+++ b/.claude/agents/implementation.md
@@ -9,6 +9,7 @@ skills:
   - python-quality-gates
   - python-314-baseline
 color: green
+user-invocable: false
 ---
 
 You are in Implementation Mode.

--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -9,6 +9,7 @@ skills:
   - backlog-task-workflow
   - implementation-planning
 color: blue
+user-invocable: false
 ---
 
 You are in Task Planning Mode. Follow the `plan-task` skill end to end.

--- a/.claude/agents/tests-creation.md
+++ b/.claude/agents/tests-creation.md
@@ -8,6 +8,7 @@ skills:
   - tests-creation
   - testing-standards
 color: yellow
+user-invocable: false
 ---
 
 You are in Tests Creation Mode.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,12 +91,20 @@ Workflow order: `architecture` → `feature-architecture` → `task-planner` →
 | `CLAUDE.md` | always-on engineering contract (all models) |
 | `.github/copilot-instructions.md` | this file — Copilot policy delta |
 | `.claude/skills/<name>/SKILL.md` | skills, shared with Claude Code (`chat.useClaudeSkills`) |
-| `.github/agents/*.agent.md` | Copilot custom agents (model-pinned) |
+| `.github/agents/*.agent.md` | Copilot custom agents (model-pinned) — **pick these** |
 | `.github/instructions/*.instructions.md` | path-scoped rules via `applyTo` globs |
 | `.vscode/mcp.json` | workspace MCP servers |
 
 Skills live under `.claude/skills/` on purpose: VS Code and Claude Code both read
 that directory, so one file serves every model. Do not create `.github/skills/`.
+
+**Agents are the exception — they cannot be shared.** VS Code reads *both*
+`.github/agents/*.agent.md` and `.claude/agents/*.md`, and the two formats express
+`model:` and `tools:` differently, so each harness needs its own file. The
+`.claude/agents/*.md` twins therefore carry `user-invocable: false`, which keeps
+them out of the VS Code agents dropdown — otherwise every agent appears twice. In
+Copilot always pick the `.github/agents/` one: only it carries the Tier L/M model
+pin and the handoff buttons. Keep the two sets in sync when you change a role.
 
 There is no `.github/prompts/` directory: prompt files are **deprecated for Agent
 Host sessions** and are not loaded there. Every former prompt is now a workflow

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     // .claude/skills/ for EVERY model — GPT, Claude, MAI, Gemini.
     // Pinned explicitly so the setup does not depend on VS Code defaults.
     "chat.useClaudeMdFile": true,
-    "chat.useClaudeSkills": true,
     "chat.tools.terminal.autoApprove": {
         "backlog": true,
         "rg": true,
@@ -22,5 +21,6 @@
             "source.fixAll.ruff": "explicit",
             "source.organizeImports.ruff": "explicit"
         }
-    }
+    },
+    "chat.useAgentSkills": true
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ Context is the scarce resource; degraded output is the cost of filling it.
 | Always-on contract (this file) | `CLAUDE.md` | Claude Code + Copilot (all models) |
 | Copilot model/cost + routing policy | `.github/copilot-instructions.md` | Copilot |
 | Skills (knowledge + workflows) | `.claude/skills/<name>/SKILL.md` | Claude Code + Copilot |
-| Claude Code subagents | `.claude/agents/*.md` | Claude Code |
+| Claude Code subagents | `.claude/agents/*.md` | Claude Code (hidden from Copilot's picker) |
 | Copilot custom agents | `.github/agents/*.agent.md` | Copilot |
 | Path-scoped rules (`applyTo`) | `.github/instructions/*.instructions.md` | Copilot |
 | Architecture decision records | `decisions/*.md` | everyone |


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the configuration and documentation to clarify the distinction between Claude Code and Copilot agents, and ensures that `.claude/agents/*.md` files are hidden from user invocation in VS Code. It also updates VS Code settings to use agent skills correctly, and adds documentation to prevent confusion about agent selection and duplication.

Key changes include:

**Agent invocation and visibility:**

* Added `user-invocable: false` to all `.claude/agents/*.md` agent files to ensure they do not appear in the VS Code agents dropdown, preventing duplicate agent listings and accidental selection. [[1]](diffhunk://#diff-9f1c7eb69e1c27f75f89bbb09afccf04abc6f5407fe2437a1055f437617c650fR11) [[2]](diffhunk://#diff-f407c11a577b8b53cf05a2711963c275f17c0160bea236a809e825f3b4b72f85R8) [[3]](diffhunk://#diff-aa8ca417e34cea1962d017a6b63f5e54d5557cd9d8af88681b71e09937cd4d91R13) [[4]](diffhunk://#diff-a0e7c233ee63eb360bb3a794310fc9f1d0a21693f722b7099c67cd971b196b19R12) [[5]](diffhunk://#diff-01598201a41dfc6d39edfa5275f2590205d5c651b4c497bb3cf850b3d84e6ff8R12) [[6]](diffhunk://#diff-3aff15d7738dbea56f7d0d534d70e41fc731ce29d3a4432f2a3d4c8b5868fe13R11)

**VS Code settings updates:**

* Updated `.vscode/settings.json` to enable `chat.useAgentSkills` and removed `chat.useClaudeSkills`, aligning the settings with the new agent skill handling. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L6) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L25-R25)

**Documentation improvements:**

* Expanded `.github/copilot-instructions.md` to explain why `.claude/agents/*.md` files are hidden, the distinction between agent file locations, and the need to keep both sets of agent files in sync.
* Clarified in `CLAUDE.md` that `.claude/agents/*.md` files are hidden from Copilot’s picker, further reducing user confusion.