### PR TITLE
Feat/migrate aws client new architecture

### DIFF
--- a/app/tests/modules/incident/test_db_operations.py
+++ b/app/tests/modules/incident/test_db_operations.py
@@ -204,6 +204,75 @@ def test_create_incident_already_exists(mock_get_incident_by_channel_id, mock_dy
 
 
 @patch("modules.incident.db_operations.dynamodb")
+@patch("modules.incident.db_operations.get_incident_by_channel_id")
+@patch("modules.incident.db_operations.datetime")
+def test_create_incident_raises_when_put_item_returns_false(mock_datetime, mock_get_incident_by_channel_id, mock_dynamodb):
+    """put_item returning the integration's literal False error contract crashes on the
+    unguarded response["ResponseMetadata"] index, unlike the tested 400-status dict.
+    """
+    mock_datetime.datetime.now.return_value.timestamp.return_value = 1234567890
+    mock_get_incident_by_channel_id.return_value = None
+    mock_dynamodb.put_item.return_value = False
+    incident_data = {
+        "id": "978f1d91-f2b4-4ad2-9f2f-86c0f1fce72d",
+        "channel_id": "channel_id",
+        "channel_name": "channel_name",
+        "name": "name",
+        "user_id": "user_id",
+        "teams": ["teams"],
+        "report_url": "report_url",
+        "meet_url": "meet_url",
+    }
+    with pytest.raises(TypeError):
+        db_operations.create_incident(incident_data)
+
+
+@patch("modules.incident.db_operations.dynamodb")
+def test_list_incidents_returns_false_unchanged(mock_dynamodb):
+    """list_incidents is a pure pass-through, so an integration False propagates unchanged."""
+    mock_dynamodb.scan.return_value = False
+    assert db_operations.list_incidents() is False
+
+
+@patch("modules.incident.db_operations.dynamodb")
+def test_get_incident_returns_false_unchanged(mock_dynamodb):
+    """get_incident is a pure pass-through, so an integration False propagates unchanged."""
+    mock_dynamodb.get_item.return_value = False
+    assert db_operations.get_incident("foo") is False
+
+
+@patch("modules.incident.db_operations.dynamodb")
+def test_lookup_incident_returns_false_unchanged(mock_dynamodb):
+    """lookup_incident is a pure pass-through, so an integration False propagates unchanged."""
+    mock_dynamodb.scan.return_value = False
+    assert db_operations.lookup_incident("channel_id", "bar") is False
+
+
+@patch("modules.incident.db_operations.lookup_incident")
+def test_get_incident_by_channel_id_raises_when_lookup_incident_returns_false(mock_lookup_incident):
+    """A False return from lookup_incident (the integration's real error contract on
+    failure) crashes on the unguarded len(incidents) call, unlike the tested empty-list
+    "no results" case which returns None cleanly.
+    """
+    mock_lookup_incident.return_value = False
+
+    with pytest.raises(TypeError):
+        db_operations.get_incident_by_channel_id("bar")
+
+
+@patch("modules.incident.db_operations.dynamodb")
+def test_log_activity_returns_false_and_logs_error_when_integration_returns_false(mock_dynamodb):
+    """log_activity's own False branch (log an error, return False) is exercised
+    directly rather than only reached indirectly through create_incident's success path.
+    """
+    mock_dynamodb.update_item.return_value = False
+
+    result = db_operations.log_activity("incident-1", "message")
+
+    assert result is False
+
+
+@patch("modules.incident.db_operations.dynamodb")
 def test_list_incidents(
     mock_dynamodb,
 ):

--- a/app/tests/modules/incident/test_incident_folder.py
+++ b/app/tests/modules/incident/test_incident_folder.py
@@ -471,6 +471,22 @@ def test_store_update_failed(mock_current_time_est, mock_update_item, mock_scan_
 
 
 @patch("modules.incident.incident_folder.dynamodb.scan")
+@patch("modules.incident.incident_folder.dynamodb.update_item")
+@patch("modules.incident.incident_folder.current_time_est")
+def test_store_update_raises_when_update_item_returns_false(mock_current_time_est, mock_update_item, mock_scan_item):
+    """update_item returning the integration's literal False error contract crashes on
+    the unguarded response.get("ResponseMetadata", {}) call, unlike the tested
+    400-status dict.
+    """
+    mock_current_time_est.return_value = "2025-01-31 11:17:06"
+    mock_scan_item.return_value = [{"incident_updates": {"L": [{"S": "Previous update"}]}}]
+    mock_update_item.return_value = False
+
+    with pytest.raises(AttributeError):
+        incident_folder.store_update("incident_id", "New update")
+
+
+@patch("modules.incident.incident_folder.dynamodb.scan")
 def test_fetch_updates(mock_scan_item):
     mock_scan_item.return_value = [{"incident_updates": {"L": [{"S": "Update 1\n Update 2"}]}}]
 

--- a/app/tests/modules/provisioning/test_provisioning_groups.py
+++ b/app/tests/modules/provisioning/test_provisioning_groups.py
@@ -350,6 +350,21 @@ def test_get_groups_from_integration_case_aws(
 
 @patch("modules.provisioning.groups.filters")
 @patch("modules.provisioning.groups.identity_store.list_groups_with_memberships")
+def test_get_groups_from_integration_case_aws_raises_when_integration_returns_false(
+    mock_aws_list_groups_with_memberships,
+    mock_filters,
+):
+    """A False return (the integration's real error contract on failure) reaches
+    log_groups' unguarded len(groups) call and crashes, unlike an empty-list result.
+    """
+    mock_aws_list_groups_with_memberships.return_value = False
+
+    with pytest.raises(TypeError):
+        groups.get_groups_from_integration("aws_identity_center")
+
+
+@patch("modules.provisioning.groups.filters")
+@patch("modules.provisioning.groups.identity_store.list_groups_with_memberships")
 def test_get_groups_from_integration_case_invalid(
     mock_aws_list_groups_with_memberships,
     mock_filters,

--- a/app/tests/modules/slack/test_slack_webhooks.py
+++ b/app/tests/modules/slack/test_slack_webhooks.py
@@ -1,5 +1,7 @@
 from unittest.mock import ANY, patch
 
+import pytest
+
 from modules.slack import webhooks
 
 
@@ -260,6 +262,71 @@ def test_toggle_webhook(get_webhook_mock, dynamodb_mock):
         UpdateExpression="SET active = :active",
         ExpressionAttributeValues={":active": {"BOOL": ANY}},
     )
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_create_webhook_raises_when_integration_returns_false(dynamodb_mock):
+    """put_item returning the integration's literal False error contract crashes on
+    the unguarded response["ResponseMetadata"] index, unlike the tested 401-status dict.
+    """
+    dynamodb_mock.put_item.return_value = False
+    with pytest.raises(TypeError):
+        webhooks.create_webhook("test_channel", "test_user_id", "test_name")
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_delete_webhook_returns_false_unchanged(dynamodb_mock):
+    """delete_webhook is a pure pass-through, so an integration False propagates unchanged."""
+    dynamodb_mock.delete_item.return_value = False
+    assert webhooks.delete_webhook("test_id") is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_lookup_webhooks_returns_false_unchanged(mock_dynamodb):
+    """lookup_webhooks is a pure pass-through, so an integration False propagates unchanged."""
+    mock_dynamodb.scan.return_value = False
+    assert webhooks.lookup_webhooks("channel", "test_channel") is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_increment_acknowledged_count_returns_false_unchanged(dynamodb_mock):
+    """increment_acknowledged_count is a pure pass-through, so an integration False
+    propagates unchanged."""
+    dynamodb_mock.update_item.return_value = False
+    assert webhooks.increment_acknowledged_count("test_id") is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_increment_invocation_count_returns_false_unchanged(dynamodb_mock):
+    """increment_invocation_count is a pure pass-through, so an integration False
+    propagates unchanged."""
+    dynamodb_mock.update_item.return_value = False
+    assert webhooks.increment_invocation_count("test_id") is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_list_all_webhooks_returns_false_unchanged(dynamodb_mock):
+    """list_all_webhooks is a pure pass-through, so an integration False propagates unchanged."""
+    dynamodb_mock.scan.return_value = False
+    assert webhooks.list_all_webhooks() is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_revoke_webhook_returns_false_unchanged(dynamodb_mock):
+    """revoke_webhook is a pure pass-through, so an integration False propagates unchanged."""
+    dynamodb_mock.update_item.return_value = False
+    assert webhooks.revoke_webhook("test_id") is False
+
+
+@patch("modules.slack.webhooks.dynamodb")
+def test_toggle_webhook_raises_when_get_webhook_returns_none_due_to_integration_failure(dynamodb_mock):
+    """get_item returning the integration's literal False makes get_webhook return None
+    (its own defended `if response:` branch), and toggle_webhook's inline
+    `get_webhook(id)["active"]` then crashes indexing None.
+    """
+    dynamodb_mock.get_item.return_value = False
+    with pytest.raises(TypeError):
+        webhooks.toggle_webhook("test_id")
 
 
 @patch("modules.slack.webhooks.model_utils")

--- a/app/tests/unit/jobs/test_revoke_aws_sso_access.py
+++ b/app/tests/unit/jobs/test_revoke_aws_sso_access.py
@@ -234,3 +234,39 @@ def test_revoke_access_no_expired_requests(
     mock_sso.delete_account_assignment.assert_not_called()
     mock_slack_client.chat_postEphemeral.assert_not_called()
     mock_log_ops.assert_not_called()
+
+
+@pytest.mark.unit
+@patch("jobs.revoke_aws_sso_access.aws_access_requests")
+@patch("jobs.revoke_aws_sso_access.identity_store")
+@patch("jobs.revoke_aws_sso_access.sso_admin")
+@patch("jobs.revoke_aws_sso_access.log_ops_message")
+@patch("jobs.revoke_aws_sso_access.logger")
+def test_revoke_access_proceeds_with_false_user_id_when_identity_store_lookup_fails(
+    mock_logger,
+    mock_log_ops,
+    mock_sso,
+    mock_identity_store,
+    mock_aws_requests,
+    expired_request,
+    mock_slack_client,
+) -> None:
+    """Test that a failed identity_store lookup surfaces as the literal False
+    handle_aws_api_errors returns today, not a raised exception, and that the loop
+    has no guard against it.
+
+    Stub strategy: get_user_id.return_value = False (the integration's real error
+    contract) rather than a side_effect exception, since the decorator that wraps
+    every AWS call always returns False on error and never raises. This replaces
+    reliance on the sibling exception-based test as evidence of "error handling":
+    that scenario cannot occur against the real integration.
+    """
+    mock_aws_requests.get_expired_requests.return_value = [expired_request]
+    mock_identity_store.get_user_id.return_value = False
+
+    revoke_aws_sso_access(mock_slack_client)
+
+    mock_sso.delete_account_assignment.assert_called_once_with(False, "123456789", "ReadOnlyAccess")
+    mock_aws_requests.expire_request.assert_called_once_with(account_id="123456789", created_at="1704067200")
+    assert mock_slack_client.chat_postEphemeral.call_count == 1
+    mock_logger.error.assert_not_called()

--- a/app/tests/unit/modules/aws/test_aws_access_requests_handler.py
+++ b/app/tests/unit/modules/aws/test_aws_access_requests_handler.py
@@ -1,11 +1,34 @@
 """Unit tests for AWS access requests handler."""
 
 import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from modules.aws import aws_access_requests
+
+
+def _access_view_body():
+    """Build a Slack view-submission body shaped like access_view_handler expects."""
+    return {
+        "view": {
+            "state": {
+                "values": {
+                    "rationale": {"rationale": {"value": "Need access for an investigation"}},
+                    "account": {
+                        "account": {
+                            "selected_option": {
+                                "value": "account-123",
+                                "text": {"text": "TestAccount"},
+                            }
+                        }
+                    },
+                    "access_type": {"access_type": {"selected_option": {"value": "read"}}},
+                }
+            }
+        },
+        "user": {"id": "U123"},
+    }
 
 
 @pytest.mark.unit
@@ -276,3 +299,100 @@ def test_should_return_empty_list_when_no_active_requests(mock_client):
 
     # Assert
     assert result == []
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_access_requests.log_ops_message")
+@patch("modules.aws.aws_access_requests.sso_admin")
+@patch("modules.aws.aws_access_requests.create_aws_access_request")
+@patch("modules.aws.aws_access_requests.already_has_access")
+@patch("modules.aws.aws_access_requests.identity_store")
+def test_should_treat_integration_false_as_not_none_and_proceed(
+    mock_identity_store,
+    mock_already_has_access,
+    mock_create_request,
+    mock_sso_admin,
+    mock_log_ops_message,
+):
+    """Test access_view_handler proceeds past the "not registered" branch when the
+    integration returns False for a failed lookup.
+
+    Stub strategy: identity_store.get_user_id returns the literal False that
+    handle_aws_api_errors produces on error, not None. The handler's guard is
+    `if aws_user_id is None`, so False takes the same path as a real user id --
+    this is a pinned defect (the guard is effectively dead code today), not an
+    endorsed behaviour, and would need revisiting if the integration's error
+    contract ever changes from a bare False to a structured result.
+    """
+    # Arrange
+    mock_identity_store.get_user_id.return_value = False
+    mock_already_has_access.return_value = False
+    mock_create_request.return_value = True
+    mock_sso_admin.create_account_assignment.return_value = True
+    ack = MagicMock()
+    client = MagicMock()
+    client.users_info.return_value = {"user": {"profile": {"email": "user@example.com"}}}
+    body = _access_view_body()
+
+    # Act
+    aws_access_requests.access_view_handler(ack, body, MagicMock(), client)
+
+    # Assert
+    mock_create_request.assert_called_once()
+    mock_sso_admin.create_account_assignment.assert_called_once_with(False, "account-123", "read")
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_access_requests.log_ops_message")
+@patch("modules.aws.aws_access_requests.sso_admin")
+@patch("modules.aws.aws_access_requests.create_aws_access_request")
+@patch("modules.aws.aws_access_requests.already_has_access")
+@patch("modules.aws.aws_access_requests.identity_store")
+def test_should_respond_not_registered_message_never_fires_on_integration_failure(
+    mock_identity_store,
+    mock_already_has_access,
+    mock_create_request,
+    mock_sso_admin,
+    mock_log_ops_message,
+):
+    """Test access_view_handler's ephemeral message never mentions "not registered" when
+    identity_store.get_user_id returns False rather than None.
+
+    Stub strategy: same setup as the sibling test; this asserts the observable
+    Slack message text directly, confirming the "is None" guard is bypassed
+    for the actual False contract.
+    """
+    # Arrange
+    mock_identity_store.get_user_id.return_value = False
+    mock_already_has_access.return_value = False
+    mock_create_request.return_value = True
+    mock_sso_admin.create_account_assignment.return_value = True
+    ack = MagicMock()
+    client = MagicMock()
+    client.users_info.return_value = {"user": {"profile": {"email": "user@example.com"}}}
+    body = _access_view_body()
+
+    # Act
+    aws_access_requests.access_view_handler(ack, body, MagicMock(), client)
+
+    # Assert
+    sent_text = client.chat_postEphemeral.call_args.kwargs["text"]
+    assert "not registered" not in sent_text
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_access_requests.organizations")
+def test_should_raise_when_request_access_modal_organizations_call_returns_false(mock_organizations):
+    """Test request_access_modal surfaces a TypeError when organizations returns False.
+
+    Stub strategy: list_organization_accounts returns the literal False; the dict
+    comprehension over accounts pins today's crash on a non-iterable bool.
+    """
+    # Arrange
+    mock_organizations.list_organization_accounts.return_value = False
+    client = MagicMock()
+    body = {"trigger_id": "trigger-123"}
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_access_requests.request_access_modal(client, body)

--- a/app/tests/unit/modules/aws/test_aws_account_health_handler.py
+++ b/app/tests/unit/modules/aws/test_aws_account_health_handler.py
@@ -273,3 +273,108 @@ def test_should_request_health_modal(mock_organizations):
     # Assert
     mock_organizations.list_organization_accounts.assert_called_once()
     client.views_open.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.cost_explorer")
+def test_should_raise_when_cost_explorer_returns_false(mock_cost_explorer):
+    """Test get_account_spend surfaces a TypeError when the integration swallows an error to False.
+
+    Stub strategy: cost_explorer.get_cost_and_usage returns the literal False that
+    handle_aws_api_errors produces on any boto/client error, matching today's real contract
+    instead of a defended falsy fixture like {} or [].
+    """
+    # Arrange
+    mock_cost_explorer.get_cost_and_usage.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_account_health.get_account_spend("account-123", "2024-01-01", "2024-01-31")
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.config")
+def test_should_raise_when_config_summary_integration_returns_false(mock_config):
+    """Test get_config_summary surfaces a TypeError when the integration returns False.
+
+    Stub strategy: describe_aggregate_compliance_by_config_rules returns False; the unguarded
+    len() call on it pins today's crash rather than the success-path count.
+    """
+    # Arrange
+    mock_config.describe_aggregate_compliance_by_config_rules.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_account_health.get_config_summary("account-123")
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.guard_duty")
+def test_should_raise_when_guardduty_list_detectors_returns_false(mock_guard_duty):
+    """Test get_guardduty_summary surfaces a TypeError when list_detectors returns False.
+
+    Stub strategy: list_detectors returns False; indexing detector_ids[0] on a bool pins
+    today's crash.
+    """
+    # Arrange
+    mock_guard_duty.list_detectors.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_account_health.get_guardduty_summary("account-123")
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.guard_duty")
+def test_should_raise_when_guardduty_findings_statistics_returns_false(mock_guard_duty):
+    """Test get_guardduty_summary surfaces a TypeError when get_findings_statistics returns False.
+
+    Stub strategy: list_detectors succeeds so control reaches get_findings_statistics, which
+    then returns False; indexing response["FindingStatistics"] on a bool pins today's crash.
+    """
+    # Arrange
+    mock_guard_duty.list_detectors.return_value = ["detector-123"]
+    mock_guard_duty.get_findings_statistics.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_account_health.get_guardduty_summary("account-123")
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.get_ignored_security_hub_issues")
+@patch("modules.aws.aws_account_health.security_hub")
+def test_should_return_zero_securityhub_when_integration_returns_false(mock_security_hub, mock_get_ignored):
+    """Test get_securityhub_summary treats an integration False the same as an empty result list.
+
+    Stub strategy: get_findings returns the literal False; the existing `if response:` guard
+    takes the same falsy branch as the already-tested [] case, so this pins the branch
+    explicitly with False rather than assuming branch-equivalence.
+    """
+    # Arrange
+    mock_get_ignored.return_value = []
+    mock_security_hub.get_findings.return_value = False
+
+    # Act
+    result = aws_account_health.get_securityhub_summary("account-123")
+
+    # Assert
+    assert result == 0
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws_account_health.organizations")
+def test_should_raise_when_request_health_modal_organizations_call_returns_false(mock_organizations):
+    """Test request_health_modal surfaces a TypeError when list_organization_accounts returns False.
+
+    Stub strategy: list_organization_accounts returns False; the list comprehension iterating
+    over accounts pins today's crash on a non-iterable bool.
+    """
+    # Arrange
+    mock_organizations.list_organization_accounts.return_value = False
+    client = MagicMock()
+    body = MagicMock()
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        aws_account_health.request_health_modal(client, body)

--- a/app/tests/unit/modules/aws/test_aws_command_handler.py
+++ b/app/tests/unit/modules/aws/test_aws_command_handler.py
@@ -232,3 +232,112 @@ def test_should_show_error_for_unknown_command(mock_parse_command, make_command)
     respond.assert_called_once()
     assert "Unknown command" in respond.call_args[0][0]
     assert "invalid_command" in respond.call_args[0][0]
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws.aws_access_requests.create_aws_access_request")
+@patch("modules.aws.aws.identity_store")
+@patch("modules.aws.aws.get_account_id_by_name")
+def test_should_pass_through_account_id_and_user_id_on_success(mock_get_account_id, mock_identity_store, mock_create_request):
+    """Test request_aws_account_access pins today's positional call shape into
+    create_aws_access_request.
+
+    Stub strategy: get_account_id_by_name and identity_store.get_user_id resolve
+    successfully; create_aws_access_request is mocked so no DynamoDB write occurs.
+    The assertion pins the exact positional argument order the caller uses today --
+    which is shifted relative to create_aws_access_request's real parameter list
+    (access_type and start_date_time land in each other's slots) -- as a defect to
+    revisit only if this dead code path is ever wired back into production use.
+    """
+    # Arrange
+    mock_get_account_id.return_value = "account-123"
+    mock_identity_store.get_user_id.return_value = "user-123"
+    mock_create_request.return_value = True
+
+    # Act
+    aws.request_aws_account_access(
+        "TestAccount",
+        "Test rationale",
+        "2024-01-01",
+        "2024-01-31",
+        "user@example.com",
+        "read",
+    )
+
+    # Assert
+    mock_create_request.assert_called_once_with(
+        "account-123",
+        "TestAccount",
+        "user-123",
+        "user@example.com",
+        "2024-01-01",
+        "2024-01-31",
+        "read",
+        "Test rationale",
+    )
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws.aws_access_requests.create_aws_access_request")
+@patch("modules.aws.aws.identity_store")
+@patch("modules.aws.aws.get_account_id_by_name")
+def test_should_proceed_with_false_account_id_when_organizations_lookup_fails(
+    mock_get_account_id, mock_identity_store, mock_create_request
+):
+    """Test request_aws_account_access has no guard against a failed account lookup.
+
+    Stub strategy: get_account_id_by_name returns the literal False that
+    handle_aws_api_errors produces on error; there is no `is None`/`if not` check
+    on account_id, so create_aws_access_request is still invoked with False.
+    """
+    # Arrange
+    mock_get_account_id.return_value = False
+    mock_identity_store.get_user_id.return_value = "user-123"
+    mock_create_request.return_value = True
+
+    # Act
+    aws.request_aws_account_access(
+        "TestAccount",
+        "Test rationale",
+        "2024-01-01",
+        "2024-01-31",
+        "user@example.com",
+        "read",
+    )
+
+    # Assert
+    mock_create_request.assert_called_once()
+    assert mock_create_request.call_args.args[0] is False
+
+
+@pytest.mark.unit
+@patch("modules.aws.aws.aws_access_requests.create_aws_access_request")
+@patch("modules.aws.aws.identity_store")
+@patch("modules.aws.aws.get_account_id_by_name")
+def test_should_proceed_with_false_user_id_when_identity_store_lookup_fails(
+    mock_get_account_id, mock_identity_store, mock_create_request
+):
+    """Test request_aws_account_access has no guard against a failed user lookup.
+
+    Stub strategy: identity_store.get_user_id returns the literal False that
+    handle_aws_api_errors produces on error; there is no guard on user_id, so
+    create_aws_access_request is still invoked with False.
+    """
+    # Arrange
+    mock_get_account_id.return_value = "account-123"
+    mock_identity_store.get_user_id.return_value = False
+    mock_create_request.return_value = True
+
+    # Act
+    aws.request_aws_account_access(
+        "TestAccount",
+        "Test rationale",
+        "2024-01-01",
+        "2024-01-31",
+        "user@example.com",
+        "read",
+    )
+
+    # Assert
+    mock_create_request.assert_called_once()
+    assert mock_create_request.call_args.args[2] is False

--- a/app/tests/unit/modules/aws/test_identity_center_handler.py
+++ b/app/tests/unit/modules/aws/test_identity_center_handler.py
@@ -427,3 +427,27 @@ class TestProvisionAwsUsers:
         items = call_args[0][1]
         assert len(items) == 1
         assert items[0]["primaryEmail"] == "user1@example.com"
+
+
+@pytest.mark.unit
+@patch("modules.aws.identity_center.groups")
+@patch("modules.aws.identity_center.filters")
+@patch("modules.aws.identity_center.identity_store")
+def test_should_raise_when_list_users_returns_false_before_sync(mock_identity_store, mock_filters, mock_groups):
+    """Test synchronize surfaces a TypeError when identity_store.list_users returns False.
+
+    Stub strategy: identity_store.list_users returns the literal False that
+    handle_aws_api_errors produces on error; the immediate `len(target_users)`
+    logging call pins today's crash before either sync_users or sync_groups runs.
+    """
+    # Arrange
+    mock_groups.get_groups_from_integration.side_effect = [
+        [{"name": "AWS-Group1", "members": []}],  # source groups
+        [{"DisplayName": "Group1", "GroupMemberships": []}],  # target groups
+    ]
+    mock_filters.get_unique_nested_dicts.return_value = []
+    mock_identity_store.list_users.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        identity_center.synchronize()

--- a/app/tests/unit/modules/aws/test_ops_group_assignment_handler.py
+++ b/app/tests/unit/modules/aws/test_ops_group_assignment_handler.py
@@ -268,3 +268,65 @@ def test_should_handle_multiple_accounts_with_mixed_status(
     # Only Account3 should be assigned (Account1 already assigned, Account2/4 not ACTIVE)
     assert mock_sso_admin.create_account_assignment.call_count == 1
     assert result["status"] == "success"
+
+
+@pytest.mark.unit
+@patch("modules.aws.ops_group_assignment.get_aws_feature_settings")
+@patch("modules.aws.ops_group_assignment.identity_store")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+def test_should_raise_when_list_organization_accounts_returns_false(
+    mock_sso_admin,
+    mock_organizations,
+    mock_identity_store,
+    mock_get_aws_feature_settings,
+):
+    """Test execute surfaces a TypeError when organizations returns False.
+
+    Stub strategy: list_organization_accounts returns the literal False that
+    handle_aws_api_errors produces on error; the list comprehension over
+    organizations_accounts pins today's crash on a non-iterable bool.
+    """
+    # Arrange
+    mock_feature_settings = MagicMock()
+    mock_feature_settings.AWS_OPS_GROUP_NAME = "OpsGroup"
+    mock_get_aws_feature_settings.return_value = mock_feature_settings
+    mock_identity_store.get_group_id.return_value = "group-123"
+    mock_organizations.list_organization_accounts.return_value = False
+    mock_sso_admin.list_account_assignments_for_principal.return_value = []
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        ops_group_assignment.execute()
+
+
+@pytest.mark.unit
+@patch("modules.aws.ops_group_assignment.get_aws_feature_settings")
+@patch("modules.aws.ops_group_assignment.identity_store")
+@patch("modules.aws.ops_group_assignment.organizations")
+@patch("modules.aws.ops_group_assignment.sso_admin")
+def test_should_raise_when_list_account_assignments_returns_false(
+    mock_sso_admin,
+    mock_organizations,
+    mock_identity_store,
+    mock_get_aws_feature_settings,
+):
+    """Test execute surfaces a TypeError when sso_admin returns False.
+
+    Stub strategy: list_account_assignments_for_principal returns the literal False;
+    the set comprehension over account_assignments pins today's crash on a
+    non-iterable bool.
+    """
+    # Arrange
+    mock_feature_settings = MagicMock()
+    mock_feature_settings.AWS_OPS_GROUP_NAME = "OpsGroup"
+    mock_get_aws_feature_settings.return_value = mock_feature_settings
+    mock_identity_store.get_group_id.return_value = "group-123"
+    mock_organizations.list_organization_accounts.return_value = [
+        {"Id": "111111111111", "Name": "Account1", "Status": "ACTIVE"},
+    ]
+    mock_sso_admin.list_account_assignments_for_principal.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        ops_group_assignment.execute()

--- a/app/tests/unit/modules/aws/test_spending_handler.py
+++ b/app/tests/unit/modules/aws/test_spending_handler.py
@@ -315,3 +315,71 @@ def test_should_skip_update_when_spending_data_empty(mock_update, mock_generate)
     # Assert
     mock_generate.assert_called_once()
     mock_update.assert_not_called()
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.organizations")
+def test_should_raise_when_list_organization_accounts_returns_false(mock_organizations):
+    """Test generate_spending_data surfaces a TypeError when organizations returns False.
+
+    Stub strategy: list_organization_accounts returns the literal False that
+    handle_aws_api_errors produces on error; the list comprehension iterating over
+    accounts pins today's crash on a non-iterable bool.
+    """
+    # Arrange
+    mock_organizations.list_organization_accounts.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        spending.generate_spending_data()
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.organizations")
+def test_should_raise_when_get_account_details_returns_false(mock_organizations):
+    """Test get_accounts_details surfaces a TypeError when get_account_details returns False.
+
+    Stub strategy: get_account_details returns False; the subsequent item assignment
+    `details["Tags"] = ...` on a bool pins today's crash.
+    """
+    # Arrange
+    mock_organizations.get_account_details.return_value = False
+    mock_organizations.get_account_tags.return_value = []
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        spending.get_accounts_details(["123456789012"])
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.organizations")
+def test_should_raise_when_get_account_tags_returns_false(mock_organizations):
+    """Test get_accounts_details surfaces a TypeError when get_account_tags returns False.
+
+    Stub strategy: get_account_details succeeds but get_account_tags returns False;
+    the crash actually happens inside format_account_details' `for tag in account["Tags"]`,
+    reached from get_accounts_details, so the raise is asserted at the caller.
+    """
+    # Arrange
+    mock_organizations.get_account_details.return_value = {"Id": "123456789012", "Name": "TestAccount"}
+    mock_organizations.get_account_tags.return_value = False
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        spending.get_accounts_details(["123456789012"])
+
+
+@pytest.mark.unit
+@patch("modules.aws.spending.cost_explorer")
+def test_should_raise_when_cost_and_usage_returns_false(mock_cost_explorer):
+    """Test get_accounts_spending surfaces an AttributeError when cost_explorer returns False.
+
+    Stub strategy: get_cost_and_usage returns the literal False; the subsequent
+    `response.get(...)` call on a bool pins today's crash.
+    """
+    # Arrange
+    mock_cost_explorer.get_cost_and_usage.return_value = False
+
+    # Act & Assert
+    with pytest.raises(AttributeError):
+        spending.get_accounts_spending("2024", "01", span=1)

--- a/app/tests/unit/modules/provisioning/test_provisioning_users.py
+++ b/app/tests/unit/modules/provisioning/test_provisioning_users.py
@@ -106,5 +106,14 @@ class TestGetUsersFromIntegration:
 
         assert users.get_users_from_integration("aws_identity_center") == aws_users
 
+    def test_should_raise_when_aws_identity_store_list_users_returns_false(self, monkeypatch: pytest.MonkeyPatch):
+        """A False return (the integration's real error contract) crashes on the
+        subsequent len(users) logging call, unlike the empty-list success path.
+        """
+        monkeypatch.setattr(users.identity_store, "list_users", lambda *args, **kwargs: False)
+
+        with pytest.raises(TypeError):
+            users.get_users_from_integration("aws_identity_center")
+
     def test_should_not_bind_the_google_workspace_directory_module(self):
         assert not hasattr(users, "google_directory")

--- a/backlog/archive/tasks/task-25.5 - Delete-dead-AWSShield-integrations-aws-shield.py-zero-production-consumers-confirmed.md
+++ b/backlog/archive/tasks/task-25.5 - Delete-dead-AWSShield-integrations-aws-shield.py-zero-production-consumers-confirmed.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-05 16:13'
+updated_date: '2026-09-11 15:36'
 labels:
   - clients
   - phase-3
@@ -26,3 +27,12 @@ ordinal: 124000
 - [ ] #2 app/integrations/aws/shield.py and its dedicated test files (tests/unit/integrations/aws/test_shield.py, test_executor.py, tests/smoke/integrations/aws/test_shield_smoke.py) are deleted
 - [ ] #3 no production import of integrations.aws.shield exists anywhere in the repo before deletion (re-verified at implementation, not just at planning time)
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-11 15:36
+---
+Folded into TASK-25.2.6 (2026-09-11, human-directed reassessment of TASK-25.2): the shield.py deletion ships in that slice because integrations/aws/settings.py is imported only by shield.py and its tests and is deleted in the same PR. Keep this task open for human closure once TASK-25.2.6 lands.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.1 - Migrate-Google-Workspace-remainder-Drive-Docs-Calendar-Meet-Sheets-legacy-Directory-consumers-off-the-execute_google_api_call-dispatcher.md
+++ b/backlog/tasks/task-25.1 - Migrate-Google-Workspace-remainder-Drive-Docs-Calendar-Meet-Sheets-legacy-Directory-consumers-off-the-execute_google_api_call-dispatcher.md
@@ -3,10 +3,10 @@ id: TASK-25.1
 title: >-
   Migrate Google Workspace remainder (Drive/Docs/Calendar/Meet/Sheets/legacy
   Directory consumers) off the execute_google_api_call dispatcher
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 18:32'
-updated_date: '2026-09-08 14:44'
+updated_date: '2026-09-11 14:56'
 labels:
   - clients
   - phase-3
@@ -38,10 +38,16 @@ WHO CLOSES IT: TASK-25.1.6 (retitled 2026-09-02 to 'Retire the Google Workspace 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 make client-usage-matrix / a repo-wide grep of execute_google_api_call and get_google_api_command_parameters shows zero call sites outside google_service.py/google_service_next.py itself (both slated for TASK-23 deletion once this coordinator's children land)
-- [ ] #2 Every one of the 16 identified legacy consumer files is migrated behavior-neutrally (existing tests pass with identical outcomes) onto a factory-built, stub-typed Resource (google-api-python-client-stubs, per decisions/sdk-typing.md item 3) + classify_google_error, per its owning child subtask
-- [ ] #3 gmail.py and gmail_next.py are deleted (zero production consumers, confirmed)
+- [x] #1 A repo-wide grep of execute_google_api_call and get_google_api_command_parameters shows zero call sites (the only remaining hits are decisions/sdk-typing.md and the bin/check_sdk_typing.py guard pattern); google_service.py was deleted by TASK-25.1.7 and google_service_next.py by TASK-23.1
+- [x] #2 Every live legacy consumer of the retired Google Workspace modules reaches Google through an infrastructure capability (DirectoryProvider, DriveProvider, SpreadsheetProvider) or a packages/<feature>/adapters/ file that builds a factory-built, stub-typed Resource (google-api-python-client-stubs, per decisions/sdk-typing.md item 3) and classifies with classify_google_error; modules/reports/google_groups.py was deleted rather than migrated, and the only behaviour changes are the defect fixes and retry/timeout changes made deliberately by their owning subtasks
+- [x] #3 gmail.py and gmail_next.py are deleted (zero production consumers, confirmed)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CLOSEOUT VERIFICATION (2026-09-11). All seven children Done. AC#1 and AC#2 reworded where they had drifted (google_service.py deleted by TASK-25.1.7, not TASK-23; reports/google_groups.py deleted rather than migrated; consumers reach Google through the Directory, Drive and Spreadsheet providers or feature adapters), then checked individually. Evidence is recorded on TASK-25.1.6's closeout notes. The Description's endstate of frozen domain dataclasses at every boundary is met by the infrastructure providers and packages/incident_draft; the legacy-facing incident and talent adapters' dict returns are deferred to TASK-38 AC#9 and TASK-39 AC#4.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
+++ b/backlog/tasks/task-25.1.6 - Reconcile-integrations-google_workspace-client.pys-shared-execute-helpers-against-the-vendor-package-export-contract.md
@@ -3,10 +3,10 @@ id: TASK-25.1.6
 title: >-
   Retire the Google Workspace vendor mirror layer: adapters own construction and
   classification
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-01 15:31'
-updated_date: '2026-09-10 15:45'
+updated_date: '2026-09-11 14:56'
 labels:
   - clients
   - phase-3
@@ -74,13 +74,13 @@ This task closes when all twelve are Done. Its own remaining direct work is nil.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All twelve children (TASK-25.1.6.1 through .12) are Done
-- [ ] #2 app/integrations/google_workspace/ contains only client.py (per-API stub-typed factories plus classify_google_error) and settings; the six per-method mirror modules and google_service.py no longer exist
-- [ ] #3 Every Google Workspace call site in the repo lives in a packages/<feature>/adapters/ file or an infrastructure/ capability, builds its Resource from a client.py factory, performs its own try/except plus classify_google_error, and returns typed domain values rather than raw SDK dicts
-- [ ] #4 The Directory duplication is resolved as decided: GoogleDirectoryProvider survives, integrations/google_workspace/google_directory.py is deleted, and all four legacy app/modules/* consumers use the DirectoryProvider Protocol
-- [ ] #5 No business logic remains under app/integrations/google_workspace/, and grep -rn 'time.sleep' app/integrations returns zero hits (TASK-25 AC#5)
-- [ ] #6 execute_google_api_request is deleted and execute_batch_request is either relocated to the provider or covered by a written amendment to decisions/outbound-clients.md
-- [ ] #7 A CI guardrail prevents app/integrations/<vendor>/ from regrowing non-factory/non-classification/non-settings modules, so this convention is machine-enforced rather than remembered
+- [x] #1 All children are Done: TASK-25.1.6.1 through .14 and .16 (TASK-25.1.6.15 was archived)
+- [x] #2 app/integrations/google_workspace/ contains only client.py (per-API stub-typed factories plus classify_google_error), with Google settings in infrastructure/configuration/integrations/google.py; the six per-method mirror modules and google_service.py no longer exist
+- [x] #3 Every Google Workspace call site lives in a packages/<feature>/adapters/ file or an infrastructure/ capability, builds its Resource from a client.py factory, and performs its own try/except plus classify_google_error. The Directory, Drive and Spreadsheet infrastructure capabilities and packages/incident_draft return typed domain values; the packages/incident/{documents,drive,meet,scheduling} and packages/talent adapters still return dicts to their legacy modules/ callers, and typing those returns is owned by TASK-38 (incident) and TASK-39 (talent)
+- [x] #4 The Directory duplication is resolved as decided: GoogleDirectoryProvider survives, integrations/google_workspace/google_directory.py is deleted, and the live legacy consumers (modules/permissions/handler.py, modules/provisioning/users.py, modules/provisioning/groups.py) use the DirectoryProvider Protocol; modules/reports/google_groups.py was deleted rather than migrated
+- [x] #5 No business logic remains under app/integrations/google_workspace/, and grep -rn 'time.sleep' app/integrations returns zero hits (TASK-25 AC#5)
+- [x] #6 execute_google_api_request and execute_batch_request are deleted; batch orchestration was relocated into GoogleDirectoryProvider by TASK-25.1.6.3.1, so decisions/outbound-clients.md needed no amendment
+- [x] #7 A CI guardrail (bin/check_vendor_package_contract.py, run as make check-vendor-package-contract in .github/workflows/ci_code.yml) prevents app/integrations/<vendor>/ from regrowing non-factory/non-classification/non-settings modules, and its baseline has no Google Workspace entries
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -116,6 +116,15 @@ AC#1 classification for these 5: NONE live in a real packages/<feature>/adapters
 TEST-COVERAGE GAP flagged for whoever picks this up (discovered during TASK-25.1.3): app/modules/reports/google_groups.py and app/modules/aws/spending.py have NO automated regression coverage for their Sheets call sites — before or after TASK-25.1.3. (app/tests/modules/aws/test_spending_handler.py covers a different function, not the Sheets call site.) TASK-25.1.3's behavior-neutrality for these two files rests solely on preserved public signatures/return shapes, not on a green test suite. Any reconciliation work that changes their error-handling shape (which is the whole point of AC#3 for them) is therefore UNGUARDED and must add characterization tests FIRST, before touching either file. Do not treat 'existing tests pass' as evidence of safety for these two.
 
 DECOMPOSITION NOTE (2026-09-01): with .1/.2/.3 reported, the known inventory is already Calendar/Meet + 3 Docs + 5 Sheets sites across 3 vendor modules and ~7 legacy app/modules/* consumer files, plus app/packages/incident_draft/adapters/google_docs.py — and .4/.5 (legacy Directory consumers, Drive) have yet to report. This task as scoped (inline everywhere + build/file adapters for every legacy consumer + delete the helper) will NOT fit a single reviewable PR. Expect to decompose it before implementation, roughly: (a) one task per real adapters/ file to inline (incident_draft/adapters/google_docs.py is already named in comment 2026-09-01 17:13); (b) one task per legacy feature area needing a new adapter (incident Docs/Drive/Calendar; incident Sheets incl. the relocated parse-range rule; reports/google_groups; aws/spending — each gated on adding characterization tests first where coverage is missing); (c) a final small task deleting execute_google_api_request from client.py once the call-site count reaches zero. Run this through the implementation-planning size gate rather than attempting it as one change.
+
+CLOSEOUT VERIFICATION (2026-09-11). All children Done (.1-.14, .16; .15 archived). ACs reworded where they had drifted from the shipped subtasks, then checked individually:
+- app/integrations/google_workspace/ holds only __init__.py and client.py (six factories plus classify_google_error).
+- rg for execute_google_api_call, get_google_api_command_parameters, execute_google_api_request, execute_batch_request and retry_request in app/: zero hits for the retired Google symbols (the only retry_request hits are the unrelated access-request service method).
+- rg 'time\.sleep' app/integrations: zero hits.
+- Only infrastructure/{directory,drive,spreadsheets} and packages/*/adapters import integrations.google_workspace; each call site classifies with classify_google_error.
+- uv run python bin/check_vendor_package_contract.py -> "OK: no net-new vendor-package contract violations (29 baselined entry(ies) remain)", no Google entries; wired in ci_code.yml as make check-vendor-package-contract.
+- uv run python bin/check_sdk_typing.py -> "OK: no net-new SDK anti-patterns (11 baselined file(s) remain)".
+AC#3 amended (human-decided): the incident documents/drive/meet/scheduling adapters and the talent Drive adapter still return dicts because their callers are legacy modules/ code. Typing those returns moves with the caller migrations, recorded as TASK-38 AC#9 and TASK-39 AC#4.
 <!-- SECTION:NOTES:END -->
 
 ## Comments

--- a/backlog/tasks/task-25.1.6.16 - Disable-SDK-retries-on-the-Google-writes-that-construction-time-retry-made-unsafe-to-replay.md
+++ b/backlog/tasks/task-25.1.6.16 - Disable-SDK-retries-on-the-Google-writes-that-construction-time-retry-made-unsafe-to-replay.md
@@ -3,10 +3,10 @@ id: TASK-25.1.6.16
 title: >-
   Disable SDK retries on the Google writes that construction-time retry made
   unsafe to replay
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 13:59'
-updated_date: '2026-09-11 14:28'
+updated_date: '2026-09-11 14:42'
 labels:
   - clients
   - phase-3

--- a/backlog/tasks/task-25.2 - Migrate-AWS-remainder-organizations-sso-admin-cost-explorer-config-guard-duty-security-hub-lambdas-legacy-identity-storedynamodb-off-integrations-aws-client.pys-dispatcher.md
+++ b/backlog/tasks/task-25.2 - Migrate-AWS-remainder-organizations-sso-admin-cost-explorer-config-guard-duty-security-hub-lambdas-legacy-identity-storedynamodb-off-integrations-aws-client.pys-dispatcher.md
@@ -1,13 +1,12 @@
 ---
 id: TASK-25.2
 title: >-
-  Migrate AWS remainder
-  (organizations/sso-admin/cost-explorer/config/guard-duty/security-hub/lambdas/legacy
-  identity-store+dynamodb) off integrations/aws/client.py's dispatcher
+  Retire integrations/aws to client.py: typed factory, SDK-native
+  retry/pagination/AssumeRole, adapters own classification
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-08-31 18:52'
+updated_date: '2026-09-11 15:56'
 labels:
   - clients
   - phase-3
@@ -18,7 +17,12 @@ dependencies:
 references:
   - decisions/outbound-clients.md
   - decisions/sdk-typing.md
+  - decisions/feature-packages.md
+  - decisions/capability-packages.md
+  - decisions/workplace-systems.md
+  - decisions/layers.md
   - app/integrations/aws/client.py
+  - app/integrations/google_workspace/client.py
 parent_task_id: TASK-25
 priority: high
 ordinal: 117000
@@ -27,14 +31,33 @@ ordinal: 117000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Coordinator for the AWS-remainder slice of TASK-25. Confirmed via repo grep (2026-07-31): a THIRD, oldest AWS generation - integrations/aws/client.py's execute_aws_api_call/handle_aws_api_errors (distinct from both the deprecated infrastructure/clients/aws/ facade, already fully covered by TASK-22.1-22.5, and the _next generation tracked by TASK-23) - is still live and consumed by 9 services across 14 distinct production files, none in packages/: organizations (aws/aws_access_requests.py, aws/spending.py, aws/ops_group_assignment.py, aws/aws.py, aws/aws_account_health.py), sso_admin (aws/aws_access_requests.py, aws/ops_group_assignment.py, jobs/revoke_aws_sso_access.py), cost_explorer (aws/spending.py, aws/aws_account_health.py), config/guard_duty/security_hub (all only aws/aws_account_health.py), lambdas (aws/lambdas.py), identity_store - the NON-_next module, a separate consumer set from TASK-22.3's packages/access/sync scope (aws/aws_access_requests.py, aws/ops_group_assignment.py, aws/aws.py, aws/identity_center.py, provisioning/users.py, provisioning/groups.py, jobs/scheduled_tasks.py, jobs/revoke_aws_sso_access.py), dynamodb - the NON-_next module, a separate consumer set from TASK-22.2's infrastructure/storage scope (incident/incident_folder.py, incident/db_operations.py, slack/webhooks.py). integrations/aws/sqs.py has ZERO production consumers (confirmed) - delete outright. handle_aws_api_errors is worse than the Google equivalent: it SWALLOWS every exception and returns False, never re-raising - callers cannot distinguish a real error from a legitimate falsy/empty result today; migration must make this explicit (raise + classify) rather than preserve the silent-False behavior verbatim, flagged for human sign-off per subtask. This coordinator is Done only when all its per-cluster children are Done and integrations/aws/client.py itself is deleted (zero remaining callers).
+Coordinator for the AWS slice of TASK-25, re-scoped 2026-09-11 (human-directed) after TASK-25.1 showed that the Google migration needed a second, larger series once the per-method mirror modules were treated as the destination. This series reaches the AWS endstate in one pass, fixing the vendor client and its seams rather than the business features that call it.
+
+ENDSTATE. app/integrations/aws/ ends as __init__.py, client.py and settings.py, and nothing else (the three modules the vendor-package guard allows). client.py exports get_aws_client, overloaded on Literal service names so each call returns the types-boto3 typed client without a cast, configured once with SDK-native standard retries, connect/read timeouts, an explicit retries-disabled option for non-idempotent writes, eager AssumeRole through the public sts.assume_role API, and the single dynamodb-local endpoint gate; and classify_aws_error(exc) -> (OperationStatus, error_code, retry_after). No dispatcher, no decorator, no hand-rolled paginator, no per-service mirror module.
+
+SETTINGS (human decision 2026-09-11). integrations/aws/settings.py, colocated with client.py, is the home of every AWS setting until the business features reach their final packages and define their own settings.py (TASK-88). It already holds the transport fields (region, endpoint, retry mode/attempts, timeouts, error-code catalogues) that the factory today fails to read; the feature-level fields still in infrastructure/configuration/integrations/aws.py (SSO permission sets, AUDIT/ORG/LOGGING role ARNs, SSO instance id/ARN, SERVICE_ROLE_MAP) move into it, and the infrastructure module plus its export in infrastructure/configuration/integrations/__init__.py are retired: that barrel is the reason AWS settings were being moved out of infrastructure/configuration, so reading from or growing it would be a regression. The AWS client needs no credentials of its own because the app runs inside an AWS account on the ambient credential chain, unlike the Google client, which carries a service-account key; a separate spike (TASK-89) assesses hosting outside AWS.
+
+WHERE THE CALLS GO. Every legacy AWS call site (modules/aws/*, modules/provisioning/{users,groups}.py, modules/slack/webhooks.py, modules/incident/{db_operations,incident_folder}.py, jobs/{revoke_aws_sso_access,scheduled_tasks}.py) moves onto an adapter that holds the typed client, calls the SDK directly (pagination via client.get_paginator), does try/except + classify_aws_error and returns OperationResult; callers branch on the result instead of on the silent False that handle_aws_api_errors returns today. Adapters live under a PROVISIONAL packages/aws_platform/adapters/<service>.py (one per AWS service: identity_center, organizations, sso_admin, config, cost_explorer, guard_duty, security_hub, lambda, dynamodb). packages/aws_platform is a transition seam, not a feature or capability package: modules/aws was a vendor-named mix of business features (access requests, account health, spending, Lambda inventory, Identity Center administration) and the feature split is deferred to TASK-88, which migrates those modules to feature packages per decisions/feature-packages.md and dissolves packages/aws_platform. Do not add business logic to packages/aws_platform beyond what an in-flight caller already needs.
+
+TIER RULES (so the Google-series pattern of vendor-neutral infrastructure services for workplace concerns is not repeated). Nothing in this series creates an app/infrastructure/<service>/ Protocol. Eventual homes, owned by TASK-88: Identity Center holds people's accounts, so a shared Identity Center adapter belongs in a capability package (decisions/capability-packages.md, decisions/people-and-accounts.md), never in infrastructure/; Organizations, SSO-Admin, Config, Cost Explorer, GuardDuty, Security Hub and Lambda are Path B feature adapters (decisions/layers.md) and stay inside the feature that acts on AWS; DynamoDB is a hosting service whose home is the existing infrastructure/storage capability, so the thin DynamoDB adapter here is a seam and its callers move onto the storage Protocol later (TASK-88 with TASK-27).
+
+SCOPE NOTE ON packages/access. The access feature is not enabled yet and still in development, so migrating or improving it is not a priority in this series and no shims or workarounds are built for it; it keeps working because get_aws_client("identitystore", role_arn=...) and classify_aws_error keep their call shapes. Small direct edits that fall out of this work are fine (dropping a redundant cast, repointing its settings import); its own migration and improvements come later, with the feature. infrastructure/storage, idempotency and retry-store keep their existing compliant use of the factory (only casts are removed). DynamoDBStorageService is not adopted by legacy callers in this series.
+
+ERROR CONTRACT (human-decided 2026-09-11). Adapters return OperationResult at every boundary; callers handle status explicitly. This is a behaviour change from the False-swallow: each subtask documents the resulting error-path behaviour per call site for review, and TASK-25.2.1 locks the current behaviour in tests first so the change is visible in diffs.
+
+TESTS. Adapters are unit-tested with botocore.stub.Stubber (SDK-native request validation against the service model) plus classification tests per mapped error family. Existing moto suites (DynamoDB storage, identitystore conformance) are retargeted or kept; no new moto conformance ACs.
+
+SEQUENCING. 25.2.1 characterization gate -> 25.2.2 client.py + settings consolidation -> 25.2.3 Identity Center -> 25.2.4 Organizations/SSO-Admin/account-health/Lambda -> 25.2.5 DynamoDB -> 25.2.6 deletions (folds TASK-25.5). Each adapter subtask deletes the mirror modules and legacy tests it orphans, so 25.2.6 only removes client.py's legacy helpers, shield/sqs/schemas, the infrastructure settings module, and prunes the guard baselines. Prose consumer lists in every subtask are starting points: re-grep before planning (lesson recorded on TASK-25.1).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 make client-usage-matrix / a repo-wide grep of execute_aws_api_call and handle_aws_api_errors sourced from integrations.aws.client shows zero call sites; integrations/aws/client.py is deleted
-- [ ] #2 Every one of the 14 identified legacy consumer files is migrated onto get_aws_client + classify_aws_error (reusing the TASK-22.2/22.3 primitive and its DynamoDB/IdentityStore instances directly where the same service is involved, not reinventing), with each error path now raising/classifying instead of the current silent-False swallow - human-reviewed per subtask since this is a behavior change, not zero-diff
-- [ ] #3 integrations/aws/sqs.py is deleted (zero production consumers, confirmed)
+- [ ] #1 app/integrations/aws/ contains only __init__.py, client.py (get_aws_client + classify_aws_error) and settings.py; bin/baselines/vendor_package_contract.txt and bin/baselines/sdk_typing_antipatterns.txt carry no integrations/aws entries; make client-usage-matrix and a repo-wide grep show zero callers of execute_aws_api_call, handle_aws_api_errors, paginator, assume_role_session and get_aws_service_client
+- [ ] #2 Every legacy AWS call site listed in the description reaches AWS through a packages/aws_platform adapter that returns OperationResult, with per-call-site error-path behaviour documented and human-reviewed in the owning subtask
+- [ ] #3 get_aws_client returns typed clients via Literal overloads with SDK-native retries, timeouts, eager AssumeRole and a retries-disabled option, reading every AWS setting from integrations/aws/settings.py; infrastructure/configuration/integrations/aws.py and its barrel export no longer exist; no boto3.client or boto3.Session construction exists outside client.py in production code
+- [ ] #4 TASK-25 AC#3, AC#4 and AC#5 hold for AWS: classification tests per mapped family with one unmapped exception propagating, zero shield code hits under app/integrations, no hand-rolled retry in app/integrations
+- [ ] #5 No new app/infrastructure/<service>/ package or Protocol is introduced by this series; TASK-88 records the eventual home of each adapter (capability package for Identity Center, feature adapters for the Path B services, infrastructure/storage for DynamoDB callers)
+- [ ] #6 A follow-up top-level task (TASK-88) and a hosting-outside-AWS spike (TASK-89) exist
 <!-- AC:END -->
 
 ## Comments

--- a/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
@@ -1,12 +1,12 @@
 ---
 id: TASK-25.2.1
 title: >-
-  Migrate AWS Config/Cost Explorer/GuardDuty/Security Hub (account-health
-  cluster) off execute_aws_api_call
+  Add characterization tests for the AWS call sites lacking unit coverage before
+  adapter work
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-08-04 19:39'
+updated_date: '2026-09-11 15:36'
 labels:
   - clients
   - phase-3
@@ -14,12 +14,14 @@ milestone: m-3
 dependencies:
   - TASK-22.2
 references:
-  - decisions/outbound-clients.md
-  - decisions/sdk-typing.md
-  - app/integrations/aws/config.py
-  - app/integrations/aws/cost_explorer.py
-  - app/integrations/aws/guard_duty.py
-  - app/integrations/aws/security_hub.py
+  - app/integrations/aws/client.py
+  - app/modules/aws
+  - app/modules/provisioning
+  - app/modules/slack/webhooks.py
+  - app/modules/incident/db_operations.py
+  - app/modules/incident/incident_folder.py
+  - app/jobs/scheduled_tasks.py
+  - app/jobs/revoke_aws_sso_access.py
 parent_task_id: TASK-25.2
 priority: high
 ordinal: 118000
@@ -28,13 +30,15 @@ ordinal: 118000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Slice 1 of TASK-25.2 (smallest, done first). Migrate integrations/aws/{config,cost_explorer,guard_duty,security_hub}.py off integrations/aws/client.py's execute_aws_api_call/handle_aws_api_errors onto get_aws_client + classify_aws_error (reuse/extend the TASK-22.2 primitive; these 4 services have no existing get_aws_client instance yet - add them). Production consumers (grep-confirmed 2026-07-31): modules/aws/aws_account_health.py (all 4 services) and modules/aws/spending.py (cost_explorer only). Critically: today's handle_aws_api_errors SWALLOWS all exceptions and returns False - the migration must convert this to raise+classify (explicit OperationResult or a documented behavior change at the 2 consumer call sites), not silently preserve the swallow; flag the exact resulting behavior for human sign-off since it is not zero-diff.
+Slice 0 of TASK-25.2 (tests-only gate, mirrors TASK-25.1.6.1). Before adapters replace the False-swallowing integrations/aws mirrors, lock the current observable behaviour of each legacy call site, including what the caller does when the integration returns False today, so the switch to OperationResult in later slices shows up as an explicit, reviewable diff rather than a silent behaviour change.
+
+Known coverage state (2026-09-11, starting point only; the planner re-greps it): tests/unit/modules/aws/* cover aws_access_requests, aws_account_health, identity_center, lambdas, ops_group_assignment and spending handlers; tests/unit/jobs/test_revoke_aws_sso_access.py exists; tests/unit/modules/provisioning has test_provisioning_users.py only (groups is covered by the legacy tests/modules/provisioning suite); modules/slack/webhooks.py and modules/incident/{db_operations,incident_folder}.py are covered only by legacy tests/modules suites and the webhooks e2e; jobs/scheduled_tasks.py's identity_store.healthcheck path and modules/aws/aws.py's get_user_id / get_account_id_by_name path have no targeted test.
+
+Production code is not modified. New tests go under app/tests/ per the testing-standards skill, named test_<domain>_<entity>_<action>.py, with docstrings describing observable behaviour and stub strategy only.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 integrations/aws/config.py, cost_explorer.py, guard_duty.py, and security_hub.py no longer call execute_aws_api_call/handle_aws_api_errors; each routes through get_aws_client(<service>) + classify_aws_error, raising/classifying per the outbound-clients.md contract
-- [ ] #2 modules/aws/aws_account_health.py and modules/aws/spending.py are updated to handle the new raise+classify contract explicitly (no silent False-swallowing); resulting behavior on error paths is documented and human-reviewed, not assumed zero-diff
-- [ ] #3 classify_aws_error gains any Config/CostExplorer/GuardDuty/SecurityHub-specific mapped families with unit coverage under tests/unit/integrations/aws/
-- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise cost_explorer.py's get_cost_and_usage and security_hub.py's get_findings against real ce/securityhub semantics via moto.mock_aws(), additive alongside existing MagicMock-based unit tests -- EXCLUDES config.py (its sole call, describe_aggregate_compliance_by_config_rules, is unimplemented in moto per getmoto/moto IMPLEMENTATION_COVERAGE.md) and guard_duty.py's get_findings_statistics (also unimplemented in moto); guard_duty.py's list_detectors MAY be moto-covered but is not required by this AC since get_findings_statistics cannot be, so this task's guardduty/config paths keep MagicMock-only coverage
+- [ ] #1 Every production call into integrations.aws.{identity_store,organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambdas,dynamodb} has at least one unit test asserting the caller's success path and its behaviour when the integration returns False; the verified call-site inventory is recorded in notes
+- [ ] #2 No production file is modified; ruff, mypy and pytest pass with output recorded
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
@@ -3,10 +3,11 @@ id: TASK-25.2.1
 title: >-
   Add characterization tests for the AWS call sites lacking unit coverage before
   adapter work
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 16:15'
+updated_date: '2026-09-11 16:35'
 labels:
   - clients
   - phase-3
@@ -39,8 +40,8 @@ Production code is not modified. New tests go under app/tests/ per the testing-s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every production call into integrations.aws.{identity_store,organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambdas,dynamodb} has at least one unit test asserting the caller's success path and its behaviour when the integration returns False; the verified call-site inventory is recorded in notes
-- [ ] #2 No production file is modified; ruff, mypy and pytest pass with output recorded
+- [x] #1 Every production call into integrations.aws.{identity_store,organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambdas,dynamodb} has at least one unit test asserting the caller's success path and its behaviour when the integration returns False; the verified call-site inventory is recorded in notes
+- [x] #2 No production file is modified; ruff, mypy and pytest pass with output recorded
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -189,3 +190,48 @@ ASSUMPTIONS AND HOW TO VERIFY THEM
 BLAST RADIUS AND ROLLBACK
 - Zero production code changes; a `git revert` of this PR is always safe and trivially restores nothing-changed. The only risk is a mis-pinned characterization test asserting behaviour that isn't actually today's behaviour -- mitigated by running the new tests against the unmodified checkout before merging (see assumptions above) and by every crash-path test using `pytest.raises(<exact type>)` rather than a loose assertion.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Files changed (all under app/tests/, zero production files modified):
+- tests/unit/modules/aws/test_aws_account_health_handler.py (+6 tests; 19 total)
+- tests/unit/modules/aws/test_spending_handler.py (+4 tests; 17 total)
+- tests/unit/modules/aws/test_ops_group_assignment_handler.py (+2 tests; 11 total)
+- tests/unit/modules/aws/test_aws_access_requests_handler.py (+4 tests; 16 total)
+- tests/unit/modules/aws/test_aws_command_handler.py (+3 tests; 13 total)
+- tests/unit/modules/aws/test_identity_center_handler.py (+1 test; 15 total)
+- tests/unit/modules/provisioning/test_provisioning_users.py (+1 test; 8 total)
+- tests/modules/provisioning/test_provisioning_groups.py (+1 test; 19 total, legacy tree)
+- tests/modules/slack/test_slack_webhooks.py (+8 tests; 27 total, legacy tree)
+- tests/modules/incident/test_db_operations.py (+6 tests; 21 total, legacy tree)
+- tests/modules/incident/test_incident_folder.py (+1 test; 42 total, legacy tree)
+- tests/unit/jobs/test_revoke_aws_sso_access.py (+1 test; 6 total)
+Total: 38 new tests across 12 files.
+
+Call-site disposition (plan's 39-row inventory, file:line -> fn):
+- Added now (crash pinned with pytest.raises or defended-branch/pass-through pinned with literal False): rows 1,2,3,4,6,7,8,9,10,12,13,16,17,18,19,20,21,22,24,25,27,28,29,30,32,33,34,36,37,38,39 -- all covered by the new tests above exactly as planned.
+- Branch-equivalent, no new test (existing falsy fixture takes the identical `if x:`/`if not x:` branch as False): rows 5,11,14,15,26,31,35 -- verified by re-reading each guard during implementation, matches the plan's disposition record.
+- Already adequate, no new test: row 23 (jobs/scheduled_tasks.py identity_store.healthcheck) -- confirmed already exercised via test_identity_store.py and the integration-agnostic healthcheck loop, per the plan's grounding note.
+
+Behavioural claims corrected: none. Every planned exception type (TypeError/AttributeError) and every planned pass-through/defended-branch assertion matched today's real behaviour on first run; no test needed re-deriving from an actual stack trace.
+
+Verification commands and results (run from app/):
+- `uv run ruff check .` -> All checks passed!
+- `uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'` -> 88 pre-existing errors in 32 production files (none in app/tests/, none in files touched by this task -- e.g. modules/incident/core.py, modules/webhooks/aws_sns_notification.py, packages/incident/scheduling/adapters/google_calendar.py); unrelated to this tests-only change, not fixed per the stop-condition on pre-existing unrelated gate failures.
+- `uv run pytest tests --ignore=tests/smoke` -> 3294 passed, 6 failed. The 6 failures are in tests/modules/webhooks/test_webhooks_aws_sns.py (3 tests) and tests/unit/infrastructure/directory/test_google.py (3 tests) -- files this task never touches. Each of the 6 passes in isolation and as a pair-run; they only fail as part of the full ordered suite, indicating pre-existing full-suite state leakage unrelated to this change. Not fixed, per the stop-condition on pre-existing unrelated failures.
+- Each of the 12 extended files was also run standalone; all pass (counts listed above).
+
+Remaining for human: PR review of the 12 extended test files; optional decision on whether to open a follow-up investigation task for the pre-existing full-suite-only failures in test_webhooks_aws_sns.py / test_google.py (unrelated to TASK-25.2.1's scope) and for the two dead-code/positional-argument defects documented inline in the plan (aws.py request_aws_account_access positional shift; aws_access_requests.py access_view_handler's `is None` vs `is False` dead branch).
+
+INDEPENDENT VERIFICATION OF THE GATE CLAIMS (2026-09-11, main session, after the implementation agent's run):
+- ruff: `uv run ruff check .` -> All checks passed.
+- mypy: `uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'` -> 88 errors in 32 production files. mypy excludes tests/ by config (pyproject [tool.mypy] exclude = ["^tests/"]), so a tests-only change cannot add or remove any of them; CI runs mypy non-blocking (`make lint-ci` appends `|| true`). Pre-existing, unrelated, not fixed.
+- pytest, combined invocation `uv run pytest tests --ignore=tests/smoke` -> 3294 passed, 6 failed (3 in tests/modules/webhooks/test_webhooks_aws_sns.py, 3 in tests/unit/infrastructure/directory/test_google.py).
+  Proof the 6 are pre-existing and independent of this change:
+  (a) same invocation with all 12 modified test files excluded via --ignore -> the same 6 fail, 3080 passed;
+  (b) each of the 12 modified files run ahead of the two failing files -> all pass (117-153 passed per pair);
+  (c) CI-shaped splits are green: `pytest tests/unit tests/integration` -> 2475 passed; `pytest tests/api tests/modules tests/integrations tests/utils tests/test_factory_validation.py` (the make test-legacy list) -> 825 passed.
+  The failures are an order-dependent state leak that only surfaces when the unit and legacy trees run in one process; candidate for a separate bug task, out of this slice's scope.
+- Hygiene: rg over the 12 files finds no task ids, sprint labels or plan-step references; pinned-defect comments describe the defect and its revisit trigger in words.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
@@ -3,11 +3,11 @@ id: TASK-25.2.1
 title: >-
   Add characterization tests for the AWS call sites lacking unit coverage before
   adapter work
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 16:35'
+updated_date: '2026-09-11 16:41'
 labels:
   - clients
   - phase-3

--- a/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.1 - Migrate-AWS-Config-Cost-Explorer-GuardDuty-Security-Hub-account-health-cluster-off-execute_aws_api_call.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 15:36'
+updated_date: '2026-09-11 16:15'
 labels:
   - clients
   - phase-3
@@ -42,3 +42,150 @@ Production code is not modified. New tests go under app/tests/ per the testing-s
 - [ ] #1 Every production call into integrations.aws.{identity_store,organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambdas,dynamodb} has at least one unit test asserting the caller's success path and its behaviour when the integration returns False; the verified call-site inventory is recorded in notes
 - [ ] #2 No production file is modified; ruff, mypy and pytest pass with output recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+GROUNDING (2026-09-11, re-grepped against current code; task-description prose lists were a starting point only)
+
+Re-grep commands run: `rg -n "integrations\.aws" app --glob '!tests/**' modules jobs packages` and per-file reads of every hit plus `integrations/aws/client.py`. Confirmed `handle_aws_api_errors` (client.py:137-186) catches BotoCoreError/ClientError/Exception, logs, and always returns `False` (line 184) -- never None, never raises. `packages/access/sync/adapters/aws_identity_center.py` already calls `get_aws_client`/`classify_aws_error` directly (not through the mirrors) and is explicitly out of scope per TASK-25.2's access-feature scope note. `modules/aws/aws_access_requests.py`'s DynamoDB helpers (`already_has_access`, `create_aws_access_request`, `expire_request`, `get_expired_requests`, `get_active_requests`) use a private raw-boto3 client (`_get_dynamodb_client()`), NOT `integrations.aws.dynamodb` -- out of scope for this AC (no False-swallow to characterize there).
+
+CALL-SITE INVENTORY (file:line -> integration fn -> today's False-path behaviour -> existing coverage)
+
+Cluster A: config/cost_explorer/guard_duty/security_hub/organizations (account health + spending)
+1. modules/aws/aws_account_health.py:53 cost_explorer.get_cost_and_usage -> indexes response["ResultsByTime"] unguarded -> CRASHES (TypeError) on False. Success: covered (test_aws_account_health_handler.py::test_should_get_account_spend_with_data). False: NOT covered.
+2. modules/aws/aws_account_health.py:66 config.describe_aggregate_compliance_by_config_rules -> `len(response)` -> CRASHES on False. Success: covered. False: NOT covered.
+3. modules/aws/aws_account_health.py:70 guard_duty.list_detectors -> `detector_ids[0]` -> CRASHES on False. Success: covered. False: NOT covered.
+4. modules/aws/aws_account_health.py:78 guard_duty.get_findings_statistics -> indexes response["FindingStatistics"] -> CRASHES on False. Success: covered. False: NOT covered.
+5. modules/aws/aws_account_health.py:105 security_hub.get_findings -> `if response:` -- DEFENDED, False -> issues=0 (same branch as [] already tested). Success: covered. False: covered by branch-equivalence with the existing empty-list test; skip.
+6. modules/aws/aws_account_health.py:211 organizations.list_organization_accounts (request_health_modal) -> dict/list comprehension over accounts -> CRASHES on False. Success: covered (test_should_request_health_modal). False: NOT covered.
+7. modules/aws/spending.py:40 organizations.list_organization_accounts (generate_spending_data) -> list comprehension -> CRASHES on False. Only exercised with organizations fully mocked to a success list; False NOT covered.
+8. modules/aws/spending.py:61 organizations.get_account_details (get_accounts_details) -> `details["Tags"] = ...` -> CRASHES on False (item assignment on bool). NOT covered at all (existing spending tests mock get_accounts_details itself away).
+9. modules/aws/spending.py:62 organizations.get_account_tags (get_accounts_details) -> assignment succeeds, but format_account_details' `for tag in account["Tags"]` CRASHES when Tags=False. NOT covered.
+10. modules/aws/spending.py:79 cost_explorer.get_cost_and_usage (get_accounts_spending) -> `response.get(...)` -> CRASHES (AttributeError) on False. NOT covered.
+11. modules/aws/ops_group_assignment.py:20 identity_store.get_group_id -> `if not aws_ops_group_id:` -- DEFENDED and False path already covered (test_should_return_failed_when_group_not_found).
+12. modules/aws/ops_group_assignment.py:29 organizations.list_organization_accounts -> list comprehension over it -> CRASHES on False. NOT covered.
+13. modules/aws/ops_group_assignment.py:30 sso_admin.list_account_assignments_for_principal -> set comprehension -> CRASHES on False. NOT covered.
+14. modules/aws/ops_group_assignment.py:66 sso_admin.create_account_assignment -> `if success:` -- DEFENDED and covered (test_should_return_failed_when_assignment_fails).
+15. modules/aws/lambdas.py:48/68 aws_lambdas.list_functions/list_layers -> `if response:` -- DEFENDED; existing tests use `[]`, which takes the identical branch as False. Skip (branch-equivalent, already characterized).
+
+Cluster B: identity_store consumers (provisioning, identity_center, aws.py, aws_access_requests, revoke job)
+16. modules/provisioning/users.py:58 identity_store.list_users (get_users_from_integration, "aws_identity_center" case) -> `log.info(..., users_count=len(users))` -> CRASHES on False (len(False) is TypeError; len([]) is NOT the same -- this is NOT branch-equivalent, unlike the `if x:` cases above). Existing test (test_provisioning_users.py:105-107) only uses a real list. NOT covered.
+17. modules/provisioning/groups.py:142 identity_store.list_groups_with_memberships (get_groups_from_integration, "aws_identity_center" case) -> falls through to log_groups' `len(groups)` -> CRASHES on False. Existing tests (test_provisioning_groups.py:334-422) only use real lists. NOT covered.
+18. modules/aws/identity_center.py:70,79 identity_store.list_users (synchronize) -> `len(target_users)` and passed to sync_users/sync_groups -> CRASHES on False. Existing tests (test_identity_center_handler.py) set `list_users.return_value = []`, not False -- same non-equivalence as #16. NOT covered.
+19. modules/aws/aws.py:157-158 organizations.get_account_id_by_name / identity_store.get_user_id (request_aws_account_access) -> no guard at all, both flow unconditionally into `aws_access_requests.create_aws_access_request(...)`. ZERO test coverage exists for this function (confirmed: `rg request_aws_account_access` finds only its own definition). NOTE (found while grounding, NOT fixed here per the tests-only AC#2): the call passes args positionally as (account_id, account_name, user_id, user_email, start_date, end_date, access_type, rationale) but `create_aws_access_request`'s signature is (account_id, account_name, user_id, email, access_type, rationale, start_date_time=None, end_date_time=None) -- positions 5-8 are shifted, so `access_type` receives a datetime and `start_date_time` receives the access_type string. This function is also unreferenced anywhere in production (dead code; matches the "(currently disabled)" note in aws.py's own help text), so the test isolates identity_store/organizations usage by mocking `create_aws_access_request` itself and pins TODAY's (buggy) positional call shape rather than exercising the real DynamoDB write.
+20. modules/aws/aws_access_requests.py:194 (access_view_handler) identity_store.get_user_id -> checked via `if aws_user_id is None:` -- but the integration returns `False` on error, never `None`, so this branch is DEAD CODE today: a get_user_id failure falls through into `already_has_access(...)` and then into `create_aws_access_request(...) and sso_admin.create_account_assignment(aws_user_id, ...)` with `aws_user_id=False`. ZERO coverage of access_view_handler exists (only that aws.py delegates to request_access_modal, in test_aws_command_handler.py). NOT covered.
+21. modules/aws/aws_access_requests.py:241 (request_access_modal) organizations.list_organization_accounts -> dict comprehension over accounts -> CRASHES on False. NOT covered.
+22. jobs/revoke_aws_sso_access.py:30 identity_store.get_user_id -> no guard, `False` flows unconditionally into `sso_admin.delete_account_assignment(False, account_id, access_type)`. Existing test `test_revoke_access_handles_identity_store_error` uses `side_effect = RuntimeError(...)`, which can never happen in production (the decorator swallows to False, never raises) -- it characterizes an impossible scenario, not today's real contract. NOT covered for the real False-return behaviour.
+23. jobs/scheduled_tasks.py:128 identity_store.healthcheck -- SURPRISE: already adequately covered. `identity_store.healthcheck()` itself is fully tested for both its healthy and unhealthy (list_users returns [], same falsy branch as False) paths in tests/integrations/aws/test_identity_store.py::test_healtcheck_is_healthy/is_unhealthy. The generic per-key failure branch in `integration_healthchecks()` is already exercised with other integration keys failing (test_healthcheck_partial_failures, opsgenie/incident_drive=False) -- the loop is integration-name-agnostic, so adding an "aws key specifically fails" case would exercise no new code path. The parent task's "known coverage state" note about this call site is stale. No new test planned for #23; noted here as the required per-call-site disposition record.
+
+Cluster C: dynamodb consumers (slack webhooks, incident db_operations, incident_folder)
+24. modules/slack/webhooks.py:26 dynamodb.put_item (create_webhook) -> indexes response["ResponseMetadata"] unguarded -> CRASHES on False. Existing tests only use dict responses with good/bad HTTPStatusCode (test_create_webhook, test_create_webhook_with_type, test_create_webhook_return_none uses status 401, still a dict). NOT covered for the real False contract.
+25. modules/slack/webhooks.py:48 dynamodb.delete_item (delete_webhook) -> pure pass-through, returns response unchanged. Only success-dict tested. False pass-through NOT covered.
+26. modules/slack/webhooks.py:53 dynamodb.get_item (get_webhook) -> `if response:` -- DEFENDED; existing "no_result" test uses `{}`, same falsy branch as False. Skip (branch-equivalent).
+27. modules/slack/webhooks.py:62 dynamodb.scan (lookup_webhooks) -> pure pass-through. Only success-list tested. NOT covered.
+28. modules/slack/webhooks.py:70/80 dynamodb.update_item (increment_acknowledged_count/increment_invocation_count) -> pure pass-through. Only success-dict tested. NOT covered.
+29. modules/slack/webhooks.py:90 dynamodb.scan (list_all_webhooks) -> pure pass-through. Only success-list tested. NOT covered.
+30. modules/slack/webhooks.py:95 dynamodb.update_item (revoke_webhook) -> pure pass-through. Only success-dict tested. NOT covered.
+31. modules/slack/webhooks.py:106 dynamodb.get_item (is_active) -- DEFENDED and ALREADY fully covered (True/False-active/not-found, 3 tests). Skip.
+32. modules/slack/webhooks.py:118 toggle_webhook calls get_webhook(id) inline: `not get_webhook(id)["active"]["BOOL"]` -> get_webhook returns None on any falsy/False response -> `None["active"]` CRASHES. Existing test only mocks get_webhook to a valid dict. NOT covered.
+33. modules/incident/db_operations.py:40 dynamodb.put_item (create_incident) -> indexes response["ResponseMetadata"] unguarded -> CRASHES on False. Existing failure test uses a 400-status dict, not False. NOT covered for the real contract.
+34. modules/incident/db_operations.py:67 dynamodb.scan (list_incidents) -> pure pass-through. Only list/[] tested. NOT covered for False.
+35. modules/incident/db_operations.py:90 dynamodb.update_item (update_incident_field) -- DEFENDED (`if response:`); existing failure test uses `None`, same falsy branch as False. Skip (branch-equivalent).
+36. modules/incident/db_operations.py:108 dynamodb.update_item (log_activity) -- DEFENDED (`if response:`), not directly tested standalone but reached via create_incident's success path only; add a direct False-path test since log_activity's own False branch (returns False, logs error) is unexercised.
+37. modules/incident/db_operations.py:138 dynamodb.get_item (get_incident) -> pure pass-through. Only success dict tested. NOT covered for False.
+38. modules/incident/db_operations.py:158 dynamodb.scan (lookup_incident, reached from get_incident_by_channel_id) -> pure pass-through AND `get_incident_by_channel_id`'s `len(incidents) > 0` CRASHES on False. Existing "no_results" test uses `[]` (works fine), not False (crashes) -- NOT branch-equivalent, real gap.
+39. modules/incident/incident_folder.py:546 dynamodb.update_item (store_update) -> `response.get("ResponseMetadata", {})...` -> CRASHES (AttributeError) on False. Existing `test_store_update_failed` uses a 400-status dict, not False. NOT covered for the real contract.
+
+NEW/EXTENDED TEST FILES AND CASES
+
+A. app/tests/unit/modules/aws/test_aws_account_health_handler.py (EXTEND)
+   - test_should_raise_when_cost_explorer_returns_false (get_account_spend, cost_explorer.get_cost_and_usage=False, pytest.raises(TypeError))
+   - test_should_raise_when_config_summary_integration_returns_false (get_config_summary, config...=False, pytest.raises(TypeError))
+   - test_should_raise_when_guardduty_list_detectors_returns_false (pytest.raises(TypeError))
+   - test_should_raise_when_guardduty_findings_statistics_returns_false (pytest.raises(TypeError))
+   - test_should_return_zero_securityhub_when_integration_returns_false (get_securityhub_summary, security_hub.get_findings=False -> issues == 0; documents the existing defended branch explicitly with False, not just [])
+   - test_should_raise_when_request_health_modal_organizations_call_returns_false (pytest.raises(TypeError))
+
+B. app/tests/unit/modules/aws/test_spending_handler.py (EXTEND)
+   - test_should_raise_when_list_organization_accounts_returns_false (generate_spending_data, organizations.list_organization_accounts=False, pytest.raises(TypeError))
+   - test_should_raise_when_get_account_details_returns_false (get_accounts_details, organizations.get_account_details=False, pytest.raises(TypeError))
+   - test_should_raise_when_get_account_tags_returns_false (get_accounts_details, get_account_details succeeds + get_account_tags=False, pytest.raises(TypeError) -- crash happens in format_account_details, not get_accounts_details itself; assert the raise propagates through get_accounts_details)
+   - test_should_raise_when_cost_and_usage_returns_false (get_accounts_spending, cost_explorer.get_cost_and_usage=False, pytest.raises(AttributeError))
+
+C. app/tests/unit/modules/aws/test_ops_group_assignment_handler.py (EXTEND)
+   - test_should_raise_when_list_organization_accounts_returns_false (pytest.raises(TypeError))
+   - test_should_raise_when_list_account_assignments_returns_false (pytest.raises(TypeError))
+
+D. app/tests/unit/modules/aws/test_aws_access_requests_handler.py (EXTEND -- new section for the handler-level functions this file does not yet touch)
+   - class-level fixture patching modules.aws.aws_access_requests.identity_store/.organizations/.sso_admin/.dynamodb_client as needed
+   - test_should_treat_integration_false_as_not_none_and_proceed (access_view_handler; identity_store.get_user_id=False; asserts the "not registered" branch is NOT taken -- i.e. the `is None` check is pinned-not-fixed dead code -- and that create_aws_access_request/sso_admin.create_account_assignment are still invoked with aws_user_id=False; comment marks this as a pinned defect, not endorsed, per the precedent's convention)
+   - test_should_respond_not_registered_message_never_fires_on_integration_failure (companion assertion on the chat_postEphemeral message text actually sent)
+   - test_should_raise_when_request_access_modal_organizations_call_returns_false (pytest.raises(TypeError))
+
+E. app/tests/unit/modules/aws/test_aws_command_handler.py (EXTEND -- request_aws_account_access lives in modules.aws.aws, this file's subject module)
+   - test_should_pass_through_account_id_and_user_id_on_success (request_aws_account_access; identity_store.get_user_id and organizations.get_account_id_by_name mocked to real values; create_aws_access_request mocked; asserts call_args pins today's argument order/positions -- comment notes the positional-shift defect found while grounding, pinned not fixed)
+   - test_should_proceed_with_false_account_id_when_organizations_lookup_fails (organizations.get_account_id_by_name=False; asserts create_aws_access_request is still called, no guard)
+   - test_should_proceed_with_false_user_id_when_identity_store_lookup_fails (identity_store.get_user_id=False; same shape)
+
+F. app/tests/unit/modules/aws/test_identity_center_handler.py (EXTEND)
+   - test_should_raise_when_list_users_returns_false_before_sync (synchronize; identity_store.list_users=False on the first call; pytest.raises(TypeError) from len(target_users))
+
+G. app/tests/unit/modules/provisioning/test_provisioning_users.py (EXTEND)
+   - test_should_raise_when_aws_identity_store_list_users_returns_false (get_users_from_integration("aws_identity_center"); identity_store.list_users=False via monkeypatch as the existing style; pytest.raises(TypeError))
+
+H. app/tests/modules/provisioning/test_provisioning_groups.py (EXTEND -- legacy tree, still collected under testpaths=["tests"]; groups.py has no app/tests/unit counterpart today per the parent task's coverage note)
+   - test_get_groups_from_integration_case_aws_raises_when_integration_returns_false (identity_store.list_groups_with_memberships=False; pytest.raises(TypeError) from log_groups' len(groups))
+
+I. app/tests/modules/slack/test_slack_webhooks.py (EXTEND -- legacy tree, natural home matching existing per-function test style)
+   - test_create_webhook_raises_when_integration_returns_false (put_item=False, pytest.raises(TypeError))
+   - test_delete_webhook_returns_false_unchanged (delete_item=False, assert result is False -- pins the pass-through contract)
+   - test_lookup_webhooks_returns_false_unchanged (scan=False)
+   - test_increment_acknowledged_count_returns_false_unchanged (update_item=False)
+   - test_increment_invocation_count_returns_false_unchanged (update_item=False)
+   - test_list_all_webhooks_returns_false_unchanged (scan=False)
+   - test_revoke_webhook_returns_false_unchanged (update_item=False)
+   - test_toggle_webhook_raises_when_get_webhook_returns_none_due_to_integration_failure (get_item=False so get_webhook returns None; pytest.raises(TypeError) on the inline `get_webhook(id)["active"]`)
+
+J. app/tests/modules/incident/test_db_operations.py (EXTEND)
+   - test_create_incident_raises_when_put_item_returns_false (pytest.raises(TypeError), contrasted with the existing 400-status-dict test)
+   - test_list_incidents_returns_false_unchanged (scan=False)
+   - test_get_incident_returns_false_unchanged (get_item=False)
+   - test_lookup_incident_returns_false_unchanged (scan=False)
+   - test_get_incident_by_channel_id_raises_when_lookup_incident_returns_false (pytest.raises(TypeError) from len(False), contrasted with the existing empty-list "no_results" test which does NOT crash)
+   - test_log_activity_returns_false_and_logs_error_when_integration_returns_false (direct call, not just via create_incident's success path)
+
+K. app/tests/modules/incident/test_incident_folder.py (EXTEND)
+   - test_store_update_raises_when_update_item_returns_false (pytest.raises(AttributeError), contrasted with the existing 400-status-dict test)
+
+L. app/tests/unit/jobs/test_revoke_aws_sso_access.py (EXTEND)
+   - test_revoke_access_proceeds_with_false_user_id_when_identity_store_lookup_fails (identity_store.get_user_id.return_value = False, NOT a raised exception; asserts sso_admin.delete_account_assignment is still called with user_id=False, no guard, and the loop continues to expire_request/chat_postEphemeral -- this replaces reliance on the existing RuntimeError side_effect test as evidence of "error handling," since that scenario cannot occur in production)
+
+DISPOSITION RECORD FOR "ALREADY ADEQUATE" CALL SITES (for the notes, satisfies AC#1's "verified call-site inventory" without adding redundant tests)
+- #5, #15, #23, #26, #31, #35: existing tests already exercise the identical branch False would take (an `if x:`/`if not x:` truthy check where the existing falsy fixture -- `[]`, `{}`, `None` -- and `False` are behaviourally indistinguishable). No new test added; recorded here as the verification evidence.
+- #14, #11: DEFENDED and already directly tested with False.
+
+STUB STRATEGY
+- Mirror each subject module's existing house style exactly (all of these already use `unittest.mock.patch`/`monkeypatch` on the module-level integration import, e.g. `@patch("modules.aws.aws_account_health.cost_explorer")`, `monkeypatch.setattr(users.identity_store, "list_users", ...)`); no new mocking library, no pytest-mock, no Protocol fakes -- these are legacy app/modules/* callers of plain function modules with no Protocol, matching the precedent's ACCEPTED rationale for MagicMock module doubles (decisions/testing.md last-choice double, accepted 2026-09-02 for this exact situation and carried forward here since nothing has changed).
+- Patch the integration functions exactly as imported by each caller (`from integrations.aws import X` -> patch `modules.<path>.X.<fn>`), never `integrations.aws.client.execute_aws_api_call` or `handle_aws_api_errors` directly -- that boundary is what the later adapter slices (25.2.3-25.2.5) replace, so tests must pin the CALLER's contract, not the decorator's internals (those already have their own coverage in tests/integrations/aws/test_legacy_aws_client.py and tests/unit/integrations/aws/test_aws_client.py).
+- Every new "returns False" case sets the mock's return value to the literal `False` (never `None`, `{}`, or `[]`) to match `handle_aws_api_errors`' actual contract; every crash case uses `pytest.raises(<ExactExceptionType>)` around the call, not a bare try/except, so the exact exception type is part of the pinned contract for the later OperationResult diff to visibly change.
+- No `botocore.stub.Stubber`, no `moto` here -- those are reserved for the adapter unit tests in 25.2.3-25.2.5 per TASK-25.2's TESTS section; this gate stays at the caller/integration-module-mock boundary consistent with all the tests it extends.
+
+VERIFICATION COMMANDS (run from app/, evidence recorded in notes)
+- cd app && uv run ruff check .
+- cd app && uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'
+- cd app && uv run pytest tests --ignore=tests/smoke
+- git diff --stat (confirm zero non-test files changed, satisfying AC#2)
+
+AC TRACEABILITY
+- AC#1 (every call site has success + False-path coverage, inventory recorded in notes): satisfied by the 39-row inventory above plus the 12 new/extended test files (A-L) covering every NOT-covered row, and the disposition record for every row skipped as already-adequate. The verified inventory itself is the AC#1 deliverable and will be carried into the notes verbatim at finalization.
+- AC#2 (no production file modified; gates pass with output recorded): satisfied by running the three verification commands and recording `git diff --stat` showing only app/tests/** paths, at finalization time (this plan authorizes no production edits).
+
+ASSUMPTIONS AND HOW TO VERIFY THEM
+- Assumes `handle_aws_api_errors` is the ONLY error boundary in play for every listed call site (i.e., no caller wraps the integration call in its own try/except that would change the exception type pinned above) -- verified by reading each caller function in full during grounding; re-verify at implementation time by running each new test once against the CURRENT (unmodified) code and confirming it fails for the right reason before the fix, or passes as a pin if no code changes are made (this is a characterization task, so tests should pass unmodified against today's code -- a red test here means the inventory's behavioural claim was wrong and must be re-derived from the real stack trace, not adjusted to force a pass).
+- Assumes `tests/modules/**` (the legacy tree) is collected by `pytest tests --ignore=tests/smoke` -- verified directly: app/pyproject.toml:95 sets `testpaths = ["tests"]` with no marker-based exclusion of `legacy`, so plain collection includes it.
+- Assumes the aws.py:130 `request_aws_account_access` positional-argument mismatch and the aws_access_requests.py:194 `is None` vs `is False` dead-branch are real, not misreadings -- verified by direct signature-vs-call-site comparison during grounding (documented inline above); flagged as pinned-not-fixed per AC#2, candidates for a follow-up fix task the human may want to create before 25.2.4/25.2.5 touch these files (same pattern as TASK-25.1.6.1's A1-quoting finding).
+
+BLAST RADIUS AND ROLLBACK
+- Zero production code changes; a `git revert` of this PR is always safe and trivially restores nothing-changed. The only risk is a mis-pinned characterization test asserting behaviour that isn't actually today's behaviour -- mitigated by running the new tests against the unmodified checkout before merging (see assumptions above) and by every crash-path test using `pytest.raises(<exact type>)` rather than a loose assertion.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-25.2.2 - Migrate-legacy-non-_next-DynamoDB-consumers-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.2 - Migrate-legacy-non-_next-DynamoDB-consumers-off-execute_aws_api_call.md
@@ -1,10 +1,13 @@
 ---
 id: TASK-25.2.2
-title: Migrate legacy (non-_next) DynamoDB consumers off execute_aws_api_call
+title: >-
+  Rationalize integrations/aws/client.py: typed Literal-overloaded factory,
+  eager AssumeRole, SDK-native retry and timeout policy, settings consolidated
+  in integrations/aws/settings.py
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-08-04 19:39'
+updated_date: '2026-09-11 15:56'
 labels:
   - clients
   - phase-3
@@ -12,9 +15,15 @@ milestone: m-3
 dependencies:
   - TASK-25.2.1
 references:
+  - app/integrations/aws/client.py
+  - app/integrations/aws/settings.py
+  - app/infrastructure/configuration/integrations/aws.py
   - decisions/outbound-clients.md
   - decisions/sdk-typing.md
-  - app/integrations/aws/dynamodb.py
+  - app/infrastructure/storage/service.py
+  - app/infrastructure/idempotency/factory.py
+  - app/infrastructure/resilience/retry/factory.py
+  - app/integrations/google_workspace/client.py
 parent_task_id: TASK-25.2
 priority: high
 ordinal: 119000
@@ -23,13 +32,21 @@ ordinal: 119000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Slice 2 of TASK-25.2. Migrate integrations/aws/dynamodb.py (a THIRD, older DynamoDB generation, distinct from both the deprecated facade and dynamodb_next.py) off execute_aws_api_call/handle_aws_api_errors, reusing get_aws_client("dynamodb") + classify_aws_error already built in TASK-22.2 directly (do not build a second DynamoDB primitive). Production consumers (grep-confirmed 2026-07-31): modules/incident/incident_folder.py, modules/incident/db_operations.py, modules/slack/webhooks.py. Also hardcodes its own ENVIRONMENT in (local,dev,ci) -> http://dynamodb-local:8000 endpoint gate (matches the convention TASK-22.2 already reconciled for dynamodb_next - reuse the same gate, do not reintroduce a third copy). Same silent-False-swallow caveat as sibling slices: must convert to raise+classify explicitly, human-reviewed, not zero-diff.
+Slice 1 of TASK-25.2. Rework get_aws_client into the single AWS client factory the rest of the series builds on, without yet touching the legacy helpers: handle_aws_api_errors, execute_aws_api_call, paginator, assume_role_session and get_aws_service_client stay as they are until TASK-25.2.6 so the mirror modules keep working through the intermediate slices.
+
+Target shape: get_aws_client(service, *, role_arn=None, session_name=..., retries=True) overloaded on Literal service names (dynamodb, identitystore, organizations, sso-admin, ce, config, guardduty, securityhub, lambda, sts) so each call returns the matching types-boto3 client type and call sites need no cast; the session_config/client_config dict kwargs are removed. AssumeRole is done eagerly through the public API (sts.assume_role, then boto3.Session from the returned credentials) instead of writing DeferredRefreshableCredentials into botocore's private _session._credentials; clients are built per operation and never cached, so no credential refresh is needed. Retries use Config(retries={"mode": "standard", "max_attempts": N}) with explicit connect/read timeouts (decisions/outbound-clients.md items 20-23), plus a retries-disabled variant for non-idempotent writes (item 25) that later slices use wherever a replay is unsafe. The dynamodb-local endpoint gate stays, once (botocore's native AWS_ENDPOINT_URL_DYNAMODB variable is the SDK-native replacement if the local/ci environment files can set it; evaluate at planning, do not assume).
+
+Settings (human decision 2026-09-11): integrations/aws/settings.py, colocated with client.py, becomes the single source of every AWS setting for this series. It already defines the transport fields (AWS_REGION, AWS_ENDPOINT_URL, RETRY_MODE, RETRY_MAX_ATTEMPTS, CONNECT/READ timeouts, NOT_FOUND/UNAUTHORIZED/TRANSIENT code catalogues) that client.py today tries to read through getattr defaults from infrastructure/configuration/integrations/aws.py, where they do not exist; wire get_aws_client and classify_aws_error to it. Add to it, with identical field names and env aliases, the feature-level fields the mirrors and the later adapters need (SYSTEM_ADMIN_PERMISSIONS, VIEW_ONLY_PERMISSIONS, AUDIT/ORG/LOGGING_ROLE_ARN, INSTANCE_ID, INSTANCE_ARN, SERVICE_ROLE_MAP) so TASK-25.2.3 onwards read only this module. Mirror modules keep importing the infrastructure module until they are deleted; the infrastructure module and its barrel export are retired in TASK-25.2.6. Do not add AWS fields to infrastructure/configuration (the export barrel there is why they are being moved out).
+
+Callers updated: infrastructure/storage/service.py, infrastructure/idempotency/factory.py and infrastructure/resilience/retry/factory.py drop their casts. packages/access/sync/adapters/aws_identity_center.py keeps working as is (its get_aws_client("identitystore", role_arn=...) call stays valid); dropping its now-redundant cast is a fine incidental edit, but nothing beyond that: the access feature is not enabled yet and its own migration is out of this series' scope.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 integrations/aws/dynamodb.py no longer calls execute_aws_api_call/handle_aws_api_errors; routes through the SAME get_aws_client("dynamodb")/classify_aws_error instance TASK-22.2 built for infrastructure/storage (not a new one)
-- [ ] #2 modules/incident/incident_folder.py, modules/incident/db_operations.py, and modules/slack/webhooks.py are updated to the raise+classify contract explicitly; resulting error-path behavior documented and human-reviewed
-- [ ] #3 integrations/aws/dynamodb.py's hardcoded dynamodb-local endpoint gate is removed in favor of the single shared gate from TASK-22.2 (no duplicate ENVIRONMENT-check copies remain)
-- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise integrations/aws/dynamodb.py's query/scan/put_item/get_item/update_item/delete_item against real DynamoDB semantics via moto.mock_aws() (reuse/extend the TASK-69 conformance fixture pattern for the same get_aws_client("dynamodb") primitive rather than building a second one), additive alongside existing MagicMock-based unit tests
+- [ ] #1 get_aws_client is overloaded on Literal service names and returns the types-boto3 client type for each; mypy passes with the casts removed from the storage, idempotency and retry-store callers; packages/access needs at most its redundant cast removed
+- [ ] #2 AssumeRole uses sts.assume_role and a public boto3.Session constructor; no private botocore attribute is accessed anywhere under app/integrations
+- [ ] #3 Retry mode, max attempts, connect and read timeouts, region and endpoint are read from integrations/aws/settings.py and set once at construction, a retries-disabled option exists, and unit tests assert the botocore Config the factory produces for both variants and that environment overrides take effect
+- [ ] #4 classify_aws_error reads its code catalogues from integrations/aws/settings.py and its tests cover each mapped family (not-found, unauthorized, transient with retry_after, ConditionalCheckFailedException permanent, BotoCoreError transient) plus one unmapped ClientError propagating
+- [ ] #5 integrations/aws/settings.py carries the feature-level fields (permission sets, role ARNs, SSO instance id/ARN, SERVICE_ROLE_MAP) with the same names and env aliases as the infrastructure module, covered by tests; infrastructure/configuration gains no AWS field
+- [ ] #6 The legacy helpers remain callable and every existing mirror-module test still passes
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
+++ b/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
@@ -1,12 +1,12 @@
 ---
 id: TASK-25.2.3
 title: >-
-  Migrate AWS Lambda integration off execute_aws_api_call; delete
-  integrations/aws/sqs.py
+  Build the Identity Center adapter and migrate its legacy callers; delete
+  integrations/aws/identity_store.py
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-08-04 19:39'
+updated_date: '2026-09-11 15:56'
 labels:
   - clients
   - phase-3
@@ -14,10 +14,12 @@ milestone: m-3
 dependencies:
   - TASK-25.2.2
 references:
+  - app/integrations/aws/identity_store.py
+  - app/integrations/aws/client.py
   - decisions/outbound-clients.md
   - decisions/sdk-typing.md
-  - app/integrations/aws/lambdas.py
-  - app/integrations/aws/sqs.py
+  - decisions/feature-packages.md
+  - app/packages/incident/drive/adapters/google_drive.py
 parent_task_id: TASK-25.2
 priority: high
 ordinal: 120000
@@ -26,13 +28,19 @@ ordinal: 120000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Slice 3 of TASK-25.2 (tiny). Migrate integrations/aws/lambdas.py off execute_aws_api_call/handle_aws_api_errors onto get_aws_client("lambda") + classify_aws_error. Sole production consumer (grep-confirmed 2026-07-31): modules/aws/lambdas.py. Also delete integrations/aws/sqs.py in this slice - zero production consumers confirmed via grep, no migration needed, pure deletion.
+Slice 2 of TASK-25.2, done first among the adapters because Identity Center has the most callers and the only non-trivial composition. Create packages/aws_platform/adapters/identity_center.py: holds the typed identitystore client from get_aws_client("identitystore", role_arn=...), resolves the identity store id from settings, exposes the operations legacy callers use (healthcheck, create_user, delete_user, get_user_id, describe_user, list_users, get_group_id, list_groups, create_group_membership, delete_group_membership, get_group_membership_id, list_group_memberships, list_groups_with_memberships), paginates through client.get_paginator, wraps each SDK call in try/except + classify_aws_error and returns OperationResult. The groups-with-memberships join and its utils.filters usage move into the adapter with the call; no other business logic is added. Non-idempotent writes (create_user, create_group_membership) are evaluated for the retries-disabled factory option.
+
+Callers migrated (starting list, re-grep before planning): modules/aws/identity_center.py, modules/aws/aws.py, modules/aws/aws_access_requests.py (get_user_id only), modules/aws/ops_group_assignment.py (get_group_id only), modules/provisioning/users.py, modules/provisioning/groups.py, jobs/revoke_aws_sso_access.py (get_user_id only), jobs/scheduled_tasks.py (healthcheck). Each caller branches on OperationResult; the resulting behaviour where it previously received False is documented per call site in notes for human review.
+
+Deleted with the last caller: integrations/aws/identity_store.py and tests/integrations/aws/test_identity_store.py; tests/integration/integrations/aws/test_identity_store_conformance.py is retargeted at the adapter (moto stays) or deleted if fully superseded by Stubber tests.
+
+packages/access/sync/adapters/aws_identity_center.py is not reused: it exposes platform-sync operations (ensure_user, apply_entitlement, reconcile), not the raw Identity Store calls needed here. The access feature is not enabled yet; its own migration onto whatever shared Identity Center adapter emerges is later work, not a shim built here.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 integrations/aws/lambdas.py no longer calls execute_aws_api_call/handle_aws_api_errors; routes through get_aws_client("lambda") + classify_aws_error
-- [ ] #2 modules/aws/lambdas.py is updated to the raise+classify contract explicitly; resulting error-path behavior documented and human-reviewed (not zero-diff, per the silent-False-swallow caveat noted in sibling slices)
-- [ ] #3 integrations/aws/sqs.py is deleted
-- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise integrations/aws/lambdas.py's list_functions/list_layers/get_layer_version against real Lambda semantics via moto.mock_aws() (mirroring tests/integration/infrastructure/idempotency/conftest.py's fixture pattern), additive alongside existing MagicMock-based unit tests
+- [ ] #1 packages/aws_platform/adapters/identity_center.py returns OperationResult from every operation, builds its client only through get_aws_client, and has botocore Stubber unit tests for each operation plus classification paths
+- [ ] #2 The eight listed caller files no longer import integrations.aws.identity_store; each handles OperationResult explicitly, with per-call-site error-path behaviour recorded in notes and reviewed
+- [ ] #3 integrations/aws/identity_store.py and its legacy tests are deleted; both guard baselines are pruned of identity_store entries
+- [ ] #4 packages/access is not reworked; the access feature's own migration stays out of scope
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
+++ b/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 15:56'
+updated_date: '2026-09-11 16:19'
 labels:
   - clients
   - phase-3
@@ -43,4 +43,16 @@ packages/access/sync/adapters/aws_identity_center.py is not reused: it exposes p
 - [ ] #2 The eight listed caller files no longer import integrations.aws.identity_store; each handles OperationResult explicitly, with per-call-site error-path behaviour recorded in notes and reviewed
 - [ ] #3 integrations/aws/identity_store.py and its legacy tests are deleted; both guard baselines are pruned of identity_store entries
 - [ ] #4 packages/access is not reworked; the access feature's own migration stays out of scope
+- [ ] #5 Defect found by TASK-25.2.1's characterization pass is resolved deliberately, not carried across the seam: modules/aws/aws_access_requests.py's access_view_handler guards get_user_id with 'is None' although the integration only ever returns False, so its 'not registered with AWS SSO' reply is unreachable and a lookup failure flows into already_has_access and create_account_assignment with a False user id. With OperationResult, NOT_FOUND sends that reply and any other failure status stops before the assignment; the pinned characterization tests are updated to the new contract
+- [ ] #6 jobs/revoke_aws_sso_access.py no longer passes a failed get_user_id result into delete_account_assignment: a non-success status ends the job step with an explicit log and result
+- [ ] #7 modules/aws/aws.py's request_aws_account_access is unreferenced in production and calls create_aws_access_request with positionally shifted arguments (access_type receives a datetime, start_date_time receives the access type string); it is deleted, or fixed if the planner finds a live caller, with the pinned test removed or corrected accordingly
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-11 16:19
+---
+2026-09-11: three defects surfaced by the TASK-25.2.1 characterization pass were assigned here as explicit ACs (unreachable 'not registered' branch, revoke job forwarding False, dead request_aws_account_access with shifted positional args) so they are fixed or deleted deliberately when these call sites move to OperationResult, rather than pinned forever.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
@@ -1,26 +1,29 @@
 ---
 id: TASK-25.2.4
 title: >-
-  Migrate Organizations/SSO-Admin + legacy (non-_next) Identity Store consumers
-  off execute_aws_api_call
+  Build the Organizations, SSO-Admin, Config, Cost Explorer, GuardDuty, Security
+  Hub and Lambda adapters and migrate their callers; delete the seven mirrors
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:49'
-updated_date: '2026-08-04 19:39'
+updated_date: '2026-09-11 15:36'
 labels:
   - clients
   - phase-3
 milestone: m-3
 dependencies:
   - TASK-25.2.3
-  - TASK-22.3
 references:
-  - decisions/outbound-clients.md
-  - decisions/sdk-typing.md
   - app/integrations/aws/organizations.py
   - app/integrations/aws/sso_admin.py
-  - app/integrations/aws/identity_store.py
+  - app/integrations/aws/config.py
+  - app/integrations/aws/cost_explorer.py
+  - app/integrations/aws/guard_duty.py
+  - app/integrations/aws/security_hub.py
+  - app/integrations/aws/lambdas.py
   - app/integrations/aws/client.py
+  - decisions/outbound-clients.md
+  - decisions/sdk-typing.md
 parent_task_id: TASK-25.2
 priority: high
 ordinal: 121000
@@ -29,13 +32,18 @@ ordinal: 121000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Slice 4 (largest, done last) of TASK-25.2. Migrate integrations/aws/{organizations,sso_admin}.py off execute_aws_api_call/handle_aws_api_errors onto get_aws_client + classify_aws_error (new instances for organizations/sso-admin); migrate integrations/aws/identity_store.py (a SEPARATE consumer set from TASK-22.3's packages/access/sync scope) reusing the SAME get_aws_client("identitystore")/classify_aws_error instance TASK-22.3 built (not a new one). These 3 services share a tightly-coupled consumer set (grep-confirmed 2026-07-31, done together deliberately rather than as 3 separate PRs to avoid repeatedly touching the same ~8 files): modules/aws/aws_access_requests.py, modules/aws/ops_group_assignment.py, modules/aws/aws.py, modules/aws/aws_account_health.py (organizations only), modules/aws/spending.py (organizations only), jobs/revoke_aws_sso_access.py, modules/aws/identity_center.py, modules/provisioning/users.py, modules/provisioning/groups.py, jobs/scheduled_tasks.py. Done last so the get_aws_client/classify_aws_error extraction pattern is proven on 3 smaller/isolated slices first. Once this slice lands, integrations/aws/client.py's execute_aws_api_call/handle_aws_api_errors should have zero remaining callers repo-wide - delete integrations/aws/client.py itself as the final step (feeds TASK-25.2's own coordinator AC#1).
+Slice 3 of TASK-25.2. Create packages/aws_platform/adapters/{organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambda}.py following the shape proven by TASK-25.2.3: typed client from get_aws_client (with the AUDIT/ORG/LOGGING/SSO role ARNs from settings where the mirror uses them today), SDK paginators, try/except + classify_aws_error, OperationResult returns, Stubber unit tests. Organizations' small helpers (active account names, account id by name) travel with the adapter. SSO-Admin's create/delete account-assignment status checks travel too; create_account_assignment is evaluated for the retries-disabled option.
+
+Callers migrated (starting list, re-grep before planning): modules/aws/aws_access_requests.py, modules/aws/ops_group_assignment.py, modules/aws/aws.py, modules/aws/spending.py, modules/aws/aws_account_health.py, modules/aws/lambdas.py, jobs/revoke_aws_sso_access.py. Error-path behaviour is documented per call site.
+
+Deleted with their last caller: integrations/aws/{organizations,sso_admin,config,cost_explorer,guard_duty,security_hub,lambdas}.py and tests/integrations/aws/test_{organizations,sso_admin,legacy_config,cost_explorer,guard_duty,security_hub,lambas}.py.
+
+Size gate: seven small adapters (about 400 production LOC) plus seven caller files sit at the single-PR limit. The planner splits this into an Organizations + SSO-Admin subtask and an account-health + Lambda subtask if the plan exceeds it.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 integrations/aws/organizations.py and sso_admin.py no longer call execute_aws_api_call/handle_aws_api_errors; identity_store.py is repointed onto TASK-22.3's existing get_aws_client("identitystore")/classify_aws_error instance (not a new one)
-- [ ] #2 All identified consumer files behave per the raise+classify contract explicitly (no silent False-swallowing); resulting error-path behavior documented and human-reviewed per file, not assumed zero-diff
-- [ ] #3 integrations/aws/client.py is deleted (zero remaining execute_aws_api_call/handle_aws_api_errors callers repo-wide, verified via grep)
-- [ ] #4 moto-backed integration conformance test(s) under app/tests/integration/ exercise organizations.py's list_accounts/describe_account/list_tags_for_resource, sso_admin.py's create_account_assignment/delete_account_assignment/list_account_assignments_for_principal/list_accounts_for_provisioned_permission_set, and identity_store.py's ops already covered by TASK-22.3's suite (excluding get_group_membership_id, which moto does not implement) against real semantics via moto.mock_aws(), additive alongside existing MagicMock-based unit tests
+- [ ] #1 The seven adapters exist under packages/aws_platform/adapters/, return OperationResult, build clients only through get_aws_client, and have Stubber unit tests
+- [ ] #2 The seven listed caller files no longer import any of the seven mirrors and handle OperationResult explicitly, with error-path behaviour recorded in notes and reviewed
+- [ ] #3 The seven mirror modules and their legacy tests are deleted and both guard baselines pruned accordingly
 <!-- AC:END -->

--- a/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
+++ b/backlog/tasks/task-25.2.4 - Migrate-Organizations-SSO-Admin-legacy-non-_next-Identity-Store-consumers-off-execute_aws_api_call.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:49'
-updated_date: '2026-09-11 15:36'
+updated_date: '2026-09-11 16:19'
 labels:
   - clients
   - phase-3
@@ -46,4 +46,14 @@ Size gate: seven small adapters (about 400 production LOC) plus seven caller fil
 - [ ] #1 The seven adapters exist under packages/aws_platform/adapters/, return OperationResult, build clients only through get_aws_client, and have Stubber unit tests
 - [ ] #2 The seven listed caller files no longer import any of the seven mirrors and handle OperationResult explicitly, with error-path behaviour recorded in notes and reviewed
 - [ ] #3 The seven mirror modules and their legacy tests are deleted and both guard baselines pruned accordingly
+- [ ] #4 Every caller that today crashes on a False return from organizations, cost_explorer, config, guard_duty, security_hub or lambdas (dict/list comprehensions and len() over the result in aws_access_requests.request_access_modal, aws_account_health, spending, ops_group_assignment and lambdas, as pinned by TASK-25.2.1) handles the non-success OperationResult status explicitly with a user-visible or logged outcome; the pinned crash tests are replaced by tests of the new behaviour
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-11 16:19
+---
+2026-09-11: TASK-25.2.1's characterization pass pinned several crash-on-False paths in this slice's callers (TypeError from comprehensions and len() over a bool). They are listed here so the migration replaces each with explicit status handling. The dead request_aws_account_access in modules/aws/aws.py is owned by TASK-25.2.3.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.5 - Build-the-DynamoDB-adapter-for-legacy-callers-and-migrate-webhooks-incident-and-access-request-persistence-delete-integrations-aws-dynamodb.py.md
+++ b/backlog/tasks/task-25.2.5 - Build-the-DynamoDB-adapter-for-legacy-callers-and-migrate-webhooks-incident-and-access-request-persistence-delete-integrations-aws-dynamodb.py.md
@@ -1,0 +1,50 @@
+---
+id: TASK-25.2.5
+title: >-
+  Build the DynamoDB adapter for legacy callers and migrate webhooks, incident
+  and access-request persistence; delete integrations/aws/dynamodb.py
+status: To Do
+assignee: []
+created_date: '2026-09-11 15:36'
+labels:
+  - clients
+  - phase-3
+milestone: m-3
+dependencies:
+  - TASK-25.2.4
+references:
+  - app/integrations/aws/dynamodb.py
+  - app/modules/aws/aws_access_requests.py
+  - app/modules/slack/webhooks.py
+  - app/modules/incident/db_operations.py
+  - app/modules/incident/incident_folder.py
+  - app/infrastructure/idempotency/dynamodb.py
+  - app/infrastructure/storage/service.py
+  - decisions/outbound-clients.md
+parent_task_id: TASK-25.2
+priority: high
+ordinal: 122000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 4 of TASK-25.2. Create packages/aws_platform/adapters/dynamodb.py: a thin adapter over the typed dynamodb client from get_aws_client("dynamodb") that keeps the low-level AttributeValue request/response shapes legacy callers use today (query, scan, put_item, get_item, update_item, delete_item, list_tables), paginates through client.get_paginator, and returns OperationResult. DynamoDBStorageService is deliberately not adopted by these callers here (human decision 2026-09-11); a later feature migration may switch them.
+
+Callers migrated (starting list, re-grep before planning): modules/slack/webhooks.py, modules/incident/db_operations.py, modules/incident/incident_folder.py, and modules/aws/aws_access_requests.py, which today builds its own boto3.client("dynamodb") with a hardcoded local endpoint and reads ResponseMetadata status codes; it moves onto the adapter so no boto3 construction remains outside client.py.
+
+Retry safety: audit every update_item whose expression is not idempotent under replay (ADD counters, list appends) and route those through the retries-disabled factory option or a condition expression, per decisions/outbound-clients.md item 25.
+
+Also in scope (from the earlier TASK-25.2 comment): reassess the classify-and-continue downgrade in infrastructure/idempotency/dynamodb.py, where a classified SDK failure while re-reading a contended claim becomes ClaimResult.IN_PROGRESS, together with any other classify-and-continue site found on the DynamoDB paths; decide raise vs keep per site and record the decision.
+
+Deleted: integrations/aws/dynamodb.py and tests/unit/integrations/aws/test_dynamodb_local_endpoint.py (endpoint-gate coverage moves to the client.py tests if not already there).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 packages/aws_platform/adapters/dynamodb.py returns OperationResult for each operation, keeps AttributeValue shapes, builds its client only through get_aws_client, and has Stubber unit tests
+- [ ] #2 webhooks.py, incident db_operations.py, incident_folder.py and aws_access_requests.py use the adapter; no boto3.client or boto3.Session construction remains in production code outside integrations/aws/client.py
+- [ ] #3 Non-idempotent update_item sites are inventoried and each either uses the retries-disabled option or a conditional write, with the inventory in notes
+- [ ] #4 The idempotency-store classify-and-continue downgrade is reassessed with a recorded decision and a matching test
+- [ ] #5 integrations/aws/dynamodb.py and its legacy tests are deleted; both guard baselines pruned
+<!-- AC:END -->

--- a/backlog/tasks/task-25.2.6 - Delete-the-legacy-AWS-dispatcher-shield-sqs-and-schemas-move-AWS-transport-settings-into-infrastructure-configuration.md
+++ b/backlog/tasks/task-25.2.6 - Delete-the-legacy-AWS-dispatcher-shield-sqs-and-schemas-move-AWS-transport-settings-into-infrastructure-configuration.md
@@ -1,0 +1,54 @@
+---
+id: TASK-25.2.6
+title: >-
+  Delete the legacy AWS dispatcher, shield, sqs, schemas and the infrastructure
+  AWS settings module; prune the guard baselines
+status: To Do
+assignee: []
+created_date: '2026-09-11 15:36'
+updated_date: '2026-09-11 15:56'
+labels:
+  - clients
+  - phase-3
+  - cleanup
+milestone: m-3
+dependencies:
+  - TASK-25.2.3
+  - TASK-25.2.4
+  - TASK-25.2.5
+references:
+  - app/integrations/aws/client.py
+  - app/integrations/aws/settings.py
+  - app/integrations/aws/shield.py
+  - app/integrations/aws/sqs.py
+  - app/integrations/aws/schemas.py
+  - app/infrastructure/configuration/integrations/aws.py
+  - app/infrastructure/configuration/integrations/__init__.py
+  - app/packages/access/sync/adapters/aws_identity_center.py
+  - app/bin/check_vendor_package_contract.py
+  - app/bin/check_sdk_typing.py
+  - decisions/outbound-clients.md
+parent_task_id: TASK-25.2
+priority: high
+ordinal: 123000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 5 (final) of TASK-25.2. With no mirror module left, remove from integrations/aws/client.py: handle_aws_api_errors, execute_aws_api_call, paginator, assume_role_session, get_aws_service_client and the module-level constants re-exported from settings (SYSTEM_ADMIN_PERMISSIONS, VIEW_ONLY_PERMISSIONS, AWS_REGION, THROTTLING_ERRS, RESOURCE_NOT_FOUND_ERRS). Delete integrations/aws/shield.py (this executes TASK-25.5: zero production consumers), sqs.py (zero consumers) and schemas.py (unused Pydantic models). integrations/aws/settings.py STAYS: it is the colocated home of all AWS settings until TASK-88 (human decision 2026-09-11); shield.py's AWSSettings usage is simply removed with shield.
+
+Retire infrastructure/configuration/integrations/aws.py and its AwsSettings/get_aws_settings export from infrastructure/configuration/integrations/__init__.py (that barrel is why AWS settings were moved out of infrastructure/configuration). Its last reader is packages/access/sync/adapters/aws_identity_center.py (SERVICE_ROLE_MAP and INSTANCE_ID); since TASK-25.2.2 gives integrations/aws/settings.py the same field names, repoint that single import line and nothing else in packages/access. Small direct edits to packages/access for this repoint are fine; the access feature is not enabled yet, so anything beyond keeping it importing and passing its tests is out of scope.
+
+Tests deleted: tests/unit/integrations/aws/{test_executor,test_shield}.py, tests/integrations/aws/{test_sqs,test_legacy_aws_client}.py, tests/smoke/integrations/aws/test_shield_smoke.py; the AWS entries in tests/unit/infrastructure/configuration/test_integration_settings_singletons.py go with the infrastructure module; tests/unit/integrations/aws/conftest.py keeps its AWSSettings fixture for client.py tests.
+
+Guardrails: bin/baselines/vendor_package_contract.txt and bin/baselines/sdk_typing_antipatterns.txt end with no integrations/aws entries; make check-vendor-package-contract, make check-sdk-typing and make client-usage-matrix are run and their output recorded. decisions/outbound-clients.md gets at most one short dated sentence if the eager AssumeRole choice needs recording.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 integrations/aws/ contains only __init__.py, client.py and settings.py; client.py exports get_aws_client and classify_aws_error only
+- [ ] #2 shield.py, sqs.py, schemas.py and the listed tests are deleted; grep -rn shield app/integrations returns zero code hits
+- [ ] #3 infrastructure/configuration/integrations/aws.py and its barrel export are deleted, with packages/access repointed to integrations/aws/settings.py
+- [ ] #4 Both guard baselines have no integrations/aws entries and the three make checks pass with output recorded in notes
+<!-- AC:END -->

--- a/backlog/tasks/task-38 - Migrate-modules-incident-to-a-feature-package.md
+++ b/backlog/tasks/task-38 - Migrate-modules-incident-to-a-feature-package.md
@@ -4,7 +4,7 @@ title: Migrate modules/incident to a feature package
 status: To Do
 assignee: []
 created_date: '2026-07-07 19:56'
-updated_date: '2026-09-10 15:45'
+updated_date: '2026-09-11 14:53'
 labels:
   - migration
   - phase-5
@@ -67,6 +67,7 @@ Steps:
 - [ ] #6 Shared incident vocabulary lives in packages/incident/common/ with no I/O and at least two subdomain consumers per item; no subdomain imports another subdomain
 - [ ] #7 TASK-18 contract (e) gains a packages.incident container with exhaustive = true and lint-imports is green
 - [ ] #8 packages/incident_draft and packages/incident_summary no longer exist; their code, tests and locales live under packages/incident/ and no packages/incident_* directory remains anywhere under app/packages/
+- [ ] #9 The packages/incident/{documents,drive,meet,scheduling} Google adapters return frozen domain dataclasses instead of dicts once their modules/incident callers move into the package (decisions/sdk-typing.md item 3; handed off by TASK-25.1.6 AC#3)
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-39 - Migrate-the-small-modules-role-secret-atip.md
+++ b/backlog/tasks/task-39 - Migrate-the-small-modules-role-secret-atip.md
@@ -4,7 +4,7 @@ title: 'Migrate the small modules: role, secret, atip'
 status: To Do
 assignee: []
 created_date: '2026-07-07 19:56'
-updated_date: '2026-07-08 16:58'
+updated_date: '2026-09-11 14:53'
 labels:
   - migration
   - phase-5
@@ -35,6 +35,7 @@ Steps per module (role, then secret, then atip):
 - [ ] #1 Three feature packages exist matching the layout; three module directories deleted
 - [ ] #2 Smoke tests pass pre/post for each module independently
 - [ ] #3 Baselines only shrank
+- [ ] #4 packages/talent/adapters/google_drive.py returns frozen domain dataclasses instead of {id, name} dicts once modules/role moves into the talent package (decisions/sdk-typing.md item 3; handed off by TASK-25.1.6 AC#3)
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-88 - Migrate-modules-aws-modules-provisioning-and-the-AWS-jobs-to-feature-packages-dissolve-packages-aws_platform.md
+++ b/backlog/tasks/task-88 - Migrate-modules-aws-modules-provisioning-and-the-AWS-jobs-to-feature-packages-dissolve-packages-aws_platform.md
@@ -1,0 +1,47 @@
+---
+id: TASK-88
+title: >-
+  Migrate modules/aws, modules/provisioning and the AWS jobs to feature
+  packages; dissolve packages/aws_platform
+status: To Do
+assignee: []
+created_date: '2026-09-11 15:36'
+updated_date: '2026-09-11 15:53'
+labels:
+  - phase-5
+dependencies:
+  - TASK-25.2
+references:
+  - decisions/feature-packages.md
+  - decisions/capability-packages.md
+  - decisions/workplace-systems.md
+  - decisions/people-and-accounts.md
+  - decisions/layers.md
+  - app/modules/aws
+  - app/modules/provisioning
+  - app/integrations/aws/settings.py
+priority: medium
+ordinal: 189000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up to TASK-25.2 (created 2026-09-11). modules/aws was named after a vendor but holds several business features with mixed concerns: AWS access requests (aws_access_requests.py, ops_group_assignment.py, jobs/revoke_aws_sso_access.py), AWS account health reporting (aws_account_health.py), spending reports (spending.py), Lambda inventory (lambdas.py), and Identity Center user/group administration (identity_center.py, users.py, groups.py, aws.py), which overlaps modules/provisioning/{users,groups}.py and the disabled packages/access feature. TASK-25.2 isolates their AWS SDK calls behind packages/aws_platform/adapters/, a provisional adapters-only package that is neither a feature nor a capability package.
+
+This task decides the feature boundaries per decisions/feature-packages.md and decisions/capability-packages.md, migrates each module with the standard feature-package recipe (TASK-38 and TASK-39 are the incident and small-module precedents), moves each adapter into its owning home, types adapter returns as frozen domain dataclasses (decisions/sdk-typing.md item 3), relocates the feature-level AWS settings (permission sets, role ARNs, SSO instance, SERVICE_ROLE_MAP) out of integrations/aws/settings.py into the owning packages' settings.py so the vendor package keeps only the transport fields its client needs, and deletes packages/aws_platform together with the legacy modules. Decompose into per-feature subtasks at planning time. Do not start before TASK-25.2 is Done.
+
+EVENTUAL HOMES (recorded 2026-09-11 so the Google-series pattern of vendor-neutral infrastructure services for workplace concerns, see decisions/workplace-systems.md, is not repeated):
+- Identity Center holds people's AWS accounts. A shared Identity Center adapter goes to a capability package (decisions/capability-packages.md; likely the people-and-accounts capability, decisions/people-and-accounts.md), promoted only when the second feature actually needs it. Never infrastructure/.
+- Organizations, SSO-Admin, Config, Cost Explorer, GuardDuty, Security Hub and Lambda are Path B adapters (decisions/layers.md): the feature exists to act on AWS, so each adapter lives inside its feature. Promote to a capability package only if a second feature needs the same operation, with the justification recorded.
+- DynamoDB is a hosting service. The thin adapter TASK-25.2.5 builds is a seam; its callers move onto the existing infrastructure/storage Protocol (with the TASK-27 storage redesign), and the seam is deleted.
+- No new app/infrastructure/<service>/ Protocol is created for any of these.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Feature boundaries for the former modules/aws, modules/provisioning and AWS jobs are decided and recorded, with one subtask per feature package
+- [ ] #2 Every adapter under packages/aws_platform/adapters/ lives in the eventual home stated in the description (feature adapter, capability package with second-feature justification, or infrastructure/storage for DynamoDB callers) and returns typed domain values; no new infrastructure/<service> Protocol was introduced
+- [ ] #3 packages/aws_platform, modules/aws, modules/provisioning and the migrated jobs are deleted
+- [ ] #4 Feature-level AWS settings (permission sets, role ARNs, SSO instance, SERVICE_ROLE_MAP) move from integrations/aws/settings.py into the owning packages' settings.py; integrations/aws/settings.py keeps only the transport fields the client itself needs
+<!-- AC:END -->

--- a/backlog/tasks/task-89 - Assess-the-impact-on-the-AWS-integration-of-hosting-the-app-outside-AWS.md
+++ b/backlog/tasks/task-89 - Assess-the-impact-on-the-AWS-integration-of-hosting-the-app-outside-AWS.md
@@ -1,0 +1,37 @@
+---
+id: TASK-89
+title: Assess the impact on the AWS integration of hosting the app outside AWS
+status: To Do
+assignee: []
+created_date: '2026-09-11 15:49'
+updated_date: '2026-09-11 15:53'
+labels:
+  - architecture
+dependencies: []
+references:
+  - app/integrations/aws/client.py
+  - decisions/cloud-portability.md
+  - decisions/workplace-systems.md
+  - decisions/layers.md
+  - decisions/outbound-clients.md
+priority: medium
+type: spike
+ordinal: 190000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Spike (created 2026-09-11 during the TASK-25.2 reassessment). The AWS vendor client (app/integrations/aws/client.py) needs no credentials of its own because the SRE Bot runs inside an AWS account and uses boto3's ambient credential chain, unlike the Google Workspace client, which carries a service-account key. That assumption is implicit and undocumented.
+
+AWS plays two roles for this app: hosting provider (DynamoDB, Secrets Manager, ECS) and the target system of several Path B business features (Identity Center administration, access requests via SSO-Admin, Organizations and account-health reporting, Lambda inventory). decisions/workplace-systems.md states that leaving AWS touches only hosting implementations; that holds for the hosting role but not for the second role, which must keep reaching AWS from wherever the app runs.
+
+Assess, for a hypothetical move of hosting to another cloud (e.g. Azure): how the client obtains credentials (OIDC / workload identity federation into an IAM role vs static keys vs a proxy account), whether get_aws_client's eager AssumeRole and role ARN settings still fit, which settings would then become required and whether they belong in integrations/aws/settings.py (transport, per decisions/outbound-clients.md) or in feature settings, and what changes in decisions/cloud-portability.md and decisions/workplace-systems.md. Output is a written assessment and a decision-record amendment proposal (at most one short dated sentence per changed decision, amended in place), not code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A written assessment covers credential acquisition options, the fit of the current factory (eager AssumeRole, role ARN settings) and the settings that would become required, with sources cited
+- [ ] #2 A proposed amendment to decisions/cloud-portability.md and/or decisions/workplace-systems.md distinguishes AWS as hosting provider from AWS as a Path B target system
+- [ ] #3 The implicit ambient-credentials assumption is documented where the human decides it belongs (decision record or client.py module docstring)
+<!-- AC:END -->

--- a/backlog/tasks/task-90 - Fix-the-test-order-state-leaks-that-break-the-combined-pytest-run-SNS-validator-instance-monkeypatch-and-cached-structlog-loggers.md
+++ b/backlog/tasks/task-90 - Fix-the-test-order-state-leaks-that-break-the-combined-pytest-run-SNS-validator-instance-monkeypatch-and-cached-structlog-loggers.md
@@ -1,0 +1,42 @@
+---
+id: TASK-90
+title: >-
+  Fix the test-order state leaks that break the combined pytest run: SNS
+  validator instance monkeypatch and cached structlog loggers
+status: To Do
+assignee: []
+created_date: '2026-09-11 16:49'
+labels:
+  - tests
+dependencies: []
+references:
+  - app/tests/integration/webhooks/conftest.py
+  - app/tests/modules/webhooks/test_webhooks_aws_sns.py
+  - app/tests/unit/infrastructure/directory/test_google.py
+  - app/infrastructure/logging/setup.py
+  - app/modules/webhooks/aws_sns.py
+  - .claude/skills/testing-standards/SKILL.md
+priority: medium
+type: bug
+ordinal: 191000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found 2026-09-11 while verifying a tests-only change. The mandated single-process gate `cd app && uv run pytest tests --ignore=tests/smoke` fails 6 tests that pass in isolation and under the CI-shaped splits (`pytest tests/unit tests/integration` and the make test-legacy list are both green), so CI never sees them. Bisected to two independent state leaks; neither is caused by the failing tests themselves.
+
+LEAK 1: tests/modules/webhooks/test_webhooks_aws_sns.py (3 tests: validates_model, signature_verification_failure, rejects_invalid_signature_outside_production) fail with `ValueError: Unable to load PEM file ... MalformedFraming` after tests/integration/webhooks/test_webhook_e2e.py has run. Cause: tests/integration/webhooks/conftest.py's mock_sns_signature_validation_disabled does `monkeypatch.setattr("modules.webhooks.aws_sns.sns_message_validator.validate_message", ...)` on the module-level SNSMessageValidator INSTANCE. monkeypatch reads the existing value through the instance, gets the bound method, and on teardown writes that bound method back as an instance attribute. From then on the instance attribute shadows the class attribute, so the unit tests' `@patch("modules.webhooks.aws_sns.SNSMessageValidator.validate_message")` (class-level) no longer takes effect and the real validator tries to fetch the fake SigningCertURL.
+
+LEAK 2: tests/unit/infrastructure/directory/test_google.py (3 tests asserting `directory_group_skipped` warnings via structlog.testing.capture_logs) find zero captured entries after any suite that starts the app lifespan has run: tests/api/routes/test_landing.py, tests/integration/test_app_state_initialization.py, tests/integration/webhooks/test_webhook_e2e.py. Cause: the lifespan calls infrastructure/logging/setup.py configure_logging, which runs structlog.configure(cache_logger_on_first_use=True). Module-level loggers such as infrastructure/directory/google.py's are then bound with the production processor chain and cached, and capture_logs' processor swap never reaches them (the warning still prints to stderr, as the captured stderr shows).
+
+Fix at the source, not by reordering or skipping: patch the class attribute (or patch.object on the class) in the webhooks conftest; give the test session a structlog configuration with the cache disabled (or reset structlog after any app-lifespan fixture) so capture_logs works regardless of order. Then promote both lessons into the testing-standards skill per the skill-promotion rule: never monkeypatch an attribute on a module-level singleton instance; structlog's logger cache must be off under pytest.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 cd app && uv run pytest tests --ignore=tests/smoke passes in a single process, and so do the two CI-shaped splits
+- [ ] #2 The webhooks e2e conftest no longer monkeypatches the SNS validator instance; the unit tests' class-level patch is effective after the e2e suite has run (verified by running the e2e file followed by the unit file)
+- [ ] #3 structlog log capture works after an app-lifespan fixture has run (verified by running tests/api/routes/test_landing.py followed by tests/unit/infrastructure/directory/test_google.py), achieved by a shared test configuration or reset rather than per-test workarounds
+- [ ] #4 The testing-standards skill gains the two rules (no instance-level monkeypatch of module singletons; structlog logger cache off under pytest)
+<!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request adds comprehensive tests to ensure that when AWS and DynamoDB integrations return their real error contract (a literal `False`), the application either propagates the error or crashes in the same way it would in production. The new tests cover multiple modules, confirming that unguarded code paths behave as expected when integrations fail, and that error handling matches real-world scenarios. This improves the reliability of the test suite by explicitly pinning current error-handling behavior and surfacing any unhandled exceptions.

The most important changes are:

**Incident and Slack Webhook Integration Error Handling:**
- Added tests in `test_db_operations.py`, `test_incident_folder.py`, and `test_slack_webhooks.py` to verify that when DynamoDB methods return `False`, functions either propagate the error unchanged or raise `TypeError`/`AttributeError` due to unguarded accesses, matching real integration behavior. [[1]](diffhunk://#diff-2129d7b72d0b068187d4bfaabef598360e5702f797bac2c7d5db6d8d1362caafR206-R274) [[2]](diffhunk://#diff-7e6f060ff3141549571aee34f9bb526314befe07b25233838e9114f7371c03d3R473-R488) [[3]](diffhunk://#diff-c69a44369ff08f20919fbfb8b7126804cdbf0a345c315b99f34827ed3a5e65adR267-R331)

**AWS Access and Health Handler Integration Failures:**
- Introduced tests in `test_aws_access_requests_handler.py` and `test_aws_account_health_handler.py` to confirm that AWS integration methods returning `False` cause the correct exceptions or fallback behaviors, such as surfacing `TypeError` or returning zero for security hub summaries. [[1]](diffhunk://#diff-324ac82a0247205056ca0e77bfb3fef2e1d5b36d897a1e30d4dc1d934cf895a1R302-R398) [[2]](diffhunk://#diff-3e2e9999b73d31eb04f04272c854e3006b93d6ada7eceb46deff1ad2648858bfR276-R380)

**Provisioning Groups Integration Error Handling:**
- Added a test in `test_provisioning_groups.py` to ensure that a `False` return from AWS group listing causes a crash due to unguarded `len(groups)`, accurately reflecting the current error contract.

**AWS SSO Access Revocation:**
- Added a test in `test_revoke_aws_sso_access.py` to verify that a failed user ID lookup (returning `False`) is passed through to downstream calls without raising, matching the integration's behavior.

**General Test Suite Improvements:**
- Added utility functions and improved test arrangement for clarity and reusability in AWS-related test files. [[1]](diffhunk://#diff-324ac82a0247205056ca0e77bfb3fef2e1d5b36d897a1e30d4dc1d934cf895a1L4-R33) [[2]](diffhunk://#diff-c69a44369ff08f20919fbfb8b7126804cdbf0a345c315b99f34827ed3a5e65adR3-R4)

These changes explicitly document and test the application's behavior when integrations fail in production-like ways, making error handling more robust and transparent.