### PR TITLE
Feat/aws identity center adapter

### DIFF
--- a/app/integrations/aws/client.py
+++ b/app/integrations/aws/client.py
@@ -214,7 +214,8 @@ def classify_aws_error(exc: Exception) -> tuple[OperationStatus, str | None, int
         return OperationStatus.UNAUTHORIZED, code, None
     if code in settings.TRANSIENT_CODES:
         return OperationStatus.TRANSIENT_ERROR, code, settings.TRANSIENT_RETRY_AFTER_SECONDS
-    if code == "ConditionalCheckFailedException":
+    if code in ("ConditionalCheckFailedException", "ConflictException"):
+        # DynamoDB conditional writes and Identity Store "already exists" conflicts are final outcomes.
         return OperationStatus.PERMANENT_ERROR, code, None
 
     raise exc

--- a/app/packages/aws_platform/__init__.py
+++ b/app/packages/aws_platform/__init__.py
@@ -1,0 +1,4 @@
+"""Provisional AWS platform seam: adapters for legacy AWS callers until TASK-88 moves them into feature packages.
+
+Namespace only: no hookimpls, no re-exports, no entry-point registration.
+"""

--- a/app/packages/aws_platform/adapters/__init__.py
+++ b/app/packages/aws_platform/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Path B adapters for AWS services consumed by legacy modules and jobs."""

--- a/app/packages/aws_platform/adapters/identity_center.py
+++ b/app/packages/aws_platform/adapters/identity_center.py
@@ -1,0 +1,306 @@
+"""AWS Identity Center (identitystore) adapter for the legacy modules and jobs.
+
+Holds typed boto3 identitystore clients built by ``get_aws_client``, calls the
+SDK directly (pagination through ``get_paginator``), classifies expected SDK
+errors with ``classify_aws_error`` and returns ``OperationResult`` at every
+operation. Programmer errors propagate.
+
+Clients carry eagerly assumed STS credentials, so callers build the adapter
+with :func:`build_identity_center_adapter` at function entry, never at import.
+"""
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+from botocore.exceptions import BotoCoreError, ClientError
+
+from infrastructure.operations import OperationResult
+from integrations.aws.client import classify_aws_error, get_aws_client
+from integrations.aws.settings import get_aws_settings
+
+if TYPE_CHECKING:
+    from types_boto3_identitystore.client import IdentityStoreClient
+
+logger = structlog.get_logger()
+
+type GroupFilter = Callable[[dict[str, Any]], bool]
+type _PaginatorName = Literal["list_users", "list_groups", "list_group_memberships"]
+
+_GROUP_PROJECTION_KEYS = ("GroupId", "DisplayName", "Description", "IdentityStoreId")
+_DESCRIBE_USER_DROPPED_KEYS = ("ResponseMetadata", "IdentityStoreId")
+
+
+class IdentityCenterAdapter:
+    """Identity Store operations returning ``OperationResult``.
+
+    Args:
+        identitystore: standard-retry client for reads, gets and deletes.
+        identitystore_no_retry: retries-disabled client for the non-idempotent
+            creates (``CreateUser`` and ``CreateGroupMembership`` have no client
+            token, so an SDK retry after a timeout could re-send a create that
+            already succeeded).
+        identity_store_id: ``IdentityStoreId`` sent on every call.
+    """
+
+    def __init__(
+        self,
+        identitystore: IdentityStoreClient,
+        identitystore_no_retry: IdentityStoreClient,
+        identity_store_id: str,
+    ) -> None:
+        self._identitystore = identitystore
+        self._identitystore_no_retry = identitystore_no_retry
+        self._identity_store_id = identity_store_id
+
+    # -- error handling -----------------------------------------------------
+
+    @staticmethod
+    def _map_sdk_exception(operation: str, exc: Exception) -> OperationResult[Any]:
+        """Classify an expected botocore exception into an error result."""
+        status, error_code, retry_after = classify_aws_error(exc)
+        logger.warning(
+            "aws_identity_store_operation_failed",
+            operation=operation,
+            status=status.value,
+            error_code=error_code,
+        )
+        return OperationResult.error(
+            status,
+            message=str(exc),
+            error_code=error_code,
+            retry_after=retry_after,
+            provider="aws",
+            operation=operation,
+        )
+
+    def _call[T](self, operation: str, fn: Callable[[], T]) -> OperationResult[T]:
+        """Run one SDK call, classifying ClientError/BotoCoreError; anything else propagates."""
+        try:
+            return OperationResult.success(data=fn(), provider="aws", operation=operation)
+        except (ClientError, BotoCoreError) as exc:
+            return self._map_sdk_exception(operation, exc)
+
+    def _paginate(
+        self, paginator_name: _PaginatorName, response_key: str, **kwargs: Any
+    ) -> OperationResult[list[dict[str, Any]]]:
+        """Flatten every page of a paginated operation into one list."""
+
+        def collect() -> list[dict[str, Any]]:
+            paginator = self._identitystore.get_paginator(paginator_name)
+            items: list[dict[str, Any]] = []
+            for page in paginator.paginate(IdentityStoreId=self._identity_store_id, **kwargs):
+                page_items = page.get(response_key, [])
+                if isinstance(page_items, list):
+                    items.extend(page_items)
+            return items
+
+        return self._call(paginator_name, collect)
+
+    # -- health -------------------------------------------------------------
+
+    def healthcheck(self) -> OperationResult[bool]:
+        """Healthy iff a single-page ListUsers succeeds; an empty store is healthy."""
+
+        def probe() -> bool:
+            self._identitystore.list_users(IdentityStoreId=self._identity_store_id, MaxResults=1)
+            return True
+
+        return self._call("healthcheck", probe)
+
+    # -- users --------------------------------------------------------------
+
+    def create_user(self, email: str, first_name: str, family_name: str) -> OperationResult[str]:
+        """Create a user keyed by email; returns the new UserId. Sent without SDK retries."""
+        return self._call(
+            "create_user",
+            lambda: self._identitystore_no_retry.create_user(
+                IdentityStoreId=self._identity_store_id,
+                UserName=email,
+                Emails=[{"Value": email, "Type": "WORK", "Primary": True}],
+                Name={"GivenName": first_name, "FamilyName": family_name},
+                DisplayName=f"{first_name} {family_name}",
+            )["UserId"],
+        )
+
+    def delete_user(self, user_id: str) -> OperationResult[bool]:
+        """Delete a user by id."""
+
+        def delete() -> bool:
+            self._identitystore.delete_user(IdentityStoreId=self._identity_store_id, UserId=user_id)
+            return True
+
+        return self._call("delete_user", delete)
+
+    def get_user_id(self, user_name: str) -> OperationResult[str]:
+        """Resolve a UserId from its userName (NOT_FOUND when no user matches)."""
+        return self._call(
+            "get_user_id",
+            lambda: self._identitystore.get_user_id(
+                IdentityStoreId=self._identity_store_id,
+                # AttributeValue is a boto3 "document" type (any JSON scalar); the generated stub
+                # over-narrows it to Mapping[str, Any], as packages/access notes.
+                AlternateIdentifier={"UniqueAttribute": {"AttributePath": "userName", "AttributeValue": user_name}},  # type: ignore[typeddict-item]
+            )["UserId"],
+        )
+
+    def describe_user(self, user_id: str) -> OperationResult[dict[str, Any]]:
+        """Return the user's attributes without the response envelope keys."""
+
+        def describe() -> dict[str, Any]:
+            response = self._identitystore.describe_user(IdentityStoreId=self._identity_store_id, UserId=user_id)
+            return {key: value for key, value in response.items() if key not in _DESCRIBE_USER_DROPPED_KEYS}
+
+        return self._call("describe_user", describe)
+
+    def list_users(self, filters: list[dict[str, str]] | None = None) -> OperationResult[list[dict[str, Any]]]:
+        """List every user, optionally narrowed by Identity Store Filters."""
+        kwargs: dict[str, Any] = {"Filters": filters} if filters is not None else {}
+        return self._paginate("list_users", "Users", **kwargs)
+
+    # -- groups -------------------------------------------------------------
+
+    def get_group_id(self, group_name: str) -> OperationResult[str]:
+        """Resolve a GroupId from its displayName (NOT_FOUND when no group matches)."""
+        return self._call(
+            "get_group_id",
+            lambda: self._identitystore.get_group_id(
+                IdentityStoreId=self._identity_store_id,
+                # AttributeValue is a boto3 "document" type (any JSON scalar); the generated stub
+                # over-narrows it to Mapping[str, Any], as packages/access notes.
+                AlternateIdentifier={"UniqueAttribute": {"AttributePath": "displayName", "AttributeValue": group_name}},  # type: ignore[typeddict-item]
+            )["GroupId"],
+        )
+
+    def list_groups(self, filters: list[dict[str, str]] | None = None) -> OperationResult[list[dict[str, Any]]]:
+        """List every group, optionally narrowed by Identity Store Filters."""
+        kwargs: dict[str, Any] = {"Filters": filters} if filters is not None else {}
+        return self._paginate("list_groups", "Groups", **kwargs)
+
+    # -- memberships --------------------------------------------------------
+
+    def create_group_membership(self, group_id: str, user_id: str) -> OperationResult[str]:
+        """Add a user to a group; returns the MembershipId. Sent without SDK retries."""
+        return self._call(
+            "create_group_membership",
+            lambda: self._identitystore_no_retry.create_group_membership(
+                IdentityStoreId=self._identity_store_id,
+                GroupId=group_id,
+                MemberId={"UserId": user_id},
+            )["MembershipId"],
+        )
+
+    def delete_group_membership(self, membership_id: str) -> OperationResult[bool]:
+        """Remove a group membership by id."""
+
+        def delete() -> bool:
+            self._identitystore.delete_group_membership(IdentityStoreId=self._identity_store_id, MembershipId=membership_id)
+            return True
+
+        return self._call("delete_group_membership", delete)
+
+    def get_group_membership_id(self, group_id: str, user_id: str) -> OperationResult[str]:
+        """Resolve the MembershipId linking a user to a group."""
+        return self._call(
+            "get_group_membership_id",
+            lambda: self._identitystore.get_group_membership_id(
+                IdentityStoreId=self._identity_store_id,
+                GroupId=group_id,
+                MemberId={"UserId": user_id},
+            )["MembershipId"],
+        )
+
+    def list_group_memberships(self, group_id: str) -> OperationResult[list[dict[str, Any]]]:
+        """List every membership of a group."""
+        return self._paginate("list_group_memberships", "GroupMemberships", GroupId=group_id)
+
+    def list_groups_with_memberships(
+        self,
+        groups_filters: Iterable[GroupFilter] | None = None,
+        tolerate_errors: bool = False,
+    ) -> OperationResult[list[dict[str, Any]]]:
+        """Join groups, their memberships and the member user records.
+
+        Groups are filtered by the given callables and projected to GroupId,
+        DisplayName, Description and IdentityStoreId; each membership's
+        ``MemberId`` is enriched with the matching user record. A group whose
+        membership listing fails is logged and skipped. A membership whose user
+        is unknown drops the group unless ``tolerate_errors`` is set. Groups
+        without memberships are omitted. A failed ListGroups or ListUsers is
+        returned as the operation's own failure.
+        """
+        log = logger.bind(operation="list_groups_with_memberships", tolerate_errors=tolerate_errors)
+        groups_result = self.list_groups()
+        if not groups_result.is_success:
+            return groups_result
+        groups = groups_result.data or []
+        log.info("aws_identity_store_groups_fetched", count=len(groups))
+        if not groups:
+            return OperationResult.success(data=[], provider="aws", operation="list_groups_with_memberships")
+
+        if groups_filters is not None:
+            original_count = len(groups)
+            for group_filter in groups_filters:
+                groups = [group for group in groups if group_filter(group)]
+            log.info("aws_identity_store_groups_filtered", original_count=original_count, filtered_count=len(groups))
+
+        projected_groups = [{key: value for key, value in group.items() if key in _GROUP_PROJECTION_KEYS} for group in groups]
+
+        users_result = self.list_users()
+        if not users_result.is_success:
+            return users_result
+        users_by_id: dict[str, Mapping[str, Any]] = {user["UserId"]: user for user in users_result.data or []}
+        log.info("aws_identity_store_users_fetched", count=len(users_by_id))
+
+        groups_with_memberships: list[dict[str, Any]] = []
+        for group in projected_groups:
+            group_id = group.get("GroupId", "")
+            group_name = group.get("DisplayName", "unknown")
+            memberships_result = self.list_group_memberships(group_id)
+            if not memberships_result.is_success:
+                log.error(
+                    "aws_identity_store_group_memberships_error",
+                    group_id=group_id,
+                    group_name=group_name,
+                    status=memberships_result.status.value,
+                    error_code=memberships_result.error_code,
+                )
+                continue
+
+            memberships = memberships_result.data or []
+            error_occurred = False
+            for membership in memberships:
+                member_user_id = membership["MemberId"]["UserId"]
+                member_details = users_by_id.get(member_user_id)
+                if member_details is None:
+                    log.warning(
+                        "aws_identity_store_member_error",
+                        group_id=group_id,
+                        group_name=group_name,
+                        member_id=member_user_id,
+                    )
+                    error_occurred = True
+                    if not tolerate_errors:
+                        break
+                    continue
+                membership["MemberId"].update(member_details)
+
+            if memberships and (not error_occurred or tolerate_errors):
+                group["GroupMemberships"] = memberships
+                groups_with_memberships.append(group)
+
+        log.info("aws_identity_store_operation_complete", count=len(groups_with_memberships))
+        return OperationResult.success(data=groups_with_memberships, provider="aws", operation="list_groups_with_memberships")
+
+
+def build_identity_center_adapter() -> IdentityCenterAdapter:
+    """Build the adapter from AWS settings: org role for identitystore, IdentityStoreId from INSTANCE_ID.
+
+    Two clients are built per call: a standard-retry client and a
+    retries-disabled one for the non-idempotent creates.
+    """
+    settings = get_aws_settings()
+    role_arn = settings.SERVICE_ROLE_MAP.get("identitystore") or None
+    identitystore = get_aws_client("identitystore", role_arn=role_arn)
+    identitystore_no_retry = get_aws_client("identitystore", role_arn=role_arn, retries=False)
+    return IdentityCenterAdapter(identitystore, identitystore_no_retry, settings.INSTANCE_ID)

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -105,6 +105,10 @@ markers = [
     "smoke: Smoke tests that exercise live or sandbox external systems; excluded from default runs"
 ]
 env = [
+    # Feature warmups must not depend on the developer's .env: tests that need a
+    # feature enable it explicitly. ACCESS_SYNC_ENABLED=true would make lifespan
+    # build the AWS Identity Center adapter (and assume its role) at startup.
+    "ACCESS_SYNC_ENABLED=false",
     "SLACK_ENABLED=false",
     "SLACK_TOKEN=xoxb-test-token-for-tests",
     "SLACK_BOT_TOKEN=xoxb-test-token-for-tests",

--- a/app/tests/api/conftest.py
+++ b/app/tests/api/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for the API route tests.
+
+These tests boot the real FastAPI lifespan through ``TestClient``. Any feature
+warmup that builds an AWS client with a role ARN would otherwise perform a live
+STS ``AssumeRole`` call, so the seam is stubbed for every test in this tree.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+_FAKE_ASSUMED_CREDENTIALS = {
+    "AccessKeyId": "ASIATESTASSUMEDKEY",
+    "SecretAccessKey": "test-assumed-secret",
+    "SessionToken": "test-assumed-session-token",
+}
+
+
+@pytest.fixture(autouse=True)
+def _autouse_stub_aws_assume_role(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub the AWS AssumeRole seam so app startup never reaches STS.
+
+    Stub strategy: replace ``integrations.aws.client._assume_role_credentials``
+    with a function returning static temporary credentials; the client factory
+    then builds a normal boto3 session from them without any network call.
+    """
+    monkeypatch.setattr(
+        "integrations.aws.client._assume_role_credentials",
+        lambda sts, role_arn, session_name: dict(_FAKE_ASSUMED_CREDENTIALS),
+    )
+    yield

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -11,6 +11,28 @@ from fastapi.testclient import TestClient
 
 from server.server import handler
 
+_FAKE_ASSUMED_CREDENTIALS = {
+    "AccessKeyId": "ASIATESTASSUMEDKEY",
+    "SecretAccessKey": "test-assumed-secret",
+    "SessionToken": "test-assumed-session-token",
+}
+
+
+@pytest.fixture(autouse=True)
+def _autouse_stub_aws_assume_role(monkeypatch):
+    """Stub the AWS AssumeRole seam so no integration test reaches STS.
+
+    Integration tests boot the real lifespan and feature warmups; a client
+    built with a role ARN would otherwise call ``sts.assume_role`` for real.
+    The seam ``integrations.aws.client._assume_role_credentials`` returns
+    static temporary credentials instead, and the factory builds an ordinary
+    boto3 session from them. Tests of the seam itself live under tests/unit.
+    """
+    monkeypatch.setattr(
+        "integrations.aws.client._assume_role_credentials",
+        lambda sts, role_arn, session_name: dict(_FAKE_ASSUMED_CREDENTIALS),
+    )
+
 
 @pytest.fixture(autouse=True)
 def _autouse_mock_dynamodb_audit(monkeypatch):

--- a/app/tests/unit/integrations/aws/test_aws_client_classify_error.py
+++ b/app/tests/unit/integrations/aws/test_aws_client_classify_error.py
@@ -47,6 +47,11 @@ class TestMappedFamilies:
 
         assert result == (OperationStatus.PERMANENT_ERROR, "ConditionalCheckFailedException", None)
 
+    def test_conflict_is_permanent(self) -> None:
+        result = aws_client.classify_aws_error(_client_error("ConflictException"))
+
+        assert result == (OperationStatus.PERMANENT_ERROR, "ConflictException", None)
+
     def test_botocore_transport_errors_are_transient_without_a_retry_hint(self) -> None:
         exc = EndpointConnectionError(endpoint_url="https://dynamodb.ca-central-1.amazonaws.com")
 

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
@@ -238,7 +238,7 @@ class TestListGroupsWithMemberships:
             )
             stub.add_response(
                 "list_users",
-                {"Users": []},
+                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com"}]},
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             # g-1 fails
@@ -250,10 +250,10 @@ class TestListGroupsWithMemberships:
                     "GroupId": "g-1",
                 },
             )
-            # g-2 succeeds
+            # g-2 succeeds with one membership
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": []},
+                {"GroupMemberships": [{"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}}]},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "g-2",
@@ -265,8 +265,9 @@ class TestListGroupsWithMemberships:
             stub.assert_no_pending_responses()
 
         assert result.is_success
-        # Only g-2 is returned (g-1 was skipped)
-        assert len(result.data) == 0  # g-2 also has no memberships
+        # Only g-2 survives: g-1's membership listing failed and was skipped, the run still succeeds.
+        assert [group["GroupId"] for group in result.data] == ["g-2"]
+        assert result.data[0]["GroupMemberships"][0]["MemberId"]["UserName"] == "bob@example.com"
 
     def test_missing_user_drops_group_when_tolerate_errors_false(self) -> None:
         """A membership whose user is absent drops the group when tolerate_errors=False."""

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
@@ -67,16 +67,31 @@ class TestListGroupsWithMemberships:
         )
 
         def filter_admins(group: dict[str, Any]) -> bool:
-            return "Admin" in group.get("DisplayName", "")
+            return "admin" in group.get("DisplayName", "").lower()
 
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
                 {
                     "Groups": [
-                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Admin users"},
-                        {"GroupId": "g-2", "DisplayName": "Users", "Description": "Regular users"},
-                        {"GroupId": "g-3", "DisplayName": "Superadmins", "Description": "Super users"},
+                        {
+                            "GroupId": "g-1",
+                            "DisplayName": "Admins",
+                            "Description": "Admin users",
+                            "IdentityStoreId": "d-1234567890",
+                        },
+                        {
+                            "GroupId": "g-2",
+                            "DisplayName": "Users",
+                            "Description": "Regular users",
+                            "IdentityStoreId": "d-1234567890",
+                        },
+                        {
+                            "GroupId": "g-3",
+                            "DisplayName": "Superadmins",
+                            "Description": "Super users",
+                            "IdentityStoreId": "d-1234567890",
+                        },
                     ]
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
@@ -128,9 +143,10 @@ class TestListGroupsWithMemberships:
                     "Groups": [
                         {
                             "GroupId": "g-1",
+                            "IdentityStoreId": "d-1234567890",
                             "DisplayName": "Admins",
                             "Description": "Admin users",
-                            "ExtraField": "should be removed",
+                            "CreatedBy": "should be removed",
                         }
                     ]
                 },
@@ -138,12 +154,20 @@ class TestListGroupsWithMemberships:
             )
             stub.add_response(
                 "list_users",
-                {"Users": []},
+                {"Users": [{"UserId": "user-1", "UserName": "alice@example.com", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                {
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        }
+                    ]
+                },
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "g-1",
@@ -162,7 +186,7 @@ class TestListGroupsWithMemberships:
         assert "Description" in group
         assert "IdentityStoreId" in group
         assert group["GroupId"] == "g-1"
-        assert "ExtraField" not in group
+        assert "CreatedBy" not in group
 
     def test_user_details_merged_into_membership(self) -> None:
         """User details (UserId, UserName, Name, Emails) are merged into membership['MemberId']."""
@@ -176,7 +200,16 @@ class TestListGroupsWithMemberships:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": "Admin users"}]},
+                {
+                    "Groups": [
+                        {
+                            "GroupId": "g-1",
+                            "DisplayName": "Admins",
+                            "Description": "Admin users",
+                            "IdentityStoreId": "d-1234567890",
+                        }
+                    ]
+                },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
@@ -186,6 +219,7 @@ class TestListGroupsWithMemberships:
                         {
                             "UserId": "user-1",
                             "UserName": "alice@example.com",
+                            "IdentityStoreId": "d-1234567890",
                             "Name": {"GivenName": "Alice", "FamilyName": "Smith"},
                             "Emails": [{"Value": "alice@example.com", "Type": "WORK"}],
                         }
@@ -195,7 +229,15 @@ class TestListGroupsWithMemberships:
             )
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                {
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        }
+                    ]
+                },
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "g-1",
@@ -230,15 +272,15 @@ class TestListGroupsWithMemberships:
                 "list_groups",
                 {
                     "Groups": [
-                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": ""},
-                        {"GroupId": "g-2", "DisplayName": "Users", "Description": ""},
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Group", "IdentityStoreId": "d-1234567890"},
+                        {"GroupId": "g-2", "DisplayName": "Users", "Description": "Group", "IdentityStoreId": "d-1234567890"},
                     ]
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
                 "list_users",
-                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com"}]},
+                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             # g-1 fails
@@ -253,7 +295,15 @@ class TestListGroupsWithMemberships:
             # g-2 succeeds with one membership
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": [{"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}}]},
+                {
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-2",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-2"},
+                        }
+                    ]
+                },
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "g-2",
@@ -281,7 +331,11 @@ class TestListGroupsWithMemberships:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Group", "IdentityStoreId": "d-1234567890"}
+                    ]
+                },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
@@ -291,8 +345,8 @@ class TestListGroupsWithMemberships:
                         {
                             "UserId": "user-1",
                             "UserName": "alice@example.com",
+                            "IdentityStoreId": "d-1234567890",
                             "Name": {"GivenName": "Alice"},
-                            "Emails": [],
                         }
                     ]
                 },
@@ -302,8 +356,16 @@ class TestListGroupsWithMemberships:
                 "list_group_memberships",
                 {
                     "GroupMemberships": [
-                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
-                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},  # user-2 missing
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        },
+                        {
+                            "MembershipId": "m-2",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-2"},
+                        },  # user-2 missing
                     ]
                 },
                 expected_params={
@@ -332,7 +394,11 @@ class TestListGroupsWithMemberships:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Group", "IdentityStoreId": "d-1234567890"}
+                    ]
+                },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
@@ -342,8 +408,8 @@ class TestListGroupsWithMemberships:
                         {
                             "UserId": "user-1",
                             "UserName": "alice@example.com",
+                            "IdentityStoreId": "d-1234567890",
                             "Name": {"GivenName": "Alice"},
-                            "Emails": [],
                         }
                     ]
                 },
@@ -353,8 +419,16 @@ class TestListGroupsWithMemberships:
                 "list_group_memberships",
                 {
                     "GroupMemberships": [
-                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
-                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        },
+                        {
+                            "MembershipId": "m-2",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-2"},
+                        },
                     ]
                 },
                 expected_params={
@@ -406,7 +480,11 @@ class TestListGroupsWithMemberships:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Group", "IdentityStoreId": "d-1234567890"}
+                    ]
+                },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_client_error(
@@ -436,15 +514,15 @@ class TestListGroupsWithMemberships:
                 "list_groups",
                 {
                     "Groups": [
-                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": ""},
-                        {"GroupId": "g-2", "DisplayName": "Users", "Description": ""},
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Group", "IdentityStoreId": "d-1234567890"},
+                        {"GroupId": "g-2", "DisplayName": "Users", "Description": "Group", "IdentityStoreId": "d-1234567890"},
                     ]
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
                 "list_users",
-                {"Users": []},
+                {"Users": [{"UserId": "user-1", "UserName": "alice@example.com", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             # g-1 has no memberships
@@ -459,7 +537,15 @@ class TestListGroupsWithMemberships:
             # g-2 has a membership
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                {
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        }
+                    ]
+                },
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "g-2",

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py
@@ -1,0 +1,475 @@
+"""Behavior tests for IdentityCenterAdapter.list_groups_with_memberships.
+
+The join operation applies group filters, projects group dicts to four keys,
+lists all users once, then per group lists memberships and merges user details.
+Failed list_groups or list_users return their failure result with no further
+calls. Per-group membership failures are logged and the group skipped. Missing
+users drop the group when tolerate_errors=False and keep it when True. Empty
+groups list returns success([]) with no list_users call. Groups with no
+memberships are omitted from the result.
+"""
+
+from typing import Any
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+from infrastructure.operations.status import OperationStatus
+from packages.aws_platform.adapters.identity_center import IdentityCenterAdapter
+
+pytestmark = pytest.mark.unit
+
+
+def _identitystore_client() -> Any:
+    """Build a real boto3 identitystore client with dummy static credentials."""
+    return boto3.client(
+        "identitystore",
+        region_name="ca-central-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+
+
+class TestListGroupsWithMemberships:
+    """list_groups_with_memberships handles filtering, joining, and error paths."""
+
+    def test_empty_groups_returns_empty_list_no_list_users_call(self) -> None:
+        """Empty groups list returns success([]) without calling list_users."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": []},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == []
+
+    def test_group_filters_applied_via_callables(self) -> None:
+        """Group filters are applied; only matching groups proceed to membership lookup."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        def filter_admins(group: dict[str, Any]) -> bool:
+            return "Admin" in group.get("DisplayName", "")
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": "Admin users"},
+                        {"GroupId": "g-2", "DisplayName": "Users", "Description": "Regular users"},
+                        {"GroupId": "g-3", "DisplayName": "Superadmins", "Description": "Super users"},
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            # Only g-1 and g-3 pass the filter
+            stub.add_response(
+                "list_users",
+                {"Users": []},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            # Only memberships for filtered groups are requested
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": []},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": []},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-3",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships(groups_filters=[filter_admins])
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == []  # All groups have no memberships
+
+    def test_groups_projected_to_four_keys(self) -> None:
+        """Groups are projected to GroupId, DisplayName, Description, IdentityStoreId."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {
+                    "Groups": [
+                        {
+                            "GroupId": "g-1",
+                            "DisplayName": "Admins",
+                            "Description": "Admin users",
+                            "ExtraField": "should be removed",
+                        }
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {"Users": []},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert len(result.data) == 1
+        group = result.data[0]
+        assert "GroupId" in group
+        assert "DisplayName" in group
+        assert "Description" in group
+        assert "IdentityStoreId" in group
+        assert group["GroupId"] == "g-1"
+        assert "ExtraField" not in group
+
+    def test_user_details_merged_into_membership(self) -> None:
+        """User details (UserId, UserName, Name, Emails) are merged into membership['MemberId']."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": "Admin users"}]},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {
+                    "Users": [
+                        {
+                            "UserId": "user-1",
+                            "UserName": "alice@example.com",
+                            "Name": {"GivenName": "Alice", "FamilyName": "Smith"},
+                            "Emails": [{"Value": "alice@example.com", "Type": "WORK"}],
+                        }
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert len(result.data) == 1
+        group = result.data[0]
+        assert len(group["GroupMemberships"]) == 1
+        membership = group["GroupMemberships"][0]
+        assert membership["MembershipId"] == "m-1"
+        assert membership["MemberId"]["UserId"] == "user-1"
+        assert membership["MemberId"]["UserName"] == "alice@example.com"
+        assert membership["MemberId"]["Name"]["GivenName"] == "Alice"
+
+    def test_group_membership_failure_skipped_and_logged(self) -> None:
+        """A failed list_group_memberships is logged and the group skipped; others proceed."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": ""},
+                        {"GroupId": "g-2", "DisplayName": "Users", "Description": ""},
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {"Users": []},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            # g-1 fails
+            stub.add_client_error(
+                "list_group_memberships",
+                service_error_code="AccessDeniedException",
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+            # g-2 succeeds
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": []},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-2",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        # Only g-2 is returned (g-1 was skipped)
+        assert len(result.data) == 0  # g-2 also has no memberships
+
+    def test_missing_user_drops_group_when_tolerate_errors_false(self) -> None:
+        """A membership whose user is absent drops the group when tolerate_errors=False."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {
+                    "Users": [
+                        {
+                            "UserId": "user-1",
+                            "UserName": "alice@example.com",
+                            "Name": {"GivenName": "Alice"},
+                            "Emails": [],
+                        }
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {
+                    "GroupMemberships": [
+                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
+                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},  # user-2 missing
+                    ]
+                },
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships(tolerate_errors=False)
+
+            stub.assert_no_pending_responses()
+
+        # Group is dropped because user-2 is missing
+        assert result.is_success
+        assert result.data == []
+
+    def test_missing_user_keeps_group_when_tolerate_errors_true(self) -> None:
+        """A membership whose user is absent keeps the group when tolerate_errors=True."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {
+                    "Users": [
+                        {
+                            "UserId": "user-1",
+                            "UserName": "alice@example.com",
+                            "Name": {"GivenName": "Alice"},
+                            "Emails": [],
+                        }
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {
+                    "GroupMemberships": [
+                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
+                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},
+                    ]
+                },
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships(tolerate_errors=True)
+
+            stub.assert_no_pending_responses()
+
+        # Group is kept with the available user
+        assert result.is_success
+        assert len(result.data) == 1
+
+    def test_failed_list_groups_returns_failure_no_further_calls(self) -> None:
+        """A failed list_groups returns that failure result with no further calls."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_client_error(
+                "list_groups",
+                service_error_code="AccessDeniedException",
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.UNAUTHORIZED
+        assert result.error_code == "AccessDeniedException"
+
+    def test_failed_list_users_returns_failure_no_further_calls(self) -> None:
+        """A failed list_users returns that failure result with no further calls."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "g-1", "DisplayName": "Admins", "Description": ""}]},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_client_error(
+                "list_users",
+                service_error_code="ThrottlingException",
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "ThrottlingException"
+
+    def test_groups_with_no_memberships_omitted(self) -> None:
+        """Groups with no memberships are omitted from the result."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {
+                    "Groups": [
+                        {"GroupId": "g-1", "DisplayName": "Admins", "Description": ""},
+                        {"GroupId": "g-2", "DisplayName": "Users", "Description": ""},
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
+                {"Users": []},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            # g-1 has no memberships
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": []},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-1",
+                },
+            )
+            # g-2 has a membership
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "g-2",
+                },
+            )
+
+            result = adapter.list_groups_with_memberships()
+
+            stub.assert_no_pending_responses()
+
+        # Only g-2 is in the result (g-1 has no memberships)
+        assert result.is_success
+        assert len(result.data) == 1
+        assert result.data[0]["GroupId"] == "g-2"

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
@@ -280,7 +280,12 @@ class TestListUsers:
         assert result.data[1]["UserId"] == "user-2"
 
     def test_list_users_pagination_two_pages(self) -> None:
-        """ListUsers flattens users across two pages via NextToken."""
+        """ListUsers flattens users across two pages via NextToken.
+
+        Stub strategy: two canned ListUsers responses on the real client; the
+        first carries a NextToken and the second expects that token back, which
+        proves the adapter drives the SDK paginator rather than a single call.
+        """
         client = _identitystore_client()
         adapter = IdentityCenterAdapter(
             identitystore=client,
@@ -289,21 +294,26 @@ class TestListUsers:
         )
 
         with Stubber(client) as stub:
-            paginator = stub.client.get_paginator("list_users")
-            paginator.paginate = lambda **kwargs: [
+            stub.add_response(
+                "list_users",
                 {
                     "Users": [{"UserId": "user-1", "UserName": "alice@example.com"}],
                     "NextToken": "token123",
                 },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_users",
                 {"Users": [{"UserId": "user-2", "UserName": "bob@example.com"}]},
-            ]
-            stub.client.get_paginator = lambda op: paginator if op == "list_users" else None
+                expected_params={"IdentityStoreId": "d-1234567890", "NextToken": "token123"},
+            )
 
-            _ = adapter.list_users()
+            result = adapter.list_users()
 
-            # For paginator-based tests, we verify the structure after paginate completes
-        # Note: Stubber works with low-level pagination; for high-level paginate,
-        # we're testing the pagination logic directly via the real paginator interface.
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert [user["UserId"] for user in result.data] == ["user-1", "user-2"]
 
     def test_list_users_with_filters(self) -> None:
         """ListUsers includes Filters parameter only when filters are provided."""
@@ -399,6 +409,39 @@ class TestListGroups:
         assert result.is_success
         assert len(result.data) == 2
         assert result.data[0]["GroupId"] == "group-1"
+
+    def test_list_groups_pagination_two_pages(self) -> None:
+        """ListGroups flattens groups across two pages via NextToken.
+
+        Stub strategy: two canned ListGroups responses, the second expecting the
+        NextToken issued by the first, so a single-call implementation leaves a
+        pending response and fails.
+        """
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "group-1", "DisplayName": "Admins"}], "NextToken": "g-token"},
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "group-2", "DisplayName": "Users"}]},
+                expected_params={"IdentityStoreId": "d-1234567890", "NextToken": "g-token"},
+            )
+
+            result = adapter.list_groups()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert [group["GroupId"] for group in result.data] == ["group-1", "group-2"]
 
     def test_list_groups_with_filters(self) -> None:
         """ListGroups includes Filters parameter only when filters are provided."""
@@ -555,6 +598,45 @@ class TestListGroupMemberships:
         assert result.is_success
         assert len(result.data) == 2
         assert result.data[0]["MembershipId"] == "m-1"
+
+    def test_list_group_memberships_pagination_two_pages(self) -> None:
+        """ListGroupMemberships flattens memberships across two pages via NextToken.
+
+        Stub strategy: two canned responses for the same GroupId, the second
+        expecting the NextToken from the first; both must be consumed.
+        """
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_group_memberships",
+                {
+                    "GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}],
+                    "NextToken": "m-token",
+                },
+                expected_params={"IdentityStoreId": "d-1234567890", "GroupId": "group-123"},
+            )
+            stub.add_response(
+                "list_group_memberships",
+                {"GroupMemberships": [{"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "group-123",
+                    "NextToken": "m-token",
+                },
+            )
+
+            result = adapter.list_group_memberships("group-123")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert [m["MembershipId"] for m in result.data] == ["m-1", "m-2"]
 
 
 class TestErrorClassification:

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
@@ -71,7 +71,7 @@ class TestHealthcheck:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_users",
-                {"Users": [{"UserId": "user-123"}]},
+                {"Users": [{"UserId": "user-123", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890", "MaxResults": 1},
             )
 
@@ -99,7 +99,7 @@ class TestCreateUser:
         with Stubber(no_retry_client) as stub:
             stub.add_response(
                 "create_user",
-                {"UserId": "user-456"},
+                {"UserId": "user-456", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "UserName": "alice@example.com",
@@ -129,7 +129,7 @@ class TestCreateUser:
         with Stubber(std_client) as std_stub, Stubber(no_retry_client) as no_retry_stub:
             no_retry_stub.add_response(
                 "create_user",
-                {"UserId": "user-456"},
+                {"UserId": "user-456", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "UserName": "bob@example.com",
@@ -189,7 +189,7 @@ class TestGetUserId:
         with Stubber(client) as stub:
             stub.add_response(
                 "get_user_id",
-                {"UserId": "user-789"},
+                {"UserId": "user-789", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "AlternateIdentifier": {
@@ -263,8 +263,8 @@ class TestListUsers:
                 "list_users",
                 {
                     "Users": [
-                        {"UserId": "user-1", "UserName": "alice@example.com"},
-                        {"UserId": "user-2", "UserName": "bob@example.com"},
+                        {"UserId": "user-1", "UserName": "alice@example.com", "IdentityStoreId": "d-1234567890"},
+                        {"UserId": "user-2", "UserName": "bob@example.com", "IdentityStoreId": "d-1234567890"},
                     ]
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
@@ -297,14 +297,14 @@ class TestListUsers:
             stub.add_response(
                 "list_users",
                 {
-                    "Users": [{"UserId": "user-1", "UserName": "alice@example.com"}],
+                    "Users": [{"UserId": "user-1", "UserName": "alice@example.com", "IdentityStoreId": "d-1234567890"}],
                     "NextToken": "token123",
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
                 "list_users",
-                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com"}]},
+                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890", "NextToken": "token123"},
             )
 
@@ -329,7 +329,7 @@ class TestListUsers:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_users",
-                {"Users": [{"UserId": "user-1", "UserName": "alice@example.com"}]},
+                {"Users": [{"UserId": "user-1", "UserName": "alice@example.com", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "Filters": filters,
@@ -358,7 +358,7 @@ class TestGetGroupId:
         with Stubber(client) as stub:
             stub.add_response(
                 "get_group_id",
-                {"GroupId": "group-123"},
+                {"GroupId": "group-123", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "AlternateIdentifier": {
@@ -395,8 +395,8 @@ class TestListGroups:
                 "list_groups",
                 {
                     "Groups": [
-                        {"GroupId": "group-1", "DisplayName": "Admins"},
-                        {"GroupId": "group-2", "DisplayName": "Users"},
+                        {"GroupId": "group-1", "DisplayName": "Admins", "IdentityStoreId": "d-1234567890"},
+                        {"GroupId": "group-2", "DisplayName": "Users", "IdentityStoreId": "d-1234567890"},
                     ]
                 },
                 expected_params={"IdentityStoreId": "d-1234567890"},
@@ -427,12 +427,15 @@ class TestListGroups:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "group-1", "DisplayName": "Admins"}], "NextToken": "g-token"},
+                {
+                    "Groups": [{"GroupId": "group-1", "DisplayName": "Admins", "IdentityStoreId": "d-1234567890"}],
+                    "NextToken": "g-token",
+                },
                 expected_params={"IdentityStoreId": "d-1234567890"},
             )
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "group-2", "DisplayName": "Users"}]},
+                {"Groups": [{"GroupId": "group-2", "DisplayName": "Users", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={"IdentityStoreId": "d-1234567890", "NextToken": "g-token"},
             )
 
@@ -457,7 +460,7 @@ class TestListGroups:
         with Stubber(client) as stub:
             stub.add_response(
                 "list_groups",
-                {"Groups": [{"GroupId": "group-1", "DisplayName": "Admins"}]},
+                {"Groups": [{"GroupId": "group-1", "DisplayName": "Admins", "IdentityStoreId": "d-1234567890"}]},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "Filters": filters,
@@ -487,7 +490,7 @@ class TestCreateGroupMembership:
         with Stubber(no_retry_client) as stub:
             stub.add_response(
                 "create_group_membership",
-                {"MembershipId": "membership-789"},
+                {"MembershipId": "membership-789", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "group-123",
@@ -548,7 +551,7 @@ class TestGetGroupMembershipId:
         with Stubber(client) as stub:
             stub.add_response(
                 "get_group_membership_id",
-                {"MembershipId": "membership-999"},
+                {"MembershipId": "membership-999", "IdentityStoreId": "d-1234567890"},
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "group-123",
@@ -581,8 +584,16 @@ class TestListGroupMemberships:
                 "list_group_memberships",
                 {
                     "GroupMemberships": [
-                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
-                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        },
+                        {
+                            "MembershipId": "m-2",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-2"},
+                        },
                     ]
                 },
                 expected_params={
@@ -616,14 +627,28 @@ class TestListGroupMemberships:
             stub.add_response(
                 "list_group_memberships",
                 {
-                    "GroupMemberships": [{"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}}],
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-1",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-1"},
+                        }
+                    ],
                     "NextToken": "m-token",
                 },
                 expected_params={"IdentityStoreId": "d-1234567890", "GroupId": "group-123"},
             )
             stub.add_response(
                 "list_group_memberships",
-                {"GroupMemberships": [{"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}}]},
+                {
+                    "GroupMemberships": [
+                        {
+                            "MembershipId": "m-2",
+                            "IdentityStoreId": "d-1234567890",
+                            "MemberId": {"UserId": "user-2"},
+                        }
+                    ]
+                },
                 expected_params={
                     "IdentityStoreId": "d-1234567890",
                     "GroupId": "group-123",

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py
@@ -1,0 +1,746 @@
+"""Behavior tests for IdentityCenterAdapter operations.
+
+A real boto3 identitystore client built with static dummy credentials is wrapped
+in botocore.stub.Stubber, which validates requests against the service model and
+replays canned responses. Each operation test covers the success path with
+expected params (including IdentityStoreId) and the data shape, pagination across
+two pages with NextToken, conditional Filters, and classification paths for
+ResourceNotFoundException, AccessDeniedException, ThrottlingException,
+ConflictException, BotoCoreError transient errors, and unmapped errors propagating.
+Healthcheck succeeds on an empty Users page.
+"""
+
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+from botocore.stub import Stubber
+
+from infrastructure.operations.status import OperationStatus
+from packages.aws_platform.adapters.identity_center import IdentityCenterAdapter
+
+pytestmark = pytest.mark.unit
+
+
+def _identitystore_client() -> Any:
+    """Build a real boto3 identitystore client with dummy static credentials."""
+    return boto3.client(
+        "identitystore",
+        region_name="ca-central-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+
+
+class TestHealthcheck:
+    """Healthcheck succeeds when ListUsers returns a page (empty or not)."""
+
+    def test_healthcheck_returns_success_with_true_on_list_users_success(self) -> None:
+        """ListUsers with MaxResults=1 succeeds; result.data is True."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_users",
+                {"Users": []},
+                expected_params={"IdentityStoreId": "d-1234567890", "MaxResults": 1},
+            )
+
+            result = adapter.healthcheck()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data is True
+
+    def test_healthcheck_succeeds_on_non_empty_page(self) -> None:
+        """Empty store is healthy; single page with users is also healthy."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_users",
+                {"Users": [{"UserId": "user-123"}]},
+                expected_params={"IdentityStoreId": "d-1234567890", "MaxResults": 1},
+            )
+
+            result = adapter.healthcheck()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data is True
+
+
+class TestCreateUser:
+    """CreateUser uses the no-retry client and returns UserId."""
+
+    def test_create_user_success_payload_and_data(self) -> None:
+        """CreateUser payload includes email, name, and display name; returns UserId."""
+        no_retry_client = _identitystore_client()
+        std_client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=std_client,
+            identitystore_no_retry=no_retry_client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(no_retry_client) as stub:
+            stub.add_response(
+                "create_user",
+                {"UserId": "user-456"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "UserName": "alice@example.com",
+                    "Emails": [{"Value": "alice@example.com", "Type": "WORK", "Primary": True}],
+                    "Name": {"GivenName": "Alice", "FamilyName": "Smith"},
+                    "DisplayName": "Alice Smith",
+                },
+            )
+
+            result = adapter.create_user("alice@example.com", "Alice", "Smith")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "user-456"
+
+    def test_create_user_on_no_retry_client_only(self) -> None:
+        """CreateUser must be sent through the no-retry client."""
+        no_retry_client = _identitystore_client()
+        std_client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=std_client,
+            identitystore_no_retry=no_retry_client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(std_client) as std_stub, Stubber(no_retry_client) as no_retry_stub:
+            no_retry_stub.add_response(
+                "create_user",
+                {"UserId": "user-456"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "UserName": "bob@example.com",
+                    "Emails": [{"Value": "bob@example.com", "Type": "WORK", "Primary": True}],
+                    "Name": {"GivenName": "Bob", "FamilyName": "Jones"},
+                    "DisplayName": "Bob Jones",
+                },
+            )
+
+            result = adapter.create_user("bob@example.com", "Bob", "Jones")
+
+            no_retry_stub.assert_no_pending_responses()
+            std_stub.assert_no_pending_responses()
+
+        assert result.is_success
+
+
+class TestDeleteUser:
+    """DeleteUser returns True on success."""
+
+    def test_delete_user_success_returns_true(self) -> None:
+        """DeleteUser succeeds and returns True."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "delete_user",
+                {},
+                expected_params={"IdentityStoreId": "d-1234567890", "UserId": "user-123"},
+            )
+
+            result = adapter.delete_user("user-123")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data is True
+
+
+class TestGetUserId:
+    """GetUserId via AlternateIdentifier userName lookup returns UserId."""
+
+    def test_get_user_id_success_by_username(self) -> None:
+        """GetUserId with userName AlternateIdentifier returns UserId."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "get_user_id",
+                {"UserId": "user-789"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "AlternateIdentifier": {
+                        "UniqueAttribute": {
+                            "AttributePath": "userName",
+                            "AttributeValue": "alice@example.com",
+                        }
+                    },
+                },
+            )
+
+            result = adapter.get_user_id("alice@example.com")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "user-789"
+
+
+class TestDescribeUser:
+    """DescribeUser returns the user dict without ResponseMetadata and IdentityStoreId."""
+
+    def test_describe_user_success_stripped_dict(self) -> None:
+        """DescribeUser returns the response dict minus ResponseMetadata and IdentityStoreId."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "describe_user",
+                {
+                    "UserId": "user-789",
+                    "UserName": "alice@example.com",
+                    "Name": {"GivenName": "Alice", "FamilyName": "Smith"},
+                    "IdentityStoreId": "d-1234567890",
+                    "ResponseMetadata": {"RequestId": "abc123"},
+                },
+                expected_params={"IdentityStoreId": "d-1234567890", "UserId": "user-789"},
+            )
+
+            result = adapter.describe_user("user-789")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == {
+            "UserId": "user-789",
+            "UserName": "alice@example.com",
+            "Name": {"GivenName": "Alice", "FamilyName": "Smith"},
+        }
+
+
+class TestListUsers:
+    """ListUsers paginates through Users and only passes Filters when given."""
+
+    def test_list_users_success_single_page(self) -> None:
+        """ListUsers flattens single page."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_users",
+                {
+                    "Users": [
+                        {"UserId": "user-1", "UserName": "alice@example.com"},
+                        {"UserId": "user-2", "UserName": "bob@example.com"},
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+
+            result = adapter.list_users()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert len(result.data) == 2
+        assert result.data[0]["UserId"] == "user-1"
+        assert result.data[1]["UserId"] == "user-2"
+
+    def test_list_users_pagination_two_pages(self) -> None:
+        """ListUsers flattens users across two pages via NextToken."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            paginator = stub.client.get_paginator("list_users")
+            paginator.paginate = lambda **kwargs: [
+                {
+                    "Users": [{"UserId": "user-1", "UserName": "alice@example.com"}],
+                    "NextToken": "token123",
+                },
+                {"Users": [{"UserId": "user-2", "UserName": "bob@example.com"}]},
+            ]
+            stub.client.get_paginator = lambda op: paginator if op == "list_users" else None
+
+            _ = adapter.list_users()
+
+            # For paginator-based tests, we verify the structure after paginate completes
+        # Note: Stubber works with low-level pagination; for high-level paginate,
+        # we're testing the pagination logic directly via the real paginator interface.
+
+    def test_list_users_with_filters(self) -> None:
+        """ListUsers includes Filters parameter only when filters are provided."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        filters = [{"AttributePath": "name.givenName", "AttributeValue": "Alice"}]
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_users",
+                {"Users": [{"UserId": "user-1", "UserName": "alice@example.com"}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "Filters": filters,
+                },
+            )
+
+            result = adapter.list_users(filters=filters)
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+
+
+class TestGetGroupId:
+    """GetGroupId via AlternateIdentifier displayName lookup returns GroupId."""
+
+    def test_get_group_id_success_by_displayname(self) -> None:
+        """GetGroupId with displayName AlternateIdentifier returns GroupId."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "get_group_id",
+                {"GroupId": "group-123"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "AlternateIdentifier": {
+                        "UniqueAttribute": {
+                            "AttributePath": "displayName",
+                            "AttributeValue": "Admins",
+                        }
+                    },
+                },
+            )
+
+            result = adapter.get_group_id("Admins")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "group-123"
+
+
+class TestListGroups:
+    """ListGroups paginates through Groups and only passes Filters when given."""
+
+    def test_list_groups_success_single_page(self) -> None:
+        """ListGroups flattens single page."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {
+                    "Groups": [
+                        {"GroupId": "group-1", "DisplayName": "Admins"},
+                        {"GroupId": "group-2", "DisplayName": "Users"},
+                    ]
+                },
+                expected_params={"IdentityStoreId": "d-1234567890"},
+            )
+
+            result = adapter.list_groups()
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert len(result.data) == 2
+        assert result.data[0]["GroupId"] == "group-1"
+
+    def test_list_groups_with_filters(self) -> None:
+        """ListGroups includes Filters parameter only when filters are provided."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        filters = [{"AttributePath": "displayName", "AttributeValue": "Admins"}]
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_groups",
+                {"Groups": [{"GroupId": "group-1", "DisplayName": "Admins"}]},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "Filters": filters,
+                },
+            )
+
+            result = adapter.list_groups(filters=filters)
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+
+
+class TestCreateGroupMembership:
+    """CreateGroupMembership uses the no-retry client and returns MembershipId."""
+
+    def test_create_group_membership_success_returns_membership_id(self) -> None:
+        """CreateGroupMembership with UserId MemberId returns MembershipId."""
+        no_retry_client = _identitystore_client()
+        std_client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=std_client,
+            identitystore_no_retry=no_retry_client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(no_retry_client) as stub:
+            stub.add_response(
+                "create_group_membership",
+                {"MembershipId": "membership-789"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "group-123",
+                    "MemberId": {"UserId": "user-456"},
+                },
+            )
+
+            result = adapter.create_group_membership("group-123", "user-456")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "membership-789"
+
+
+class TestDeleteGroupMembership:
+    """DeleteGroupMembership returns True on success."""
+
+    def test_delete_group_membership_success_returns_true(self) -> None:
+        """DeleteGroupMembership succeeds and returns True."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "delete_group_membership",
+                {},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "MembershipId": "membership-789",
+                },
+            )
+
+            result = adapter.delete_group_membership("membership-789")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data is True
+
+
+class TestGetGroupMembershipId:
+    """GetGroupMembershipId with UserId MemberId returns MembershipId."""
+
+    def test_get_group_membership_id_success(self) -> None:
+        """GetGroupMembershipId returns the MembershipId."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "get_group_membership_id",
+                {"MembershipId": "membership-999"},
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "group-123",
+                    "MemberId": {"UserId": "user-456"},
+                },
+            )
+
+            result = adapter.get_group_membership_id("group-123", "user-456")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "membership-999"
+
+
+class TestListGroupMemberships:
+    """ListGroupMemberships paginates through GroupMemberships."""
+
+    def test_list_group_memberships_success_single_page(self) -> None:
+        """ListGroupMemberships flattens single page."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_response(
+                "list_group_memberships",
+                {
+                    "GroupMemberships": [
+                        {"MembershipId": "m-1", "MemberId": {"UserId": "user-1"}},
+                        {"MembershipId": "m-2", "MemberId": {"UserId": "user-2"}},
+                    ]
+                },
+                expected_params={
+                    "IdentityStoreId": "d-1234567890",
+                    "GroupId": "group-123",
+                },
+            )
+
+            result = adapter.list_group_memberships("group-123")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert len(result.data) == 2
+        assert result.data[0]["MembershipId"] == "m-1"
+
+
+class TestErrorClassification:
+    """Errors are classified via classify_aws_error; unmapped errors propagate."""
+
+    def test_resource_not_found_classification(self) -> None:
+        """ResourceNotFoundException maps to NOT_FOUND."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_client_error(
+                "get_user_id",
+                service_error_code="ResourceNotFoundException",
+                http_status_code=404,
+            )
+
+            result = adapter.get_user_id("nonexistent@example.com")
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.NOT_FOUND
+        assert result.error_code == "ResourceNotFoundException"
+
+    def test_access_denied_classification(self) -> None:
+        """AccessDeniedException maps to UNAUTHORIZED."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_client_error(
+                "list_users",
+                service_error_code="AccessDeniedException",
+                http_status_code=403,
+            )
+
+            result = adapter.list_users()
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.UNAUTHORIZED
+        assert result.error_code == "AccessDeniedException"
+
+    def test_throttling_classification_with_retry_after(self) -> None:
+        """ThrottlingException maps to TRANSIENT_ERROR with retry_after=60."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_client_error(
+                "delete_user",
+                service_error_code="ThrottlingException",
+                http_status_code=429,
+            )
+
+            result = adapter.delete_user("user-123")
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "ThrottlingException"
+        assert result.retry_after == 60
+
+    def test_conflict_exception_on_create_user_is_permanent(self) -> None:
+        """ConflictException on create_user maps to PERMANENT_ERROR."""
+        no_retry_client = _identitystore_client()
+        std_client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=std_client,
+            identitystore_no_retry=no_retry_client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(no_retry_client) as stub:
+            stub.add_client_error(
+                "create_user",
+                service_error_code="ConflictException",
+                http_status_code=409,
+            )
+
+            result = adapter.create_user("alice@example.com", "Alice", "Smith")
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "ConflictException"
+
+    def test_conflict_exception_on_create_group_membership_is_permanent(self) -> None:
+        """ConflictException on create_group_membership maps to PERMANENT_ERROR."""
+        no_retry_client = _identitystore_client()
+        std_client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=std_client,
+            identitystore_no_retry=no_retry_client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(no_retry_client) as stub:
+            stub.add_client_error(
+                "create_group_membership",
+                service_error_code="ConflictException",
+                http_status_code=409,
+            )
+
+            result = adapter.create_group_membership("group-123", "user-456")
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.PERMANENT_ERROR
+        assert result.error_code == "ConflictException"
+
+    def test_botocore_connection_error_is_transient(self) -> None:
+        """BotoCoreError (EndpointConnectionError) maps to TRANSIENT_ERROR."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            # Monkeypatch the client method to raise an endpoint error
+            def raise_endpoint_error(*args: Any, **kwargs: Any) -> None:
+                raise EndpointConnectionError(endpoint_url="https://identitystore.ca-central-1.amazonaws.com")
+
+            stub.client.list_groups = raise_endpoint_error
+
+            result = adapter.list_groups()
+
+            stub.assert_no_pending_responses()
+
+        assert result.status == OperationStatus.TRANSIENT_ERROR
+        assert result.error_code == "EndpointConnectionError"
+
+    def test_unmapped_client_error_propagates(self) -> None:
+        """ValidationException (unmapped) propagates as ClientError."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+            stub.add_client_error(
+                "delete_user",
+                service_error_code="ValidationException",
+                http_status_code=400,
+            )
+
+            with pytest.raises(ClientError) as excinfo:
+                adapter.delete_user("invalid")
+
+            stub.assert_no_pending_responses()
+
+        assert excinfo.value.response["Error"]["Code"] == "ValidationException"
+
+    def test_programmer_error_propagates(self) -> None:
+        """Non-ClientError exceptions (e.g., KeyError) propagate unchanged."""
+        client = _identitystore_client()
+        adapter = IdentityCenterAdapter(
+            identitystore=client,
+            identitystore_no_retry=client,
+            identity_store_id="d-1234567890",
+        )
+
+        with Stubber(client) as stub:
+
+            def raise_key_error(*args: Any, **kwargs: Any) -> None:
+                raise KeyError("missing_key")
+
+            stub.client.describe_user = raise_key_error
+
+            with pytest.raises(KeyError):
+                adapter.describe_user("user-123")
+
+            stub.assert_no_pending_responses()

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
@@ -211,7 +211,7 @@ class TestBuildIdentityCenterAdapter:
                 # Only register on no_retry_stub
                 no_retry_stub.add_response(
                     "create_user",
-                    {"UserId": "user-123"},
+                    {"UserId": "user-123", "IdentityStoreId": "d-1234567890"},
                     expected_params={
                         "IdentityStoreId": "d-1234567890",
                         "UserName": "test@example.com",
@@ -255,7 +255,7 @@ class TestBuildIdentityCenterAdapter:
                 # Only register on std_stub
                 std_stub.add_response(
                     "get_user_id",
-                    {"UserId": "user-789"},
+                    {"UserId": "user-789", "IdentityStoreId": "d-1234567890"},
                     expected_params={
                         "IdentityStoreId": "d-1234567890",
                         "AlternateIdentifier": {
@@ -301,7 +301,7 @@ class TestBuildIdentityCenterAdapter:
                 # Only register on no_retry_stub
                 no_retry_stub.add_response(
                     "create_group_membership",
-                    {"MembershipId": "membership-123"},
+                    {"MembershipId": "membership-123", "IdentityStoreId": "d-1234567890"},
                     expected_params={
                         "IdentityStoreId": "d-1234567890",
                         "GroupId": "group-456",

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
@@ -1,0 +1,293 @@
+"""Behavior tests for build_identity_center_adapter and client routing.
+
+The provider is monkeypatched to record get_aws_client calls and verify routing:
+two calls to get_aws_client('identitystore', ...), the second with retries=False.
+Environment variables AWS_SSO_INSTANCE_ID and AWS_ORG_ACCOUNT_ROLE_ARN are set
+and get_aws_settings cache is cleared before and after. The adapter receives
+two Stubbers: create_user and create_group_membership use the no-retry client,
+get_user_id uses the standard-retry client. Both clients assert no pending
+responses.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+from integrations.aws.settings import get_aws_settings
+from packages.aws_platform.adapters.identity_center import build_identity_center_adapter
+
+pytestmark = pytest.mark.unit
+
+
+def _identitystore_client() -> Any:
+    """Build a real boto3 identitystore client with dummy static credentials."""
+    return boto3.client(
+        "identitystore",
+        region_name="ca-central-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+
+
+class TestBuildIdentityCenterAdapter:
+    """build_identity_center_adapter routes clients and reads settings."""
+
+    @pytest.fixture(autouse=True)
+    def clear_settings_cache(self) -> None:
+        """Clear settings cache before and after each test."""
+        get_aws_settings.cache_clear()
+        yield
+        get_aws_settings.cache_clear()
+
+    def test_two_get_aws_client_calls_standard_and_no_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """build_identity_center_adapter calls get_aws_client twice: standard and no-retry."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        get_aws_client_calls: list[dict[str, Any]] = []
+
+        def record_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            get_aws_client_calls.append(
+                {
+                    "service_name": service_name,
+                    "role_arn": role_arn,
+                    "session_name": session_name,
+                    "retries": retries,
+                }
+            )
+            return _identitystore_client()
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=record_get_aws_client,
+        ):
+            _ = build_identity_center_adapter()
+
+        assert len(get_aws_client_calls) == 2
+        # First call: standard retry
+        assert get_aws_client_calls[0]["service_name"] == "identitystore"
+        assert get_aws_client_calls[0]["role_arn"] == "arn:aws:iam::123456789012:role/org-role"
+        assert get_aws_client_calls[0]["retries"] is True
+
+        # Second call: no retry
+        assert get_aws_client_calls[1]["service_name"] == "identitystore"
+        assert get_aws_client_calls[1]["role_arn"] == "arn:aws:iam::123456789012:role/org-role"
+        assert get_aws_client_calls[1]["retries"] is False
+
+    def test_role_arn_from_service_role_map(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Role ARN is read from SERVICE_ROLE_MAP['identitystore']."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        get_aws_client_calls: list[dict[str, Any]] = []
+
+        def record_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            get_aws_client_calls.append({"role_arn": role_arn})
+            return _identitystore_client()
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=record_get_aws_client,
+        ):
+            _ = build_identity_center_adapter()
+
+        # Both calls should have the role ARN from SERVICE_ROLE_MAP
+        assert get_aws_client_calls[0]["role_arn"] == "arn:aws:iam::123456789012:role/org-role"
+        assert get_aws_client_calls[1]["role_arn"] == "arn:aws:iam::123456789012:role/org-role"
+
+    def test_role_arn_none_when_setting_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Role ARN is None when AWS_ORG_ACCOUNT_ROLE_ARN is empty."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "")
+
+        get_aws_client_calls: list[dict[str, Any]] = []
+
+        def record_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            get_aws_client_calls.append({"role_arn": role_arn})
+            return _identitystore_client()
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=record_get_aws_client,
+        ):
+            _ = build_identity_center_adapter()
+
+        # Both calls should have None role ARN
+        assert get_aws_client_calls[0]["role_arn"] is None
+        assert get_aws_client_calls[1]["role_arn"] is None
+
+    def test_identity_store_id_from_aws_sso_instance_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """IdentityStoreId is read from AWS_SSO_INSTANCE_ID."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-9876543210")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        def stub_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            return _identitystore_client()
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=stub_get_aws_client,
+        ):
+            adapter = build_identity_center_adapter()
+
+        # Verify the adapter has the correct IdentityStoreId
+        assert adapter._identity_store_id == "d-9876543210"
+
+    def test_create_user_uses_no_retry_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CreateUser is sent through the no-retry client."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        std_client = _identitystore_client()
+        no_retry_client = _identitystore_client()
+
+        def stub_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            return std_client if retries else no_retry_client
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=stub_get_aws_client,
+        ):
+            adapter = build_identity_center_adapter()
+
+            with Stubber(std_client) as std_stub, Stubber(no_retry_client) as no_retry_stub:
+                # Only register on no_retry_stub
+                no_retry_stub.add_response(
+                    "create_user",
+                    {"UserId": "user-123"},
+                    expected_params={
+                        "IdentityStoreId": "d-1234567890",
+                        "UserName": "test@example.com",
+                        "Emails": [{"Value": "test@example.com", "Type": "WORK", "Primary": True}],
+                        "Name": {"GivenName": "Test", "FamilyName": "User"},
+                        "DisplayName": "Test User",
+                    },
+                )
+
+                result = adapter.create_user("test@example.com", "Test", "User")
+
+                no_retry_stub.assert_no_pending_responses()
+                std_stub.assert_no_pending_responses()
+
+        assert result.is_success
+
+    def test_get_user_id_uses_standard_retry_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GetUserId is sent through the standard-retry client."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        std_client = _identitystore_client()
+        no_retry_client = _identitystore_client()
+
+        def stub_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            return std_client if retries else no_retry_client
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=stub_get_aws_client,
+        ):
+            adapter = build_identity_center_adapter()
+
+            with Stubber(std_client) as std_stub, Stubber(no_retry_client) as no_retry_stub:
+                # Only register on std_stub
+                std_stub.add_response(
+                    "get_user_id",
+                    {"UserId": "user-789"},
+                    expected_params={
+                        "IdentityStoreId": "d-1234567890",
+                        "AlternateIdentifier": {
+                            "UniqueAttribute": {
+                                "AttributePath": "userName",
+                                "AttributeValue": "test@example.com",
+                            }
+                        },
+                    },
+                )
+
+                result = adapter.get_user_id("test@example.com")
+
+                std_stub.assert_no_pending_responses()
+                no_retry_stub.assert_no_pending_responses()
+
+        assert result.is_success
+
+    def test_create_group_membership_uses_no_retry_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CreateGroupMembership is sent through the no-retry client."""
+        monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-1234567890")
+        monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        std_client = _identitystore_client()
+        no_retry_client = _identitystore_client()
+
+        def stub_get_aws_client(
+            service_name: str,
+            *,
+            role_arn: str | None = None,
+            session_name: str = "sre-bot",
+            retries: bool = True,
+        ) -> Any:
+            return std_client if retries else no_retry_client
+
+        with patch(
+            "packages.aws_platform.adapters.identity_center.get_aws_client",
+            side_effect=stub_get_aws_client,
+        ):
+            adapter = build_identity_center_adapter()
+
+            with Stubber(std_client) as std_stub, Stubber(no_retry_client) as no_retry_stub:
+                # Only register on no_retry_stub
+                no_retry_stub.add_response(
+                    "create_group_membership",
+                    {"MembershipId": "membership-123"},
+                    expected_params={
+                        "IdentityStoreId": "d-1234567890",
+                        "GroupId": "group-456",
+                        "MemberId": {"UserId": "user-789"},
+                    },
+                )
+
+                result = adapter.create_group_membership("group-456", "user-789")
+
+                no_retry_stub.assert_no_pending_responses()
+                std_stub.assert_no_pending_responses()
+
+        assert result.is_success

--- a/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
+++ b/app/tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py
@@ -9,6 +9,7 @@ get_user_id uses the standard-retry client. Both clients assert no pending
 responses.
 """
 
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
@@ -36,7 +37,7 @@ class TestBuildIdentityCenterAdapter:
     """build_identity_center_adapter routes clients and reads settings."""
 
     @pytest.fixture(autouse=True)
-    def clear_settings_cache(self) -> None:
+    def clear_settings_cache(self) -> Iterator[None]:
         """Clear settings cache before and after each test."""
         get_aws_settings.cache_clear()
         yield
@@ -138,9 +139,16 @@ class TestBuildIdentityCenterAdapter:
         assert get_aws_client_calls[1]["role_arn"] is None
 
     def test_identity_store_id_from_aws_sso_instance_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """IdentityStoreId is read from AWS_SSO_INSTANCE_ID."""
+        """IdentityStoreId sent on the wire comes from AWS_SSO_INSTANCE_ID.
+
+        Stub strategy: the built adapter issues one GetUserId whose expected
+        params pin the IdentityStoreId, so the assertion is on the request the
+        SDK would send rather than on adapter internals.
+        """
         monkeypatch.setenv("AWS_SSO_INSTANCE_ID", "d-9876543210")
         monkeypatch.setenv("AWS_ORG_ACCOUNT_ROLE_ARN", "arn:aws:iam::123456789012:role/org-role")
+
+        client = _identitystore_client()
 
         def stub_get_aws_client(
             service_name: str,
@@ -149,7 +157,7 @@ class TestBuildIdentityCenterAdapter:
             session_name: str = "sre-bot",
             retries: bool = True,
         ) -> Any:
-            return _identitystore_client()
+            return client
 
         with patch(
             "packages.aws_platform.adapters.identity_center.get_aws_client",
@@ -157,8 +165,24 @@ class TestBuildIdentityCenterAdapter:
         ):
             adapter = build_identity_center_adapter()
 
-        # Verify the adapter has the correct IdentityStoreId
-        assert adapter._identity_store_id == "d-9876543210"
+        with Stubber(client) as stub:
+            stub.add_response(
+                "get_user_id",
+                {"UserId": "user-1", "IdentityStoreId": "d-9876543210"},
+                expected_params={
+                    "IdentityStoreId": "d-9876543210",
+                    "AlternateIdentifier": {
+                        "UniqueAttribute": {"AttributePath": "userName", "AttributeValue": "alice@example.com"}
+                    },
+                },
+            )
+
+            result = adapter.get_user_id("alice@example.com")
+
+            stub.assert_no_pending_responses()
+
+        assert result.is_success
+        assert result.data == "user-1"
 
     def test_create_user_uses_no_retry_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CreateUser is sent through the no-retry client."""

--- a/backlog/tasks/task-25.2 - Migrate-AWS-remainder-organizations-sso-admin-cost-explorer-config-guard-duty-security-hub-lambdas-legacy-identity-storedynamodb-off-integrations-aws-client.pys-dispatcher.md
+++ b/backlog/tasks/task-25.2 - Migrate-AWS-remainder-organizations-sso-admin-cost-explorer-config-guard-duty-security-hub-lambdas-legacy-identity-storedynamodb-off-integrations-aws-client.pys-dispatcher.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 15:56'
+updated_date: '2026-09-11 19:54'
 labels:
   - clients
   - phase-3
@@ -66,5 +66,15 @@ SEQUENCING. 25.2.1 characterization gate -> 25.2.2 client.py + settings consolid
 created: 2026-08-31 18:52
 ---
 Forward reference from TASK-23.2 planning (2026-08-31): the DynamoDB idempotency store keeps a conservative error-swallow on one path - a classified (mapped) SDK failure while re-reading a contended claim is downgraded to ClaimResult.IN_PROGRESS rather than raised. That was deliberately left as-is for TASK-23.2 and is flagged for reassessment during this AWS-remainder work, alongside the same question for other classify-and-continue call sites.
+---
+
+created: 2026-09-11 19:48
+---
+2026-09-11 finding from TASK-25.2.3.1's full-suite run: since TASK-25.2.2 made AssumeRole eager, app startup (lifespan -> plugin manager -> packages/access/sync providers -> build_aws_identity_center_adapter -> get_aws_client('identitystore', role_arn=ORG_ROLE_ARN)) performs a real sts.assume_role whenever AWS_ORG_ACCOUNT_ROLE_ARN is set. In this devcontainer (role ARNs exported, compose dummy keys) that raises InvalidClientTokenId and errors 32 API/e2e tests that build the app through TestClient; .github/workflows/ci_code.yml:72 also injects AWS_ORG_ACCOUNT_ROLE_ARN from secrets, so CI may hit the same startup call. Not caused by and not fixed in 25.2.3.1. Candidate follow-up: make the access-sync adapter build lazily (at first sync) or stub STS in the app-startup test fixtures; the access feature is not enabled so a lazy build has no runtime cost.
+---
+
+created: 2026-09-11 19:54
+---
+2026-09-11 correction to the previous comment (human challenged the attribution): the AssumeRole at app startup is not a devcontainer-only artefact. pytest-env pins AWS_ORG_ACCOUNT_ROLE_ARN to a placeholder for every test run, and app/.env's ACCESS_SYNC_ENABLED=true is read by pydantic env_file during tests, so any developer with that .env line gets 32 startup errors in the api/e2e/app-state tests since TASK-25.2.2 made AssumeRole eager. CI does not enable access sync, so CI is unaffected. Root gaps are in test isolation, not in 25.2.2's design: (1) settings read the developer's real .env under pytest, so feature toggles leak into tests; (2) the app-startup fixtures stub the directory provider but not the AWS boundary, so a warmup can reach STS. Proposed tests-only fix: pin ACCESS_SYNC_ENABLED=false in pytest-env (tests that need the feature enable it explicitly) and add an autouse fixture in the startup-test conftests that patches integrations.aws.client._assume_role_credentials, plus optionally a no-network guard. Awaiting the human's decision on where to track it.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
+++ b/backlog/tasks/task-25.2.3 - Migrate-AWS-Lambda-integration-off-execute_aws_api_call-delete-integrations-aws-sqs.py.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-07-31 18:48'
-updated_date: '2026-09-11 16:19'
+updated_date: '2026-09-11 19:20'
 labels:
   - clients
   - phase-3
@@ -54,5 +54,10 @@ packages/access/sync/adapters/aws_identity_center.py is not reused: it exposes p
 created: 2026-09-11 16:19
 ---
 2026-09-11: three defects surfaced by the TASK-25.2.1 characterization pass were assigned here as explicit ACs (unreachable 'not registered' branch, revoke job forwarding False, dead request_aws_account_access with shifted positional args) so they are fixed or deleted deliberately when these call sites move to OperationResult, rather than pinned forever.
+---
+
+created: 2026-09-11 19:20
+---
+2026-09-11 planning: split under the single-PR size gate (estimate ~12 production files mixing new adapter code, a behaviour-changing caller migration and a 379-line deletion). 25.2.3 stays the coordinator with its ACs unchanged: AC#1 and AC#4 are delivered by TASK-25.2.3.1 (adapter + Stubber tests + ConflictException mapping, on branch feat/aws_identity_center_adapter); AC#2, #3, #5, #6, #7 by TASK-25.2.3.2 (caller migration, defect resolution, deletion, baseline pruning). Human decisions recorded on the subtasks: retries=False client for the two creates; ConflictException -> PERMANENT_ERROR; healthcheck = single-page ListUsers succeeds; provider build_identity_center_adapter() in the adapter module; failed bulk listings raise the module-local Directory*UnavailableError; access_view_handler reuses the existing 'Failed to provision' reply for non-NOT_FOUND failures; revoke job logs and skips on any non-success. Finding: tests/integration/integrations/aws/test_identity_store_conformance.py targets packages/access's adapter via moto and never imports the legacy module, so it is not orphaned and stays untouched.
 ---
 <!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
+++ b/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
@@ -1,0 +1,103 @@
+---
+id: TASK-25.2.3.1
+title: >-
+  Build the Identity Center adapter with Stubber tests; map ConflictException in
+  classify_aws_error
+status: To Do
+assignee: []
+created_date: '2026-09-11 19:18'
+updated_date: '2026-09-11 19:20'
+labels:
+  - clients
+  - phase-3
+milestone: m-3
+dependencies:
+  - TASK-25.2.2
+references:
+  - app/integrations/aws/identity_store.py
+  - app/integrations/aws/client.py
+  - app/integrations/aws/settings.py
+  - app/packages/access/sync/adapters/aws_identity_center.py
+  - decisions/outbound-clients.md
+  - decisions/sdk-typing.md
+  - decisions/feature-packages.md
+parent_task_id: TASK-25.2.3
+priority: high
+ordinal: 192000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 1 (expand) of TASK-25.2.3, split 2026-09-11 under the single-PR size gate (the combined task estimated ~12 production files mixing new code, a behaviour-changing caller migration and a deletion). Nothing consumes the adapter yet; TASK-25.2.3.2 migrates the callers and deletes the legacy module.
+
+Create packages/aws_platform/adapters/identity_center.py: IdentityCenterAdapter holds typed identitystore clients from get_aws_client("identitystore", role_arn=...), reads IdentityStoreId from AWSSettings.INSTANCE_ID, exposes the thirteen operations the legacy callers use (healthcheck, create_user, delete_user, get_user_id, describe_user, list_users, get_group_id, list_groups, create_group_membership, delete_group_membership, get_group_membership_id, list_group_memberships, list_groups_with_memberships), paginates through client.get_paginator, wraps each SDK call in try/except + classify_aws_error and returns OperationResult. build_identity_center_adapter() is the provider (mirrors packages/access's build_aws_identity_center_adapter; clients carry eagerly assumed credentials, so callers build the adapter at function entry, never at import time).
+
+Human decisions 2026-09-11: create_user and create_group_membership use a retries=False client (no client token on those APIs); every other operation uses the standard-retry client. ConflictException (entity already exists, an expected sync outcome) is mapped to PERMANENT_ERROR in classify_aws_error next to ConditionalCheckFailedException. healthcheck means "a single-page ListUsers succeeds" (an empty store is healthy). The groups-with-memberships join keeps its legacy semantics (group filters, user details merged into MemberId, per-group membership failures logged and skipped, tolerate_errors kept); the filter step is a one-line comprehension inside the adapter rather than an import of utils.filters, because packages/ imports nothing from utils today.
+
+packages/aws_platform is the provisional transition seam described in TASK-25.2 (dissolved by TASK-88): empty __init__.py files, no hookimpls, no entry-point, no settings.py, no business logic beyond the join the callers already need.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 packages/aws_platform/adapters/identity_center.py defines IdentityCenterAdapter exposing healthcheck, create_user, delete_user, get_user_id, describe_user, list_users, get_group_id, list_groups, create_group_membership, delete_group_membership, get_group_membership_id, list_group_memberships and list_groups_with_memberships, each returning OperationResult; ClientError/BotoCoreError go through classify_aws_error and any other exception propagates
+- [ ] #2 build_identity_center_adapter() constructs clients only through get_aws_client('identitystore', role_arn=SERVICE_ROLE_MAP['identitystore'] or None), reads IdentityStoreId from AWSSettings.INSTANCE_ID, and hands create_user and create_group_membership a retries=False client while every other operation uses the standard-retry client; no boto3 construction and no cast in the adapter
+- [ ] #3 list_users, list_groups and list_group_memberships paginate through client.get_paginator; list_groups_with_memberships keeps the legacy join semantics (group filters applied, user details merged into MemberId, per-group membership failures logged and skipped, tolerate_errors preserved) and returns a failed list_groups or list_users as its own failure result
+- [ ] #4 healthcheck returns a success result iff a single-page list_users call (MaxResults=1) succeeds
+- [ ] #5 classify_aws_error maps ConflictException to PERMANENT_ERROR, covered by a test alongside the existing mapped families in tests/unit/integrations/aws/test_aws_client_classify_error.py
+- [ ] #6 botocore Stubber unit tests under tests/unit/packages/aws_platform/ cover each operation's success path with expected params (IdentityStoreId on every call), pagination across two pages, the join cases, and the classification paths NOT_FOUND, UNAUTHORIZED, transient with retry_after, ConflictException permanent, BotoCoreError transient and an unmapped ClientError propagating; provider tests assert which client each write uses
+- [ ] #7 No production caller changes and integrations/aws/identity_store.py is untouched; ruff, mypy (no new errors) and pytest pass with output recorded; make check-sdk-typing and make check-vendor-package-contract pass with no baseline edits
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+GROUNDING (2026-09-11, re-grepped against current code after TASK-25.2.2 merged)
+- Legacy surface being mirrored (app/integrations/aws/identity_store.py, 379 lines, all through execute_aws_api_call + @handle_aws_api_errors, role_arn=settings.ORG_ROLE_ARN, IdentityStoreId=settings.INSTANCE_ID): healthcheck :29 (list_users truthy); create_user :49 (UserName=email, Emails=[{Value,Type=WORK,Primary=True}], Name={GivenName,FamilyName}, DisplayName="first last" -> UserId); delete_user :74 (-> True); get_user_id :96 (AlternateIdentifier.UniqueAttribute AttributePath "userName" -> UserId); describe_user :118 (response minus ResponseMetadata/IdentityStoreId); list_users :138 (paginated, key Users, optional Filters); get_group_id :148 (AttributePath "displayName" -> GroupId); list_groups :174 (paginated, key Groups, optional Filters); create_group_membership :194 (GroupId, MemberId={UserId} -> MembershipId); delete_group_membership :217 (-> True); get_group_membership_id :239 (-> MembershipId); list_group_memberships :259 (paginated, key GroupMemberships); list_groups_with_memberships :285-379 (list_groups, filter groups by callables, project groups to GroupId/DisplayName/Description/IdentityStoreId, list_users once, per group list_group_memberships with failures logged+skipped, merge the matching user dict into membership["MemberId"], missing user -> warning and break unless tolerate_errors, keep groups with memberships only).
+- Factory/classifier as shipped by 25.2.2: get_aws_client(service, *, role_arn=None, session_name="sre-bot", retries=True) client.py:138-161, identitystore overload :66-71, retries=False -> max_attempts 0 :166; classify_aws_error(exc) -> (OperationStatus, code, retry_after) client.py:196-221, re-raises unmapped codes at :221, ConditionalCheckFailedException hardcoded at :218. Settings: integrations/aws/settings.py get_aws_settings() :120 (lru_cache), INSTANCE_ID :101, SERVICE_ROLE_MAP :105-116 (identitystore -> ORG_ROLE_ARN), catalogues :56-93 (NOT_FOUND: ResourceNotFoundException...; UNAUTHORIZED: AccessDeniedException...; TRANSIENT: ThrottlingException... with TRANSIENT_RETRY_AFTER_SECONDS default 60).
+- Pattern to mirror: packages/access/sync/adapters/aws_identity_center.py _map_sdk_exception/_call/_paginate :105-128 and build_aws_identity_center_adapter :1216-1226 (settings -> SERVICE_ROLE_MAP.get("identitystore") or None -> get_aws_client -> adapter). OperationResult: infrastructure/operations/result.py:21-277 (.success/.error, is_success); OperationStatus: status.py:10-25.
+- Stubber precedent: tests/unit/integrations/aws/test_aws_client_assume_role.py:48-58 (real client + Stubber + expected_params + assert_no_pending_responses). Typed paginators exist in types_boto3_identitystore (client.pyi get_paginator overloads for list_users/list_groups/list_group_memberships), so no cast is needed.
+- Layout: packages/<pkg>/__init__.py and adapters/__init__.py are empty (packages/incident/drive); tests/unit/packages/<pkg>/__init__.py exists per package. packages/ imports nothing from utils today (rg), so the group filter step is an inline comprehension, not utils.filters.
+- Guards: bin/check_sdk_typing.py and bin/check_vendor_package_contract.py scan app/integrations only; a new module under packages/ cannot trip them and client.py stays baselined for execute_aws_api_call. mypy excludes tests/ and carries 87 pre-existing errors in untouched files (25.2.2 notes).
+- Pre-flight (dev environment, no repo change): the container was rebuilt; before trusting local mypy run `cd app && uv sync --locked` and confirm `uv run python -c "import types_boto3_identitystore"` resolves, as 25.2.2 found a stray boto3-stubs shadowing types-boto3.
+
+DESIGN DECISIONS (human, 2026-09-11)
+- Two clients per adapter instance: standard-retry for reads/deletes/gets, retries=False for create_user and create_group_membership (no client token on those APIs).
+- ConflictException -> PERMANENT_ERROR in classify_aws_error, hardcoded next to ConditionalCheckFailedException (not a settings catalogue).
+- healthcheck = single-page ListUsers(MaxResults=1) succeeds; empty store is healthy.
+- Provider is build_identity_center_adapter() in the adapter module; callers build at function entry (assumed credentials expire; nothing at import time).
+- Return shapes stay dict-based (the callers consume raw Identity Store dicts through provisioning helpers); no domain dataclass is introduced in this seam (TASK-88 owns the eventual capability package).
+
+SIZE ESTIMATE / GATE: 4 production files (packages/aws_platform/__init__.py 0 LOC, adapters/__init__.py 0 LOC, adapters/identity_center.py ~260 LOC, integrations/aws/client.py +2/-1) ~265 production LOC, one subsystem plus a two-line classifier edit; no caller changes. Under the single-PR gate. Tests ~450 LOC across three new files plus one case in an existing file.
+
+STEPS
+1. TDD first: write the failing tests (see TEST MATRIX) under tests/unit/packages/aws_platform/ (__init__.py empty) and the ConflictException case in tests/unit/integrations/aws/test_aws_client_classify_error.py next to test_conditional_check_failure_is_permanent. Run them; they fail on ImportError / unmapped propagation. (AC#5, AC#6)
+2. app/integrations/aws/client.py:218: extend the permanent branch to `if code in ("ConditionalCheckFailedException", "ConflictException")`; docstring line notes Identity Store already-exists conflicts. Nothing else in client.py changes. (AC#5)
+3. Create app/packages/aws_platform/__init__.py and app/packages/aws_platform/adapters/__init__.py, both empty (module docstring only), no hookimpl, no entry-point line in pyproject.toml. (AC#1)
+4. Create app/packages/aws_platform/adapters/identity_center.py: (AC#1, AC#2, AC#3, AC#4)
+   - Imports: structlog; botocore.exceptions ClientError, BotoCoreError; collections.abc Callable, Mapping; typing TYPE_CHECKING, Any; infrastructure.operations OperationResult, OperationStatus; integrations.aws.client classify_aws_error, get_aws_client; integrations.aws.settings get_aws_settings; under TYPE_CHECKING: types_boto3_identitystore.client.IdentityStoreClient.
+   - class IdentityCenterAdapter.__init__(self, identitystore: IdentityStoreClient, identitystore_no_retry: IdentityStoreClient, identity_store_id: str).
+   - Helpers: _map_sdk_exception(exc) -> OperationResult.error(status, message=str(exc), error_code=..., retry_after=..., provider="aws", operation=name); _call(operation, fn) catching (ClientError, BotoCoreError) only; _paginate(operation, paginator_name, response_key, **kwargs) using self._identitystore.get_paginator(...) and flattening pages. Every other exception propagates.
+   - Operations, all keyword `IdentityStoreId=self._identity_store_id`: healthcheck() -> list_users(MaxResults=1) -> success(data=True); create_user(email, first_name, family_name) on the no-retry client, same payload as legacy :62-68, data=UserId; delete_user(user_id) data=True; get_user_id(user_name) AlternateIdentifier userName, data=UserId; describe_user(user_id) data=dict without ResponseMetadata/IdentityStoreId; list_users(filters=None) paginated Users (Filters only when given); get_group_id(group_name) AlternateIdentifier displayName, data=GroupId; list_groups(filters=None) paginated Groups; create_group_membership(group_id, user_id) on the no-retry client, data=MembershipId; delete_group_membership(membership_id) data=True; get_group_membership_id(group_id, user_id) data=MembershipId; list_group_memberships(group_id) paginated GroupMemberships.
+   - list_groups_with_memberships(groups_filters: list[Callable[[dict], bool]] | None = None, tolerate_errors: bool = False) -> OperationResult[list[dict]]: groups = self.list_groups(); non-success -> return it; empty -> success([]); apply each filter with a comprehension; project the four keys; users = self.list_users(); non-success -> return it; index users by UserId once (dict) instead of the legacy linear `next(...)`, same merge result; per group: memberships = self.list_group_memberships(group_id); non-success -> log error with status/error_code and skip the group (legacy: logged + continue); merge user details into membership["MemberId"]; missing user -> warning, error_occurred=True, break unless tolerate_errors; keep group only if memberships and (not error_occurred or tolerate_errors); return success(data=groups_with_memberships). Same structured log event names as legacy (aws_identity_store_*), so dashboards keep working.
+   - build_identity_center_adapter() -> IdentityCenterAdapter: settings = get_aws_settings(); role_arn = settings.SERVICE_ROLE_MAP.get("identitystore") or None; two get_aws_client("identitystore", role_arn=role_arn) calls, the second with retries=False; IdentityStoreId=settings.INSTANCE_ID.
+5. Verification gates from app/: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'` (zero errors in the new files; pre-existing count unchanged), `uv run pytest tests/unit/packages/aws_platform tests/unit/integrations/aws -q`, then the full `uv run pytest tests --ignore=tests/smoke`, `make check-sdk-typing`, `make check-vendor-package-contract`. Record outputs in notes. (AC#7)
+6. Notes: record that no caller was migrated, that identity_store.py is untouched, and the one classifier behaviour change (ConflictException now PERMANENT_ERROR for every classify_aws_error caller) for review.
+
+TEST MATRIX (file names per testing-standards; docstrings describe behaviour and stub strategy only)
+- tests/unit/packages/aws_platform/test_aws_platform_identity_center_operations.py — fixture builds a real boto3 identitystore client with dummy static credentials + region, wraps it in Stubber, and constructs IdentityCenterAdapter(client, client, "d-1234567890"). Per operation: success path with expected_params including IdentityStoreId and the exact legacy payload (create_user Emails/Name/DisplayName; get_user_id AttributePath userName; get_group_id AttributePath displayName; healthcheck MaxResults=1) and the data shape asserted (UserId / GroupId / MembershipId / True / stripped describe_user dict). Boundary: list_users, list_groups and list_group_memberships flatten two pages (NextToken) and pass Filters only when provided; healthcheck succeeds on an empty Users page. Failure/classification (add_client_error on one representative operation each, codes from the default catalogues): ResourceNotFoundException -> NOT_FOUND with error_code; AccessDeniedException -> UNAUTHORIZED; ThrottlingException -> TRANSIENT_ERROR with retry_after 60; ConflictException on create_user and create_group_membership -> PERMANENT_ERROR; BotoCoreError (monkeypatch the client method to raise botocore.exceptions.EndpointConnectionError) -> TRANSIENT_ERROR; ValidationException (unmapped) propagates as ClientError; a programmer error (KeyError from a monkeypatched method) propagates. Every test ends with assert_no_pending_responses.
+- tests/unit/packages/aws_platform/test_aws_platform_identity_center_groups_join.py — list_groups_with_memberships through Stubber: groups filtered by a callable; projection to the four keys; user details merged into MemberId; a group whose list_group_memberships fails is skipped while the rest are returned; a membership whose user is absent drops the group when tolerate_errors=False and keeps it when True; empty groups -> success([]); failed list_groups -> that failure result, no further calls; failed list_users -> that failure result.
+- tests/unit/packages/aws_platform/test_aws_platform_identity_center_provider.py — monkeypatch integrations.aws.client.get_aws_client through the adapter module namespace with a recorder: asserts exactly two calls, both service "identitystore" with role_arn from SERVICE_ROLE_MAP["identitystore"] (set via AWS_ORG_ACCOUNT_ROLE_ARN env + cache_clear), the second with retries=False, and None role_arn when the setting is empty; asserts IdentityStoreId from AWS_SSO_INSTANCE_ID; write routing: two Stubbers, create_user/create_group_membership responses registered only on the no-retry stub and get_user_id only on the standard stub, both assert_no_pending_responses.
+- tests/unit/integrations/aws/test_aws_client_classify_error.py — test_conflict_is_permanent: ConflictException -> (PERMANENT_ERROR, "ConflictException", None).
+
+AC TRACEABILITY: AC#1 -> steps 3-4, operations file; AC#2 -> step 4 provider, provider file; AC#3 -> step 4 paginate/join, operations + groups_join files; AC#4 -> step 4 healthcheck, operations file; AC#5 -> step 2, classify test; AC#6 -> step 1, all three files; AC#7 -> step 5.
+
+ASSUMPTIONS AND DOUBTS (verify during implementation)
+- Stubber validates params against the identitystore service model, so MaxResults=1 on ListUsers and the AlternateIdentifier shapes must be model-valid; if Stubber rejects a legacy payload, the legacy payload was already wrong and the adapter follows the model (record in notes).
+- types-boto3 identitystore get_paginator returns typed paginators whose page TypedDicts satisfy mypy without cast; verify with `uv run mypy app/packages/aws_platform`. Fallback is annotating the page loop with Mapping[str, Any], never cast.
+- The legacy ORG_ROLE_ARN was passed even when empty ("" -> assume_role_session skipped it); SERVICE_ROLE_MAP.get(...) or None reproduces that, as packages/access already does.
+- ConflictException mapping also changes packages/access's adapter (a raised conflict becomes a PERMANENT_ERROR result on ensure_user) and the DynamoDB stores (DynamoDB does not emit ConflictException, so no effect); the access feature is not enabled, noted for review only.
+- Devcontainer venv state after the rebuild may again shadow types-boto3; pre-flight above.
+
+BLAST RADIUS AND ROLLBACK: additive; no production caller imports the new package, so runtime behaviour is unchanged except the classifier mapping above. A single git revert of the PR restores the previous state. No config, env or manifest prerequisite. Ordering: 25.2.3.2 must not start until this merges.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
+++ b/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
@@ -3,11 +3,11 @@ id: TASK-25.2.3.1
 title: >-
   Build the Identity Center adapter with Stubber tests; map ConflictException in
   classify_aws_error
-status: In Progress
+status: Done
 assignee:
   - '@me'
 created_date: '2026-09-11 19:18'
-updated_date: '2026-09-11 19:34'
+updated_date: '2026-09-11 20:09'
 labels:
   - clients
   - phase-3
@@ -41,13 +41,14 @@ packages/aws_platform is the provisional transition seam described in TASK-25.2 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 packages/aws_platform/adapters/identity_center.py defines IdentityCenterAdapter exposing healthcheck, create_user, delete_user, get_user_id, describe_user, list_users, get_group_id, list_groups, create_group_membership, delete_group_membership, get_group_membership_id, list_group_memberships and list_groups_with_memberships, each returning OperationResult; ClientError/BotoCoreError go through classify_aws_error and any other exception propagates
-- [ ] #2 build_identity_center_adapter() constructs clients only through get_aws_client('identitystore', role_arn=SERVICE_ROLE_MAP['identitystore'] or None), reads IdentityStoreId from AWSSettings.INSTANCE_ID, and hands create_user and create_group_membership a retries=False client while every other operation uses the standard-retry client; no boto3 construction and no cast in the adapter
-- [ ] #3 list_users, list_groups and list_group_memberships paginate through client.get_paginator; list_groups_with_memberships keeps the legacy join semantics (group filters applied, user details merged into MemberId, per-group membership failures logged and skipped, tolerate_errors preserved) and returns a failed list_groups or list_users as its own failure result
-- [ ] #4 healthcheck returns a success result iff a single-page list_users call (MaxResults=1) succeeds
-- [ ] #5 classify_aws_error maps ConflictException to PERMANENT_ERROR, covered by a test alongside the existing mapped families in tests/unit/integrations/aws/test_aws_client_classify_error.py
-- [ ] #6 botocore Stubber unit tests under tests/unit/packages/aws_platform/ cover each operation's success path with expected params (IdentityStoreId on every call), pagination across two pages, the join cases, and the classification paths NOT_FOUND, UNAUTHORIZED, transient with retry_after, ConflictException permanent, BotoCoreError transient and an unmapped ClientError propagating; provider tests assert which client each write uses
-- [ ] #7 No production caller changes and integrations/aws/identity_store.py is untouched; ruff, mypy (no new errors) and pytest pass with output recorded; make check-sdk-typing and make check-vendor-package-contract pass with no baseline edits
+- [x] #1 packages/aws_platform/adapters/identity_center.py defines IdentityCenterAdapter exposing healthcheck, create_user, delete_user, get_user_id, describe_user, list_users, get_group_id, list_groups, create_group_membership, delete_group_membership, get_group_membership_id, list_group_memberships and list_groups_with_memberships, each returning OperationResult; ClientError/BotoCoreError go through classify_aws_error and any other exception propagates
+- [x] #2 build_identity_center_adapter() constructs clients only through get_aws_client('identitystore', role_arn=SERVICE_ROLE_MAP['identitystore'] or None), reads IdentityStoreId from AWSSettings.INSTANCE_ID, and hands create_user and create_group_membership a retries=False client while every other operation uses the standard-retry client; no boto3 construction and no cast in the adapter
+- [x] #3 list_users, list_groups and list_group_memberships paginate through client.get_paginator; list_groups_with_memberships keeps the legacy join semantics (group filters applied, user details merged into MemberId, per-group membership failures logged and skipped, tolerate_errors preserved) and returns a failed list_groups or list_users as its own failure result
+- [x] #4 healthcheck returns a success result iff a single-page list_users call (MaxResults=1) succeeds
+- [x] #5 classify_aws_error maps ConflictException to PERMANENT_ERROR, covered by a test alongside the existing mapped families in tests/unit/integrations/aws/test_aws_client_classify_error.py
+- [x] #6 botocore Stubber unit tests under tests/unit/packages/aws_platform/ cover each operation's success path with expected params (IdentityStoreId on every call), pagination across two pages, the join cases, and the classification paths NOT_FOUND, UNAUTHORIZED, transient with retry_after, ConflictException permanent, BotoCoreError transient and an unmapped ClientError propagating; provider tests assert which client each write uses
+- [x] #7 No production caller changes and integrations/aws/identity_store.py is untouched; ruff, mypy (no new errors) and pytest pass with output recorded; make check-sdk-typing and make check-vendor-package-contract pass with no baseline edits
+- [x] #8 Test isolation (folded in 2026-09-11 by human decision): pytest-env pins ACCESS_SYNC_ENABLED=false so a developer's .env cannot switch feature warmups on in tests, and an autouse fixture in the app-startup test conftests patches the AssumeRole seam so no test can reach STS; tests/api, tests/integration and the app-state/webhook e2e files pass without the 32 startup errors
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -106,6 +107,46 @@ BLAST RADIUS AND ROLLBACK: additive; no production caller imports the new packag
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-09-11 tests-first checkpoint (no production code changed). Added under app/tests/unit/packages/aws_platform/ (new __init__.py): test_aws_platform_identity_center_operations.py (27 tests: every operation's success path with Stubber expected_params incl. IdentityStoreId, two-page pagination for list_users/list_groups/list_group_memberships, Filters only when given, healthcheck MaxResults=1 on empty and non-empty pages, classification NOT_FOUND/UNAUTHORIZED/transient retry_after 60/ConflictException permanent on both creates/BotoCoreError transient, unmapped ValidationException and a KeyError propagating), test_aws_platform_identity_center_groups_join.py (10 tests: filters, four-key projection, user merge into MemberId, failed group skipped while the rest survive, missing user drop/keep by tolerate_errors, empty groups, failed list_groups/list_users returned as the failure), test_aws_platform_identity_center_provider.py (7 tests: two get_aws_client calls with the second retries=False, role_arn from AWS_ORG_ACCOUNT_ROLE_ARN or None when empty, IdentityStoreId from AWS_SSO_INSTANCE_ID proven on the wire, create_user/create_group_membership routed to the no-retry stub, get_user_id to the standard stub). Added test_conflict_is_permanent to tests/unit/integrations/aws/test_aws_client_classify_error.py.
-Evidence: `uv run ruff check` and `ruff format --check` clean on the new files. `uv run pytest tests/unit/packages/aws_platform tests/unit/integrations/aws/test_aws_client_classify_error.py -q` -> 3 collection errors (ModuleNotFoundError: packages.aws_platform) and test_conflict_is_permanent failing on the re-raised ClientError; `uv run pytest tests/unit/integrations/aws -q` -> 1 failed (that case), 132 passed. Review notes on the generated tests: replaced a lambda-patched paginator with real two-page Stubber responses, removed `from __future__ import annotations` from the new files (deprecated on 3.14), made the provider store-id test assert the request rather than a private attribute, and gave the skipped-group join test a surviving group so it proves selective skipping. Full suite deliberately not run at this checkpoint.
+2026-09-11 tests-first checkpoint (no production code changed). Added under app/tests/unit/packages/aws_platform/ (new __init__.py): test_aws_platform_identity_center_operations.py, test_aws_platform_identity_center_groups_join.py, test_aws_platform_identity_center_provider.py, plus test_conflict_is_permanent in tests/unit/integrations/aws/test_aws_client_classify_error.py. Review fixes applied to the generated tests: real two-page Stubber pagination instead of a lambda-patched paginator; removed `from __future__ import annotations` (deprecated on 3.14); provider store-id test asserts the request instead of a private attribute; skipped-group join test keeps a surviving group.
+
+2026-09-11 implementation complete (awaiting human review; not moved to Done).
+WHAT CHANGED
+- app/packages/aws_platform/__init__.py and adapters/__init__.py: empty namespace modules (docstring only), no hookimpl, no entry-point, no settings.py.
+- app/packages/aws_platform/adapters/identity_center.py (~270 LOC): IdentityCenterAdapter(identitystore, identitystore_no_retry, identity_store_id) with the thirteen operations returning OperationResult (provider="aws", operation=<name>), _call/_paginate helpers catching only ClientError/BotoCoreError and classifying through classify_aws_error (everything else propagates), get_paginator for the three list operations, healthcheck = ListUsers(MaxResults=1) succeeds, create_user and create_group_membership on the no-retry client, list_groups_with_memberships with the legacy join semantics (filters as an inline comprehension, four-key projection, users indexed by UserId once, failed membership listing logged and skipped, missing user drops the group unless tolerate_errors, groups without memberships omitted, failed list_groups/list_users returned as the failure) and the legacy aws_identity_store_* log event names. build_identity_center_adapter() builds both clients per call from get_aws_settings() (SERVICE_ROLE_MAP["identitystore"] or None, INSTANCE_ID). Two `# type: ignore[typeddict-item]` on AttributeValue, same stub over-narrowing packages/access already documents.
+- app/integrations/aws/client.py: ConflictException joins ConditionalCheckFailedException as PERMANENT_ERROR (one line + comment). No other production file touched; integrations/aws/identity_store.py untouched; no caller migrated.
+- Test fixtures corrected during implementation because botocore Stubber validates canned responses against the identitystore model: every User/Group/GroupMembership entry and every Get*/Create* response now carries the required IdentityStoreId; Group Description must be non-empty; Emails cannot be an empty list; a made-up ExtraField became the real CreatedBy member; the filter callable is case-insensitive so "Superadmins" is consumed; the projection and omitted-groups fixtures list the member user so the missing-user rule does not drop the group under test.
+EVIDENCE (from app/)
+- `uv run ruff check .` -> All checks passed!; `uv run ruff format --check .` -> 728 files already formatted.
+- `uv run mypy . --exclude '(?:^|/)\.venv(?:/|$)'` -> Found 87 errors in 31 files, identical to the pre-existing count recorded on TASK-25.2.2; `uv run mypy packages/aws_platform` -> Success: no issues found in 3 source files.
+- `uv run pytest tests/unit/packages/aws_platform tests/unit/integrations/aws/test_aws_client_classify_error.py -q` -> 63 passed (27 operations, 10 join, 7 provider, 19 classifier incl. the new case). `uv run pytest tests/unit/integrations/aws -q` -> 133 passed.
+- `make check-sdk-typing` -> OK (11 baselined files remain); `make check-vendor-package-contract` -> OK (29 baselined entries remain). No baseline edited.
+- `uv run pytest tests --ignore=tests/smoke -q` -> 3 failed, 3354 passed, 32 errors. AC#7 left UNCHECKED for the human because the suite is not green locally; both groups are pre-existing and independent of this slice:
+  (a) 32 errors, all `ClientError: InvalidClientTokenId when calling AssumeRole` raised during app startup in tests/api/routes/test_landing.py, tests/integration/test_app_state_initialization.py and tests/integration/webhooks/test_webhook_e2e.py. Mechanism (corrected 2026-09-11 after the human questioned the first attribution): pytest-env (pyproject.toml [tool.pytest.ini_options] env) pins the placeholder AWS_ORG_ACCOUNT_ROLE_ARN=AWS_ORG_ACCOUNT_ROLE_ARN for every test; app/.env sets ACCESS_SYNC_ENABLED=true and pydantic settings read .env through env_file, so the access-sync plugin's initialize hook (packages/access/sync/__init__.py:83) warms get_access_sync_coordinator -> build_aws_identity_center_adapter -> get_aws_client("identitystore", role_arn=<placeholder>) -> the eager sts.assume_role introduced by TASK-25.2.2 -> a real STS request that fails with the compose dummy keys. The startup fixtures (tests/integration/conftest.py app_with_lifespan, TestClient(server_app) in the api/e2e files) stub only the directory provider, not the AWS boundary. Before 25.2.2 the deferred credential provider hid this: no STS call happened at construction. CI does not set ACCESS_SYNC_ENABLED, so the warmup returns early there and the errors are local-only (any developer whose .env enables access sync). Nothing outside tests imports packages.aws_platform and the ConflictException branch is not on that path. Not fixed here (test-isolation gap, out of scope); see the comment on TASK-25.2.
+  (b) 3 failures in tests/unit/infrastructure/directory/test_google.py, the order-dependent state leak already documented in TASK-25.2.1 notes; the file passes alone (99 passed).
+BEHAVIOUR CHANGE TO REVIEW: classify_aws_error now returns PERMANENT_ERROR for ConflictException for every caller (packages/access ensure_user gets a result instead of a raised ClientError on an already-existing user; the DynamoDB stores never emit that code).
+REMAINING FOR HUMAN: PR review; decision on AC#7 given the pre-existing full-suite state; decide how the test-isolation gap (real .env leaking into tests, unstubbed STS at startup) is tracked.
 <!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-11 20:00
+---
+2026-09-11 test-isolation fix folded in (AC#8, human decision after challenging the first root-cause attribution).
+WHAT CHANGED (tests/config only)
+- app/pyproject.toml [tool.pytest.ini_options] env: added ACCESS_SYNC_ENABLED=false with a comment. Rationale: pydantic settings read app/.env via env_file under pytest, so a developer's ACCESS_SYNC_ENABLED=true switched the access-sync warmup on in the app-startup tests; pytest-env now pins it off and feature tests enable it explicitly (tests/unit/packages/access and tests/integration/packages/access already do).
+- app/tests/integration/conftest.py and new app/tests/api/conftest.py: autouse fixture patching integrations.aws.client._assume_role_credentials to return static temporary credentials, so no test that boots the lifespan can reach STS even when a feature warmup builds a role-assuming client. The seam's own tests (tests/unit/integrations/aws/test_aws_client_assume_role.py, tests/integrations/aws/test_legacy_aws_client.py) sit outside both trees and are unaffected.
+EVIDENCE (from app/)
+- `uv run ruff check .` -> All checks passed!; `ruff format --check .` -> 729 files already formatted.
+- `uv run pytest tests/api tests/integration/test_app_state_initialization.py tests/integration/webhooks -q` -> 62 passed (previously 32 errors).
+- `uv run pytest tests/unit/packages/access tests/integration/packages/access -q` -> 392 passed (the pin does not break feature tests).
+- Belt-and-braces proof: `ACCESS_SYNC_ENABLED=true uv run pytest -p no:env tests/integration/test_app_state_initialization.py -q` (pytest-env disabled, feature forced on) -> 7 passed, i.e. the AssumeRole stub alone keeps startup off the network.
+- `uv run pytest tests --ignore=tests/smoke -q` -> 6 failed, 3383 passed, 0 errors. The 6 are exactly the pre-existing order-dependent failures TASK-25.2.1 documented (3 in tests/modules/webhooks/test_webhooks_aws_sns.py, 3 in tests/unit/infrastructure/directory/test_google.py); each file passes alone (12 passed / 99 passed). AC#7 still left for the human on that basis.
+OBSERVATION for a possible follow-up (not changed): tests/integration/packages/access/sync/conftest.py strips ACCESS_SYNC_* from os.environ for isolation, which lets pydantic fall back to app/.env for those keys; the deeper fix for ".env leaks into tests" is to stop settings from reading env_file under pytest, which is a production settings change and out of this slice.
+---
+
+created: 2026-09-11 20:08
+---
+2026-09-11 AC#7 checked on the human's review: ruff clean, mypy at the pre-existing 87 errors with none in touched files, make test green (2564 + 825 passed), both guard checks OK with no baseline edits, no production caller changed and identity_store.py untouched. The six failures seen only in a single-process full run are the order-dependent leaks documented on TASK-25.2.1 and pass per file. Human reports 'aws groups sync sre' works locally; note that this command still uses the legacy integrations.aws.identity_store until TASK-25.2.3.2 migrates the callers, so it exercises the 25.2.2 client factory rather than the new adapter.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
+++ b/backlog/tasks/task-25.2.3.1 - Build-the-Identity-Center-adapter-with-Stubber-tests-map-ConflictException-in-classify_aws_error.md
@@ -3,10 +3,11 @@ id: TASK-25.2.3.1
 title: >-
   Build the Identity Center adapter with Stubber tests; map ConflictException in
   classify_aws_error
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@me'
 created_date: '2026-09-11 19:18'
-updated_date: '2026-09-11 19:20'
+updated_date: '2026-09-11 19:34'
 labels:
   - clients
   - phase-3
@@ -101,3 +102,10 @@ ASSUMPTIONS AND DOUBTS (verify during implementation)
 
 BLAST RADIUS AND ROLLBACK: additive; no production caller imports the new package, so runtime behaviour is unchanged except the classifier mapping above. A single git revert of the PR restores the previous state. No config, env or manifest prerequisite. Ordering: 25.2.3.2 must not start until this merges.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-09-11 tests-first checkpoint (no production code changed). Added under app/tests/unit/packages/aws_platform/ (new __init__.py): test_aws_platform_identity_center_operations.py (27 tests: every operation's success path with Stubber expected_params incl. IdentityStoreId, two-page pagination for list_users/list_groups/list_group_memberships, Filters only when given, healthcheck MaxResults=1 on empty and non-empty pages, classification NOT_FOUND/UNAUTHORIZED/transient retry_after 60/ConflictException permanent on both creates/BotoCoreError transient, unmapped ValidationException and a KeyError propagating), test_aws_platform_identity_center_groups_join.py (10 tests: filters, four-key projection, user merge into MemberId, failed group skipped while the rest survive, missing user drop/keep by tolerate_errors, empty groups, failed list_groups/list_users returned as the failure), test_aws_platform_identity_center_provider.py (7 tests: two get_aws_client calls with the second retries=False, role_arn from AWS_ORG_ACCOUNT_ROLE_ARN or None when empty, IdentityStoreId from AWS_SSO_INSTANCE_ID proven on the wire, create_user/create_group_membership routed to the no-retry stub, get_user_id to the standard stub). Added test_conflict_is_permanent to tests/unit/integrations/aws/test_aws_client_classify_error.py.
+Evidence: `uv run ruff check` and `ruff format --check` clean on the new files. `uv run pytest tests/unit/packages/aws_platform tests/unit/integrations/aws/test_aws_client_classify_error.py -q` -> 3 collection errors (ModuleNotFoundError: packages.aws_platform) and test_conflict_is_permanent failing on the re-raised ClientError; `uv run pytest tests/unit/integrations/aws -q` -> 1 failed (that case), 132 passed. Review notes on the generated tests: replaced a lambda-patched paginator with real two-page Stubber responses, removed `from __future__ import annotations` from the new files (deprecated on 3.14), made the provider store-id test assert the request rather than a private attribute, and gave the skipped-group join test a surviving group so it proves selective skipping. Full suite deliberately not run at this checkpoint.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25.2.3.2 - Migrate-the-eight-Identity-Center-callers-onto-the-adapter-resolve-the-three-characterized-defects-delete-integrations-aws-identity_store.py.md
+++ b/backlog/tasks/task-25.2.3.2 - Migrate-the-eight-Identity-Center-callers-onto-the-adapter-resolve-the-three-characterized-defects-delete-integrations-aws-identity_store.py.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-11 19:18'
+updated_date: '2026-09-11 20:09'
 labels:
   - clients
   - phase-3
@@ -54,3 +55,12 @@ Test files to retarget (patch build_identity_center_adapter / a fake adapter ins
 - [ ] #9 integrations/aws/identity_store.py and tests/integrations/aws/test_identity_store.py are deleted; the identity_store lines are removed from bin/baselines/sdk_typing_antipatterns.txt and bin/baselines/vendor_package_contract.txt; test_identity_store_conformance.py and packages/access are untouched
 - [ ] #10 ruff, mypy (no new errors), pytest, make check-sdk-typing and make check-vendor-package-contract pass with output recorded; a repo-wide grep shows zero references to integrations.aws.identity_store
 <!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-09-11 20:09
+---
+2026-09-11 carried over from TASK-25.2.3.1 for the caller migration: classify_aws_error now maps ConflictException to PERMANENT_ERROR (app/integrations/aws/client.py), where it previously propagated as a raised ClientError. When migrating each call site, account for that at every write that can conflict: create_user and create_group_membership in modules/aws/identity_center.py's provision_entities bridge (an 'already exists' conflict must be recorded as a failed entity and the sync must continue, matching the legacy False-swallow rather than aborting), and any other classify_aws_error consumer touched by the migration. Also verify packages/access's ensure_user path still behaves acceptably now that a conflict arrives as a result instead of an exception (the access feature is not enabled; document, do not rework). The per-call-site error-path notes required by AC#1 must state explicitly how a PERMANENT_ERROR conflict is handled at each site.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/task-25.2.3.2 - Migrate-the-eight-Identity-Center-callers-onto-the-adapter-resolve-the-three-characterized-defects-delete-integrations-aws-identity_store.py.md
+++ b/backlog/tasks/task-25.2.3.2 - Migrate-the-eight-Identity-Center-callers-onto-the-adapter-resolve-the-three-characterized-defects-delete-integrations-aws-identity_store.py.md
@@ -1,0 +1,56 @@
+---
+id: TASK-25.2.3.2
+title: >-
+  Migrate the eight Identity Center callers onto the adapter, resolve the three
+  characterized defects, delete integrations/aws/identity_store.py
+status: To Do
+assignee: []
+created_date: '2026-09-11 19:18'
+labels:
+  - clients
+  - phase-3
+milestone: m-3
+dependencies:
+  - TASK-25.2.3.1
+references:
+  - app/integrations/aws/identity_store.py
+  - app/modules/aws/identity_center.py
+  - app/modules/aws/aws.py
+  - app/modules/aws/aws_access_requests.py
+  - app/modules/aws/ops_group_assignment.py
+  - app/modules/provisioning/users.py
+  - app/modules/provisioning/groups.py
+  - app/modules/provisioning/entities.py
+  - app/jobs/revoke_aws_sso_access.py
+  - app/jobs/scheduled_tasks.py
+  - decisions/outbound-clients.md
+parent_task_id: TASK-25.2.3
+priority: high
+ordinal: 193000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Slice 2 (contract) of TASK-25.2.3, split 2026-09-11 under the single-PR size gate. Depends on TASK-25.2.3.1 (the adapter). Moves every production caller of integrations.aws.identity_store onto packages/aws_platform/adapters/identity_center.build_identity_center_adapter(), resolves the three defects the TASK-25.2.1 characterization pass pinned, deletes the legacy module and its 890-line test file, and prunes the two guard baselines.
+
+Callers (re-grepped 2026-09-11; eight files, ten call sites): modules/aws/identity_center.py (list_users at :70/:79; create_user/delete_user/create_group_membership/delete_group_membership passed as callables to entities.provision_entities at :155/:171/:261/:282/:329/:348), modules/aws/aws.py (:158 inside request_aws_account_access, dead), modules/aws/aws_access_requests.py (:194 get_user_id), modules/aws/ops_group_assignment.py (:20 get_group_id), modules/provisioning/users.py (:58 list_users), modules/provisioning/groups.py (:142 list_groups_with_memberships), jobs/revoke_aws_sso_access.py (:30 get_user_id), jobs/scheduled_tasks.py (:128 healthcheck).
+
+Human decisions 2026-09-11 on the error paths: bulk listings that fail raise the module-local DirectoryUsersUnavailableError / DirectoryGroupsUnavailableError (mirroring the Google branches) instead of crashing with TypeError; access_view_handler sends the existing "not registered with AWS SSO" reply on NOT_FOUND and falls to the existing "Failed to provision" reply on any other failure, never reaching already_has_access or create_account_assignment; the revoke job logs status/error_code, skips delete_account_assignment and expire_request for that request and continues (same outcome as today's exception path, made explicit); request_aws_account_access is deleted with its pinned tests; the healthcheck registration becomes lambda: build_identity_center_adapter().healthcheck().is_success. entities.provision_entities is not changed: it tests `if response:` and an OperationResult instance is always truthy, so modules/aws/identity_center.py wraps each adapter write in a small local bridge that maps the entity dict to adapter arguments and returns result.data on success or False (logged with status and error_code) on failure.
+
+Test files to retarget (patch build_identity_center_adapter / a fake adapter instead of the legacy module): tests/unit/modules/aws/{test_identity_center_handler,test_aws_access_requests_handler,test_aws_command_handler,test_ops_group_assignment_handler}.py, tests/unit/modules/provisioning/test_provisioning_users.py, tests/modules/provisioning/test_provisioning_groups.py, tests/unit/jobs/test_revoke_aws_sso_access.py, tests/integration/jobs/{test_revoke_aws_sso_access_integration,test_scheduled_tasks_integration}.py. tests/integration/integrations/aws/test_identity_store_conformance.py is NOT orphaned: it exercises moto against packages/access's adapter and never imports the legacy module, so it stays untouched. packages/access is not reworked.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The eight caller files no longer import integrations.aws.identity_store; each obtains the adapter through build_identity_center_adapter() at function entry and branches on OperationResult explicitly, with per-call-site error-path behaviour recorded in notes for review
+- [ ] #2 modules/aws/identity_center.py bridges entities.provision_entities with a local unwrap: each create/delete callable maps the entity dict to adapter arguments and returns result.data on success or False on a non-success (logged with status and error_code), so failed entities are still recorded as failed; provision_entities itself is unchanged
+- [ ] #3 synchronize and the AWS branches of provisioning/users.py and provisioning/groups.py raise DirectoryUsersUnavailableError / DirectoryGroupsUnavailableError carrying message and error_code when a listing fails; the pinned TypeError characterization tests are replaced by tests of the new contract
+- [ ] #4 access_view_handler: a NOT_FOUND get_user_id sends the existing 'not registered with AWS SSO' reply; any other non-success falls to the existing 'Failed to provision' reply; already_has_access and create_account_assignment are not called on either failure; the two pinned tests are rewritten to the new contract
+- [ ] #5 revoke_aws_sso_access: a non-success get_user_id logs status and error_code, skips delete_account_assignment and expire_request for that request and continues with the next; the pinned false-user-id test is replaced
+- [ ] #6 request_aws_account_access and its three pinned tests are deleted (no production caller exists), and the now-unused get_account_id_by_name import is removed from modules/aws/aws.py
+- [ ] #7 ops_group_assignment: NOT_FOUND keeps the existing 'not found' failed status; any other non-success returns a failed status carrying the result message; success path unchanged
+- [ ] #8 jobs/scheduled_tasks.py registers lambda: build_identity_center_adapter().healthcheck().is_success under the 'aws' key, with the integration test retargeted
+- [ ] #9 integrations/aws/identity_store.py and tests/integrations/aws/test_identity_store.py are deleted; the identity_store lines are removed from bin/baselines/sdk_typing_antipatterns.txt and bin/baselines/vendor_package_contract.txt; test_identity_store_conformance.py and packages/access are untouched
+- [ ] #10 ruff, mypy (no new errors), pytest, make check-sdk-typing and make check-vendor-package-contract pass with output recorded; a repo-wide grep shows zero references to integrations.aws.identity_store
+<!-- AC:END -->


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new AWS Identity Center adapter for legacy modules, improves error classification for AWS SDK calls, and ensures that tests do not make live AWS AssumeRole calls. The main themes are the addition of a new adapter, improved error handling, and enhancements to test isolation.

**AWS Identity Center Adapter:**
- Added a new `IdentityCenterAdapter` in `aws_platform/adapters/identity_center.py` that provides a typed interface for AWS Identity Store operations, including user, group, and membership management, with robust error handling and result typing. This adapter is built per-call with eagerly assumed credentials to avoid issues with long-lived clients.
- Introduced `aws_platform/__init__.py` and `aws_platform/adapters/__init__.py` as provisional namespaces for legacy AWS adapter code, clarifying their transitional role. [[1]](diffhunk://#diff-b3462589eade2ac95fc4c9dc2a2600eced493b92d91d480b51dd384f83e78da6R1-R4) [[2]](diffhunk://#diff-2eafd7ac6ccb5d46c62d53967869c7ae7eb878193bd27c51bd64aecd72cd2ff6R1)

**Error Handling Improvements:**
- Updated `classify_aws_error` to treat both `ConditionalCheckFailedException` and `ConflictException` as permanent errors, ensuring correct classification of non-retryable AWS SDK outcomes.
- Added a unit test to verify that `ConflictException` is classified as a permanent error.

**Test Isolation and Configuration:**
- Added fixtures in `tests/api/conftest.py` and `tests/integration/conftest.py` to stub out AWS AssumeRole calls, preventing tests from making live calls to AWS STS and ensuring test isolation. [[1]](diffhunk://#diff-937ad7356d0b67777f49d179586aec9be981af4a7864a8b5aae8e637b64ffc60R1-R31) [[2]](diffhunk://#diff-1e818699fffe3a53777bec5b7ca7651aa9d92dc109d1ca663baecd5dc40763feR14-R35)
- Updated test environment configuration in `pyproject.toml` to explicitly disable feature warmups that would otherwise trigger AWS Identity Center adapter initialization during tests.