### PR TITLE
Feat/set explicit google timeout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,16 @@
         "${workspaceFolder}/app/.venv/bin/python"
     ],
     "ruff.organizeImports": true,
+    // Run the project-pinned mypy rather than the extension's bundled copy, and
+    // keep the editor's cache separate: two mypy processes sharing app/.mypy_cache
+    // corrupt it and crash the CLI quality gate.
+    "mypy-type-checker.interpreter": [
+        "${workspaceFolder}/app/.venv/bin/python"
+    ],
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "mypy-type-checker.args": [
+        "--cache-dir=.mypy_cache/vscode"
+    ],
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,

--- a/app/infrastructure/configuration/integrations/google.py
+++ b/app/infrastructure/configuration/integrations/google.py
@@ -21,6 +21,7 @@ class GoogleWorkspaceSettings(IntegrationSettings):
         GOOGLE_WORKSPACE_CUSTOMER_ID: Google Workspace customer ID (defaults to "my_customer")
         GCP_SRE_SERVICE_ACCOUNT_KEY_FILE: Path to service account key file
         GOOGLE_API_NUM_RETRIES: Number of automatic retries for transient Google API failures
+        GOOGLE_API_TIMEOUT_SECONDS: Per-attempt HTTP timeout in seconds for Google API calls (defaults to 10.0)
 
     Example:
         ```python
@@ -42,6 +43,13 @@ class GoogleWorkspaceSettings(IntegrationSettings):
         default=3,
         alias="GOOGLE_API_NUM_RETRIES",
         description="Number of automatic retries googleapiclient applies to transient (429/5xx) API call failures, configured once at service construction.",
+    )
+    # Move alongside GOOGLE_API_NUM_RETRIES when Google Workspace settings get their own vendor package module.
+    GOOGLE_API_TIMEOUT_SECONDS: float = Field(
+        default=10.0,
+        alias="GOOGLE_API_TIMEOUT_SECONDS",
+        gt=0,
+        description="Per-attempt HTTP timeout in seconds for every Google Workspace API client, configured once at service construction. Defaults to 10.0; must be positive.",
     )
 
 

--- a/app/integrations/google_workspace/client.py
+++ b/app/integrations/google_workspace/client.py
@@ -11,6 +11,8 @@ import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
+import google_auth_httplib2
+import httplib2
 import structlog
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -56,6 +58,18 @@ def _build_request_builder(num_retries: int) -> Callable[..., HttpRequest]:
         return _DefaultingRetryHttpRequest(*args, default_num_retries=num_retries, **kwargs)
 
     return request_builder
+
+
+def _build_authorized_http(credentials: Any, timeout_seconds: float) -> google_auth_httplib2.AuthorizedHttp:
+    """Build a new authorized http with an explicit per-attempt timeout.
+
+    Mirrors googleapiclient.http.build_http, which otherwise falls back to the
+    library's 60-second default: 308 is removed from the automatic redirect codes
+    because Drive resumable uploads use it as a status rather than a redirect.
+    """
+    http = httplib2.Http(timeout=timeout_seconds)
+    http.redirect_codes = http.redirect_codes - {308}
+    return google_auth_httplib2.AuthorizedHttp(credentials, http=http)
 
 
 def get_admin_directory_service(
@@ -135,12 +149,15 @@ def _build_service(
     if scopes:
         creds = creds.with_scopes(scopes)
 
-    # Resource construction propagates this builder to nested resources, so all
-    # Google API calls inherit one SDK-native retry policy without call-site drift.
+    # Timeout and retry policy are both fixed here, once per service: the http
+    # carries the per-attempt timeout, and resource construction propagates the
+    # request builder to nested resources so every call inherits one SDK-native
+    # retry policy without call-site drift. httplib2.Http is not thread-safe, so
+    # each built service owns a new http; never cache or share one.
     return build(
         api_name,
         api_version,
-        credentials=creds,
+        http=_build_authorized_http(creds, settings.GOOGLE_API_TIMEOUT_SECONDS),
         cache_discovery=False,
         static_discovery=True,
         requestBuilder=_build_request_builder(settings.GOOGLE_API_NUM_RETRIES),

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -84,7 +84,7 @@ exclude = ["^tests/"]
 explicit_package_bases = true
 
 [[tool.mypy.overrides]]
-module = ["google.oauth2.service_account", "googleapiclient.*"]
+module = ["google.oauth2.service_account", "googleapiclient.*", "google_auth_httplib2"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/app/tests/unit/infrastructure/spreadsheets/test_google_spreadsheet_provider.py
+++ b/app/tests/unit/infrastructure/spreadsheets/test_google_spreadsheet_provider.py
@@ -241,6 +241,7 @@ def test_sheets_factory_resource_inherits_configured_retry_default(
         GCP_SRE_SERVICE_ACCOUNT_KEY_FILE='{"client_email":"sre-bot@example.com","private_key":"FAKE"}',
         SRE_BOT_EMAIL="sre-bot@example.com",
         GOOGLE_API_NUM_RETRIES=3,
+        GOOGLE_API_TIMEOUT_SECONDS=10.0,
     )
 
     class FakeCredentials:

--- a/app/tests/unit/integrations/google_workspace/test_google_workspace_client.py
+++ b/app/tests/unit/integrations/google_workspace/test_google_workspace_client.py
@@ -11,9 +11,11 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+import google_auth_httplib2
 import pytest
 from googleapiclient.errors import HttpError
 from googleapiclient.http import HttpRequest
+from pydantic import ValidationError
 
 from infrastructure.operations.status import OperationStatus
 
@@ -96,6 +98,7 @@ def test_get_admin_directory_service_builds_with_static_discovery_and_no_cache(
         GCP_SRE_SERVICE_ACCOUNT_KEY_FILE='{"client_email":"sre-bot@example.com","private_key":"FAKE"}',
         SRE_BOT_EMAIL="sre-bot@example.com",
         GOOGLE_API_NUM_RETRIES=3,
+        GOOGLE_API_TIMEOUT_SECONDS=10.0,
     )
 
     class FakeCredentials:
@@ -141,11 +144,13 @@ def _install_fake_build(
     monkeypatch: pytest.MonkeyPatch,
     google_client_module: Any,
     captured: dict[str, Any],
+    timeout_seconds: float = 10.0,
 ) -> Any:
     settings = SimpleNamespace(
         GCP_SRE_SERVICE_ACCOUNT_KEY_FILE='{"client_email":"sre-bot@example.com","private_key":"FAKE"}',
         SRE_BOT_EMAIL="sre-bot@example.com",
         GOOGLE_API_NUM_RETRIES=3,
+        GOOGLE_API_TIMEOUT_SECONDS=timeout_seconds,
     )
 
     class FakeCredentials:
@@ -284,3 +289,140 @@ def test_service_factories_use_explicit_delegated_user_email(
     factory(scopes=["https://www.googleapis.com/auth/calendar"], delegated_user_email="delegate@example.com")
 
     assert captured["delegated_subject"] == "delegate@example.com"
+
+
+@pytest.mark.unit
+def test_build_service_sets_explicit_http_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    google_client_module: Any,
+) -> None:
+    """A built service carries an authorized http whose timeout comes from settings.
+
+    googleapiclient.discovery.build is stubbed so the kwargs it receives can be
+    inspected without network access, and the settings double supplies a
+    distinctive timeout so the assertion proves the value is read from
+    configuration rather than hard-coded. The library rejects http and
+    credentials together, so credentials must be absent from the build kwargs.
+    """
+    captured: dict[str, Any] = {}
+    _install_fake_build(monkeypatch, google_client_module, captured, timeout_seconds=7.5)
+
+    google_client_module.get_calendar_service(scopes=["https://www.googleapis.com/auth/calendar"])
+
+    authorized_http = captured["build_kwargs"]["http"]
+    assert isinstance(authorized_http, google_auth_httplib2.AuthorizedHttp)
+    assert authorized_http.http.timeout == 7.5
+    assert "credentials" not in captured["build_kwargs"]
+
+
+@pytest.mark.unit
+def test_build_service_http_preserves_resumable_upload_redirect_handling(
+    monkeypatch: pytest.MonkeyPatch,
+    google_client_module: Any,
+) -> None:
+    """The hand-built http drops 308 from httplib2's automatic redirect codes.
+
+    googleapiclient's own build_http makes the same adjustment; resumable Drive
+    uploads rely on seeing 308 responses instead of having httplib2 follow them,
+    so replacing the library's http must not silently regress that behavior.
+    """
+    captured: dict[str, Any] = {}
+    _install_fake_build(monkeypatch, google_client_module, captured)
+
+    google_client_module.get_drive_service(scopes=["https://www.googleapis.com/auth/drive"])
+
+    assert 308 not in captured["build_kwargs"]["http"].http.redirect_codes
+
+
+@pytest.mark.unit
+def test_build_service_applies_timeout_and_retry_builder_together(
+    monkeypatch: pytest.MonkeyPatch,
+    google_client_module: Any,
+) -> None:
+    """One built service carries both the configured timeout and the retry default.
+
+    HttpRequest.execute is stubbed to record the retry count the request
+    builder supplies, so the two construction-time policies are asserted on the
+    same service rather than in isolation — a request builder that survived but
+    lost its retry default would otherwise go unnoticed.
+    """
+    captured: dict[str, Any] = {}
+    _install_fake_build(monkeypatch, google_client_module, captured, timeout_seconds=7.5)
+
+    observed_retries: list[int] = []
+
+    def fake_parent_execute(self: HttpRequest, http: Any = None, num_retries: int = 0, **kwargs: Any) -> Any:
+        observed_retries.append(num_retries)
+        return {"ok": True}
+
+    monkeypatch.setattr(HttpRequest, "execute", fake_parent_execute)
+
+    google_client_module.get_sheets_service(scopes=["https://www.googleapis.com/auth/spreadsheets"])
+
+    build_kwargs = captured["build_kwargs"]
+    assert build_kwargs["http"].http.timeout == 7.5
+
+    request = build_kwargs["requestBuilder"](None, MagicMock(), "https://example.test")
+    request.execute()
+    assert observed_retries == [3]
+
+
+@pytest.mark.unit
+def test_build_service_creates_a_new_http_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+    google_client_module: Any,
+) -> None:
+    """Each built service owns a distinct http instance.
+
+    httplib2.Http is not thread-safe and the legacy callers build services from
+    worker threads, so construction must not cache or share an http. Two
+    successive builds are captured and compared by identity at both the
+    authorized wrapper and the wrapped httplib2 layer.
+    """
+    captured: dict[str, Any] = {}
+    _install_fake_build(monkeypatch, google_client_module, captured)
+
+    google_client_module.get_calendar_service(scopes=["https://www.googleapis.com/auth/calendar"])
+    first_http = captured["build_kwargs"]["http"]
+
+    google_client_module.get_calendar_service(scopes=["https://www.googleapis.com/auth/calendar"])
+    second_http = captured["build_kwargs"]["http"]
+
+    assert first_http is not second_http
+    assert first_http.http is not second_http.http
+
+
+@pytest.mark.unit
+def test_google_workspace_settings_timeout_defaults_and_reads_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-attempt timeout has a documented default and is environment-overridable.
+
+    The settings class is constructed directly rather than through its cached
+    provider so each assertion sees a fresh read of the environment.
+    """
+    from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
+
+    assert GoogleWorkspaceSettings().GOOGLE_API_TIMEOUT_SECONDS == 10.0
+    monkeypatch.setenv("GOOGLE_API_TIMEOUT_SECONDS", "2.5")
+    assert GoogleWorkspaceSettings().GOOGLE_API_TIMEOUT_SECONDS == 2.5
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_timeout", ["0", "-1"])
+def test_google_workspace_settings_timeout_rejects_non_positive(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_timeout: str,
+) -> None:
+    """A non-positive timeout fails validation at settings construction.
+
+    Zero or negative values would make every Google call fail immediately, so
+    the misconfiguration must surface at startup rather than as opaque socket
+    errors at call time.
+    """
+    from infrastructure.configuration.integrations.google import GoogleWorkspaceSettings
+
+    monkeypatch.setenv("GOOGLE_API_TIMEOUT_SECONDS", invalid_timeout)
+
+    with pytest.raises(ValidationError):
+        GoogleWorkspaceSettings()

--- a/backlog/tasks/task-25.1.6.11 - Delete-execute_google_api_request-and-enforce-the-Google-Workspace-vendor-export-contract.md
+++ b/backlog/tasks/task-25.1.6.11 - Delete-execute_google_api_request-and-enforce-the-Google-Workspace-vendor-export-contract.md
@@ -3,10 +3,10 @@ id: TASK-25.1.6.11
 title: >-
   Delete execute_google_api_request and enforce the Google Workspace vendor
   export contract
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-02 15:04'
-updated_date: '2026-09-10 18:05'
+updated_date: '2026-09-11 13:17'
 labels:
   - clients
   - phase-3
@@ -46,12 +46,12 @@ THEN: TASK-25.1's AC#1 and TASK-25's AC#1/#2 become provable for the Google vend
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TASK-25.1.6.11.1, TASK-25.1.6.11.2 and TASK-25.1.6.11.3 are Done
-- [ ] #2 integrations/google_workspace/client.py::execute_google_api_request and execute_batch_request are deleted with their tests, and grep confirms zero references repo-wide outside backlog/ and tmp/. execute_batch_request's orchestration was already relocated into GoogleDirectoryProvider by TASK-25.1.6.3.1, so no amendment to decisions/outbound-clients.md is needed
-- [ ] #3 app/integrations/google_workspace/ contains only __init__.py and client.py (settings.py permitted once TASK-24 creates it). The six per-method mirror modules, google_meet.py and google_service.py are gone, and schemas.py lives under app/tests/factories/
-- [ ] #4 No file under app/integrations/google_workspace/ references OperationResult, and every remaining reference elsewhere under app/integrations/ is frozen in the vendor-package guardrail baseline (TASK-25 AC#2 provable for the Google vendor)
-- [ ] #5 A CI guardrail fails the build when app/integrations/<vendor>/ gains a non-factory/non-classification/non-settings module or a new OperationResult reference, proven by a deliberately failing fixture in the check's own tests
-- [ ] #6 app/bin/baselines/sdk_typing_antipatterns.txt and the vendor-package guardrail baseline both have zero google_workspace entries, and both checks pass
+- [x] #1 TASK-25.1.6.11.1, TASK-25.1.6.11.2 and TASK-25.1.6.11.3 are Done
+- [x] #2 integrations/google_workspace/client.py::execute_google_api_request and execute_batch_request are deleted with their tests, and grep confirms zero references repo-wide outside backlog/ and tmp/. execute_batch_request's orchestration was already relocated into GoogleDirectoryProvider by TASK-25.1.6.3.1, so no amendment to decisions/outbound-clients.md is needed
+- [x] #3 app/integrations/google_workspace/ contains only __init__.py and client.py (settings.py permitted once TASK-24 creates it). The six per-method mirror modules, google_meet.py and google_service.py are gone, and schemas.py lives under app/tests/factories/
+- [x] #4 No file under app/integrations/google_workspace/ references OperationResult, and every remaining reference elsewhere under app/integrations/ is frozen in the vendor-package guardrail baseline (TASK-25 AC#2 provable for the Google vendor)
+- [x] #5 A CI guardrail fails the build when app/integrations/<vendor>/ gains a non-factory/non-classification/non-settings module or a new OperationResult reference, proven by a deliberately failing fixture in the check's own tests
+- [x] #6 app/bin/baselines/sdk_typing_antipatterns.txt and the vendor-package guardrail baseline both have zero google_workspace entries, and both checks pass
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-25.1.6.14 - Set-an-explicit-per-attempt-timeout-on-Google-Workspace-API-clients-at-construction.md
+++ b/backlog/tasks/task-25.1.6.14 - Set-an-explicit-per-attempt-timeout-on-Google-Workspace-API-clients-at-construction.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-10 14:56'
+updated_date: '2026-09-10 20:35'
 labels:
   - clients
   - phase-3
@@ -51,3 +52,73 @@ NOT IN SCOPE: changing retry counts; handling non-idempotent writes (separate ta
 - [ ] #6 decisions/outbound-clients.md's Migration section no longer lists Google factories inheriting the 60-second default timeout
 - [ ] #7 Full test suite, ruff, mypy and app/bin/check_sdk_typing.py pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Decisions settled with the human (2026-09-10)
+1. Default timeout is 10.0 s, the same as the AWS factories (app/integrations/aws/client.py:43-44). The number is NOT written into decisions/outbound-clients.md: the record states rules, the AWS default isn't recorded there either, and a number in the record would go stale whenever the setting changes. The default is documented on the settings field.
+2. The setting is a float.
+3. Passing `http=` to build() loses no capability in use today (see Seam).
+4. The new settings tests go in test_client.py, next to the existing retry-count settings test.
+
+## Seam (verified empirically, google-api-python-client 2.198.0)
+- build_from_document (discovery.py:543-553) raises ValueError when `http=` and `credentials=` are both passed. So `_build_service` stops passing `credentials=` and builds the authorized http itself.
+- The library's own path when http is None is `_auth.authorized_http(creds)` -> `google_auth_httplib2.AuthorizedHttp(creds, http=build_http())`. `build_http()` is `httplib2.Http(timeout=socket.getdefaulttimeout() or 60)` plus `redirect_codes -= {308}`, which Drive resumable uploads need (guarded by try/except AttributeError for old httplib2).
+- The replacement does the same with an explicit timeout: `httplib2.Http(timeout=settings.GOOGLE_API_TIMEOUT_SECONDS)`, the same 308 adjustment, then `AuthorizedHttp(creds, http=...)`, passed as `build(http=...)`. Verified: `AuthorizedHttp(...).http is` the wrapped Http, `.http.timeout` is the value set, and `.credentials` exists.
+- What `http=` skips is the `if http is None:` block (discovery.py:592-719). With this repo's inputs it changes nothing:
+  - Credential acquisition and scoping: `_build_service` already scopes and delegates the credentials itself.
+  - `always_use_jwt_access`: an opt-in build() argument that defaults to False and exists only inside googleapiclient. `_build_service` has never passed it, so the branch never ran.
+  - mTLS client certificate and endpoint selection: driven by GOOGLE_API_USE_CLIENT_CERTIFICATE and GOOGLE_API_USE_MTLS_ENDPOINT (default "auto", which switches only when a client cert exists). A repo-wide search, including deploy config and excluding .venv/backlog, finds zero references, so the endpoint stays the standard one.
+  - The universe-domain compatibility check still runs on the else branch (discovery.py:720-723) through `http.credentials`.
+- Rejected: `socket.setdefaulttimeout` is process-global and would change every socket in the process.
+
+## Files touched
+1. app/infrastructure/configuration/integrations/google.py: add next to GOOGLE_API_NUM_RETRIES:
+   GOOGLE_API_TIMEOUT_SECONDS: float = Field(default=10.0, alias="GOOGLE_API_TIMEOUT_SECONDS", gt=0, description="Per-attempt HTTP timeout in seconds for every Google Workspace API client, configured once at service construction.")
+   `gt=0` rejects non-positive values without a hand-written validator (AC#2). Add the variable to the class docstring's Environment Variables list. Any comment on the field describes when to revisit (the move to a per-vendor Google Workspace settings module), never a task id.
+2. app/integrations/google_workspace/client.py:
+   - Import httplib2 and google_auth_httplib2.
+   - Add `_build_authorized_http(credentials, timeout_seconds: float)` next to `_build_request_builder`. It builds a new `httplib2.Http(timeout=...)`, applies the 308 adjustment the way build_http does, and returns `AuthorizedHttp(credentials, http=...)`. It is a plain, uncached function, so each call returns a new Http (AC#4). A future retries-disabled factory variant can reuse it without restructuring `_build_service`.
+   - `_build_service`: after delegation and scoping, call `build(api, version, http=_build_authorized_http(creds, settings.GOOGLE_API_TIMEOUT_SECONDS), cache_discovery=False, static_discovery=True, requestBuilder=_build_request_builder(settings.GOOGLE_API_NUM_RETRIES))`. The requestBuilder is unchanged (AC#3).
+   - Extend the existing comment above build() so it covers both the timeout and the retry default, and says each built service owns its Http (httplib2 is not thread-safe).
+   - Add no caching anywhere (no lru_cache, no module-level Http or Resource).
+3. app/pyproject.toml: add "google_auth_httplib2" to the existing mypy ignore_missing_imports override next to googleapiclient.* (the package ships no py.typed or stubs). httplib2 needs no override because its stubs are installed.
+4. decisions/outbound-clients.md: remove the Migration bullet "Google factories that inherit the library's 60-second default timeout (TASK-25.1.6.14)" (AC#6). Add one short dated sentence to Changes, dated the day it lands, e.g. "- <date>: Google factories set an explicit per-attempt timeout." Leave the rest of the record unchanged.
+
+## Worst-case latency at the defaults
+GOOGLE_API_NUM_RETRIES=3 means up to 4 attempts. `_retry_request` sleeps `rand() * 2**n` before retry n (verified), so at most 2+4+8 = 14 s of backoff, and it also retries socket timeouts. Worst case per call is about 4 x 10 + 14 = 54 s, down from about 4 x 60 + 14 = 254 s today.
+
+## Tests (extend app/tests/unit/integrations/google_workspace/test_client.py)
+Reuse the existing fake_build / _install_fake_build capture (captured["build_kwargs"]). The SimpleNamespace settings doubles gain GOOGLE_API_TIMEOUT_SECONDS=10.0.
+- test_build_service_sets_explicit_http_timeout: build_kwargs["http"] is an AuthorizedHttp, its .http.timeout equals the configured value, 308 is not in .http.redirect_codes, and "credentials" is not among the build kwargs (AC#1).
+- test_build_service_applies_timeout_and_retry_builder_together: one built service carries both the timed http and the requestBuilder retry default (AC#3, AC#5).
+- test_build_service_creates_a_new_http_per_call: two builds capture two `http` objects that are not the same object, and neither are their wrapped Http objects (AC#4).
+- test_google_workspace_settings_timeout_defaults_and_reads_environment: default 10.0; monkeypatch.setenv("GOOGLE_API_TIMEOUT_SECONDS", "2.5") is read as 2.5. Mirrors the retry-count settings test in the same file.
+- test_google_workspace_settings_timeout_rejects_non_positive: parametrized over "0" and "-1"; constructing the settings raises pydantic.ValidationError (AC#2).
+Docstrings describe observable behaviour, the stub strategy and why the assertion matters, per testing-standards.
+Order: write the tests first and see them fail, then change settings and client.py.
+
+## AC traceability
+- AC#1 -> _build_authorized_http plus the _build_service change; test_build_service_sets_explicit_http_timeout.
+- AC#2 -> Field(gt=0, default=10.0) plus docstring; the two settings tests.
+- AC#3 -> unchanged requestBuilder; test_build_service_applies_timeout_and_retry_builder_together.
+- AC#4 -> uncached per-call construction; test_build_service_creates_a_new_http_per_call.
+- AC#5 -> test_build_service_applies_timeout_and_retry_builder_together.
+- AC#6 -> ADR Migration bullet removed.
+- AC#7 -> Verification.
+
+## Blast radius and rollback
+_build_service is the only place Google services are built, so every Google Workspace service (Directory, Calendar, Meet, Docs, Drive, Sheets) gets the timeout; there are no per-call overrides. Risk: a call that used to succeed after more than 10 s now times out and is retried, and if it still fails it surfaces as a socket timeout. Mitigation: the setting can be changed through the environment without a code change. A single revert restores the library default.
+
+## Verification (from app/)
+uv run ruff check .
+uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'
+uv run pytest tests/unit/integrations/google_workspace tests/unit/infrastructure/directory tests/unit/infrastructure/drive tests/unit/infrastructure/spreadsheets
+uv run pytest tests --ignore=tests/smoke
+uv run python bin/check_sdk_typing.py
+uv run python bin/check_vendor_package_contract.py
+
+## Size gate
+2 production files (client.py, settings), 1 mypy override line, 1 ADR bullet, roughly 40-60 production LOC, one subsystem, a single behaviour change. Within the single-PR gate; no decomposition needed.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-25.1.6.14 - Set-an-explicit-per-attempt-timeout-on-Google-Workspace-API-clients-at-construction.md
+++ b/backlog/tasks/task-25.1.6.14 - Set-an-explicit-per-attempt-timeout-on-Google-Workspace-API-clients-at-construction.md
@@ -3,10 +3,10 @@ id: TASK-25.1.6.14
 title: >-
   Set an explicit per-attempt timeout on Google Workspace API clients at
   construction
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-10 14:56'
-updated_date: '2026-09-10 20:35'
+updated_date: '2026-09-11 13:31'
 labels:
   - clients
   - phase-3
@@ -44,12 +44,12 @@ NOT IN SCOPE: changing retry counts; handling non-idempotent writes (separate ta
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every service built by app/integrations/google_workspace/client.py uses an explicit per-attempt HTTP timeout read from typed Google Workspace settings, not the google-api-python-client default
-- [ ] #2 The timeout setting has a documented default and rejects non-positive values
-- [ ] #3 The construction-time retry default still applies to every built service
-- [ ] #4 Each built service gets its own Http instance; no Http or Resource is cached and shared across threads
-- [ ] #5 Factory unit tests assert both the configured timeout and the retry request builder on a built service
-- [ ] #6 decisions/outbound-clients.md's Migration section no longer lists Google factories inheriting the 60-second default timeout
+- [x] #1 Every service built by app/integrations/google_workspace/client.py uses an explicit per-attempt HTTP timeout read from typed Google Workspace settings, not the google-api-python-client default
+- [x] #2 The timeout setting has a documented default and rejects non-positive values
+- [x] #3 The construction-time retry default still applies to every built service
+- [x] #4 Each built service gets its own Http instance; no Http or Resource is cached and shared across threads
+- [x] #5 Factory unit tests assert both the configured timeout and the retry request builder on a built service
+- [x] #6 decisions/outbound-clients.md's Migration section no longer lists Google factories inheriting the 60-second default timeout
 - [ ] #7 Full test suite, ruff, mypy and app/bin/check_sdk_typing.py pass
 <!-- AC:END -->
 
@@ -122,3 +122,24 @@ uv run python bin/check_vendor_package_contract.py
 ## Size gate
 2 production files (client.py, settings), 1 mypy override line, 1 ADR bullet, roughly 40-60 production LOC, one subsystem, a single behaviour change. Within the single-PR gate; no decomposition needed.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Implementation
+- client.py: `_build_authorized_http(credentials, timeout_seconds)` builds a new `httplib2.Http(timeout=...)`, drops 308 from `redirect_codes` (as `googleapiclient.http.build_http` does), and wraps it in `google_auth_httplib2.AuthorizedHttp`. `_build_service` passes `http=` instead of `credentials=`; `requestBuilder` is unchanged. Nothing is cached.
+- The library's `AttributeError` guard around `redirect_codes` was not copied: google-api-python-client>=2.190 requires an httplib2 version that has the attribute, and the stubs type it.
+- settings: `GOOGLE_API_TIMEOUT_SECONDS: float`, default 10.0, `gt=0`, documented on the field and in the class docstring.
+- pyproject: `google_auth_httplib2` added to the mypy `ignore_missing_imports` override.
+- decisions/outbound-clients.md: Migration bullet removed; one dated line added under Changes.
+- tests/unit/infrastructure/spreadsheets/test_google_spreadsheet_provider.py: settings double gains `GOOGLE_API_TIMEOUT_SECONDS`, since construction now reads it.
+
+## AC #7 left unchecked: pre-existing gate failures
+Checked by running both gates with this change temporarily reverted:
+- mypy: 88 errors in 32 files, output identical line for line with and without the change; none in touched files.
+- pytest: 6 failures present with and without the change (3 in tests/modules/webhooks/test_webhooks_aws_sns.py, 3 in tests/unit/infrastructure/directory/test_google.py). The directory ones pass when run alone, so they depend on test order.
+- ruff, check_sdk_typing.py and check_vendor_package_contract.py pass.
+
+## Environment fix (.vscode/settings.json)
+The mypy VS Code extension ran its bundled mypy 1.15.0 against the same app/.mypy_cache as the pinned CLI mypy 1.19.1. The CLI gate crashed with `KeyError: 'setter_type'` and gave inconsistent results. The workspace settings now point the extension at app/.venv (`importStrategy: fromEnvironment`) and give it its own `--cache-dir=.mypy_cache/vscode`.
+<!-- SECTION:NOTES:END -->

--- a/decisions/outbound-clients.md
+++ b/decisions/outbound-clients.md
@@ -61,9 +61,9 @@ Clients **raise typed SDK exceptions**. They do not return `OperationResult`, do
 Ticket: client-layer convergence (delete `infrastructure/clients/`, resolve `_next` twins, refactor `AWSShield`). Tolerated until closed:
 - the seven baselined deprecated-client consumers;
 - the shield-shaped AWS client;
-- Google factories that inherit the library's 60-second default timeout (TASK-25.1.6.14);
 - non-idempotent Google writes (Drive create and copy) issued on the retrying handle (TASK-25.1.6.15).
 
 **Changes:**
 - 2026-09-08: adapters must not leak vendor-only concepts through Path A Protocols.
 - 2026-09-10: added explicit timeout, non-idempotent write and thread-safety rules, and corrected how Google retries are configured.
+- 2026-09-11: Google factories set an explicit per-attempt timeout.


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces an explicit, configurable per-attempt HTTP timeout for all Google Workspace API clients, ensuring that each API call does not exceed a defined duration. The timeout is set at client construction time, is environment-overridable, and defaults to 10 seconds. The implementation also ensures that each client instance uses a distinct, non-shared HTTP object, and preserves correct handling for resumable Drive uploads. Comprehensive tests verify the new behavior and configuration validation.

**Google Workspace API client improvements:**
* Added a `GOOGLE_API_TIMEOUT_SECONDS` setting to `GoogleWorkspaceSettings`, with a default of 10.0 seconds, validated to be positive and overridable via environment variable. [[1]](diffhunk://#diff-1b83fc3fc62c30d9fd14bf8d4c60ff66a009679433c4578ff4f19b37055d0be1R24) [[2]](diffhunk://#diff-1b83fc3fc62c30d9fd14bf8d4c60ff66a009679433c4578ff4f19b37055d0be1R47-R53)
* Updated the Google Workspace client to construct a new `httplib2.Http` instance with the configured timeout for each service, wrapped in an `AuthorizedHttp`, and ensured that 308 is removed from automatic redirect codes for Drive upload compatibility. [[1]](diffhunk://#diff-955497e20ef788c1aca23759d8784beb9fe89f7f1c982719ea742ea6d2febbdcR14-R15) [[2]](diffhunk://#diff-955497e20ef788c1aca23759d8784beb9fe89f7f1c982719ea742ea6d2febbdcR63-R74) [[3]](diffhunk://#diff-955497e20ef788c1aca23759d8784beb9fe89f7f1c982719ea742ea6d2febbdcL138-R160)
* Ensured that each service factory call creates a distinct HTTP instance to avoid thread-safety issues.

**Testing and validation:**
* Added and updated unit tests to confirm that the timeout is correctly applied, is environment-overridable, is validated as positive, and that HTTP instances are not shared. Tests also verify preservation of Drive upload behavior and combined application of timeout and retry settings. [[1]](diffhunk://#diff-91dfe8280873708180a85cbad4b7ab790cc8fbe140027538696c9b3aab3a4623R14-R18) [[2]](diffhunk://#diff-91dfe8280873708180a85cbad4b7ab790cc8fbe140027538696c9b3aab3a4623R101) [[3]](diffhunk://#diff-91dfe8280873708180a85cbad4b7ab790cc8fbe140027538696c9b3aab3a4623R147-R153) [[4]](diffhunk://#diff-91dfe8280873708180a85cbad4b7ab790cc8fbe140027538696c9b3aab3a4623R292-R428) [[5]](diffhunk://#diff-e7a60426749ab6869282c7d878981e0d3bec711671e9fea079d5aeb240305043R244)
* Extended mypy configuration and test dependencies to cover new imports.

**Developer tooling:**
* Updated `.vscode/settings.json` to use the project-pinned mypy with a separate cache directory to avoid corruption and CLI crashes.

**Documentation and backlog:**
* Updated backlog task status and acceptance criteria to reflect completion and progress of related tasks. [[1]](diffhunk://#diff-ffab41413d0f549a625d570304b6ca1bbbc217faaeac59d39629bf11dba64b31L6-R9) [[2]](diffhunk://#diff-ffab41413d0f549a625d570304b6ca1bbbc217faaeac59d39629bf11dba64b31L49-R54) [[3]](diffhunk://#diff-60ab5264f002721e38bef043dbfa60973819acdce501df7344f2e2dd0d32c490L6-R9)